### PR TITLE
fix: make repl support multi-line code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raven"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 authors = ["martian56"]
 description = "A modern programming language with advanced features"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod format;
 pub mod lexer;
 pub mod parser;
 pub mod paths;
+pub mod repl;
 pub mod span;
 pub mod type_checker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Arg, Command};
 use raven::code_gen::Interpreter;
 use raven::lexer::Lexer;
 use raven::parser::Parser;
+use raven::repl::delimiter_depth;
 use raven::type_checker::TypeChecker;
 use std::fs;
 use std::process;
@@ -148,43 +149,86 @@ fn execute_file(file_name: &str, verbose: bool, check_only: bool, show_ast: bool
     }
 }
 
-fn start_repl(verbose: bool) {
+enum ReplInput {
+    /// stdin closed before any code
+    Eof,
+    Quit,
+    Help,
+    Code(String),
+}
+
+/// Read one logical snippet: multiple lines while `(` / `{` depth is non-zero (outside strings
+/// and comments). Single-line statements run as soon as delimiters balance.
+fn read_repl_snippet() -> Result<ReplInput, std::io::Error> {
     use std::io::{self, Write};
 
+    let mut buffer = String::new();
+    loop {
+        if buffer.is_empty() {
+            print!("raven> ");
+        } else {
+            print!("...> ");
+        }
+        io::stdout().flush()?;
+
+        let mut line = String::new();
+        let n = io::stdin().read_line(&mut line)?;
+        if n == 0 {
+            if buffer.is_empty() {
+                return Ok(ReplInput::Eof);
+            }
+            return Ok(ReplInput::Code(buffer));
+        }
+
+        let trimmed = line.trim();
+        if buffer.is_empty() {
+            if trimmed == "exit" || trimmed == "quit" {
+                return Ok(ReplInput::Quit);
+            }
+            if trimmed == "help" {
+                return Ok(ReplInput::Help);
+            }
+            if trimmed.is_empty() {
+                continue;
+            }
+        }
+
+        buffer.push_str(&line);
+        let (p, b, bk) = delimiter_depth(&buffer);
+        if p > 0 || b > 0 || bk > 0 {
+            continue;
+        }
+        return Ok(ReplInput::Code(buffer));
+    }
+}
+
+fn start_repl(verbose: bool) {
     println!("🐦 Welcome to Raven REPL!");
     println!("Type 'exit' or 'quit' to exit, 'help' for help");
+    println!("Multi-line: keep typing until `()`, `{{}}`, and `[]` match (prompt changes to ...>)");
     println!("─────────────────────────────────────────");
 
     let mut interpreter = Interpreter::new();
     let mut type_checker = TypeChecker::new();
 
     loop {
-        print!("raven> ");
-        io::stdout().flush().unwrap();
-
-        let mut input = String::new();
-        match io::stdin().read_line(&mut input) {
-            Ok(_) => {
-                let input = input.trim();
-
-                if input.is_empty() {
-                    continue;
-                }
-
-                if input == "exit" || input == "quit" {
-                    println!("Goodbye!");
-                    break;
-                }
-
-                if input == "help" {
-                    println!("Available commands:");
-                    println!("  exit, quit - Exit the REPL");
-                    println!("  help - Show this help message");
-                    println!("  Any Raven code - Execute the code");
-                    continue;
-                }
-
-                match process_repl_input(input, &mut interpreter, &mut type_checker, verbose) {
+        match read_repl_snippet() {
+            Ok(ReplInput::Eof) => {
+                println!("Goodbye!");
+                break;
+            }
+            Ok(ReplInput::Quit) => {
+                println!("Goodbye!");
+                break;
+            }
+            Ok(ReplInput::Help) => {
+                println!("Available commands:");
+                println!("  exit, quit - Exit the REPL");
+                println!("  help - Show this help message");
+                println!("  Any Raven code - Execute the code (multi-line until delimiters match)");
+            }
+            Ok(ReplInput::Code(input)) => {
+                match process_repl_input(&input, &mut interpreter, &mut type_checker, verbose) {
                     Ok(_) => {}
                     Err(e) => {
                         eprintln!("❌ Error: {}", e);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,0 +1,91 @@
+//! REPL helpers: detect when accumulated source still needs more lines (unclosed delimiters).
+
+/// Count `(`, `{`, and `[` outside of strings and `//` / `/* */` comments.
+/// Used to offer multi-line input in the interactive REPL until delimiters balance.
+pub fn delimiter_depth(source: &str) -> (i32, i32, i32) {
+    let mut paren = 0i32;
+    let mut brace = 0i32;
+    let mut bracket = 0i32;
+    let mut it = source.chars().peekable();
+    while let Some(c) = it.next() {
+        // Line comment
+        if c == '/' && it.peek() == Some(&'/') {
+            it.next();
+            while let Some(x) = it.next() {
+                if x == '\n' {
+                    break;
+                }
+            }
+            continue;
+        }
+        // Block comment
+        if c == '/' && it.peek() == Some(&'*') {
+            it.next();
+            while let Some(x) = it.next() {
+                if x == '*' && it.peek() == Some(&'/') {
+                    it.next();
+                    break;
+                }
+            }
+            continue;
+        }
+        // String literal
+        if c == '"' {
+            while let Some(x) = it.next() {
+                if x == '\\' {
+                    it.next();
+                    continue;
+                }
+                if x == '"' {
+                    break;
+                }
+            }
+            continue;
+        }
+        match c {
+            '(' => paren += 1,
+            ')' => paren -= 1,
+            '{' => brace += 1,
+            '}' => brace -= 1,
+            '[' => bracket += 1,
+            ']' => bracket -= 1,
+            _ => {}
+        }
+    }
+    (paren, brace, bracket)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::delimiter_depth;
+
+    #[test]
+    fn balanced_single_line() {
+        assert_eq!(delimiter_depth("print(1);"), (0, 0, 0));
+    }
+
+    #[test]
+    fn unclosed_paren() {
+        assert_eq!(delimiter_depth("print(1"), (1, 0, 0));
+    }
+
+    #[test]
+    fn unclosed_brace() {
+        assert_eq!(delimiter_depth("fun f() -> void {"), (0, 1, 0));
+    }
+
+    #[test]
+    fn unclosed_bracket() {
+        assert_eq!(delimiter_depth("let a: int[] = ["), (0, 0, 1));
+    }
+
+    #[test]
+    fn ignores_brace_in_string() {
+        assert_eq!(delimiter_depth(r#"let s: string = "{";"#), (0, 0, 0));
+    }
+
+    #[test]
+    fn ignores_line_comment() {
+        assert_eq!(delimiter_depth("// {{\n"), (0, 0, 0));
+    }
+}


### PR DESCRIPTION
This pull request introduces improvements to the Raven REPL, enabling robust multi-line input by tracking delimiter balance and providing a better user experience. The main changes include a new `delimiter_depth` utility, a refactored REPL input loop, and supporting code organization updates.

**REPL enhancements:**

* Added a new `delimiter_depth` function in `src/repl.rs` to accurately count unclosed parentheses, braces, and brackets outside of strings and comments, supporting multi-line input in the REPL. Includes comprehensive unit tests.
* Refactored the REPL in `src/main.rs` to use a new `read_repl_snippet` function, which reads user input until all delimiters are balanced, allowing for multi-line code entry. The prompt now changes to `...>` for continued input.
* Improved REPL command handling with a new `ReplInput` enum, providing clearer handling of `exit`, `quit`, `help`, and code input.

**Code organization:**

* Added a new `repl` module in `src/lib.rs` to encapsulate REPL-related helpers.
* Updated imports in `src/main.rs` to use the new `delimiter_depth` function from the `repl` module.

**Other:**

* Bumped the crate version in `Cargo.toml` from `1.6.3` to `1.6.4` to reflect these improvements.

Closes #13 