### PR TITLE
Update workflow for MkDocs deployment to GitHub Pages

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,61 @@
+# Simple workflow for deploying MkDocs documentation to GitHub Pages
+name: Deploy MkDocs documentation to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build and deploy job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with MkDocs
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload the built site directory
+          path: './site'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the deployment of MkDocs-generated documentation to GitHub Pages whenever changes are pushed to the `main` branch or the workflow is manually triggered. The workflow sets up the environment, installs dependencies, builds the documentation, and handles deployment.

**Documentation deployment automation:**

* Added a `.github/workflows/static.yml` workflow that builds MkDocs documentation and deploys it to GitHub Pages on pushes to `main` or manual triggers. The workflow includes steps for checking out code, setting up Python, installing dependencies, building the site, uploading the artifact, and deploying to GitHub Pages.