### PR TITLE
Fix the parser, include print function....

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,21 +1,34 @@
 #[derive(Debug, Clone)]
 pub enum ASTNode {
-    VariableDecl(String, Box<Expression>),
+    VariableDecl(String, Box<Expression>),                    // old style: let x = 5;
+    VariableDeclTyped(String, String, Box<Expression>),       // new style: let x: int = 5;
     FunctionDecl(String, Vec<Parameter>, Box<Expression>),
     ForLoop(Box<Expression>, Box<Expression>, Box<Expression>, Box<ASTNode>),
     WhileLoop(Box<Expression>, Box<ASTNode>),
     Assignment(String, Box<Expression>),
-    IfStatement(Box<Expression>, Box<ASTNode>),
+    IfStatement(
+        Box<Expression>,       // The condition expression of the 'if'
+        Box<ASTNode>,          // The body of the 'if' block
+        Option<Box<ASTNode>>,  // The 'else if' (optional)
+        Option<Box<ASTNode>>,  // The 'else' (optional)
+    ),
     Block(Vec<ASTNode>),
+    Print(Box<Expression>), // 👈 Add this if it's missing
+
 }
+
 
 #[derive(Debug, Clone)]
 pub enum Expression {
     Integer(i64),
+    Float(f64),
+    Boolean(bool),
     StringLiteral(String),
     Identifier(String),
     BinaryOp(Box<Expression>, Operator, Box<Expression>),
+    // etc.
 }
