### PR TITLE
Adds github actions to build and test on pushes to main  branch

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate building and testing the Rust project on every push and pull request to the `main` branch.

Continuous integration setup:

* Added `.github/workflows/build_test.yml` to define a workflow that checks out the code, builds the project with `cargo build`, and runs tests with `cargo test` on Ubuntu for every push and pull request to `main`.