### PR TITLE
Updated Cargo.toml for debian and rpm builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,33 @@ homepage = "https://github.com/martian56/raven"
 keywords = ["programming", "language", "compiler", "interpreter"]
 categories = ["development-tools", "command-line-utilities"]
 
+# Debian package configuration
+[package.metadata.deb]
+maintainer = "martian56"
+copyright = "2024 martian56"
+license-file = ["LICENSE"]
+depends = "$auto"
+section = "devel"
+priority = "optional"
+assets = [
+    ["target/release/raven", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/raven/", "644"],
+    ["docs/syntax.md", "usr/share/doc/raven/", "644"],
+]
+
+# RPM package configuration
+[package.metadata.rpm]
+license = "MIT"
+group = "Development/Tools"
+requires = []
+[package.metadata.rpm.targets.x86_64-unknown-linux-gnu]
+path = "target/release/raven"
+assets = [
+    ["target/release/raven", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/raven/", "644"],
+    ["docs/syntax.md", "usr/share/doc/raven/", "644"],
+]
+
 [dependencies]
 clap = "4.1"
 


### PR DESCRIPTION
This pull request adds packaging metadata to `Cargo.toml` to support building Debian and RPM packages for the project. This makes it easier to distribute and install the application on Linux systems.

Packaging configuration:

* Added a `[package.metadata.deb]` section to configure Debian package generation, specifying maintainer, copyright, license, dependencies, and assets to include in the package.
* Added a `[package.metadata.rpm]` section to configure RPM package generation, including license, group, required dependencies, and assets for the `x86_64-unknown-linux-gnu` target.