+
 
 #[derive(Debug, Clone)]
 pub enum Operator {
@@ -24,7 +37,16 @@ pub enum Operator {
     Multiply,
     Divide,
     Equal,
+    NotEqual,
+    LessThan,
+    GreaterThan,
+    LessEqual,
+    GreaterEqual,
+    And, 
+    Or,
 }
+
+
 
 #[derive(Debug, Clone)]
 pub struct Parameter {

--- a/src/bin/parser_main.rs
+++ b/src/bin/parser_main.rs
@@ -44,6 +44,8 @@ fn main() {
 
     // Initialize the lexer
     let mut lexer = Lexer::new(source_code);
+    let mut parser = Parser::new(lexer.clone());
+    
     let mut token_count = 0;
 
     // Lex the source code, but only for parsing
@@ -66,7 +68,6 @@ fn main() {
     }
 
     // Initialize the parser with the lexer, not the tokens
-    let mut parser = Parser::new(lexer);
 
     // Parse the tokens and build the AST
     match parser.parse() {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -39,6 +39,14 @@ pub enum TokenType {
     LeftBrace,   // {
     RightBrace,  // }
     Arrow,       // ->
+    Ampersand,   // &
+    Bang,        // !
+    Question,    // ?
+    Tilde,       // ~
+    Backslash,   // \
+    At,          // @
+    Dollar,      // $
+    Hash,        // #
 
     // Operators
     Plus,        // +
@@ -67,7 +75,7 @@ pub enum TokenType {
     Illegal(char),
 }
 
-
+#[derive(Debug, Clone)]
 pub struct Lexer {
     input: Vec<char>,
     position: usize,
@@ -235,6 +243,26 @@ impl Lexer {
                     ')' => { self.advance(); TokenType::RightParen }
                     '{' => { self.advance(); TokenType::LeftBrace }
                     '}' => { self.advance(); TokenType::RightBrace }
+                    '&' => {
+                        if self.peek() == Some('&') {
+                            self.advance();
+                            self.advance();
+                            TokenType::And
+                        } else {
+                            self.advance();
+                            TokenType::Ampersand
+                        }
+                    }
+                    '|' => {
+                        if self.peek() == Some('|') {
+                            self.advance();
+                            self.advance();
+                            TokenType::Or
+                        } else {
+                            self.advance();
+                            TokenType::Illegal('|') // or define a single '|' token if needed
+                        }
+                    }
                     '.' => {
                         if self.peek() == Some('.') {
                             self.advance();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,73 +28,83 @@ impl Parser {
                 TokenType::Let => self.parse_variable_declaration()?,
                 TokenType::Identifier(_) => self.parse_assignment()?,
                 TokenType::If => self.parse_if_statement()?,
-                TokenType::EOF => break, // Add this line to break on EOF
+                TokenType::Print => self.parse_print_statement()?,
+                TokenType::EOF => break,
                 _ => return Err(format!("Unexpected token: {:?}", token)),
             };
     
             statements.push(stmt);
-            self.advance();
+            // self.advance(); ❌ remove this!
         }
     
         Ok(ASTNode::Block(statements))
     }
     
-
-    // pub fn parse(&mut self) -> Result<ASTNode, String> {
-    //     let mut statements: Vec<ASTNode> = Vec::new();
     
-    //     loop {
-    //         match &self.current_token {
-    //             Some(TokenType::EOF) => break,
-    //             Some(TokenType::Let) => {
-    //                 let stmt: ASTNode = self.parse_variable_declaration()?;
-    //                 statements.push(stmt);
-    //             }
-    //             Some(TokenType::Identifier(_)) => {
-    //                 let stmt: ASTNode = self.parse_assignment()?;
-    //                 statements.push(stmt);
-    //             }
-    //             Some(TokenType::If) => {
-    //                 let stmt: ASTNode = self.parse_if_statement()?;
-    //                 statements.push(stmt);
-    //             }
-    //             Some(token) => {
-    //                 return Err(format!("Unexpected token: {:?}", token));
-    //             }
-    //             None => {
-    //                 return Err("Unexpected end of input".to_string());
-    //             }
-    //         }
-    //     }
-    
-    //     Ok(ASTNode::Block(statements))
-    // }
-    
-
     fn parse_variable_declaration(&mut self) -> Result<ASTNode, String> {
-        self.advance(); // Skip "let"
-
-        if let Some(TokenType::Identifier(name)) = &self.current_token {
-            let name_clone: String = name.clone();
-            self.advance(); // Skip the identifier
-
-            if let Some(TokenType::Assign) = &self.current_token {
-                self.advance(); // Skip '='
-                let expr: Expression = self.parse_expression();
-
-                if let Some(TokenType::Semicolon) = &self.current_token {
-                    self.advance(); // Skip ';'
-                    return Ok(ASTNode::VariableDecl(name_clone, Box::new(expr)));
-                } else {
-                    return Err("Expected ';' after variable declaration.".to_string());
-                }
-            } else {
-                return Err("Expected '=' after variable name.".to_string());
-            }
+        self.advance(); // Skip 'let'
+    
+        // Step 1: Expect identifier
+        let var_name = if let Some(TokenType::Identifier(name)) = &self.current_token {
+            let name_clone = name.clone();
+            self.advance(); // Skip identifier
+            name_clone
+        } else {
+            return Err("Expected identifier after 'let'.".to_string());
+        };
+    
+        // Step 2: Expect colon
+        if let Some(TokenType::Colon) = &self.current_token {
+            self.advance(); // Skip ':'
+        } else {
+            return Err("Expected ':' after variable name.".to_string());
         }
-
-        Err("Expected identifier after 'let'.".to_string())
+    
+        // Step 3: Expect a type (IntType, FloatType, etc.)
+        let var_type = match &self.current_token {
+            Some(TokenType::IntType) => {
+                self.advance();
+                "int".to_string()
+            }
+            Some(TokenType::FloatType) => {
+                self.advance();
+                "float".to_string()
+            }
+            Some(TokenType::BoolType) => {
+                self.advance();
+                "bool".to_string()
+            }
+            Some(TokenType::StringType) => {
+                self.advance();
+                "string".to_string()
+            }
+            Some(TokenType::VoidType) => {
+                self.advance();
+                "void".to_string()
+            }
+            other => return Err(format!("Expected type after ':', got {:?}", other)),
+        };
+    
+        // Step 4: Expect '='
+        if let Some(TokenType::Assign) = &self.current_token {
+            self.advance(); // Skip '='
+        } else {
+            return Err("Expected '=' after variable type.".to_string());
+        }
+    
+        // Step 5: Parse the expression
+        let expr = self.parse_expression();
+    
+        // Step 6: Expect semicolon
+        if let Some(TokenType::Semicolon) = &self.current_token {
+            self.advance(); // Skip ';'
+        } else {
+            return Err("Expected ';' after variable declaration.".to_string());
+        }
+    
+        Ok(ASTNode::VariableDeclTyped(var_name, var_type, Box::new(expr)))
     }
+    
 
     fn parse_assignment(&mut self) -> Result<ASTNode, String> {
         if let Some(TokenType::Identifier(name)) = &self.current_token {
@@ -118,35 +128,89 @@ impl Parser {
     }
 
     fn parse_if_statement(&mut self) -> Result<ASTNode, String> {
-        self.advance(); // Skip 'if'
-
+        self.parse_if_like_statement(true)
+    }
+    
+    fn parse_if_like_statement(&mut self, is_if: bool) -> Result<ASTNode, String> {
+        self.advance(); // Skip 'If' or 'ElseIf'
+    
         if let Some(TokenType::LeftParen) = &self.current_token {
             self.advance(); // Skip '('
             let condition: Expression = self.parse_expression();
-
+    
             if let Some(TokenType::RightParen) = &self.current_token {
                 self.advance(); // Skip ')'
-
+    
                 if let Some(TokenType::LeftBrace) = &self.current_token {
                     self.advance(); // Skip '{'
-                    let body: ASTNode = self.parse()?; // Recursive parse to handle block
-
-                    if let Some(TokenType::RightBrace) = &self.current_token {
-                        self.advance(); // Skip '}'
-                        return Ok(ASTNode::IfStatement(Box::new(condition), Box::new(body)));
-                    } else {
-                        return Err("Expected '}' after if block.".to_string());
+                    let body: ASTNode = self.parse_block()?;
+                    self.advance(); // Skip '}'
+    
+                    let mut else_if = None;
+                    let mut else_block = None;
+    
+                    while let Some(token) = &self.current_token {
+                        match token {
+                            TokenType::ElseIf => {
+                                else_if = Some(self.parse_if_like_statement(false)?);
+                                break;
+                            }
+                            TokenType::Else => {
+                                self.advance(); // Skip 'Else'
+                                if let Some(TokenType::LeftBrace) = &self.current_token {
+                                    self.advance(); // Skip '{'
+                                    else_block = Some(self.parse_block()?);
+                                    self.advance(); // Skip '}'
+                                    break;
+                                } else {
+                                    return Err("Expected '{' after 'else'.".to_string());
+                                }
+                            }
+                            _ => break,
+                        }
                     }
+    
+                    return Ok(ASTNode::IfStatement(
+                        Box::new(condition),
+                        Box::new(body),
+                        else_if.map(Box::new),
+                        else_block.map(Box::new),
+                    ));
                 } else {
                     return Err("Expected '{' to start if block.".to_string());
                 }
             } else {
-                return Err("Expected ')' after if condition.".to_string());
+                return Err("Expected ')' after condition.".to_string());
             }
         }
-
-        Err("Expected '(' after 'if'.".to_string())
+    
+        Err(format!("Expected '(' after '{}'.", if is_if { "if" } else { "elseif" }))
     }
+    
+
+
+    fn parse_block(&mut self) -> Result<ASTNode, String> {
+        let mut statements = Vec::new();
+    
+        while let Some(token) = &self.current_token {
+            if let TokenType::RightBrace = token {
+                break; // Stop before consuming the closing brace
+            }
+    
+            let stmt = match token {
+                TokenType::Let => self.parse_variable_declaration()?,
+                TokenType::Identifier(_) => self.parse_assignment()?,
+                TokenType::If => self.parse_if_statement()?,
+                TokenType::Print => self.parse_print_statement()?,
+                _ => return Err(format!("Unexpected token in block: {:?}", token)),
+            };
+    
+            statements.push(stmt);
+        }
+    
+        Ok(ASTNode::Block(statements))
+    }
+    
 
     fn parse_expression(&mut self) -> Expression {
         let mut left: Expression = self.parse_term();
@@ -167,28 +231,73 @@ impl Parser {
             Some(TokenType::Star) => Some(Operator::Multiply),
             Some(TokenType::Slash) => Some(Operator::Divide),
             Some(TokenType::EqualEqual) => Some(Operator::Equal),
+            Some(TokenType::Less) => Some(Operator::LessThan),
+            Some(TokenType::Greater) => Some(Operator::GreaterThan),
+            Some(TokenType::LessEqual) => Some(Operator::LessEqual),
+            Some(TokenType::GreaterEqual) => Some(Operator::GreaterEqual),
+            Some(TokenType::NotEqual) => Some(Operator::NotEqual),
+            Some(TokenType::And) => Some(Operator::And),
+            Some(TokenType::Or) => Some(Operator::Or),
             _ => None,
         }
     }
+    
 
     fn parse_term(&mut self) -> Expression {
         match &self.current_token {
-            Some(TokenType::Integer(value)) => {
-                let val: i64 = *value;
+            Some(TokenType::IntLiteral(value)) => {
+                let val = *value;
                 self.advance();
                 Expression::Integer(val)
             }
-            Some(TokenType::Identifier(name)) => {
-                let name_clone: String = name.clone();
+            Some(TokenType::FloatLiteral(value)) => {
+                let val = *value;
                 self.advance();
-                Expression::Identifier(name_clone)
+                Expression::Float(val)
+            }
+            Some(TokenType::BoolLiteral(value)) => {
+                let val = *value;
+                self.advance();
+                Expression::Boolean(val)
             }
             Some(TokenType::StringLiteral(s)) => {
-                let s_clone: String = s.clone();
+                let s_clone = s.clone();
                 self.advance();
                 Expression::StringLiteral(s_clone)
+            }
+            Some(TokenType::Identifier(name)) => {
+                let name_clone = name.clone();
+                self.advance();
+                Expression::Identifier(name_clone)
             }
             _ => panic!("Unexpected token in expression: {:?}", self.current_token),
         }
     }
+
+    fn parse_print_statement(&mut self) -> Result<ASTNode, String> {
+        self.advance(); // Skip 'print'
+    
+        if let Some(TokenType::LeftParen) = &self.current_token {
+            self.advance(); // Skip '('
+    
+            let expr = self.parse_expression();
+    
+            if let Some(TokenType::RightParen) = &self.current_token {
+                self.advance(); // Skip ')'
+    
+                if let Some(TokenType::Semicolon) = &self.current_token {
+                    self.advance(); // Skip ';'
+                    return Ok(ASTNode::Print(Box::new(expr)));
+                } else {
+                    return Err("Expected ';' after print statement.".to_string());
+                }
+            } else {
+                return Err("Expected ')' after expression in print.".to_string());
+            }
+        }
+    
+        Err("Expected '(' after 'print'.".to_string())
+    }
+    
+    
 }

--- a/tests/samples.md
+++ b/tests/samples.md
@@ -1,0 +1,59 @@
+
+## We have a parse method example
+
+// pub fn parse(&mut self) -> Result<ASTNode, String> {
+//     let mut statements: Vec<ASTNode> = Vec::new();
+
+//     loop {
+//         match &self.current_token {
+//             Some(TokenType::EOF) => break,
+//             Some(TokenType::Let) => {
+//                 let stmt: ASTNode = self.parse_variable_declaration()?;
+//                 statements.push(stmt);
+//             }
+//             Some(TokenType::Identifier(_)) => {
+//                 let stmt: ASTNode = self.parse_assignment()?;
+//                 statements.push(stmt);
+//             }
+//             Some(TokenType::If) => {
+//                 let stmt: ASTNode = self.parse_if_statement()?;
+//                 statements.push(stmt);
+//             }
+//             Some(token) => {
+//                 return Err(format!("Unexpected token: {:?}", token));
+//             }
+//             None => {
+//                 return Err("Unexpected end of input".to_string());
+//             }
+//         }
+//     }
+
+//     Ok(ASTNode::Block(statements))
+// }
+
+## Parse_Variable_declaration without type (this will not be used)
+
+fn parse_variable_declaration(&mut self) -> Result<ASTNode, String> {
+    self.advance(); // Skip "let"
+
+    if let Some(TokenType::Identifier(name)) = &self.current_token {
+        let name_clone: String = name.clone();
+        self.advance(); // Skip the identifier
+
+        if let Some(TokenType::Assign) = &self.current_token {
+            self.advance(); // Skip '='
+            let expr: Expression = self.parse_expression();
+
+            if let Some(TokenType::Semicolon) = &self.current_token {
+                self.advance(); // Skip ';'
+                return Ok(ASTNode::VariableDecl(name_clone, Box::new(expr)));
+            } else {
+                return Err("Expected ';' after variable declaration.".to_string());
+            }
+        } else {
+            return Err("Expected '=' after variable name.".to_string());
+        }
+    }
+
+    Err("Expected identifier after 'let'.".to_string())
+}


### PR DESCRIPTION
This pull request includes significant changes to the abstract syntax tree (AST) structure, lexer, and parser components. The modifications aim to enhance the language's capabilities by introducing new token types, refining the parsing logic for variable declarations and control flow statements, and adding support for new expression types.

### AST Enhancements:
* Added `VariableDeclTyped` to support typed variable declarations.
* Expanded `IfStatement` to include optional `else if` and `else` blocks.
* Introduced `Print` node to the AST.
* Added `Float` and `Boolean` types to the `Expression` enum.
* Added new operators to the `Operator` enum, including comparison and logical operators.

### Lexer Improvements:
* Added new token types such as `Ampersand`, `Bang`, `Question`, `Tilde`, `Backslash`, `At`, `Dollar`, and `Hash`.
* Implemented logic for recognizing `&&` and `||` as `And` and `Or` tokens, respectively.

### Parser Enhancements:
* Refactored variable declaration parsing to support typed declarations.
* Introduced `parse_if_like_statement` to handle `if` and `else if` statements uniformly.
* Added `parse_block` method to handle block parsing.
* Added support for parsing `Print` statements.

### Test Updates:
* Added examples and test cases for parsing methods and variable declarations in `tests/samples.md`.…and, or, comparison and others

Closes #2 