### PR TITLE
Add GitHub linguist configuration for Raven language recognition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Raven Language Recognition
+*.rv linguist-language=Raven
+*.rv linguist-detectable=true
+
+# Documentation
+docs/* linguist-documentation
+README.md linguist-documentation
+*.md linguist-documentation
+
+# Generated files
+target/* linguist-vendored
+node_modules/* linguist-vendored
+*.vsix linguist-generated
+
+# Examples
+examples/* linguist-detectable=true

--- a/linguist.yml
+++ b/linguist.yml
@@ -1,0 +1,14 @@
+{
+  "name": "Raven",
+  "type": "programming",
+  "color": "#1a1a2e",
+  "extensions": [
+    ".rv"
+  ],
+  "aliases": [
+    "raven"
+  ],
+  "tm_scope": "source.raven",
+  "ace_mode": "text",
+  "language_id": 1000001
+}


### PR DESCRIPTION
- Add .gitattributes to map .rv files to Raven language
- Add linguist.yml to define Raven as programming language
- Configure midnight blue color (#1a1a2e) for Raven
- Exclude documentation and build artifacts from language stats
- Enable proper syntax highlighting on GitHub for .rv files