### PR TITLE
fix: add web module to windows release

### DIFF
--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -140,6 +140,7 @@
                             <File Id='network_rv' Source='lib\network.rv'/>
                             <File Id='testing_rv' Source='lib\testing.rv'/>
                             <File Id='json_rv' Source='lib\json.rv'/>
+                            <File Id='web_rv' Source='lib\web.rv'/>
                         </Component>
                     </Directory>
                 </Directory>


### PR DESCRIPTION
This pull request makes a small update to the installer configuration by including a new file in the installation package.

* Added `lib\web.rv` to the list of files installed by the installer in `wix/main.wxs`.

Closes #45 