### PR TITLE
fix: improve versioning in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,10 @@ jobs:
       - name: Create .exe bootstrapper (setup installer)
         run: |
           $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-          $msi = (Get-ChildItem target\wix\*.msi)[0]
-          $version = "${{ github.ref_name }}".TrimStart('v')
+          $msi = (Get-ChildItem target\wix\*.msi | Select-Object -First 1)
+          $version = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"(.*)"$').Matches[0].Groups[1].Value
           candle -ext WixBalExtension -dMsiPath="$($msi.FullName)" -dVersion="$version" bundle.wxs
-          light -ext WixBalExtension bundle.wixobj -o target\wix\raven-setup.exe
+          light -ext WixBalExtension bundle.wixobj -o "target\wix\raven-setup-$version.exe"
 
       - name: Create portable .zip
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "raven"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 authors = ["martian56"]
 description = "A modern programming language with advanced features"
 license = "MIT"
 repository = "https://github.com/martian56/raven"
-homepage = "https://github.com/martian56/raven"
+homepage = "https://raven.ufazien.com"
 keywords = ["programming", "language", "compiler", "interpreter"]
 categories = ["development-tools", "command-line-utilities"]
 
 # Debian package configuration
 [package.metadata.deb]
 maintainer = "martian56"
-copyright = "2024 martian56"
+copyright = "2026 martian56"
 license-file = ["LICENSE"]
 depends = "$auto"
 section = "devel"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::process;
 
 fn main() {
     let matches = Command::new("Raven")
-        .version("1.4.1")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("martian56 <https://github.com/martian56>")
         .about("Raven compiler and interpreter")
         .arg(


### PR DESCRIPTION
This pull request includes several improvements to the release process and project metadata for the `raven` project. The main changes involve automating version management, updating project information, and improving the naming of release artifacts.

**Release process and version automation:**

* The release workflow now automatically extracts the version number from `Cargo.toml` instead of using the GitHub ref name, ensuring consistency between the code and release artifacts. The generated installer executable is now named with the version (e.g., `raven-setup-1.4.1.exe`).
* The CLI tool in `src/main.rs` now uses the package version from the build environment (`CARGO_PKG_VERSION`) rather than a hardcoded version string, reducing the risk of version mismatches.

**Project metadata updates:**

* Updated the project version in `Cargo.toml` from `1.4.0` to `1.4.1`, changed the homepage URL, and updated the copyright year.

Closes #39 