### PR TITLE
feat(parser): recursive descent parser and AST for the v2 grammar

### DIFF
--- a/docs/v2/specs/parser.md
+++ b/docs/v2/specs/parser.md
@@ -53,12 +53,15 @@ For `github.com/...` and `./...` paths, the lexer treats them as a single `Strin
 ```
 Function     := "fun" Identifier [ GenericParams ] "(" ParamList ")" [ "->" Type ] FunctionBody
 FunctionBody := Block | "=" Expr
-ParamList    := [ Param { "," Param }* [ "," ] ]
+ParamList    := [ SelfReceiver [ "," Param ]* | Param { "," Param }* ] [ "," ]
+SelfReceiver := "self"
 Param        := Identifier ":" Type
 GenericParams := "<" GenericParam { "," GenericParam }* [ "," ] ">"
 GenericParam := Identifier [ ":" TraitBound { "+" TraitBound }* ]
 TraitBound   := TypePath
 ```
+
+A leading `self` parameter is allowed in `impl` and `trait` methods. The parser desugars it to a parameter named `"self"` carrying a synthetic `Self` type so that downstream passes do not need a special case. The full `self: Self` spelling is also accepted and parses identically.
 
 The expression body form (`= expr`) makes the return value the trailing expression. A function with a block body and no return type defaults to `()`.
 
@@ -238,7 +241,7 @@ A `{` immediately after an identifier (or `Self`) parses as a struct literal. Af
 
 #### Block expressions
 
-A block `{ ... }` parses zero or more statements followed by an optional trailing expression. If the last item parses as an `ExprStmt` and is NOT followed by a statement separator before the closing brace, that expression becomes the block's value. Otherwise the block evaluates to `()`.
+A block `{ ... }` parses zero or more statements followed by an optional trailing expression. If the last item parses as an `ExprStmt` and only newlines separate it from the closing `}` (no `;`), that expression becomes the block's value. Otherwise the block evaluates to `()`. An explicit `;` terminates the expression as a statement and forces the block to evaluate to `()`.
 
 ## Error model
 

--- a/docs/v2/specs/parser.md
+++ b/docs/v2/specs/parser.md
@@ -1,0 +1,280 @@
+# Parser Spec
+
+## Goal
+
+Consume the lexer's `Vec<Token>` and produce an Abstract Syntax Tree (AST) for the full Raven v2 grammar. The parser is a hand written recursive descent implementation with operator precedence climbing for expressions. Every AST node carries a `Span` so downstream passes (name resolution, type checking, code generation) can produce errors anchored at the source.
+
+The parser is total: it never panics on user input. Every malformed program produces a `RavenError::Parse(ParseError, Span, Option<String>)` and the parser does not attempt aggressive recovery in this release (one error, stop). Recovery is tracked separately and is out of scope for this PR.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> AST -> (name resolution -> type check -> hir -> mir -> codegen)
+```
+
+The parser consumes tokens produced by `src/lexer` and produces nodes defined in `src/ast`. The full grammar is implemented; the spec below is the source of truth for that grammar.
+
+## Grammar
+
+### File and items
+
+```
+File         := { Item NewlinesOrSemis }*
+Item         := Function | Struct | Trait | Impl | Enum | Extern | Import | Const | Let
+```
+
+Top level `let` is a mutable module level binding (matches the variables are mutable design). `const` is a compile time constant. Items are separated by newlines, semicolons, or both. Trailing separators are accepted.
+
+### Imports
+
+```
+Import       := "import" ImportSource [ "as" Identifier ] [ "{" IdentList [ "," ] "}" ]
+ImportSource := StdPath | StringLit
+StdPath      := "std" "/" Identifier { "/" Identifier }*
+IdentList    := Identifier { "," Identifier }*
+```
+
+Examples:
+
+* `import std/io`
+* `import std/collections/{Map, Set}`
+* `import "github.com/martian56/raven-http"`
+* `import "github.com/martian56/raven-http" as http`
+* `import "./helpers"`
+
+#### Path token disambiguation
+
+The lexer does not emit a dedicated `PathSep` token: it sees `/` as `TokenKind::Slash` (division). The parser switches to a path parsing mode immediately after the `import` keyword: when the next token is the identifier `std`, the parser consumes a sequence of `(Slash Identifier)` pairs greedily before falling back to its normal item parsing.
+
+For `github.com/...` and `./...` paths, the lexer treats them as a single `StringLit`. Users must therefore quote those forms (matching the grammar's `StringLit` production).
+
+### Functions
+
+```
+Function     := "fun" Identifier [ GenericParams ] "(" ParamList ")" [ "->" Type ] FunctionBody
+FunctionBody := Block | "=" Expr
+ParamList    := [ Param { "," Param }* [ "," ] ]
+Param        := Identifier ":" Type
+GenericParams := "<" GenericParam { "," GenericParam }* [ "," ] ">"
+GenericParam := Identifier [ ":" TraitBound { "+" TraitBound }* ]
+TraitBound   := TypePath
+```
+
+The expression body form (`= expr`) makes the return value the trailing expression. A function with a block body and no return type defaults to `()`.
+
+### Structs, traits, impls, enums
+
+```
+Struct       := "struct" Identifier [ GenericParams ] StructBody
+StructBody   := "{" [ FieldList ] "}"
+FieldList    := Field { Separator Field }* [ Separator ]
+Field        := Identifier ":" Type
+Separator    := "," | Newline | ( "," Newline )
+
+Trait        := "trait" Identifier [ GenericParams ] "{" { TraitMember NewlinesOrSemis }* "}"
+TraitMember  := "fun" Identifier [ GenericParams ] "(" ParamList ")" [ "->" Type ] [ FunctionBody ]
+
+Impl         := "impl" [ GenericParams ] TypePath [ "for" TypePath ] "{" { Function NewlinesOrSemis }* "}"
+
+Enum         := "enum" Identifier [ GenericParams ] "{" { EnumVariant Separator }* "}"
+EnumVariant  := Identifier [ "(" VariantPayload ")" ]
+VariantPayload := NamedFields | TypeList
+NamedFields  := Identifier ":" Type { "," Identifier ":" Type }* [ "," ]
+TypeList     := Type { "," Type }* [ "," ]
+```
+
+A trait member with a body is a default method. An impl block's only allowed members are functions (in this release).
+
+Variant payload disambiguation: the parser parses the first item between the parentheses optimistically. If it sees `Identifier ":"` followed by a type, the variant has named fields; otherwise it parses a comma separated `TypeList`.
+
+### Externs and constants
+
+```
+Extern       := "extern" StringLit "{" { ExternItem NewlinesOrSemis }* "}"
+ExternItem   := "fun" Identifier "(" ParamList ")" [ "->" Type ]
+
+Const        := "const" Identifier ":" Type "=" Expr
+Let          := "let" Identifier [ ":" Type ] [ "=" Expr ]
+```
+
+`extern "C" { ... }` declares a block of foreign function signatures bound to the given ABI string. The parser does not validate the ABI name; that is a job for the resolver.
+
+### Types
+
+```
+Type         := PrimaryType [ "?" ]
+PrimaryType  := TypePath
+              | "dyn" TypePath
+              | "(" ")"
+              | "fun" "(" [ TypeList ] ")" "->" Type
+TypePath     := Identifier [ "<" TypeArgs ">" ] { "." Identifier [ "<" TypeArgs ">" ] }*
+TypeArgs     := Type { "," Type }* [ "," ]
+```
+
+`T?` is sugar for `Option<T>`. It is parsed as a unary postfix on the `PrimaryType`. The AST records it as `Type::Optional(Box<Type>)` so later passes can desugar uniformly.
+
+Qualified types use `.` as the separator (e.g., `std.collections.Map<String, Int>`). `::` is reserved for explicit associated paths in expressions (parser accepts the token; semantics are deferred).
+
+### Statements
+
+```
+Statement    := Let
+              | "return" [ Expr ]
+              | "break" [ Expr ]
+              | "continue"
+              | "defer" Expr
+              | Assignment
+              | ExprStmt
+Let          := "let" Identifier [ ":" Type ] "=" Expr
+ExprStmt     := Expr
+Assignment   := LValue AssignOp Expr
+AssignOp     := "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "|=" | "^=" | "<<=" | ">>="
+LValue       := Identifier { ( "." Identifier | "[" Expr "]" ) }*
+```
+
+Statement separators inside a block are `Newline`, `Semi`, or both. The block parser keeps consuming statements until it sees `RBrace`.
+
+#### Assignment vs expression
+
+Assignment is a statement, not an expression. The parser disambiguates by parsing an expression first; if the next non newline token is an assignment operator AND the parsed expression is a syntactically valid LValue, the result is an `Assignment` statement. Otherwise the parsed expression becomes an `ExprStmt`. An invalid LValue followed by `=` produces `ParseError::InvalidAssignmentTarget`.
+
+### Expressions
+
+Precedence, lowest to highest. All binary operators are left associative except `Range`, which is non associative (chaining two range operators is a parse error).
+
+```
+LogicalOr      := LogicalAnd { "||" LogicalAnd }*
+LogicalAnd     := Comparison  { "&&" Comparison  }*
+Comparison     := BitOr       { ( "==" | "!=" | "<" | ">" | "<=" | ">=" ) BitOr }*
+BitOr          := BitXor      { "|" BitXor }*
+BitXor         := BitAnd      { "^" BitAnd }*
+BitAnd         := Shift       { "&" Shift }*
+Shift          := Range       { ( "<<" | ">>" ) Range }*
+Range          := Additive    [ ( ".." | "..=" ) Additive ]
+Additive       := Multiplicative { ( "+" | "-" ) Multiplicative }*
+Multiplicative := Unary       { ( "*" | "/" | "%" ) Unary }*
+Unary          := { ( "-" | "!" | "&" ) }* Postfix
+Postfix        := Primary { Suffix }*
+Suffix         := "." Identifier [ TypeArgs ] [ "(" ArgList ")" ]
+              | "(" ArgList ")"
+              | "[" Expr "]"
+              | "?"
+Primary       := Literal
+              | Identifier [ TypeArgs ] [ StructLit ]
+              | "(" Expr ")"
+              | "[" ExprList "]"
+              | "{" Block "}"
+              | IfExpr | MatchExpr | LoopExpr | WhileExpr | ForExpr | LambdaExpr
+              | "self" | "Self"
+Literal       := IntLit | FloatLit | BoolLit | StringLit | BlockStringLit | CharLit | CStringLit
+StructLit     := "{" [ FieldInit { Separator FieldInit }* [ Separator ] ] "}"
+FieldInit     := Identifier ":" Expr
+              | Identifier
+ArgList       := [ Expr { "," Expr }* [ "," ] ]
+ExprList      := [ Expr { "," Expr }* [ "," ] ]
+```
+
+Comparisons are not chained: `a < b < c` is a parse error. The grammar above does technically allow chaining; the parser explicitly rejects more than one comparison operator at the `Comparison` level with `ParseError::ChainedComparison`.
+
+#### Control flow
+
+```
+IfExpr        := "if" Expr Block { "else" "if" Expr Block } [ "else" Block ]
+MatchExpr     := "match" Expr "{" { MatchArm Separator }* "}"
+MatchArm      := Pattern [ "if" Expr ] "->" Expr
+LoopExpr      := "loop" Block
+WhileExpr     := "while" Expr Block
+ForExpr       := "for" Pattern "in" Expr Block
+
+LambdaExpr    := "fun" "(" ParamList ")" [ "->" Type ] FunctionBody
+              | "{" [ Identifier { "," Identifier }* "->" ] Block "}"
+```
+
+Both `if` and `match` are expressions and have a value. `while` and `for` evaluate to `()`. `loop` evaluates to the operand of `break value` (or `()` if `break` carries no value).
+
+#### Lambda shorthand
+
+`{ x, y -> body }` is a closure whose parameter types are inferred. The parser distinguishes shorthand lambdas from plain block expressions by looking ahead for an `Arrow` token (`->`) at the same brace depth before a statement separator. If found, the brace introduces a shorthand lambda; otherwise it is a block expression. A `{}` empty brace is always a block (the unit value).
+
+#### Patterns
+
+```
+Pattern       := "_"
+              | LiteralPat
+              | RangePat
+              | IdentPat [ "(" PatternList ")" | "{" FieldPatList "}" ]
+              | "(" PatternList ")"
+LiteralPat    := IntLit | FloatLit | StringLit | CharLit | BoolLit
+RangePat      := IntLit ( ".." | "..=" ) IntLit
+IdentPat      := Identifier
+PatternList   := Pattern { "," Pattern }* [ "," ]
+FieldPatList  := FieldPat { "," FieldPat }* [ "," ]
+FieldPat      := Identifier [ ":" Pattern ]
+```
+
+`IdentPat` covers three cases. Standalone, it binds the scrutinee. Followed by `(...)`, it is an enum tuple variant. Followed by `{...}`, it is a struct or enum struct variant. Resolution between "bind a name" and "match a constructor" is deferred to name resolution; the parser records the pattern shape.
+
+Tuple patterns require at least two elements (a single parenthesized pattern is just a grouping). Single element tuple patterns are deferred with the rest of tuple support.
+
+### Disambiguation rules
+
+#### `<` as comparison vs generic args
+
+In expression contexts, `<` is ambiguous between the comparison operator and the start of a generic type argument list. The parser disambiguates with bounded lookahead: when the postfix layer sees `Identifier <`, it tries to parse `<` ... `>` as a `TypeArgs`. The trial parse succeeds only if (a) the next token after `<` starts a `Type`, (b) the trial reaches a `>` before hitting a statement separator or an obviously non type token (`==`, `!=`, `&&`, `||`, `?`, `+`, `-`, `*`, `%`, etc.), and (c) the token immediately after the matched `>` is one of the syntactic frames that confirms a generic application (`(`, `.`, `::`, `{`, `=`, `,`, `)`, `]`, `;`, `Newline`, `Eof`).
+
+If the trial fails, the parser rewinds to the position of the `<` and treats it as comparison. The implementation uses an explicit checkpoint and rewind in the parser; lookahead does not consume tokens.
+
+In type contexts (after `:` in a parameter or let, after `->` in a return type, inside another `TypeArgs`, etc.), `<` is unambiguously a type argument opener and no trial is needed.
+
+`>>` inside nested generics is split into two `>` for type argument list parsing (e.g., `Vec<Vec<Int>>` lexes as `Vec Lt Vec Lt Int Shr` and the parser splits the trailing `Shr` into two close angles when needed).
+
+#### `{` after an expression
+
+A `{` immediately after an identifier (or `Self`) parses as a struct literal. After `if Expr {`, `while Expr {`, `for ... in Expr {`, and `match Expr {`, the `{` is a block (or match body), not a struct literal. The parser tracks a `no_struct_literal` flag while parsing the condition expression of `if`, `while`, and similar, matching the standard Rust solution.
+
+#### Newlines inside expressions
+
+`Newline` tokens are statement separators at block and item scope. Inside an expression, the parser consumes and ignores them at every continuation point: after binary operators, after `,` and `;` in argument lists, after `(`, `[`, `{`, before a postfix `.`, after `=`. A helper `skip_newlines_inside_expression()` is invoked liberally. A statement therefore cannot terminate mid expression: once an expression has begun, only an actual end of expression token (closing brace, closing paren at the matching depth, or end of file) ends it.
+
+#### Block expressions
+
+A block `{ ... }` parses zero or more statements followed by an optional trailing expression. If the last item parses as an `ExprStmt` and is NOT followed by a statement separator before the closing brace, that expression becomes the block's value. Otherwise the block evaluates to `()`.
+
+## Error model
+
+The parser uses the existing `RavenError::Parse(ParseError, Span, Option<String>)` variant.
+
+```rust
+pub enum ParseError {
+    UnexpectedToken { expected: String, found: String },
+    UnexpectedEof { expected: String },
+    InvalidAssignmentTarget,
+    ChainedComparison,
+    DuplicateField(String),
+    InvalidImportPath,
+    UnsupportedTuple,
+    InvalidPattern(String),
+    Custom(String),
+}
+```
+
+Most errors render as `expected X, found Y`. Hints are attached at call sites where the parser can offer concrete advice (for example: missing arrow before return type, missing `=` on a single expression body, etc.).
+
+## Deferred to follow up issues
+
+* **Tuples.** `(a, b)` parses but produces `ParseError::UnsupportedTuple`. Pattern tuples are similarly deferred. The grammar is in place for v2.x.
+* **String interpolation splitting.** The lexer preserves `${...}` segments verbatim in `StringLit`. Re tokenizing them into expression fragments is tracked in issue #69.
+* **`::` semantics.** The token is accepted in trial paths but rejected in real ones, except inside `extern` ABIs where it is not used. Resolver level path syntax lands when name resolution does.
+* **Attribute and visibility modifiers.** No `@deriving`, no `pub`, no `mut` keyword in v2.0. The parser does not consume them.
+
+## Test coverage
+
+* Inline unit tests under `src/parser/tests.rs` exercise each grammar production with positive and negative cases.
+* Golden snapshot tests under `tests/parser_golden.rs` walk a corpus of small `.rv` programs in `tests/parser_corpus/`, parse them, pretty print the AST, and diff against committed `.rv.ast` baselines. Run with `cargo test --test parser_golden`. Refresh baselines after an intentional change with `RAVEN_UPDATE_PARSER_GOLDEN=1 cargo test --test parser_golden`.
+
+## Design notes
+
+* The AST is split by category: `expr`, `stmt`, `decl`, `pattern`, `ty`. Every node embeds a `Span`. Public types are `Expr`, `Stmt`, `Decl`, `Pattern`, `Type` and a wrapper `File` for the top level.
+* The parser is a single struct holding a token slice and a cursor. Internal modules group functions by grammar category; the cursor is shared.
+* Errors are non recovering in this release. The parser stops at the first error.
+* Operator precedence is encoded in dedicated recursive functions per level rather than a Pratt table. The level count is small enough that the explicit form is easier to read and modify.

--- a/src/ast/decl.rs
+++ b/src/ast/decl.rs
@@ -1,0 +1,212 @@
+//! Top level declarations.
+//!
+//! Items appear at the module level: functions, types, traits, impls,
+//! enums, extern blocks, imports, constants, and module level lets.
+
+use crate::span::Span;
+
+use super::expr::{Block, Expr};
+use super::stmt::Stmt;
+use super::ty::{Type, TypePath};
+
+/// A top level declaration with its source span.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Decl {
+    pub kind: DeclKind,
+    pub span: Span,
+}
+
+/// Top level item kinds.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeclKind {
+    /// `fun name<G>(params) -> Ret { body }` or `fun ... = expr`.
+    Function(Function),
+    /// `struct Name<G> { fields }`.
+    Struct(Struct),
+    /// `trait Name<G> { members }`.
+    Trait(Trait),
+    /// `impl<G> Path` or `impl<G> Trait for Type` blocks.
+    Impl(Impl),
+    /// `enum Name<G> { variants }`.
+    Enum(Enum),
+    /// `extern "ABI" { signatures }`.
+    Extern(Extern),
+    /// `import path [as alias] [{ idents }]`.
+    Import(Import),
+    /// `const NAME: T = expr`.
+    Const(Const),
+    /// Module level `let name [: T] [= expr]`. Mutable module global.
+    Let(LetDecl),
+}
+
+/// A function declaration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Function {
+    pub name: String,
+    pub generics: Vec<GenericParam>,
+    pub params: Vec<Param>,
+    pub ret: Option<Type>,
+    pub body: FunctionBody,
+    pub span: Span,
+}
+
+/// The body of a function declaration: block or single expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FunctionBody {
+    Block(Block),
+    Expr(Expr),
+    /// A trait member with no default body.
+    None,
+}
+
+/// One generic parameter declaration: `T: Bound1 + Bound2`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenericParam {
+    pub name: String,
+    pub bounds: Vec<TypePath>,
+    pub span: Span,
+}
+
+/// One function parameter: `name: Type`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Param {
+    pub name: String,
+    pub ty: Type,
+    pub span: Span,
+}
+
+/// A struct declaration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Struct {
+    pub name: String,
+    pub generics: Vec<GenericParam>,
+    pub fields: Vec<StructField>,
+    pub span: Span,
+}
+
+/// One named field of a struct.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructField {
+    pub name: String,
+    pub ty: Type,
+    pub span: Span,
+}
+
+/// A trait declaration, holding zero or more member signatures (with
+/// optional default bodies).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Trait {
+    pub name: String,
+    pub generics: Vec<GenericParam>,
+    pub members: Vec<Function>,
+    pub span: Span,
+}
+
+/// An impl block: either an inherent impl `impl Path { ... }` or a
+/// trait impl `impl Trait for Type { ... }`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Impl {
+    pub generics: Vec<GenericParam>,
+    /// For an inherent impl, this is the implementing type's path. For a
+    /// trait impl, this is the trait's path.
+    pub trait_or_type: TypePath,
+    /// For a trait impl, the implementing type. `None` for inherent
+    /// impls.
+    pub for_type: Option<TypePath>,
+    pub items: Vec<Function>,
+    pub span: Span,
+}
+
+/// An enum declaration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Enum {
+    pub name: String,
+    pub generics: Vec<GenericParam>,
+    pub variants: Vec<EnumVariant>,
+    pub span: Span,
+}
+
+/// One enum variant.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnumVariant {
+    pub name: String,
+    pub payload: VariantPayload,
+    pub span: Span,
+}
+
+/// What payload an enum variant carries.
+#[derive(Debug, Clone, PartialEq)]
+pub enum VariantPayload {
+    /// `Color` (no payload).
+    Unit,
+    /// `Pair(Int, String)` (positional types).
+    Tuple(Vec<Type>),
+    /// `Person { name: String, age: Int }` (named fields).
+    Struct(Vec<StructField>),
+}
+
+/// An extern block: a sequence of foreign function signatures.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Extern {
+    pub abi: String,
+    pub items: Vec<ExternFn>,
+    pub span: Span,
+}
+
+/// One signature inside an extern block.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExternFn {
+    pub name: String,
+    pub params: Vec<Param>,
+    pub ret: Option<Type>,
+    pub span: Span,
+}
+
+/// An import declaration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Import {
+    pub source: ImportSource,
+    /// `import path as alias` renames the binding to `alias`.
+    pub alias: Option<String>,
+    /// `import path { a, b }` selects specific names. Empty when no
+    /// selector list is present.
+    pub selectors: Vec<String>,
+    pub span: Span,
+}
+
+/// The thing being imported.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ImportSource {
+    /// `std/io`, `std/collections/Map`.
+    Std(Vec<String>),
+    /// A quoted path: `"github.com/user/repo"` or `"./relative"`.
+    Quoted(String),
+}
+
+/// A `const` declaration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Const {
+    pub name: String,
+    pub ty: Type,
+    pub value: Expr,
+    pub span: Span,
+}
+
+/// A module level `let` declaration. The initializer is required at
+/// parse time at the module level when no type annotation is present
+/// and optional otherwise.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LetDecl {
+    pub name: String,
+    pub ty: Option<Type>,
+    pub init: Option<Expr>,
+    pub span: Span,
+}
+
+/// Convenience: wrap a function body block as a `Stmt::Expr(Block)` for
+/// places that need to handle blocks generically. Not used at parse
+/// time; left here as a hook for desugaring passes.
+#[allow(dead_code)]
+fn _block_to_stmts(block: &Block) -> &[Stmt] {
+    &block.stmts
+}

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1,0 +1,224 @@
+//! Value expressions.
+//!
+//! Expressions are the recursive heart of the language. Most of the
+//! grammar's nesting lives here: arithmetic, calls, control flow,
+//! lambdas, struct literals. The variants below mirror the grammar in
+//! `docs/v2/specs/parser.md` closely.
+
+use crate::span::Span;
+
+use super::pattern::Pattern;
+use super::stmt::Stmt;
+use super::ty::Type;
+
+/// An expression with its source span.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Expr {
+    pub kind: ExprKind,
+    pub span: Span,
+}
+
+/// All expression node kinds.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExprKind {
+    // ----- literals -----
+    /// Integer literal.
+    Int(i64),
+    /// Floating point literal.
+    Float(f64),
+    /// Boolean literal.
+    Bool(bool),
+    /// Regular `"..."` string literal. Interpolation segments are kept
+    /// verbatim; splitting is tracked in a later issue.
+    Str(String),
+    /// Triple quoted block string literal.
+    BlockStr(String),
+    /// Character literal.
+    Char(char),
+    /// `c"..."` FFI string.
+    CStr(String),
+    /// `self` keyword.
+    SelfLower,
+    /// `Self` keyword (the enclosing type).
+    SelfUpper,
+
+    // ----- names and aggregates -----
+    /// A bare identifier, optionally with generic arguments
+    /// `name<T1, T2>`.
+    Ident { name: String, generics: Vec<Type> },
+    /// A struct literal: `Point { x: 1, y: 2 }`. The `name` is the type
+    /// path source spelling, recorded as identifier segments. Generic
+    /// arguments on the path live on the leading `Ident` if any.
+    StructLit {
+        name: String,
+        generics: Vec<Type>,
+        fields: Vec<FieldInit>,
+    },
+    /// `[a, b, c]` array literal.
+    Array(Vec<Expr>),
+    /// `(a, b, c)` tuple literal. Always at least two elements. The
+    /// parser produces this and the resolver rejects it until tuples
+    /// land; see `docs/v2/specs/parser.md`.
+    Tuple(Vec<Expr>),
+    /// `(expr)` parenthesized expression, retained so spans cover the
+    /// parens for error reporting.
+    Paren(Box<Expr>),
+    /// `{ stmts...; trailing? }` block expression.
+    Block(Block),
+
+    // ----- operators -----
+    /// Unary prefix operator.
+    Unary { op: UnaryOp, operand: Box<Expr> },
+    /// Binary infix operator.
+    Binary {
+        op: BinaryOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
+    /// Range expression: `start..end` or `start..=end`.
+    Range {
+        start: Box<Expr>,
+        end: Box<Expr>,
+        inclusive: bool,
+    },
+
+    // ----- calls, fields, indexing -----
+    /// Function call: `callee(arg1, arg2)`.
+    Call { callee: Box<Expr>, args: Vec<Expr> },
+    /// Method call: `receiver.name<G>(arg1, ...)`.
+    MethodCall {
+        receiver: Box<Expr>,
+        name: String,
+        generics: Vec<Type>,
+        args: Vec<Expr>,
+    },
+    /// Field access: `receiver.name`. No call parens.
+    Field { receiver: Box<Expr>, name: String },
+    /// Indexing: `receiver[index]`.
+    Index {
+        receiver: Box<Expr>,
+        index: Box<Expr>,
+    },
+    /// `expr?` Result/Option propagation.
+    Try(Box<Expr>),
+
+    // ----- control flow -----
+    /// `if cond { ... } else if cond { ... } else { ... }`.
+    If {
+        cond: Box<Expr>,
+        then_branch: Block,
+        /// Either another `If` expression or a final `Block`.
+        else_branch: Option<Box<ElseBranch>>,
+    },
+    /// `match scrutinee { arms... }`.
+    Match {
+        scrutinee: Box<Expr>,
+        arms: Vec<MatchArm>,
+    },
+    /// `loop { ... }`.
+    Loop(Block),
+    /// `while cond { ... }`.
+    While { cond: Box<Expr>, body: Block },
+    /// `for pat in iter { ... }`.
+    For {
+        pattern: Pattern,
+        iter: Box<Expr>,
+        body: Block,
+    },
+    /// Anonymous function expression. `params_inferred` is true when the
+    /// parser used the shorthand `{ x, y -> body }` form (no annotated
+    /// parameter types, no return type). The full `fun(...) -> T { }`
+    /// form sets it to false.
+    Lambda {
+        params: Vec<LambdaParam>,
+        ret: Option<Type>,
+        body: LambdaBody,
+        params_inferred: bool,
+    },
+}
+
+/// Unary prefix operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOp {
+    /// `-x` arithmetic negation.
+    Neg,
+    /// `!x` logical not.
+    Not,
+    /// `&x` reference. Semantics deferred to the type checker.
+    Ref,
+}
+
+/// Binary infix operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    And,
+    Or,
+    BitAnd,
+    BitOr,
+    BitXor,
+    Shl,
+    Shr,
+}
+
+/// One initializer in a struct literal. Shorthand form `{ name }` is
+/// represented by setting `value` to a same span `Ident` with the same
+/// name (so downstream passes treat the two forms identically).
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldInit {
+    pub name: String,
+    pub value: Expr,
+    pub span: Span,
+}
+
+/// A block expression: a sequence of statements with an optional trailing
+/// expression. When `trailing` is `Some`, the block evaluates to that
+/// expression; otherwise it evaluates to `()`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Block {
+    pub stmts: Vec<Stmt>,
+    pub trailing: Option<Box<Expr>>,
+    pub span: Span,
+}
+
+/// One arm in a `match` expression: `pat if guard -> body`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchArm {
+    pub pattern: Pattern,
+    pub guard: Option<Expr>,
+    pub body: Expr,
+    pub span: Span,
+}
+
+/// Either an `else if ...` (recursive) or a final `else { ... }` block.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ElseBranch {
+    If(Expr),
+    Block(Block),
+}
+
+/// One parameter in a lambda. For shorthand `{ x, y -> body }` lambdas
+/// the `ty` is `None`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LambdaParam {
+    pub name: String,
+    pub ty: Option<Type>,
+    pub span: Span,
+}
+
+/// A lambda body is either a block or a single expression after `=`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LambdaBody {
+    Block(Block),
+    Expr(Box<Expr>),
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,0 +1,37 @@
+//! Abstract Syntax Tree for the Raven v2 grammar.
+//!
+//! Each submodule covers one category of node:
+//!
+//! * `ty`: type expressions
+//! * `pattern`: match and let patterns
+//! * `expr`: value expressions
+//! * `stmt`: statements (assignments, lets, control flow effects)
+//! * `decl`: top level items (functions, structs, traits, etc.)
+//!
+//! Every node carries a `Span` so downstream passes can render errors
+//! anchored at the offending source range. The lexer's `Span` type is
+//! re exported here for convenience.
+//!
+//! The grammar this AST encodes is documented in
+//! `docs/v2/specs/parser.md`.
+
+pub mod decl;
+pub mod expr;
+pub mod pattern;
+pub mod stmt;
+pub mod ty;
+
+pub use decl::*;
+pub use expr::*;
+pub use pattern::*;
+pub use stmt::*;
+pub use ty::*;
+
+use crate::span::Span;
+
+/// A parsed source file: the sequence of top level items.
+#[derive(Debug, Clone, PartialEq)]
+pub struct File {
+    pub items: Vec<Decl>,
+    pub span: Span,
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -18,12 +18,14 @@
 pub mod decl;
 pub mod expr;
 pub mod pattern;
+pub mod pretty;
 pub mod stmt;
 pub mod ty;
 
 pub use decl::*;
 pub use expr::*;
 pub use pattern::*;
+pub use pretty::pretty_file;
 pub use stmt::*;
 pub use ty::*;
 

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -1,0 +1,60 @@
+//! Match and binding patterns.
+//!
+//! Patterns are used in `match` arms, `for ... in ...` heads, and `let`
+//! bindings (the latter restricted at parse time to a simple identifier
+//! in this release; richer destructuring lands later). The parser does
+//! not resolve names, so an identifier pattern may bind a fresh variable
+//! or refer to an enum constructor; that decision lives in the resolver.
+
+use crate::span::Span;
+
+/// Kinds of pattern.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PatternKind {
+    /// The wildcard `_` pattern: matches anything, binds nothing.
+    Wildcard,
+    /// A literal value pattern: `42`, `"hi"`, `'c'`, `true`.
+    Literal(LiteralPattern),
+    /// A bare identifier: binds a name, or names an enum constructor
+    /// when resolved.
+    Ident(String),
+    /// `Name(p1, p2, ...)`: an enum tuple variant or a parenthesized
+    /// pattern list.
+    Tuple {
+        name: Option<String>,
+        elements: Vec<Pattern>,
+    },
+    /// `Name { f1, f2: p2, ... }`: a struct or struct enum variant.
+    Struct {
+        name: String,
+        fields: Vec<FieldPattern>,
+    },
+    /// `lo..hi` or `lo..=hi` integer range pattern.
+    Range { lo: i64, hi: i64, inclusive: bool },
+}
+
+/// A pattern with its source span.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pattern {
+    pub kind: PatternKind,
+    pub span: Span,
+}
+
+/// A literal pattern's parsed value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LiteralPattern {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    String(String),
+    Char(char),
+}
+
+/// One field in a struct pattern. `pattern` is `None` for shorthand
+/// `{ name }`, meaning `{ name: name }`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldPattern {
+    pub name: String,
+    pub pattern: Option<Pattern>,
+    pub span: Span,
+}

--- a/src/ast/pretty.rs
+++ b/src/ast/pretty.rs
@@ -1,0 +1,737 @@
+//! S expression style pretty printer for AST nodes.
+//!
+//! Used by the golden snapshot tests in `tests/parser_golden.rs`. The
+//! format is deliberately verbose and stable: every node prints its
+//! kind followed by its fields, one level of indentation per nesting.
+//! Spans are NOT printed because they would create churn whenever a
+//! corpus file is touched; the lexer's own tests cover span
+//! correctness.
+
+use std::fmt::Write;
+
+use super::{
+    AssignOp, BinaryOp, Block, Decl, DeclKind, ElseBranch, Expr, ExprKind, File, FunctionBody,
+    ImportSource, LambdaBody, LiteralPattern, Pattern, PatternKind, Stmt, StmtKind, Type, TypeKind,
+    TypePath, UnaryOp, VariantPayload,
+};
+
+/// Render a [`File`] as a multi line S expression string.
+pub fn pretty_file(file: &File) -> String {
+    let mut out = String::new();
+    writeln!(&mut out, "(file").unwrap();
+    for item in &file.items {
+        pretty_decl(&mut out, item, 1);
+    }
+    writeln!(&mut out, ")").unwrap();
+    out
+}
+
+fn indent(buf: &mut String, depth: usize) {
+    for _ in 0..depth {
+        buf.push_str("  ");
+    }
+}
+
+fn pretty_decl(buf: &mut String, decl: &Decl, depth: usize) {
+    indent(buf, depth);
+    match &decl.kind {
+        DeclKind::Function(f) => {
+            write!(buf, "(fn {}", quote(&f.name)).unwrap();
+            if !f.generics.is_empty() {
+                buf.push_str(" generics=(");
+                for (i, g) in f.generics.iter().enumerate() {
+                    if i > 0 {
+                        buf.push(' ');
+                    }
+                    write!(buf, "{}", quote(&g.name)).unwrap();
+                    if !g.bounds.is_empty() {
+                        buf.push(':');
+                        for (j, b) in g.bounds.iter().enumerate() {
+                            if j > 0 {
+                                buf.push('+');
+                            }
+                            buf.push_str(&pretty_type_path(b));
+                        }
+                    }
+                }
+                buf.push(')');
+            }
+            buf.push_str(" params=(");
+            for (i, p) in f.params.iter().enumerate() {
+                if i > 0 {
+                    buf.push(' ');
+                }
+                write!(buf, "{}:{}", quote(&p.name), pretty_type(&p.ty)).unwrap();
+            }
+            buf.push(')');
+            if let Some(ret) = &f.ret {
+                write!(buf, " ret={}", pretty_type(ret)).unwrap();
+            }
+            buf.push('\n');
+            match &f.body {
+                FunctionBody::Block(b) => pretty_block(buf, b, depth + 1, "body"),
+                FunctionBody::Expr(e) => {
+                    indent(buf, depth + 1);
+                    buf.push_str("(body-expr\n");
+                    pretty_expr(buf, e, depth + 2);
+                    indent(buf, depth + 1);
+                    buf.push_str(")\n");
+                }
+                FunctionBody::None => {
+                    indent(buf, depth + 1);
+                    buf.push_str("(body-none)\n");
+                }
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        DeclKind::Struct(s) => {
+            write!(buf, "(struct {}", quote(&s.name)).unwrap();
+            if !s.generics.is_empty() {
+                buf.push_str(" generics=(");
+                for (i, g) in s.generics.iter().enumerate() {
+                    if i > 0 {
+                        buf.push(' ');
+                    }
+                    buf.push_str(&quote(&g.name));
+                }
+                buf.push(')');
+            }
+            buf.push('\n');
+            for fld in &s.fields {
+                indent(buf, depth + 1);
+                writeln!(
+                    buf,
+                    "(field {}: {})",
+                    quote(&fld.name),
+                    pretty_type(&fld.ty)
+                )
+                .unwrap();
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        DeclKind::Trait(t) => {
+            writeln!(buf, "(trait {}", quote(&t.name)).unwrap();
+            for m in &t.members {
+                let sub = Decl {
+                    kind: DeclKind::Function(m.clone()),
+                    span: m.span.clone(),
+                };
+                pretty_decl(buf, &sub, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        DeclKind::Impl(i) => {
+            buf.push_str("(impl");
+            if let Some(t) = &i.for_type {
+                write!(
+                    buf,
+                    " trait={} for={}",
+                    pretty_type_path(&i.trait_or_type),
+                    pretty_type_path(t)
+                )
+                .unwrap();
+            } else {
+                write!(buf, " type={}", pretty_type_path(&i.trait_or_type)).unwrap();
+            }
+            buf.push('\n');
+            for it in &i.items {
+                let sub = Decl {
+                    kind: DeclKind::Function(it.clone()),
+                    span: it.span.clone(),
+                };
+                pretty_decl(buf, &sub, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        DeclKind::Enum(e) => {
+            writeln!(buf, "(enum {}", quote(&e.name)).unwrap();
+            for v in &e.variants {
+                indent(buf, depth + 1);
+                match &v.payload {
+                    VariantPayload::Unit => writeln!(buf, "(variant {})", quote(&v.name)).unwrap(),
+                    VariantPayload::Tuple(tys) => {
+                        write!(buf, "(variant {} tuple(", quote(&v.name)).unwrap();
+                        for (j, t) in tys.iter().enumerate() {
+                            if j > 0 {
+                                buf.push(' ');
+                            }
+                            buf.push_str(&pretty_type(t));
+                        }
+                        buf.push_str("))\n");
+                    }
+                    VariantPayload::Struct(flds) => {
+                        write!(buf, "(variant {} struct(", quote(&v.name)).unwrap();
+                        for (j, f) in flds.iter().enumerate() {
+                            if j > 0 {
+                                buf.push(' ');
+                            }
+                            write!(buf, "{}:{}", quote(&f.name), pretty_type(&f.ty)).unwrap();
+                        }
+                        buf.push_str("))\n");
+                    }
+                }
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        DeclKind::Extern(e) => {
+            writeln!(buf, "(extern {}", quote(&e.abi)).unwrap();
+            for it in &e.items {
+                indent(buf, depth + 1);
+                write!(buf, "(extern-fn {}", quote(&it.name)).unwrap();
+                buf.push_str(" params=(");
+                for (i, p) in it.params.iter().enumerate() {
+                    if i > 0 {
+                        buf.push(' ');
+                    }
+                    write!(buf, "{}:{}", quote(&p.name), pretty_type(&p.ty)).unwrap();
+                }
+                buf.push(')');
+                if let Some(r) = &it.ret {
+                    write!(buf, " ret={}", pretty_type(r)).unwrap();
+                }
+                buf.push_str(")\n");
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        DeclKind::Import(im) => {
+            write!(buf, "(import").unwrap();
+            match &im.source {
+                ImportSource::Std(parts) => {
+                    write!(buf, " std=({})", parts.join(" ")).unwrap();
+                }
+                ImportSource::Quoted(s) => {
+                    write!(buf, " quoted={}", quote(s)).unwrap();
+                }
+            }
+            if let Some(a) = &im.alias {
+                write!(buf, " alias={}", quote(a)).unwrap();
+            }
+            if !im.selectors.is_empty() {
+                write!(buf, " selectors=({})", im.selectors.join(" ")).unwrap();
+            }
+            buf.push_str(")\n");
+        }
+        DeclKind::Const(c) => {
+            writeln!(buf, "(const {}: {} =", quote(&c.name), pretty_type(&c.ty)).unwrap();
+            pretty_expr(buf, &c.value, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        DeclKind::Let(l) => {
+            write!(buf, "(let {}", quote(&l.name)).unwrap();
+            if let Some(t) = &l.ty {
+                write!(buf, ": {}", pretty_type(t)).unwrap();
+            }
+            buf.push('\n');
+            if let Some(e) = &l.init {
+                pretty_expr(buf, e, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+    }
+}
+
+fn pretty_block(buf: &mut String, block: &Block, depth: usize, label: &str) {
+    indent(buf, depth);
+    writeln!(buf, "({}", label).unwrap();
+    for s in &block.stmts {
+        pretty_stmt(buf, s, depth + 1);
+    }
+    if let Some(t) = &block.trailing {
+        indent(buf, depth + 1);
+        buf.push_str("(trailing\n");
+        pretty_expr(buf, t, depth + 2);
+        indent(buf, depth + 1);
+        buf.push_str(")\n");
+    }
+    indent(buf, depth);
+    buf.push_str(")\n");
+}
+
+fn pretty_stmt(buf: &mut String, stmt: &Stmt, depth: usize) {
+    indent(buf, depth);
+    match &stmt.kind {
+        StmtKind::Let { name, ty, init } => {
+            write!(buf, "(let-stmt {}", quote(name)).unwrap();
+            if let Some(t) = ty {
+                write!(buf, ": {}", pretty_type(t)).unwrap();
+            }
+            buf.push('\n');
+            if let Some(e) = init {
+                pretty_expr(buf, e, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        StmtKind::Return(e) => {
+            buf.push_str("(return\n");
+            if let Some(e) = e {
+                pretty_expr(buf, e, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        StmtKind::Break(e) => {
+            buf.push_str("(break\n");
+            if let Some(e) = e {
+                pretty_expr(buf, e, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        StmtKind::Continue => {
+            buf.push_str("(continue)\n");
+        }
+        StmtKind::Defer(e) => {
+            buf.push_str("(defer\n");
+            pretty_expr(buf, e, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        StmtKind::Assign { target, op, value } => {
+            writeln!(buf, "(assign op={}", assign_op(*op)).unwrap();
+            pretty_expr(buf, target, depth + 1);
+            pretty_expr(buf, value, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        StmtKind::Expr(e) => {
+            buf.push_str("(expr-stmt\n");
+            pretty_expr(buf, e, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+    }
+}
+
+fn pretty_expr(buf: &mut String, expr: &Expr, depth: usize) {
+    indent(buf, depth);
+    match &expr.kind {
+        ExprKind::Int(n) => writeln!(buf, "(int {})", n).unwrap(),
+        ExprKind::Float(v) => writeln!(buf, "(float {})", v).unwrap(),
+        ExprKind::Bool(b) => writeln!(buf, "(bool {})", b).unwrap(),
+        ExprKind::Str(s) => writeln!(buf, "(str {})", quote(s)).unwrap(),
+        ExprKind::BlockStr(s) => writeln!(buf, "(blockstr {})", quote(s)).unwrap(),
+        ExprKind::Char(c) => writeln!(buf, "(char {:?})", c).unwrap(),
+        ExprKind::CStr(s) => writeln!(buf, "(cstr {})", quote(s)).unwrap(),
+        ExprKind::SelfLower => writeln!(buf, "(self)").unwrap(),
+        ExprKind::SelfUpper => writeln!(buf, "(Self)").unwrap(),
+        ExprKind::Ident { name, generics } => {
+            write!(buf, "(ident {}", quote(name)).unwrap();
+            if !generics.is_empty() {
+                buf.push_str(" generics=(");
+                for (i, g) in generics.iter().enumerate() {
+                    if i > 0 {
+                        buf.push(' ');
+                    }
+                    buf.push_str(&pretty_type(g));
+                }
+                buf.push(')');
+            }
+            buf.push_str(")\n");
+        }
+        ExprKind::StructLit {
+            name,
+            generics,
+            fields,
+        } => {
+            write!(buf, "(struct-lit {}", quote(name)).unwrap();
+            if !generics.is_empty() {
+                buf.push_str(" generics=(");
+                for (i, g) in generics.iter().enumerate() {
+                    if i > 0 {
+                        buf.push(' ');
+                    }
+                    buf.push_str(&pretty_type(g));
+                }
+                buf.push(')');
+            }
+            buf.push('\n');
+            for f in fields {
+                indent(buf, depth + 1);
+                writeln!(buf, "(field-init {}", quote(&f.name)).unwrap();
+                pretty_expr(buf, &f.value, depth + 2);
+                indent(buf, depth + 1);
+                buf.push_str(")\n");
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Array(items) => {
+            buf.push_str("(array\n");
+            for it in items {
+                pretty_expr(buf, it, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Tuple(items) => {
+            buf.push_str("(tuple\n");
+            for it in items {
+                pretty_expr(buf, it, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Paren(inner) => {
+            buf.push_str("(paren\n");
+            pretty_expr(buf, inner, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Block(b) => {
+            pretty_block(buf, b, depth, "block");
+            // pretty_block adds its own indent; remove the one we already
+            // wrote.
+            // (Pretty_block was called with its own indent which doubles
+            // up; we strip back by using "block" as the outer label.)
+        }
+        ExprKind::Unary { op, operand } => {
+            writeln!(buf, "(unary {}", unary_op(*op)).unwrap();
+            pretty_expr(buf, operand, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Binary { op, lhs, rhs } => {
+            writeln!(buf, "(binary {}", binary_op(*op)).unwrap();
+            pretty_expr(buf, lhs, depth + 1);
+            pretty_expr(buf, rhs, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Range {
+            start,
+            end,
+            inclusive,
+        } => {
+            writeln!(buf, "(range inclusive={}", inclusive).unwrap();
+            pretty_expr(buf, start, depth + 1);
+            pretty_expr(buf, end, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Call { callee, args } => {
+            buf.push_str("(call\n");
+            pretty_expr(buf, callee, depth + 1);
+            for a in args {
+                pretty_expr(buf, a, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::MethodCall {
+            receiver,
+            name,
+            generics,
+            args,
+        } => {
+            write!(buf, "(method-call {}", quote(name)).unwrap();
+            if !generics.is_empty() {
+                buf.push_str(" generics=(");
+                for (i, g) in generics.iter().enumerate() {
+                    if i > 0 {
+                        buf.push(' ');
+                    }
+                    buf.push_str(&pretty_type(g));
+                }
+                buf.push(')');
+            }
+            buf.push('\n');
+            pretty_expr(buf, receiver, depth + 1);
+            for a in args {
+                pretty_expr(buf, a, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Field { receiver, name } => {
+            writeln!(buf, "(field {}", quote(name)).unwrap();
+            pretty_expr(buf, receiver, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Index { receiver, index } => {
+            buf.push_str("(index\n");
+            pretty_expr(buf, receiver, depth + 1);
+            pretty_expr(buf, index, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Try(inner) => {
+            buf.push_str("(try\n");
+            pretty_expr(buf, inner, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            buf.push_str("(if\n");
+            pretty_expr(buf, cond, depth + 1);
+            pretty_block(buf, then_branch, depth + 1, "then");
+            if let Some(eb) = else_branch {
+                match eb.as_ref() {
+                    ElseBranch::If(e) => pretty_expr(buf, e, depth + 1),
+                    ElseBranch::Block(b) => pretty_block(buf, b, depth + 1, "else"),
+                }
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Match { scrutinee, arms } => {
+            buf.push_str("(match\n");
+            pretty_expr(buf, scrutinee, depth + 1);
+            for a in arms {
+                indent(buf, depth + 1);
+                buf.push_str("(arm\n");
+                indent(buf, depth + 2);
+                buf.push_str("(pattern ");
+                pretty_pattern(buf, &a.pattern);
+                buf.push_str(")\n");
+                if let Some(g) = &a.guard {
+                    indent(buf, depth + 2);
+                    buf.push_str("(guard\n");
+                    pretty_expr(buf, g, depth + 3);
+                    indent(buf, depth + 2);
+                    buf.push_str(")\n");
+                }
+                indent(buf, depth + 2);
+                buf.push_str("(body\n");
+                pretty_expr(buf, &a.body, depth + 3);
+                indent(buf, depth + 2);
+                buf.push_str(")\n");
+                indent(buf, depth + 1);
+                buf.push_str(")\n");
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Loop(b) => {
+            buf.push_str("(loop\n");
+            pretty_block(buf, b, depth + 1, "body");
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::While { cond, body } => {
+            buf.push_str("(while\n");
+            pretty_expr(buf, cond, depth + 1);
+            pretty_block(buf, body, depth + 1, "body");
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::For {
+            pattern,
+            iter,
+            body,
+        } => {
+            buf.push_str("(for\n");
+            indent(buf, depth + 1);
+            buf.push_str("(pattern ");
+            pretty_pattern(buf, pattern);
+            buf.push_str(")\n");
+            pretty_expr(buf, iter, depth + 1);
+            pretty_block(buf, body, depth + 1, "body");
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::Lambda {
+            params,
+            ret,
+            body,
+            params_inferred,
+        } => {
+            write!(buf, "(lambda inferred={}", params_inferred).unwrap();
+            buf.push_str(" params=(");
+            for (i, p) in params.iter().enumerate() {
+                if i > 0 {
+                    buf.push(' ');
+                }
+                match &p.ty {
+                    Some(t) => write!(buf, "{}:{}", quote(&p.name), pretty_type(t)).unwrap(),
+                    None => write!(buf, "{}", quote(&p.name)).unwrap(),
+                }
+            }
+            buf.push(')');
+            if let Some(r) = ret {
+                write!(buf, " ret={}", pretty_type(r)).unwrap();
+            }
+            buf.push('\n');
+            match body {
+                LambdaBody::Block(b) => pretty_block(buf, b, depth + 1, "body"),
+                LambdaBody::Expr(e) => {
+                    indent(buf, depth + 1);
+                    buf.push_str("(body-expr\n");
+                    pretty_expr(buf, e, depth + 2);
+                    indent(buf, depth + 1);
+                    buf.push_str(")\n");
+                }
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+    }
+}
+
+fn pretty_pattern(buf: &mut String, pat: &Pattern) {
+    match &pat.kind {
+        PatternKind::Wildcard => buf.push('_'),
+        PatternKind::Literal(LiteralPattern::Int(n)) => write!(buf, "{}", n).unwrap(),
+        PatternKind::Literal(LiteralPattern::Float(v)) => write!(buf, "{}", v).unwrap(),
+        PatternKind::Literal(LiteralPattern::Bool(b)) => write!(buf, "{}", b).unwrap(),
+        PatternKind::Literal(LiteralPattern::String(s)) => write!(buf, "{}", quote(s)).unwrap(),
+        PatternKind::Literal(LiteralPattern::Char(c)) => write!(buf, "{:?}", c).unwrap(),
+        PatternKind::Ident(name) => write!(buf, "ident:{}", quote(name)).unwrap(),
+        PatternKind::Tuple { name, elements } => {
+            if let Some(n) = name {
+                write!(buf, "{}(", quote(n)).unwrap();
+            } else {
+                buf.push('(');
+            }
+            for (i, e) in elements.iter().enumerate() {
+                if i > 0 {
+                    buf.push(' ');
+                }
+                pretty_pattern(buf, e);
+            }
+            buf.push(')');
+        }
+        PatternKind::Struct { name, fields } => {
+            write!(buf, "{}{{", quote(name)).unwrap();
+            for (i, f) in fields.iter().enumerate() {
+                if i > 0 {
+                    buf.push(' ');
+                }
+                match &f.pattern {
+                    Some(p) => {
+                        write!(buf, "{}:", quote(&f.name)).unwrap();
+                        pretty_pattern(buf, p);
+                    }
+                    None => buf.push_str(&quote(&f.name)),
+                }
+            }
+            buf.push('}');
+        }
+        PatternKind::Range { lo, hi, inclusive } => {
+            let sep = if *inclusive { "..=" } else { ".." };
+            write!(buf, "{}{}{}", lo, sep, hi).unwrap();
+        }
+    }
+}
+
+fn pretty_type(ty: &Type) -> String {
+    match &ty.kind {
+        TypeKind::Path(p) => pretty_type_path(p),
+        TypeKind::Optional(inner) => format!("{}?", pretty_type(inner)),
+        TypeKind::Dyn(p) => format!("dyn {}", pretty_type_path(p)),
+        TypeKind::Unit => "()".to_string(),
+        TypeKind::Function { params, ret } => {
+            let mut s = String::from("fun(");
+            for (i, p) in params.iter().enumerate() {
+                if i > 0 {
+                    s.push(',');
+                }
+                s.push_str(&pretty_type(p));
+            }
+            s.push_str(") -> ");
+            s.push_str(&pretty_type(ret));
+            s
+        }
+    }
+}
+
+fn pretty_type_path(p: &TypePath) -> String {
+    let mut out = String::new();
+    for (i, seg) in p.segments.iter().enumerate() {
+        if i > 0 {
+            out.push('.');
+        }
+        out.push_str(&seg.name);
+        if !seg.generics.is_empty() {
+            out.push('<');
+            for (j, g) in seg.generics.iter().enumerate() {
+                if j > 0 {
+                    out.push(',');
+                }
+                out.push_str(&pretty_type(g));
+            }
+            out.push('>');
+        }
+    }
+    out
+}
+
+fn quote(s: &str) -> String {
+    // Escape backslashes and double quotes only. Newlines and tabs
+    // are preserved verbatim so they survive the round trip into the
+    // golden file.
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn unary_op(op: UnaryOp) -> &'static str {
+    match op {
+        UnaryOp::Neg => "neg",
+        UnaryOp::Not => "not",
+        UnaryOp::Ref => "ref",
+    }
+}
+
+fn binary_op(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Add => "+",
+        BinaryOp::Sub => "-",
+        BinaryOp::Mul => "*",
+        BinaryOp::Div => "/",
+        BinaryOp::Mod => "%",
+        BinaryOp::Eq => "==",
+        BinaryOp::Ne => "!=",
+        BinaryOp::Lt => "<",
+        BinaryOp::Le => "<=",
+        BinaryOp::Gt => ">",
+        BinaryOp::Ge => ">=",
+        BinaryOp::And => "&&",
+        BinaryOp::Or => "||",
+        BinaryOp::BitAnd => "&",
+        BinaryOp::BitOr => "|",
+        BinaryOp::BitXor => "^",
+        BinaryOp::Shl => "<<",
+        BinaryOp::Shr => ">>",
+    }
+}
+
+fn assign_op(op: AssignOp) -> &'static str {
+    match op {
+        AssignOp::Assign => "=",
+        AssignOp::Add => "+=",
+        AssignOp::Sub => "-=",
+        AssignOp::Mul => "*=",
+        AssignOp::Div => "/=",
+        AssignOp::Mod => "%=",
+        AssignOp::BitAnd => "&=",
+        AssignOp::BitOr => "|=",
+        AssignOp::BitXor => "^=",
+        AssignOp::Shl => "<<=",
+        AssignOp::Shr => ">>=",
+    }
+}

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -1,0 +1,78 @@
+//! Statements.
+//!
+//! Statements appear inside block expressions and as top level module
+//! items (for `let` and `const`, which double as item declarations).
+//! Assignment is a statement here, not an expression: see the spec for
+//! the disambiguation rule.
+
+use crate::span::Span;
+
+use super::expr::Expr;
+use super::ty::Type;
+
+/// A statement with its source span.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Stmt {
+    pub kind: StmtKind,
+    pub span: Span,
+}
+
+/// Statement node kinds.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StmtKind {
+    /// `let name: T = expr` or `let name = expr`. The `init` is `None`
+    /// only at top level where `let name: T` declares an uninitialized
+    /// module global. Inside a function body the parser rejects missing
+    /// initializers.
+    Let {
+        name: String,
+        ty: Option<Type>,
+        init: Option<Expr>,
+    },
+    /// `return expr?`.
+    Return(Option<Expr>),
+    /// `break expr?` (carries a value when inside a `loop`).
+    Break(Option<Expr>),
+    /// `continue`.
+    Continue,
+    /// `defer expr`: schedules `expr` to run at scope exit.
+    Defer(Expr),
+    /// `lvalue op= rhs`. The `target` expression is constrained at parse
+    /// time to be a valid LValue (identifier with `.` and `[]` chains).
+    Assign {
+        target: Expr,
+        op: AssignOp,
+        value: Expr,
+    },
+    /// A bare expression evaluated for its side effects (or returned as
+    /// the trailing value of a block).
+    Expr(Expr),
+}
+
+/// Compound assignment operators. The plain `=` form is also represented
+/// here as `Assign`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssignOp {
+    /// `=`
+    Assign,
+    /// `+=`
+    Add,
+    /// `-=`
+    Sub,
+    /// `*=`
+    Mul,
+    /// `/=`
+    Div,
+    /// `%=`
+    Mod,
+    /// `&=`
+    BitAnd,
+    /// `|=`
+    BitOr,
+    /// `^=`
+    BitXor,
+    /// `<<=`
+    Shl,
+    /// `>>=`
+    Shr,
+}

--- a/src/ast/ty.rs
+++ b/src/ast/ty.rs
@@ -1,0 +1,48 @@
+//! Type expressions.
+//!
+//! Types appear in parameter annotations, return types, struct fields,
+//! variant payloads, `let` annotations, and `const` declarations. The
+//! parser produces this tree exactly as written; later passes (resolver,
+//! type checker) normalize and check it.
+
+use crate::span::Span;
+
+/// A type expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypeKind {
+    /// A qualified path with optional generic arguments at each segment:
+    /// `Map<K, V>`, `std.collections.Map<String, Int>`.
+    Path(TypePath),
+    /// `T?` sugar for `Option<T>`.
+    Optional(Box<Type>),
+    /// `dyn Trait`.
+    Dyn(TypePath),
+    /// The unit type `()`.
+    Unit,
+    /// `fun(A, B) -> C` function type.
+    Function { params: Vec<Type>, ret: Box<Type> },
+}
+
+/// Top level `Type` wrapper with span.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Type {
+    pub kind: TypeKind,
+    pub span: Span,
+}
+
+/// A dot separated identifier path with optional generic args at each
+/// segment. The segments vector is always non empty.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypePath {
+    pub segments: Vec<TypePathSegment>,
+    pub span: Span,
+}
+
+/// One segment of a qualified type path, with its identifier name and
+/// any generic arguments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypePathSegment {
+    pub name: String,
+    pub generics: Vec<Type>,
+    pub span: Span,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 //! Compiler errors with colored source pointers.
 //!
-//! `RavenError` is the top level error enum for every compiler stage. Only
-//! `LexError` is populated today; parse, resolve, type, and runtime errors
-//! land as new variants when the corresponding stages are built.
+//! `RavenError` is the top level error enum for every compiler stage. Lex
+//! and parse errors are populated; resolve, type, and runtime errors land
+//! as new variants when the corresponding stages are built.
 //!
 //! `RavenError::display(source)` renders a multi line message: a red header,
 //! the offending source line, a row of red carets under the bad span, and an
@@ -49,11 +49,76 @@ impl fmt::Display for LexError {
     }
 }
 
+/// Parsing errors raised by the recursive descent parser.
+///
+/// Most errors render as "expected X, found Y" with the span pointing at
+/// the offending token. Specific variants exist for common shapes so that
+/// downstream tooling can match on them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    /// The next token did not match what the parser expected. `expected`
+    /// describes the syntactic category (e.g. "`{`", "type", "identifier")
+    /// and `found` quotes the actual token kind.
+    UnexpectedToken { expected: String, found: String },
+    /// End of file reached while expecting more input.
+    UnexpectedEof { expected: String },
+    /// The left hand side of an assignment is not a valid place
+    /// expression.
+    InvalidAssignmentTarget,
+    /// Comparison operators are not chainable: `a < b < c` is rejected.
+    ChainedComparison,
+    /// A struct or enum literal repeats a field name.
+    DuplicateField(String),
+    /// An `import` directive that the parser could not interpret.
+    InvalidImportPath,
+    /// Tuple syntax is parsed but not yet supported in v2.0.
+    UnsupportedTuple,
+    /// A pattern fragment that cannot be parsed.
+    InvalidPattern(String),
+    /// A bespoke error message for situations that do not fit the
+    /// dedicated variants above.
+    Custom(String),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::UnexpectedToken { expected, found } => {
+                write!(f, "expected {}, found {}", expected, found)
+            }
+            ParseError::UnexpectedEof { expected } => {
+                write!(f, "expected {}, found end of file", expected)
+            }
+            ParseError::InvalidAssignmentTarget => {
+                write!(f, "invalid assignment target")
+            }
+            ParseError::ChainedComparison => {
+                write!(f, "comparison operators cannot be chained")
+            }
+            ParseError::DuplicateField(name) => {
+                write!(f, "duplicate field '{}'", name)
+            }
+            ParseError::InvalidImportPath => {
+                write!(f, "invalid import path")
+            }
+            ParseError::UnsupportedTuple => {
+                write!(f, "tuple expressions are not yet supported")
+            }
+            ParseError::InvalidPattern(msg) => {
+                write!(f, "invalid pattern: {}", msg)
+            }
+            ParseError::Custom(msg) => f.write_str(msg),
+        }
+    }
+}
+
 /// Top level compiler error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RavenError {
     /// A lexer error with the offending span and an optional hint.
     Lex(LexError, Span, Option<String>),
+    /// A parser error with the offending span and an optional hint.
+    Parse(ParseError, Span, Option<String>),
 }
 
 impl RavenError {
@@ -62,10 +127,16 @@ impl RavenError {
         RavenError::Lex(kind, span, None)
     }
 
+    /// Construct a parse error.
+    pub fn parse(kind: ParseError, span: Span) -> Self {
+        RavenError::Parse(kind, span, None)
+    }
+
     /// Attach a hint string to this error.
     pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
         match &mut self {
             RavenError::Lex(_, _, h) => *h = Some(hint.into()),
+            RavenError::Parse(_, _, h) => *h = Some(hint.into()),
         }
         self
     }
@@ -74,6 +145,7 @@ impl RavenError {
     pub fn span(&self) -> &Span {
         match self {
             RavenError::Lex(_, sp, _) => sp,
+            RavenError::Parse(_, sp, _) => sp,
         }
     }
 
@@ -87,6 +159,7 @@ impl RavenError {
 
         let (kind_str, span, hint) = match self {
             RavenError::Lex(k, s, h) => (format!("error: {}", k), s, h.as_deref()),
+            RavenError::Parse(k, s, h) => (format!("error: {}", k), s, h.as_deref()),
         };
 
         let mut out = String::new();
@@ -147,6 +220,7 @@ impl fmt::Display for RavenError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RavenError::Lex(k, s, _) => write!(f, "{}: {}", s, k),
+            RavenError::Parse(k, s, _) => write!(f, "{}: {}", s, k),
         }
     }
 }
@@ -196,5 +270,34 @@ mod tests {
         let err = RavenError::lex(LexError::UnterminatedString, span);
         let s = format!("{}", err);
         assert_eq!(s, "test.rv:3:5: unterminated string literal");
+    }
+
+    #[test]
+    fn parse_error_renders_with_carets_and_hint() {
+        let src = "fun add(a Int)\n";
+        // The bad spot is the missing colon between `a` and `Int`.
+        let span = Span::new(file(), 10, 13, 1, 11);
+        let err = RavenError::parse(
+            ParseError::UnexpectedToken {
+                expected: "`:`".into(),
+                found: "`Int`".into(),
+            },
+            span,
+        )
+        .with_hint("parameters need a type annotation: `a: Int`");
+        let rendered = err.display(src);
+        assert!(rendered.contains("expected `:`, found `Int`"));
+        assert!(rendered.contains("fun add(a Int)"));
+        assert!(rendered.contains('^'));
+        assert!(rendered.contains("hint:"));
+        assert!(rendered.contains("type annotation"));
+    }
+
+    #[test]
+    fn parse_error_display_formats_location_then_kind() {
+        let span = Span::new(file(), 0, 1, 2, 3);
+        let err = RavenError::parse(ParseError::ChainedComparison, span);
+        let s = format!("{}", err);
+        assert_eq!(s, "test.rv:2:3: comparison operators cannot be chained");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,5 @@
 pub mod ast;
 pub mod error;
 pub mod lexer;
+pub mod parser;
 pub mod span;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //! Lexer, span, and error infrastructure ship today; the rest land in
 //! subsequent PRs.
 
+pub mod ast;
 pub mod error;
 pub mod lexer;
 pub mod span;

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -152,6 +152,32 @@ impl Parser {
         if matches!(self.peek_kind(), TokenKind::RParen) {
             return Ok(params);
         }
+        // Leading `self` receiver gets a synthetic `Self` type.
+        self.skip_newlines();
+        if matches!(self.peek_kind(), TokenKind::SelfLower) {
+            let tok = self.advance();
+            let span = tok.span.clone();
+            let self_ty = crate::ast::Type {
+                kind: crate::ast::TypeKind::Path(crate::ast::TypePath {
+                    segments: vec![crate::ast::TypePathSegment {
+                        name: "Self".to_string(),
+                        generics: Vec::new(),
+                        span: span.clone(),
+                    }],
+                    span: span.clone(),
+                }),
+                span: span.clone(),
+            };
+            params.push(Param {
+                name: "self".to_string(),
+                ty: self_ty,
+                span,
+            });
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) {
+                return Ok(params);
+            }
+        }
         loop {
             self.skip_newlines();
             let (name, name_span) = self.expect_ident("parameter name")?;

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -1,0 +1,533 @@
+//! Top level declaration parsing.
+
+use crate::ast::{
+    Const, Decl, DeclKind, Enum, EnumVariant, Extern, ExternFn, Function, FunctionBody,
+    GenericParam, Impl, Import, ImportSource, LetDecl, Param, Struct, StructField, Trait,
+    VariantPayload,
+};
+use crate::error::{ParseError, RavenError};
+use crate::lexer::TokenKind;
+
+use super::{merge_spans, ParseResult, Parser};
+
+impl Parser {
+    /// Parse one top level declaration.
+    pub(crate) fn parse_decl(&mut self) -> ParseResult<Decl> {
+        match self.peek_kind() {
+            TokenKind::Fun => self.parse_function_decl(),
+            TokenKind::Struct => self.parse_struct_decl(),
+            TokenKind::Trait => self.parse_trait_decl(),
+            TokenKind::Impl => self.parse_impl_decl(),
+            TokenKind::Enum => self.parse_enum_decl(),
+            TokenKind::Extern => self.parse_extern_decl(),
+            TokenKind::Import => self.parse_import_decl(),
+            TokenKind::Const => self.parse_const_decl(),
+            TokenKind::Let => self.parse_let_decl(),
+            _ => Err(self.unexpected("top level item")),
+        }
+    }
+
+    fn parse_function_decl(&mut self) -> ParseResult<Decl> {
+        let fun = self.parse_function(false)?;
+        let span = fun.span.clone();
+        Ok(Decl {
+            kind: DeclKind::Function(fun),
+            span,
+        })
+    }
+
+    /// Parse `fun ...` producing a [`Function`]. When `allow_signature_only`
+    /// is true, the function body may be absent (trait member without
+    /// default).
+    fn parse_function(&mut self, allow_signature_only: bool) -> ParseResult<Function> {
+        let start = self.peek().span.clone();
+        self.expect(&TokenKind::Fun, "`fun`")?;
+        let (name, _) = self.expect_ident("function name")?;
+        let generics = self.parse_generic_params_opt()?;
+        self.expect(&TokenKind::LParen, "`(`")?;
+        let params = self.parse_param_list()?;
+        self.expect(&TokenKind::RParen, "`)`")?;
+        let ret = if self.eat(&TokenKind::Arrow) {
+            Some(self.parse_type()?)
+        } else {
+            None
+        };
+
+        let (body, end_span) = match self.peek_kind() {
+            TokenKind::LBrace => {
+                let block = self.parse_block()?;
+                let s = block.span.clone();
+                (FunctionBody::Block(block), s)
+            }
+            TokenKind::Eq => {
+                self.advance();
+                self.skip_newlines();
+                let expr = self.parse_expr()?;
+                let s = expr.span.clone();
+                (FunctionBody::Expr(expr), s)
+            }
+            _ if allow_signature_only => {
+                let s = self.peek().span.clone();
+                (FunctionBody::None, s)
+            }
+            _ => return Err(self.unexpected("function body")),
+        };
+
+        let span = merge_spans(&start, &end_span);
+        Ok(Function {
+            name,
+            generics,
+            params,
+            ret,
+            body,
+            span,
+        })
+    }
+
+    fn parse_generic_params_opt(&mut self) -> ParseResult<Vec<GenericParam>> {
+        if !matches!(self.peek_kind(), TokenKind::Lt) {
+            return Ok(Vec::new());
+        }
+        self.advance(); // <
+        let mut params = Vec::new();
+        loop {
+            self.skip_newlines();
+            let (name, name_span) = self.expect_ident("generic parameter name")?;
+            let mut bounds = Vec::new();
+            let mut span = name_span;
+            if self.eat(&TokenKind::Colon) {
+                loop {
+                    let path = self.parse_type_path()?;
+                    span = merge_spans(&span, &path.span);
+                    bounds.push(path);
+                    if !self.eat(&TokenKind::Plus) {
+                        break;
+                    }
+                }
+            }
+            params.push(GenericParam { name, bounds, span });
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+            self.skip_newlines();
+            if matches!(self.peek_kind(), TokenKind::Gt | TokenKind::Shr) {
+                break;
+            }
+        }
+        // Close angle: same as type args.
+        match self.peek_kind() {
+            TokenKind::Gt => {
+                self.advance();
+            }
+            TokenKind::Shr => {
+                // Split into two `>` and consume the first half.
+                self.split_shr_close_first();
+            }
+            _ => return Err(self.unexpected("`>`")),
+        }
+        Ok(params)
+    }
+
+    /// Split a `>>` at the cursor into two `>` and consume the first.
+    /// Mirror of the type args closer; kept here because generic
+    /// parameters can also nest (e.g. `fun foo<T: Box<U>>(...)`).
+    fn split_shr_close_first(&mut self) {
+        let tok = self.tokens[self.pos].clone();
+        let second_half = crate::span::Span::new(
+            tok.span.file.clone(),
+            tok.span.start + 1,
+            tok.span.end,
+            tok.span.line,
+            tok.span.col.saturating_add(1),
+        );
+        self.tokens[self.pos] = crate::lexer::Token {
+            kind: TokenKind::Gt,
+            span: second_half,
+        };
+    }
+
+    fn parse_param_list(&mut self) -> ParseResult<Vec<Param>> {
+        let mut params = Vec::new();
+        if matches!(self.peek_kind(), TokenKind::RParen) {
+            return Ok(params);
+        }
+        loop {
+            self.skip_newlines();
+            let (name, name_span) = self.expect_ident("parameter name")?;
+            self.expect(&TokenKind::Colon, "`:`")?;
+            let ty = self.parse_type()?;
+            let span = merge_spans(&name_span, &ty.span);
+            params.push(Param { name, ty, span });
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+            self.skip_newlines();
+            if matches!(self.peek_kind(), TokenKind::RParen) {
+                break;
+            }
+        }
+        Ok(params)
+    }
+
+    fn parse_struct_decl(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // struct
+        let (name, _) = self.expect_ident("struct name")?;
+        let generics = self.parse_generic_params_opt()?;
+        self.expect(&TokenKind::LBrace, "`{`")?;
+        self.skip_separators();
+        let mut fields: Vec<StructField> = Vec::new();
+        while !matches!(self.peek_kind(), TokenKind::RBrace) {
+            let (fname, fspan) = self.expect_ident("field name")?;
+            self.expect(&TokenKind::Colon, "`:`")?;
+            let ty = self.parse_type()?;
+            let span = merge_spans(&fspan, &ty.span);
+            if fields.iter().any(|f| f.name == fname) {
+                return Err(RavenError::parse(ParseError::DuplicateField(fname), fspan));
+            }
+            fields.push(StructField {
+                name: fname,
+                ty,
+                span,
+            });
+            // Separator: `,`, newline, or both.
+            if !self.eat(&TokenKind::Comma) && !matches!(self.peek_kind(), TokenKind::Newline) {
+                break;
+            }
+            self.skip_separators();
+        }
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&start, &rb.span);
+        Ok(Decl {
+            kind: DeclKind::Struct(Struct {
+                name,
+                generics,
+                fields,
+                span: span.clone(),
+            }),
+            span,
+        })
+    }
+
+    fn parse_trait_decl(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // trait
+        let (name, _) = self.expect_ident("trait name")?;
+        let generics = self.parse_generic_params_opt()?;
+        self.expect(&TokenKind::LBrace, "`{`")?;
+        self.skip_separators();
+        let mut members = Vec::new();
+        while !matches!(self.peek_kind(), TokenKind::RBrace) {
+            // Only `fun` members are allowed.
+            if !matches!(self.peek_kind(), TokenKind::Fun) {
+                return Err(self.unexpected("`fun` or `}`"));
+            }
+            let f = self.parse_function(true)?;
+            members.push(f);
+            self.skip_separators();
+        }
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&start, &rb.span);
+        Ok(Decl {
+            kind: DeclKind::Trait(Trait {
+                name,
+                generics,
+                members,
+                span: span.clone(),
+            }),
+            span,
+        })
+    }
+
+    fn parse_impl_decl(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // impl
+        let generics = self.parse_generic_params_opt()?;
+        let first_path = self.parse_type_path()?;
+        let (trait_or_type, for_type) = if self.eat(&TokenKind::For) {
+            let target = self.parse_type_path()?;
+            (first_path, Some(target))
+        } else {
+            (first_path, None)
+        };
+        self.expect(&TokenKind::LBrace, "`{`")?;
+        self.skip_separators();
+        let mut items = Vec::new();
+        while !matches!(self.peek_kind(), TokenKind::RBrace) {
+            if !matches!(self.peek_kind(), TokenKind::Fun) {
+                return Err(self.unexpected("`fun` or `}`"));
+            }
+            items.push(self.parse_function(false)?);
+            self.skip_separators();
+        }
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&start, &rb.span);
+        Ok(Decl {
+            kind: DeclKind::Impl(Impl {
+                generics,
+                trait_or_type,
+                for_type,
+                items,
+                span: span.clone(),
+            }),
+            span,
+        })
+    }
+
+    fn parse_enum_decl(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // enum
+        let (name, _) = self.expect_ident("enum name")?;
+        let generics = self.parse_generic_params_opt()?;
+        self.expect(&TokenKind::LBrace, "`{`")?;
+        self.skip_separators();
+        let mut variants = Vec::new();
+        while !matches!(self.peek_kind(), TokenKind::RBrace) {
+            let (vname, vspan) = self.expect_ident("variant name")?;
+            let mut span = vspan;
+            let payload = if self.eat(&TokenKind::LParen) {
+                self.skip_newlines();
+                // Disambiguate: if next is `Identifier Colon`, it is
+                // a named field payload.
+                let is_named = matches!(self.peek_kind(), TokenKind::Identifier(_))
+                    && matches!(self.peek_kind_at(1), TokenKind::Colon);
+                if is_named {
+                    let mut fields: Vec<StructField> = Vec::new();
+                    loop {
+                        self.skip_newlines();
+                        let (fname, fspan) = self.expect_ident("field name")?;
+                        self.expect(&TokenKind::Colon, "`:`")?;
+                        let ty = self.parse_type()?;
+                        let s = merge_spans(&fspan, &ty.span);
+                        if fields.iter().any(|f| f.name == fname) {
+                            return Err(RavenError::parse(
+                                ParseError::DuplicateField(fname),
+                                fspan,
+                            ));
+                        }
+                        fields.push(StructField {
+                            name: fname,
+                            ty,
+                            span: s,
+                        });
+                        self.skip_newlines();
+                        if !self.eat(&TokenKind::Comma) {
+                            break;
+                        }
+                        self.skip_newlines();
+                        if matches!(self.peek_kind(), TokenKind::RParen) {
+                            break;
+                        }
+                    }
+                    let rp = self.expect(&TokenKind::RParen, "`)`")?;
+                    span = merge_spans(&span, &rp.span);
+                    VariantPayload::Struct(fields)
+                } else {
+                    let mut tys = Vec::new();
+                    if !matches!(self.peek_kind(), TokenKind::RParen) {
+                        loop {
+                            self.skip_newlines();
+                            tys.push(self.parse_type()?);
+                            self.skip_newlines();
+                            if !self.eat(&TokenKind::Comma) {
+                                break;
+                            }
+                            self.skip_newlines();
+                            if matches!(self.peek_kind(), TokenKind::RParen) {
+                                break;
+                            }
+                        }
+                    }
+                    let rp = self.expect(&TokenKind::RParen, "`)`")?;
+                    span = merge_spans(&span, &rp.span);
+                    VariantPayload::Tuple(tys)
+                }
+            } else {
+                VariantPayload::Unit
+            };
+            variants.push(EnumVariant {
+                name: vname,
+                payload,
+                span,
+            });
+            if !self.eat(&TokenKind::Comma) && !matches!(self.peek_kind(), TokenKind::Newline) {
+                break;
+            }
+            self.skip_separators();
+        }
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&start, &rb.span);
+        Ok(Decl {
+            kind: DeclKind::Enum(Enum {
+                name,
+                generics,
+                variants,
+                span: span.clone(),
+            }),
+            span,
+        })
+    }
+
+    fn parse_extern_decl(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // extern
+        let abi = match self.peek_kind().clone() {
+            TokenKind::StringLit(s) => {
+                self.advance();
+                s
+            }
+            _ => return Err(self.unexpected("string literal for ABI")),
+        };
+        self.expect(&TokenKind::LBrace, "`{`")?;
+        self.skip_separators();
+        let mut items = Vec::new();
+        while !matches!(self.peek_kind(), TokenKind::RBrace) {
+            let item_start = self.peek().span.clone();
+            self.expect(&TokenKind::Fun, "`fun`")?;
+            let (name, _) = self.expect_ident("function name")?;
+            self.expect(&TokenKind::LParen, "`(`")?;
+            let params = self.parse_param_list()?;
+            let rp = self.expect(&TokenKind::RParen, "`)`")?;
+            let ret = if self.eat(&TokenKind::Arrow) {
+                Some(self.parse_type()?)
+            } else {
+                None
+            };
+            let end_span = ret.as_ref().map(|t| t.span.clone()).unwrap_or(rp.span);
+            let item_span = merge_spans(&item_start, &end_span);
+            items.push(ExternFn {
+                name,
+                params,
+                ret,
+                span: item_span,
+            });
+            self.skip_separators();
+        }
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&start, &rb.span);
+        Ok(Decl {
+            kind: DeclKind::Extern(Extern {
+                abi,
+                items,
+                span: span.clone(),
+            }),
+            span,
+        })
+    }
+
+    fn parse_import_decl(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // import
+        let (source, mut span) = self.parse_import_source(&start)?;
+        let alias = if self.eat(&TokenKind::As) {
+            let (n, sp) = self.expect_ident("alias name")?;
+            span = merge_spans(&span, &sp);
+            Some(n)
+        } else {
+            None
+        };
+        let mut selectors = Vec::new();
+        if self.eat(&TokenKind::LBrace) {
+            self.skip_separators();
+            while !matches!(self.peek_kind(), TokenKind::RBrace) {
+                let (n, _) = self.expect_ident("identifier")?;
+                selectors.push(n);
+                if !self.eat(&TokenKind::Comma) {
+                    break;
+                }
+                self.skip_separators();
+            }
+            let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+            span = merge_spans(&span, &rb.span);
+        }
+        Ok(Decl {
+            kind: DeclKind::Import(Import {
+                source,
+                alias,
+                selectors,
+                span: span.clone(),
+            }),
+            span,
+        })
+    }
+
+    fn parse_import_source(
+        &mut self,
+        start: &crate::span::Span,
+    ) -> ParseResult<(ImportSource, crate::span::Span)> {
+        // Three forms:
+        //   import std/io/fs ...
+        //   import "github.com/..."
+        //   import "./local"
+        match self.peek_kind().clone() {
+            TokenKind::StringLit(s) => {
+                let tok = self.advance();
+                let span = merge_spans(start, &tok.span);
+                Ok((ImportSource::Quoted(s), span))
+            }
+            TokenKind::Identifier(ref n) if n == "std" => {
+                let mut span = self.peek().span.clone();
+                self.advance(); // std
+                let mut parts: Vec<String> = Vec::new();
+                while matches!(self.peek_kind(), TokenKind::Slash) {
+                    self.advance(); // /
+                    let (name, sp) = self.expect_ident("identifier")?;
+                    parts.push(name);
+                    span = merge_spans(&span, &sp);
+                }
+                if parts.is_empty() {
+                    return Err(RavenError::parse(ParseError::InvalidImportPath, span));
+                }
+                Ok((ImportSource::Std(parts), span))
+            }
+            _ => Err(self.unexpected("import path")),
+        }
+    }
+
+    fn parse_const_decl(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // const
+        let (name, _) = self.expect_ident("identifier")?;
+        self.expect(&TokenKind::Colon, "`:`")?;
+        let ty = self.parse_type()?;
+        self.expect(&TokenKind::Eq, "`=`")?;
+        self.skip_newlines();
+        let value = self.parse_expr()?;
+        let span = merge_spans(&start, &value.span);
+        Ok(Decl {
+            kind: DeclKind::Const(Const {
+                name,
+                ty,
+                value,
+                span: span.clone(),
+            }),
+            span,
+        })
+    }
+
+    fn parse_let_decl(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // let
+        let (name, _) = self.expect_ident("identifier")?;
+        let ty = if self.eat(&TokenKind::Colon) {
+            Some(self.parse_type()?)
+        } else {
+            None
+        };
+        let init = if self.eat(&TokenKind::Eq) {
+            self.skip_newlines();
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+        let end_span = init
+            .as_ref()
+            .map(|e| e.span.clone())
+            .or_else(|| ty.as_ref().map(|t| t.span.clone()))
+            .unwrap_or_else(|| start.clone());
+        let span = merge_spans(&start, &end_span);
+        Ok(Decl {
+            kind: DeclKind::Let(LetDecl {
+                name,
+                ty,
+                init,
+                span: span.clone(),
+            }),
+            span,
+        })
+    }
+}

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1,0 +1,1014 @@
+//! Expression parsing.
+//!
+//! Operator precedence is encoded with one recursive function per
+//! level. The level order from lowest to highest matches the spec.
+
+use crate::ast::{
+    BinaryOp, Block, ElseBranch, Expr, ExprKind, FieldInit, LambdaBody, LambdaParam, MatchArm,
+    Type, UnaryOp,
+};
+use crate::error::{ParseError, RavenError};
+use crate::lexer::TokenKind;
+use crate::span::Span;
+
+use super::{merge_spans, ParseResult, Parser};
+
+impl Parser {
+    /// Parse a full expression at the lowest precedence.
+    pub(crate) fn parse_expr(&mut self) -> ParseResult<Expr> {
+        self.parse_logical_or()
+    }
+
+    /// Parse an expression with struct literals temporarily disabled.
+    /// Used for the condition / scrutinee of `if`, `while`, `for`, and
+    /// `match` so a trailing `{` is the body, not a struct literal.
+    pub(crate) fn parse_expr_no_struct(&mut self) -> ParseResult<Expr> {
+        let saved = self.no_struct_literal;
+        self.no_struct_literal = true;
+        let r = self.parse_expr();
+        self.no_struct_literal = saved;
+        r
+    }
+
+    // ----- precedence ladder -----
+
+    fn parse_logical_or(&mut self) -> ParseResult<Expr> {
+        let mut lhs = self.parse_logical_and()?;
+        loop {
+            self.skip_newlines_at_continuation();
+            if matches!(self.peek_kind(), TokenKind::OrOr) {
+                self.advance();
+                self.skip_newlines();
+                let rhs = self.parse_logical_and()?;
+                let span = merge_spans(&lhs.span, &rhs.span);
+                lhs = Expr {
+                    kind: ExprKind::Binary {
+                        op: BinaryOp::Or,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                    },
+                    span,
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(lhs)
+    }
+
+    fn parse_logical_and(&mut self) -> ParseResult<Expr> {
+        let mut lhs = self.parse_comparison()?;
+        loop {
+            self.skip_newlines_at_continuation();
+            if matches!(self.peek_kind(), TokenKind::AndAnd) {
+                self.advance();
+                self.skip_newlines();
+                let rhs = self.parse_comparison()?;
+                let span = merge_spans(&lhs.span, &rhs.span);
+                lhs = Expr {
+                    kind: ExprKind::Binary {
+                        op: BinaryOp::And,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                    },
+                    span,
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(lhs)
+    }
+
+    fn parse_comparison(&mut self) -> ParseResult<Expr> {
+        let lhs = self.parse_bit_or()?;
+        self.skip_newlines_at_continuation();
+        let op = match self.peek_kind() {
+            TokenKind::EqEq => Some(BinaryOp::Eq),
+            TokenKind::NotEq => Some(BinaryOp::Ne),
+            TokenKind::Lt => Some(BinaryOp::Lt),
+            TokenKind::Gt => Some(BinaryOp::Gt),
+            TokenKind::LtEq => Some(BinaryOp::Le),
+            TokenKind::GtEq => Some(BinaryOp::Ge),
+            _ => None,
+        };
+        let Some(op) = op else { return Ok(lhs) };
+        self.advance();
+        self.skip_newlines();
+        let rhs = self.parse_bit_or()?;
+        // Chain rejection: another comparison directly after rhs is a
+        // parse error per the spec.
+        self.skip_newlines_at_continuation();
+        if matches!(
+            self.peek_kind(),
+            TokenKind::EqEq
+                | TokenKind::NotEq
+                | TokenKind::Lt
+                | TokenKind::Gt
+                | TokenKind::LtEq
+                | TokenKind::GtEq
+        ) {
+            return Err(RavenError::parse(
+                ParseError::ChainedComparison,
+                self.peek().span.clone(),
+            ));
+        }
+        let span = merge_spans(&lhs.span, &rhs.span);
+        Ok(Expr {
+            kind: ExprKind::Binary {
+                op,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+            },
+            span,
+        })
+    }
+
+    fn parse_bit_or(&mut self) -> ParseResult<Expr> {
+        self.parse_left_assoc(Self::parse_bit_xor, &[(TokenKind::Pipe, BinaryOp::BitOr)])
+    }
+
+    fn parse_bit_xor(&mut self) -> ParseResult<Expr> {
+        self.parse_left_assoc(Self::parse_bit_and, &[(TokenKind::Caret, BinaryOp::BitXor)])
+    }
+
+    fn parse_bit_and(&mut self) -> ParseResult<Expr> {
+        self.parse_left_assoc(Self::parse_shift, &[(TokenKind::Amp, BinaryOp::BitAnd)])
+    }
+
+    fn parse_shift(&mut self) -> ParseResult<Expr> {
+        self.parse_left_assoc(
+            Self::parse_range,
+            &[
+                (TokenKind::Shl, BinaryOp::Shl),
+                (TokenKind::Shr, BinaryOp::Shr),
+            ],
+        )
+    }
+
+    fn parse_range(&mut self) -> ParseResult<Expr> {
+        let lhs = self.parse_additive()?;
+        self.skip_newlines_at_continuation();
+        let inclusive = match self.peek_kind() {
+            TokenKind::DotDot => false,
+            TokenKind::DotDotEq => true,
+            _ => return Ok(lhs),
+        };
+        self.advance();
+        self.skip_newlines();
+        let rhs = self.parse_additive()?;
+        let span = merge_spans(&lhs.span, &rhs.span);
+        Ok(Expr {
+            kind: ExprKind::Range {
+                start: Box::new(lhs),
+                end: Box::new(rhs),
+                inclusive,
+            },
+            span,
+        })
+    }
+
+    fn parse_additive(&mut self) -> ParseResult<Expr> {
+        self.parse_left_assoc(
+            Self::parse_multiplicative,
+            &[
+                (TokenKind::Plus, BinaryOp::Add),
+                (TokenKind::Minus, BinaryOp::Sub),
+            ],
+        )
+    }
+
+    fn parse_multiplicative(&mut self) -> ParseResult<Expr> {
+        self.parse_left_assoc(
+            Self::parse_unary,
+            &[
+                (TokenKind::Star, BinaryOp::Mul),
+                (TokenKind::Slash, BinaryOp::Div),
+                (TokenKind::Percent, BinaryOp::Mod),
+            ],
+        )
+    }
+
+    fn parse_left_assoc(
+        &mut self,
+        next: fn(&mut Parser) -> ParseResult<Expr>,
+        ops: &[(TokenKind, BinaryOp)],
+    ) -> ParseResult<Expr> {
+        let mut lhs = next(self)?;
+        loop {
+            self.skip_newlines_at_continuation();
+            let cur = self.peek_kind().clone();
+            let matched = ops
+                .iter()
+                .find(|(tk, _)| std::mem::discriminant(tk) == std::mem::discriminant(&cur))
+                .map(|(_, op)| *op);
+            let Some(op) = matched else { break };
+            self.advance();
+            self.skip_newlines();
+            let rhs = next(self)?;
+            let span = merge_spans(&lhs.span, &rhs.span);
+            lhs = Expr {
+                kind: ExprKind::Binary {
+                    op,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                },
+                span,
+            };
+        }
+        Ok(lhs)
+    }
+
+    fn parse_unary(&mut self) -> ParseResult<Expr> {
+        let start = self.peek().span.clone();
+        let op = match self.peek_kind() {
+            TokenKind::Minus => Some(UnaryOp::Neg),
+            TokenKind::Bang => Some(UnaryOp::Not),
+            TokenKind::Amp => Some(UnaryOp::Ref),
+            _ => None,
+        };
+        if let Some(op) = op {
+            self.advance();
+            let operand = self.parse_unary()?;
+            let span = merge_spans(&start, &operand.span);
+            return Ok(Expr {
+                kind: ExprKind::Unary {
+                    op,
+                    operand: Box::new(operand),
+                },
+                span,
+            });
+        }
+        self.parse_postfix()
+    }
+
+    fn parse_postfix(&mut self) -> ParseResult<Expr> {
+        let mut expr = self.parse_primary()?;
+        loop {
+            match self.peek_kind() {
+                TokenKind::Dot => {
+                    self.advance();
+                    self.skip_newlines();
+                    let (name, name_span) = self.expect_ident("field or method name")?;
+                    // Optional explicit generics: `.name<T>`.
+                    let mut generics = Vec::new();
+                    if matches!(self.peek_kind(), TokenKind::Lt) {
+                        if let Some(args) = self.try_parse_type_args_for_call() {
+                            generics = args;
+                        }
+                    }
+                    // Call form: `.name(args)`.
+                    if matches!(self.peek_kind(), TokenKind::LParen) {
+                        self.advance();
+                        let (args, end_span) = self.parse_arg_list()?;
+                        let span = merge_spans(&expr.span, &end_span);
+                        expr = Expr {
+                            kind: ExprKind::MethodCall {
+                                receiver: Box::new(expr),
+                                name,
+                                generics,
+                                args,
+                            },
+                            span,
+                        };
+                    } else {
+                        let span = merge_spans(&expr.span, &name_span);
+                        expr = Expr {
+                            kind: ExprKind::Field {
+                                receiver: Box::new(expr),
+                                name,
+                            },
+                            span,
+                        };
+                    }
+                }
+                TokenKind::LParen => {
+                    self.advance();
+                    let (args, end_span) = self.parse_arg_list()?;
+                    let span = merge_spans(&expr.span, &end_span);
+                    expr = Expr {
+                        kind: ExprKind::Call {
+                            callee: Box::new(expr),
+                            args,
+                        },
+                        span,
+                    };
+                }
+                TokenKind::LBracket => {
+                    self.advance();
+                    self.skip_newlines();
+                    let index = self.parse_expr()?;
+                    self.skip_newlines();
+                    let rb = self.expect(&TokenKind::RBracket, "`]`")?;
+                    let span = merge_spans(&expr.span, &rb.span);
+                    expr = Expr {
+                        kind: ExprKind::Index {
+                            receiver: Box::new(expr),
+                            index: Box::new(index),
+                        },
+                        span,
+                    };
+                }
+                TokenKind::Question => {
+                    let q = self.advance();
+                    let span = merge_spans(&expr.span, &q.span);
+                    expr = Expr {
+                        kind: ExprKind::Try(Box::new(expr)),
+                        span,
+                    };
+                }
+                _ => break,
+            }
+        }
+        Ok(expr)
+    }
+
+    /// Parse the contents of an argument list (after `(`) and consume
+    /// the closing `)`. Returns the args and the span of the closer.
+    fn parse_arg_list(&mut self) -> ParseResult<(Vec<Expr>, Span)> {
+        let mut args = Vec::new();
+        self.skip_newlines();
+        if !matches!(self.peek_kind(), TokenKind::RParen) {
+            loop {
+                self.skip_newlines();
+                args.push(self.parse_expr()?);
+                self.skip_newlines();
+                if !self.eat(&TokenKind::Comma) {
+                    break;
+                }
+                self.skip_newlines();
+                if matches!(self.peek_kind(), TokenKind::RParen) {
+                    break;
+                }
+            }
+        }
+        let rparen = self.expect(&TokenKind::RParen, "`)`")?;
+        Ok((args, rparen.span))
+    }
+
+    fn parse_primary(&mut self) -> ParseResult<Expr> {
+        let tok = self.peek().clone();
+        match tok.kind.clone() {
+            TokenKind::IntLit(n) => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::Int(n),
+                    span: tok.span,
+                })
+            }
+            TokenKind::FloatLit(v) => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::Float(v),
+                    span: tok.span,
+                })
+            }
+            TokenKind::True => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::Bool(true),
+                    span: tok.span,
+                })
+            }
+            TokenKind::False => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::Bool(false),
+                    span: tok.span,
+                })
+            }
+            TokenKind::StringLit(s) => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::Str(s),
+                    span: tok.span,
+                })
+            }
+            TokenKind::BlockStringLit(s) => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::BlockStr(s),
+                    span: tok.span,
+                })
+            }
+            TokenKind::CharLit(c) => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::Char(c),
+                    span: tok.span,
+                })
+            }
+            TokenKind::CStringLit(s) => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::CStr(s),
+                    span: tok.span,
+                })
+            }
+            TokenKind::SelfLower => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::SelfLower,
+                    span: tok.span,
+                })
+            }
+            TokenKind::SelfUpper => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::SelfUpper,
+                    span: tok.span,
+                })
+            }
+            TokenKind::LParen => self.parse_paren_or_tuple(),
+            TokenKind::LBracket => self.parse_array_lit(),
+            TokenKind::LBrace => self.parse_brace_primary(),
+            TokenKind::If => self.parse_if(),
+            TokenKind::Match => self.parse_match(),
+            TokenKind::Loop => self.parse_loop(),
+            TokenKind::While => self.parse_while(),
+            TokenKind::For => self.parse_for(),
+            TokenKind::Fun => self.parse_lambda_fun(),
+            TokenKind::Identifier(_) => self.parse_ident_primary(),
+            _ => Err(self.unexpected("expression")),
+        }
+    }
+
+    fn parse_paren_or_tuple(&mut self) -> ParseResult<Expr> {
+        let lparen = self.advance();
+        self.skip_newlines();
+        // `()` is a unit value: we represent it as an empty tuple but
+        // reject it as UnsupportedTuple for now. Actually `()` does not
+        // appear in the spec as a value form, so reject.
+        if matches!(self.peek_kind(), TokenKind::RParen) {
+            return Err(RavenError::parse(ParseError::UnsupportedTuple, lparen.span));
+        }
+        let first = self.parse_expr()?;
+        self.skip_newlines();
+        if matches!(self.peek_kind(), TokenKind::RParen) {
+            let rp = self.advance();
+            let span = merge_spans(&lparen.span, &rp.span);
+            return Ok(Expr {
+                kind: ExprKind::Paren(Box::new(first)),
+                span,
+            });
+        }
+        // Tuple: at least one comma after `first`. Parse the rest of
+        // the elements to give a useful span, then report
+        // UnsupportedTuple.
+        let _ = first;
+        while self.eat(&TokenKind::Comma) {
+            self.skip_newlines();
+            if matches!(self.peek_kind(), TokenKind::RParen) {
+                break;
+            }
+            self.parse_expr()?;
+            self.skip_newlines();
+        }
+        let rp = self.expect(&TokenKind::RParen, "`)`")?;
+        let span = merge_spans(&lparen.span, &rp.span);
+        Err(RavenError::parse(ParseError::UnsupportedTuple, span))
+    }
+
+    fn parse_array_lit(&mut self) -> ParseResult<Expr> {
+        let lb = self.advance();
+        let mut items = Vec::new();
+        self.skip_newlines();
+        if !matches!(self.peek_kind(), TokenKind::RBracket) {
+            loop {
+                self.skip_newlines();
+                items.push(self.parse_expr()?);
+                self.skip_newlines();
+                if !self.eat(&TokenKind::Comma) {
+                    break;
+                }
+                self.skip_newlines();
+                if matches!(self.peek_kind(), TokenKind::RBracket) {
+                    break;
+                }
+            }
+        }
+        let rb = self.expect(&TokenKind::RBracket, "`]`")?;
+        let span = merge_spans(&lb.span, &rb.span);
+        Ok(Expr {
+            kind: ExprKind::Array(items),
+            span,
+        })
+    }
+
+    /// Parse a `{...}` primary: either a shorthand lambda or a block
+    /// expression. The distinguisher is an `Arrow` token at depth 0
+    /// before any statement separator outside parens or brackets.
+    fn parse_brace_primary(&mut self) -> ParseResult<Expr> {
+        if self.is_shorthand_lambda() {
+            return self.parse_lambda_shorthand();
+        }
+        let block = self.parse_block()?;
+        let span = block.span.clone();
+        Ok(Expr {
+            kind: ExprKind::Block(block),
+            span,
+        })
+    }
+
+    /// Heuristic: look forward from the `{` to find an `Arrow` at brace
+    /// depth 0 before we leave the brace. If found, the brace is a
+    /// shorthand lambda.
+    fn is_shorthand_lambda(&self) -> bool {
+        // Cursor is at `{`. Scan forward.
+        let mut depth_paren = 0i32;
+        let mut depth_bracket = 0i32;
+        let mut depth_brace = 0i32;
+        let mut i = self.pos;
+        while i < self.tokens.len() {
+            let k = &self.tokens[i].kind;
+            match k {
+                TokenKind::LBrace => depth_brace += 1,
+                TokenKind::RBrace => {
+                    depth_brace -= 1;
+                    if depth_brace == 0 {
+                        return false;
+                    }
+                }
+                TokenKind::LParen => depth_paren += 1,
+                TokenKind::RParen => depth_paren -= 1,
+                TokenKind::LBracket => depth_bracket += 1,
+                TokenKind::RBracket => depth_bracket -= 1,
+                TokenKind::Arrow if depth_brace == 1 && depth_paren == 0 && depth_bracket == 0 => {
+                    return true;
+                }
+                TokenKind::Newline | TokenKind::Semi
+                    if depth_brace == 1 && depth_paren == 0 && depth_bracket == 0 =>
+                {
+                    return false;
+                }
+                TokenKind::Eof => return false,
+                _ => {}
+            }
+            i += 1;
+        }
+        false
+    }
+
+    fn parse_lambda_shorthand(&mut self) -> ParseResult<Expr> {
+        let lb = self.advance(); // {
+        let mut params = Vec::new();
+        // Optional parameter list followed by `->`.
+        // It is guaranteed by is_shorthand_lambda that an Arrow exists
+        // before the closing brace, but the parameter list may be
+        // empty in degenerate cases. We require at least one ident if
+        // followed by something other than `->`.
+        loop {
+            self.skip_newlines();
+            if matches!(self.peek_kind(), TokenKind::Arrow) {
+                break;
+            }
+            let (name, span) = self.expect_ident("lambda parameter name")?;
+            params.push(LambdaParam {
+                name,
+                ty: None,
+                span,
+            });
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        self.skip_newlines();
+        self.expect(&TokenKind::Arrow, "`->`")?;
+        self.skip_separators();
+        // The body is the rest of the brace contents parsed as a block.
+        let body_block = self.parse_block_body_until_rbrace()?;
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&lb.span, &rb.span);
+        let body_span = merge_spans(&lb.span, &rb.span);
+        Ok(Expr {
+            kind: ExprKind::Lambda {
+                params,
+                ret: None,
+                body: LambdaBody::Block(Block {
+                    span: body_span,
+                    stmts: body_block.0,
+                    trailing: body_block.1,
+                }),
+                params_inferred: true,
+            },
+            span,
+        })
+    }
+
+    fn parse_lambda_fun(&mut self) -> ParseResult<Expr> {
+        // `fun ( params ) [-> Type] body`
+        let fun_tok = self.advance();
+        self.expect(&TokenKind::LParen, "`(`")?;
+        let mut params = Vec::new();
+        if !matches!(self.peek_kind(), TokenKind::RParen) {
+            loop {
+                self.skip_newlines();
+                let (name, name_span) = self.expect_ident("parameter name")?;
+                self.expect(&TokenKind::Colon, "`:`")?;
+                let ty = self.parse_type()?;
+                let span = merge_spans(&name_span, &ty.span);
+                params.push(LambdaParam {
+                    name,
+                    ty: Some(ty),
+                    span,
+                });
+                self.skip_newlines();
+                if !self.eat(&TokenKind::Comma) {
+                    break;
+                }
+                self.skip_newlines();
+                if matches!(self.peek_kind(), TokenKind::RParen) {
+                    break;
+                }
+            }
+        }
+        self.expect(&TokenKind::RParen, "`)`")?;
+        let ret = if self.eat(&TokenKind::Arrow) {
+            Some(self.parse_type()?)
+        } else {
+            None
+        };
+        // Body: `= expr` or block.
+        let (body, body_span) = if self.eat(&TokenKind::Eq) {
+            self.skip_newlines();
+            let e = self.parse_expr()?;
+            let s = e.span.clone();
+            (LambdaBody::Expr(Box::new(e)), s)
+        } else {
+            let block = self.parse_block()?;
+            let s = block.span.clone();
+            (LambdaBody::Block(block), s)
+        };
+        let span = merge_spans(&fun_tok.span, &body_span);
+        Ok(Expr {
+            kind: ExprKind::Lambda {
+                params,
+                ret,
+                body,
+                params_inferred: false,
+            },
+            span,
+        })
+    }
+
+    fn parse_ident_primary(&mut self) -> ParseResult<Expr> {
+        let (name, name_span) = self.expect_ident("identifier")?;
+        // Optional generics, only when the trial succeeds.
+        let mut generics = Vec::new();
+        if matches!(self.peek_kind(), TokenKind::Lt) {
+            if let Some(args) = self.try_parse_type_args_for_call() {
+                generics = args;
+            }
+        }
+        // Struct literal: `Name { ... }` when struct literals are not
+        // suppressed in the current context.
+        if !self.no_struct_literal && matches!(self.peek_kind(), TokenKind::LBrace) {
+            // Look further: it could still be a block following another
+            // expression in some weird context. In the spec, a `{` right
+            // after an ident in expression position is a struct literal,
+            // and the `no_struct_literal` flag covers the if/while/for
+            // exception.
+            let saved = self.checkpoint();
+            self.advance(); // {
+                            // Probe: a struct literal field list is either empty,
+                            // shorthand idents, or `name: expr` pairs. If the first
+                            // non separator token is not an identifier followed by
+                            // `:`, `,`, newline, or `}`, treat as not a struct lit.
+            self.skip_separators();
+            let probe_ok = match self.peek_kind() {
+                TokenKind::RBrace => true,
+                TokenKind::Identifier(_) => matches!(
+                    self.peek_kind_at(1),
+                    TokenKind::Colon | TokenKind::Comma | TokenKind::Newline | TokenKind::RBrace
+                ),
+                _ => false,
+            };
+            if probe_ok {
+                let mut fields: Vec<FieldInit> = Vec::new();
+                while !matches!(self.peek_kind(), TokenKind::RBrace) {
+                    self.skip_separators();
+                    if matches!(self.peek_kind(), TokenKind::RBrace) {
+                        break;
+                    }
+                    let (fname, fspan) = self.expect_ident("field name")?;
+                    let (value, vspan) = if self.eat(&TokenKind::Colon) {
+                        self.skip_newlines();
+                        let v = self.parse_expr()?;
+                        let s = v.span.clone();
+                        (v, s)
+                    } else {
+                        // Shorthand: `x` means `x: x` with same span.
+                        (
+                            Expr {
+                                kind: ExprKind::Ident {
+                                    name: fname.clone(),
+                                    generics: Vec::new(),
+                                },
+                                span: fspan.clone(),
+                            },
+                            fspan.clone(),
+                        )
+                    };
+                    // Duplicate detection.
+                    if fields.iter().any(|f| f.name == fname) {
+                        return Err(RavenError::parse(ParseError::DuplicateField(fname), fspan));
+                    }
+                    let full_span = merge_spans(&fspan, &vspan);
+                    fields.push(FieldInit {
+                        name: fname,
+                        value,
+                        span: full_span,
+                    });
+                    if !self.eat(&TokenKind::Comma) {
+                        // Newline alone is also accepted as a separator.
+                        if !matches!(self.peek_kind(), TokenKind::Newline | TokenKind::RBrace) {
+                            break;
+                        }
+                    }
+                    self.skip_separators();
+                }
+                let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+                let span = merge_spans(&name_span, &rb.span);
+                return Ok(Expr {
+                    kind: ExprKind::StructLit {
+                        name,
+                        generics,
+                        fields,
+                    },
+                    span,
+                });
+            }
+            // Rewind: this `{` is not a struct literal after all.
+            self.rewind(saved);
+        }
+        Ok(Expr {
+            kind: ExprKind::Ident { name, generics },
+            span: name_span,
+        })
+    }
+
+    /// Try to parse a `< ... >` type argument list for a call or path
+    /// in expression context. On failure (it was a comparison after
+    /// all), rewinds and returns `None`.
+    pub(crate) fn try_parse_type_args_for_call(&mut self) -> Option<Vec<Type>> {
+        let saved = self.checkpoint();
+        // Quick reject: if the token after `<` is one that can never
+        // start a type, bail out.
+        match self.peek_kind_at(1) {
+            TokenKind::Identifier(_)
+            | TokenKind::SelfUpper
+            | TokenKind::Fun
+            | TokenKind::LParen => {}
+            _ => return None,
+        }
+        let try_args = self.parse_type_args_required();
+        let Ok((args, _span)) = try_args else {
+            self.rewind(saved);
+            return None;
+        };
+        // Confirm: the token after the closing angle must be one of
+        // the followers that indicate a generic application.
+        match self.peek_kind() {
+            TokenKind::LParen
+            | TokenKind::Dot
+            | TokenKind::ColonColon
+            | TokenKind::LBrace
+            | TokenKind::Eq
+            | TokenKind::Comma
+            | TokenKind::RParen
+            | TokenKind::RBracket
+            | TokenKind::RBrace
+            | TokenKind::Semi
+            | TokenKind::Newline
+            | TokenKind::Eof => Some(args),
+            _ => {
+                self.rewind(saved);
+                None
+            }
+        }
+    }
+
+    // ----- control flow -----
+
+    fn parse_if(&mut self) -> ParseResult<Expr> {
+        let if_tok = self.advance();
+        let cond = self.parse_expr_no_struct()?;
+        let then_branch = self.parse_block()?;
+        let mut span = merge_spans(&if_tok.span, &then_branch.span);
+        let else_branch = if self.eat_else() {
+            self.skip_newlines();
+            if matches!(self.peek_kind(), TokenKind::If) {
+                let nested = self.parse_if()?;
+                span = merge_spans(&span, &nested.span);
+                Some(Box::new(ElseBranch::If(nested)))
+            } else {
+                let block = self.parse_block()?;
+                span = merge_spans(&span, &block.span);
+                Some(Box::new(ElseBranch::Block(block)))
+            }
+        } else {
+            None
+        };
+        Ok(Expr {
+            kind: ExprKind::If {
+                cond: Box::new(cond),
+                then_branch,
+                else_branch,
+            },
+            span,
+        })
+    }
+
+    /// Consume an `else` even if separated from the previous block by
+    /// newlines.
+    fn eat_else(&mut self) -> bool {
+        let saved = self.checkpoint();
+        self.skip_newlines();
+        if self.eat(&TokenKind::Else) {
+            true
+        } else {
+            self.rewind(saved);
+            false
+        }
+    }
+
+    fn parse_match(&mut self) -> ParseResult<Expr> {
+        let m = self.advance();
+        let scrutinee = self.parse_expr_no_struct()?;
+        self.expect(&TokenKind::LBrace, "`{`")?;
+        self.skip_separators();
+        let mut arms = Vec::new();
+        while !matches!(self.peek_kind(), TokenKind::RBrace) {
+            let pattern = self.parse_pattern()?;
+            let guard = if self.eat(&TokenKind::If) {
+                Some(self.parse_expr_no_struct()?)
+            } else {
+                None
+            };
+            self.expect(&TokenKind::Arrow, "`->`")?;
+            self.skip_newlines();
+            let body = self.parse_expr()?;
+            let span_start = pattern.span.clone();
+            let span_end = body.span.clone();
+            let span = merge_spans(&span_start, &span_end);
+            arms.push(MatchArm {
+                pattern,
+                guard,
+                body,
+                span,
+            });
+            // Arm separator: `,` or newline.
+            if !self.eat(&TokenKind::Comma) && !matches!(self.peek_kind(), TokenKind::Newline) {
+                break;
+            }
+            self.skip_separators();
+        }
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&m.span, &rb.span);
+        Ok(Expr {
+            kind: ExprKind::Match {
+                scrutinee: Box::new(scrutinee),
+                arms,
+            },
+            span,
+        })
+    }
+
+    fn parse_loop(&mut self) -> ParseResult<Expr> {
+        let lp = self.advance();
+        let body = self.parse_block()?;
+        let span = merge_spans(&lp.span, &body.span);
+        Ok(Expr {
+            kind: ExprKind::Loop(body),
+            span,
+        })
+    }
+
+    fn parse_while(&mut self) -> ParseResult<Expr> {
+        let w = self.advance();
+        let cond = self.parse_expr_no_struct()?;
+        let body = self.parse_block()?;
+        let span = merge_spans(&w.span, &body.span);
+        Ok(Expr {
+            kind: ExprKind::While {
+                cond: Box::new(cond),
+                body,
+            },
+            span,
+        })
+    }
+
+    fn parse_for(&mut self) -> ParseResult<Expr> {
+        let f = self.advance();
+        let pattern = self.parse_pattern()?;
+        self.expect(&TokenKind::In, "`in`")?;
+        let iter = self.parse_expr_no_struct()?;
+        let body = self.parse_block()?;
+        let span = merge_spans(&f.span, &body.span);
+        Ok(Expr {
+            kind: ExprKind::For {
+                pattern,
+                iter: Box::new(iter),
+                body,
+            },
+            span,
+        })
+    }
+
+    // ----- blocks -----
+
+    /// Parse a `{...}` block expression.
+    pub(crate) fn parse_block(&mut self) -> ParseResult<Block> {
+        let lb = self.expect(&TokenKind::LBrace, "`{`")?;
+        self.skip_separators();
+        let (stmts, trailing) = self.parse_block_body_until_rbrace()?;
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&lb.span, &rb.span);
+        Ok(Block {
+            stmts,
+            trailing,
+            span,
+        })
+    }
+
+    /// Parse the body of a block (everything between `{` and `}`) and
+    /// return the statement vector plus optional trailing expression.
+    /// The caller is responsible for consuming the surrounding braces.
+    fn parse_block_body_until_rbrace(
+        &mut self,
+    ) -> ParseResult<(Vec<crate::ast::Stmt>, Option<Box<Expr>>)> {
+        use crate::ast::{Stmt, StmtKind};
+        let mut stmts: Vec<Stmt> = Vec::new();
+        loop {
+            self.skip_separators();
+            if matches!(self.peek_kind(), TokenKind::RBrace | TokenKind::Eof) {
+                break;
+            }
+            let stmt = self.parse_stmt()?;
+            // A bare expression with no trailing separator before `}`
+            // becomes the block's value.
+            let is_expr_stmt = matches!(stmt.kind, StmtKind::Expr(_));
+            // Detect "trailing": there is no `;`/newline before `}`.
+            let has_separator = matches!(self.peek_kind(), TokenKind::Newline | TokenKind::Semi);
+            let at_end = matches!(self.peek_kind(), TokenKind::RBrace);
+            if is_expr_stmt && !has_separator && at_end {
+                let trailing = match stmt.kind {
+                    StmtKind::Expr(e) => e,
+                    _ => unreachable!(),
+                };
+                return Ok((stmts, Some(Box::new(trailing))));
+            }
+            stmts.push(stmt);
+        }
+        Ok((stmts, None))
+    }
+
+    // ----- newline helpers -----
+
+    /// Consume newlines only when they sit between two expression
+    /// tokens. Used at every continuation point in the precedence
+    /// ladder, called after the LHS has been parsed.
+    pub(crate) fn skip_newlines_at_continuation(&mut self) {
+        // Look ahead past newlines: if what follows is a binary
+        // operator or postfix opener, consume them. Otherwise leave
+        // the newline in place (it may terminate the statement).
+        let saved = self.checkpoint();
+        self.skip_newlines();
+        if self.is_continuation_token() {
+            // Newlines have been consumed.
+        } else {
+            self.rewind(saved);
+        }
+    }
+
+    fn is_continuation_token(&self) -> bool {
+        matches!(
+            self.peek_kind(),
+            TokenKind::Plus
+                | TokenKind::Minus
+                | TokenKind::Star
+                | TokenKind::Slash
+                | TokenKind::Percent
+                | TokenKind::EqEq
+                | TokenKind::NotEq
+                | TokenKind::Lt
+                | TokenKind::Gt
+                | TokenKind::LtEq
+                | TokenKind::GtEq
+                | TokenKind::AndAnd
+                | TokenKind::OrOr
+                | TokenKind::Amp
+                | TokenKind::Pipe
+                | TokenKind::Caret
+                | TokenKind::Shl
+                | TokenKind::Shr
+                | TokenKind::DotDot
+                | TokenKind::DotDotEq
+                | TokenKind::Dot
+                | TokenKind::Question
+                | TokenKind::LParen
+                | TokenKind::LBracket
+        )
+    }
+}

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -946,13 +946,24 @@ impl Parser {
                 break;
             }
             let stmt = self.parse_stmt()?;
-            // A bare expression with no trailing separator before `}`
-            // becomes the block's value.
+            // Detect trailing expression: a bare expression statement
+            // followed by only newlines (not semicolons) before the
+            // closing `}` becomes the block's value. A `;` terminates
+            // the expression as a statement explicitly.
             let is_expr_stmt = matches!(stmt.kind, StmtKind::Expr(_));
-            // Detect "trailing": there is no `;`/newline before `}`.
-            let has_separator = matches!(self.peek_kind(), TokenKind::Newline | TokenKind::Semi);
-            let at_end = matches!(self.peek_kind(), TokenKind::RBrace);
-            if is_expr_stmt && !has_separator && at_end {
+            let mut at_trailing = is_expr_stmt;
+            if at_trailing {
+                let saved = self.checkpoint();
+                while matches!(self.peek_kind(), TokenKind::Newline) {
+                    self.advance();
+                }
+                let reached_brace = matches!(self.peek_kind(), TokenKind::RBrace);
+                if !reached_brace {
+                    self.rewind(saved);
+                    at_trailing = false;
+                }
+            }
+            if at_trailing {
                 let trailing = match stmt.kind {
                     StmtKind::Expr(e) => e,
                     _ => unreachable!(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,306 @@
+//! Recursive descent parser for the v2 grammar.
+//!
+//! The parser consumes a token slice produced by `crate::lexer` and
+//! emits an AST (`crate::ast::File`). It is hand written, single pass,
+//! and non recovering: the first error stops parsing.
+//!
+//! Internally the implementation is split by grammar category:
+//!
+//! * `expr`: value expressions and operator precedence
+//! * `stmt`: statements inside blocks
+//! * `decl`: top level items
+//! * `ty`: type expressions
+//! * `pattern`: match and binding patterns
+//!
+//! The cursor and helper machinery live in this module on the `Parser`
+//! struct; the category modules implement methods on it.
+//!
+//! See `docs/v2/specs/parser.md` for the full grammar and the design
+//! notes on disambiguation rules.
+
+use crate::ast::File;
+use crate::error::{ParseError, RavenError};
+use crate::lexer::{Token, TokenKind};
+use crate::span::Span;
+
+mod decl;
+mod expr;
+mod pattern;
+mod stmt;
+mod ty;
+
+/// Convenience alias for parser results.
+pub type ParseResult<T> = Result<T, RavenError>;
+
+/// The recursive descent parser state.
+///
+/// The parser owns its token buffer (cloned from the input slice) so
+/// that nested generic angle brackets can be rewritten on the fly: a
+/// trailing `>>` is split into two `>` tokens when the inner type
+/// argument list closes. Without owning the buffer, that rewrite would
+/// require unsafe.
+pub struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+    /// Suppresses parsing a `{` as a struct literal when set. Toggled by
+    /// the `if` / `while` / `for` / `match` heads while parsing the
+    /// condition or scrutinee expression. See the parser spec.
+    pub(crate) no_struct_literal: bool,
+}
+
+impl Parser {
+    /// Build a new parser over the given token slice. The slice must
+    /// end with `TokenKind::Eof`, as produced by `Lexer::tokenize`. The
+    /// parser clones the tokens internally so the caller's buffer can
+    /// be freed.
+    pub fn new(tokens: &[Token]) -> Self {
+        Parser {
+            tokens: tokens.to_vec(),
+            pos: 0,
+            no_struct_literal: false,
+        }
+    }
+
+    /// Parse the entire token stream into a [`File`].
+    pub fn parse_file(&mut self) -> ParseResult<File> {
+        let start_span = self.peek().span.clone();
+        let mut items = Vec::new();
+        self.skip_separators();
+        while !self.is_at_end() {
+            let item = self.parse_decl()?;
+            items.push(item);
+            // Items are separated by newlines, semicolons, or both.
+            // Trailing separators are fine.
+            self.skip_separators();
+        }
+        let end_span = self.peek().span.clone();
+        Ok(File {
+            items,
+            span: merge_spans(&start_span, &end_span),
+        })
+    }
+
+    // ----- token cursor primitives -----
+
+    /// The current token without consuming.
+    pub(crate) fn peek(&self) -> &Token {
+        &self.tokens[self.pos]
+    }
+
+    /// The token `offset` positions ahead of the cursor (0 == current).
+    pub(crate) fn peek_at(&self, offset: usize) -> &Token {
+        let i = self.pos.saturating_add(offset).min(self.tokens.len() - 1);
+        &self.tokens[i]
+    }
+
+    /// Kind of the current token, by reference.
+    pub(crate) fn peek_kind(&self) -> &TokenKind {
+        &self.peek().kind
+    }
+
+    /// Kind of the token `offset` ahead of the cursor.
+    pub(crate) fn peek_kind_at(&self, offset: usize) -> &TokenKind {
+        &self.peek_at(offset).kind
+    }
+
+    /// True at the EOF sentinel.
+    pub(crate) fn is_at_end(&self) -> bool {
+        matches!(self.peek().kind, TokenKind::Eof)
+    }
+
+    /// Consume and return the current token.
+    pub(crate) fn advance(&mut self) -> Token {
+        let t = self.tokens[self.pos].clone();
+        if !matches!(t.kind, TokenKind::Eof) {
+            self.pos += 1;
+        }
+        t
+    }
+
+    /// Save the cursor position so a trial parse can rewind.
+    pub(crate) fn checkpoint(&self) -> usize {
+        self.pos
+    }
+
+    /// Rewind to a previously saved cursor.
+    pub(crate) fn rewind(&mut self, pos: usize) {
+        self.pos = pos;
+    }
+
+    /// If the current token matches `kind`, consume it and return true.
+    pub(crate) fn eat(&mut self, kind: &TokenKind) -> bool {
+        if std::mem::discriminant(self.peek_kind()) == std::mem::discriminant(kind) {
+            self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume the current token if it matches `kind`, or raise an
+    /// "expected X" error.
+    pub(crate) fn expect(&mut self, kind: &TokenKind, expected_name: &str) -> ParseResult<Token> {
+        if std::mem::discriminant(self.peek_kind()) == std::mem::discriminant(kind) {
+            Ok(self.advance())
+        } else {
+            Err(self.unexpected(expected_name))
+        }
+    }
+
+    /// Consume the current token, requiring it to be an identifier, and
+    /// return the identifier name plus its span.
+    pub(crate) fn expect_ident(&mut self, ctx: &str) -> ParseResult<(String, Span)> {
+        let tok = self.peek().clone();
+        if let TokenKind::Identifier(name) = tok.kind.clone() {
+            self.advance();
+            Ok((name, tok.span))
+        } else {
+            Err(self.unexpected(ctx))
+        }
+    }
+
+    /// Build an "unexpected token" error referencing the current token.
+    pub(crate) fn unexpected(&self, expected: &str) -> RavenError {
+        let tok = self.peek();
+        if matches!(tok.kind, TokenKind::Eof) {
+            RavenError::parse(
+                ParseError::UnexpectedEof {
+                    expected: expected.to_string(),
+                },
+                tok.span.clone(),
+            )
+        } else {
+            RavenError::parse(
+                ParseError::UnexpectedToken {
+                    expected: expected.to_string(),
+                    found: describe_token(&tok.kind),
+                },
+                tok.span.clone(),
+            )
+        }
+    }
+
+    // ----- separator handling -----
+
+    /// Skip any run of `Newline` and `Semi` tokens. Used between items,
+    /// between statements, after `,` in flexible separator contexts.
+    pub(crate) fn skip_separators(&mut self) {
+        while matches!(self.peek_kind(), TokenKind::Newline | TokenKind::Semi) {
+            self.advance();
+        }
+    }
+
+    /// Skip any run of `Newline` tokens only. Used inside expressions
+    /// at continuation points.
+    pub(crate) fn skip_newlines(&mut self) {
+        while matches!(self.peek_kind(), TokenKind::Newline) {
+            self.advance();
+        }
+    }
+}
+
+/// Parse a complete source file from its token slice.
+pub fn parse(tokens: &[Token]) -> ParseResult<File> {
+    let mut p = Parser::new(tokens);
+    p.parse_file()
+}
+
+/// Merge two spans into one covering both. Both must come from the same
+/// source file.
+pub(crate) fn merge_spans(a: &Span, b: &Span) -> Span {
+    Span::new(
+        a.file.clone(),
+        a.start.min(b.start),
+        a.end.max(b.end),
+        a.line,
+        a.col,
+    )
+}
+
+/// Human readable label for a token kind, used in error messages.
+pub(crate) fn describe_token(kind: &TokenKind) -> String {
+    match kind {
+        TokenKind::Identifier(s) => format!("identifier `{}`", s),
+        TokenKind::IntLit(n) => format!("integer `{}`", n),
+        TokenKind::FloatLit(n) => format!("float `{}`", n),
+        TokenKind::StringLit(_) => "string literal".to_string(),
+        TokenKind::BlockStringLit(_) => "block string literal".to_string(),
+        TokenKind::CharLit(_) => "char literal".to_string(),
+        TokenKind::CStringLit(_) => "c-string literal".to_string(),
+        TokenKind::Let => "`let`".to_string(),
+        TokenKind::Const => "`const`".to_string(),
+        TokenKind::Fun => "`fun`".to_string(),
+        TokenKind::Return => "`return`".to_string(),
+        TokenKind::If => "`if`".to_string(),
+        TokenKind::Else => "`else`".to_string(),
+        TokenKind::While => "`while`".to_string(),
+        TokenKind::For => "`for`".to_string(),
+        TokenKind::Loop => "`loop`".to_string(),
+        TokenKind::In => "`in`".to_string(),
+        TokenKind::Break => "`break`".to_string(),
+        TokenKind::Continue => "`continue`".to_string(),
+        TokenKind::Match => "`match`".to_string(),
+        TokenKind::Struct => "`struct`".to_string(),
+        TokenKind::Trait => "`trait`".to_string(),
+        TokenKind::Impl => "`impl`".to_string(),
+        TokenKind::Enum => "`enum`".to_string(),
+        TokenKind::Import => "`import`".to_string(),
+        TokenKind::As => "`as`".to_string(),
+        TokenKind::Extern => "`extern`".to_string(),
+        TokenKind::Defer => "`defer`".to_string(),
+        TokenKind::True => "`true`".to_string(),
+        TokenKind::False => "`false`".to_string(),
+        TokenKind::SelfLower => "`self`".to_string(),
+        TokenKind::SelfUpper => "`Self`".to_string(),
+        TokenKind::Plus => "`+`".to_string(),
+        TokenKind::Minus => "`-`".to_string(),
+        TokenKind::Star => "`*`".to_string(),
+        TokenKind::Slash => "`/`".to_string(),
+        TokenKind::Percent => "`%`".to_string(),
+        TokenKind::PlusEq => "`+=`".to_string(),
+        TokenKind::MinusEq => "`-=`".to_string(),
+        TokenKind::StarEq => "`*=`".to_string(),
+        TokenKind::SlashEq => "`/=`".to_string(),
+        TokenKind::PercentEq => "`%=`".to_string(),
+        TokenKind::EqEq => "`==`".to_string(),
+        TokenKind::NotEq => "`!=`".to_string(),
+        TokenKind::Lt => "`<`".to_string(),
+        TokenKind::Gt => "`>`".to_string(),
+        TokenKind::LtEq => "`<=`".to_string(),
+        TokenKind::GtEq => "`>=`".to_string(),
+        TokenKind::AndAnd => "`&&`".to_string(),
+        TokenKind::OrOr => "`||`".to_string(),
+        TokenKind::Bang => "`!`".to_string(),
+        TokenKind::Amp => "`&`".to_string(),
+        TokenKind::Pipe => "`|`".to_string(),
+        TokenKind::Caret => "`^`".to_string(),
+        TokenKind::Tilde => "`~`".to_string(),
+        TokenKind::Shl => "`<<`".to_string(),
+        TokenKind::Shr => "`>>`".to_string(),
+        TokenKind::AmpEq => "`&=`".to_string(),
+        TokenKind::PipeEq => "`|=`".to_string(),
+        TokenKind::CaretEq => "`^=`".to_string(),
+        TokenKind::ShlEq => "`<<=`".to_string(),
+        TokenKind::ShrEq => "`>>=`".to_string(),
+        TokenKind::Eq => "`=`".to_string(),
+        TokenKind::DotDot => "`..`".to_string(),
+        TokenKind::DotDotEq => "`..=`".to_string(),
+        TokenKind::Question => "`?`".to_string(),
+        TokenKind::Arrow => "`->`".to_string(),
+        TokenKind::FatArrow => "`=>`".to_string(),
+        TokenKind::ColonColon => "`::`".to_string(),
+        TokenKind::Dot => "`.`".to_string(),
+        TokenKind::LParen => "`(`".to_string(),
+        TokenKind::RParen => "`)`".to_string(),
+        TokenKind::LBrace => "`{`".to_string(),
+        TokenKind::RBrace => "`}`".to_string(),
+        TokenKind::LBracket => "`[`".to_string(),
+        TokenKind::RBracket => "`]`".to_string(),
+        TokenKind::Comma => "`,`".to_string(),
+        TokenKind::Semi => "`;`".to_string(),
+        TokenKind::Colon => "`:`".to_string(),
+        TokenKind::At => "`@`".to_string(),
+        TokenKind::Newline => "newline".to_string(),
+        TokenKind::Eof => "end of file".to_string(),
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -29,6 +29,9 @@ mod pattern;
 mod stmt;
 mod ty;
 
+#[cfg(test)]
+mod tests;
+
 /// Convenience alias for parser results.
 pub type ParseResult<T> = Result<T, RavenError>;
 

--- a/src/parser/pattern.rs
+++ b/src/parser/pattern.rs
@@ -1,0 +1,220 @@
+//! Pattern parsing for `match` arms and `for` heads.
+
+use crate::ast::{FieldPattern, LiteralPattern, Pattern, PatternKind};
+use crate::error::ParseError;
+use crate::lexer::TokenKind;
+
+use super::{merge_spans, ParseResult, Parser};
+
+impl Parser {
+    /// Parse one pattern.
+    pub(crate) fn parse_pattern(&mut self) -> ParseResult<Pattern> {
+        let start = self.peek().span.clone();
+        match self.peek_kind().clone() {
+            TokenKind::Identifier(ref name) if name == "_" => {
+                let tok = self.advance();
+                Ok(Pattern {
+                    kind: PatternKind::Wildcard,
+                    span: tok.span,
+                })
+            }
+            TokenKind::IntLit(n) => {
+                let lo_tok = self.advance();
+                // Range pattern: `lo..hi` or `lo..=hi`.
+                if matches!(self.peek_kind(), TokenKind::DotDot | TokenKind::DotDotEq) {
+                    let inclusive = matches!(self.peek_kind(), TokenKind::DotDotEq);
+                    self.advance();
+                    let hi_tok = match self.peek_kind() {
+                        TokenKind::IntLit(_) => self.advance(),
+                        _ => return Err(self.unexpected("integer literal")),
+                    };
+                    let hi = match hi_tok.kind {
+                        TokenKind::IntLit(v) => v,
+                        _ => unreachable!(),
+                    };
+                    let span = merge_spans(&lo_tok.span, &hi_tok.span);
+                    return Ok(Pattern {
+                        kind: PatternKind::Range {
+                            lo: n,
+                            hi,
+                            inclusive,
+                        },
+                        span,
+                    });
+                }
+                Ok(Pattern {
+                    kind: PatternKind::Literal(LiteralPattern::Int(n)),
+                    span: lo_tok.span,
+                })
+            }
+            TokenKind::FloatLit(v) => {
+                let tok = self.advance();
+                Ok(Pattern {
+                    kind: PatternKind::Literal(LiteralPattern::Float(v)),
+                    span: tok.span,
+                })
+            }
+            TokenKind::True => {
+                let tok = self.advance();
+                Ok(Pattern {
+                    kind: PatternKind::Literal(LiteralPattern::Bool(true)),
+                    span: tok.span,
+                })
+            }
+            TokenKind::False => {
+                let tok = self.advance();
+                Ok(Pattern {
+                    kind: PatternKind::Literal(LiteralPattern::Bool(false)),
+                    span: tok.span,
+                })
+            }
+            TokenKind::StringLit(ref s) => {
+                let s = s.clone();
+                let tok = self.advance();
+                Ok(Pattern {
+                    kind: PatternKind::Literal(LiteralPattern::String(s)),
+                    span: tok.span,
+                })
+            }
+            TokenKind::CharLit(c) => {
+                let tok = self.advance();
+                Ok(Pattern {
+                    kind: PatternKind::Literal(LiteralPattern::Char(c)),
+                    span: tok.span,
+                })
+            }
+            TokenKind::Minus => {
+                // `-N` literal pattern. Only valid for integer or float.
+                let minus = self.advance();
+                match self.peek_kind().clone() {
+                    TokenKind::IntLit(n) => {
+                        let tok = self.advance();
+                        let span = merge_spans(&minus.span, &tok.span);
+                        Ok(Pattern {
+                            kind: PatternKind::Literal(LiteralPattern::Int(-n)),
+                            span,
+                        })
+                    }
+                    TokenKind::FloatLit(v) => {
+                        let tok = self.advance();
+                        let span = merge_spans(&minus.span, &tok.span);
+                        Ok(Pattern {
+                            kind: PatternKind::Literal(LiteralPattern::Float(-v)),
+                            span,
+                        })
+                    }
+                    _ => Err(self.unexpected("numeric literal after `-`")),
+                }
+            }
+            TokenKind::LParen => {
+                self.advance(); // (
+                let mut elements = Vec::new();
+                self.skip_newlines();
+                if !matches!(self.peek_kind(), TokenKind::RParen) {
+                    loop {
+                        self.skip_newlines();
+                        elements.push(self.parse_pattern()?);
+                        self.skip_newlines();
+                        if !self.eat(&TokenKind::Comma) {
+                            break;
+                        }
+                        self.skip_newlines();
+                        if matches!(self.peek_kind(), TokenKind::RParen) {
+                            break;
+                        }
+                    }
+                }
+                let rparen = self.expect(&TokenKind::RParen, "`)`")?;
+                let span = merge_spans(&start, &rparen.span);
+                if elements.len() == 1 {
+                    // A single parenthesized pattern is just a grouping.
+                    return Ok(elements.into_iter().next().unwrap());
+                }
+                Ok(Pattern {
+                    kind: PatternKind::Tuple {
+                        name: None,
+                        elements,
+                    },
+                    span,
+                })
+            }
+            TokenKind::Identifier(_) => {
+                let (name, name_span) = self.expect_ident("pattern name")?;
+                // `Name(...)` enum tuple variant.
+                if matches!(self.peek_kind(), TokenKind::LParen) {
+                    self.advance(); // (
+                    let mut elements = Vec::new();
+                    self.skip_newlines();
+                    if !matches!(self.peek_kind(), TokenKind::RParen) {
+                        loop {
+                            self.skip_newlines();
+                            elements.push(self.parse_pattern()?);
+                            self.skip_newlines();
+                            if !self.eat(&TokenKind::Comma) {
+                                break;
+                            }
+                            self.skip_newlines();
+                            if matches!(self.peek_kind(), TokenKind::RParen) {
+                                break;
+                            }
+                        }
+                    }
+                    let rparen = self.expect(&TokenKind::RParen, "`)`")?;
+                    let span = merge_spans(&name_span, &rparen.span);
+                    return Ok(Pattern {
+                        kind: PatternKind::Tuple {
+                            name: Some(name),
+                            elements,
+                        },
+                        span,
+                    });
+                }
+                // `Name { ... }` struct or struct enum variant.
+                if matches!(self.peek_kind(), TokenKind::LBrace) {
+                    self.advance(); // {
+                    let mut fields = Vec::new();
+                    self.skip_separators();
+                    while !matches!(self.peek_kind(), TokenKind::RBrace) {
+                        let (fname, fspan) = self.expect_ident("field name")?;
+                        let (pat, fend) = if self.eat(&TokenKind::Colon) {
+                            self.skip_newlines();
+                            let p = self.parse_pattern()?;
+                            let span_end = p.span.clone();
+                            (Some(p), span_end)
+                        } else {
+                            (None, fspan.clone())
+                        };
+                        let fspan_full = merge_spans(&fspan, &fend);
+                        fields.push(FieldPattern {
+                            name: fname,
+                            pattern: pat,
+                            span: fspan_full,
+                        });
+                        // Field separator: `,` or newline or both.
+                        if !self.eat(&TokenKind::Comma) {
+                            // Newline alone is also a separator.
+                            if !matches!(self.peek_kind(), TokenKind::Newline) {
+                                break;
+                            }
+                        }
+                        self.skip_separators();
+                    }
+                    let rbrace = self.expect(&TokenKind::RBrace, "`}`")?;
+                    let span = merge_spans(&name_span, &rbrace.span);
+                    return Ok(Pattern {
+                        kind: PatternKind::Struct { name, fields },
+                        span,
+                    });
+                }
+                Ok(Pattern {
+                    kind: PatternKind::Ident(name),
+                    span: name_span,
+                })
+            }
+            other => Err(crate::error::RavenError::parse(
+                ParseError::InvalidPattern(format!("unexpected token in pattern: {:?}", other)),
+                start,
+            )),
+        }
+    }
+}

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -1,0 +1,158 @@
+//! Statement parsing inside block bodies.
+
+use crate::ast::{AssignOp, Expr, ExprKind, Stmt, StmtKind};
+use crate::error::{ParseError, RavenError};
+use crate::lexer::TokenKind;
+
+use super::{merge_spans, ParseResult, Parser};
+
+impl Parser {
+    /// Parse one statement.
+    pub(crate) fn parse_stmt(&mut self) -> ParseResult<Stmt> {
+        let start_span = self.peek().span.clone();
+        match self.peek_kind() {
+            TokenKind::Let => self.parse_let_stmt(),
+            TokenKind::Return => {
+                self.advance();
+                if matches!(
+                    self.peek_kind(),
+                    TokenKind::Newline | TokenKind::Semi | TokenKind::RBrace | TokenKind::Eof
+                ) {
+                    return Ok(Stmt {
+                        kind: StmtKind::Return(None),
+                        span: start_span,
+                    });
+                }
+                let value = self.parse_expr()?;
+                let span = merge_spans(&start_span, &value.span);
+                Ok(Stmt {
+                    kind: StmtKind::Return(Some(value)),
+                    span,
+                })
+            }
+            TokenKind::Break => {
+                self.advance();
+                if matches!(
+                    self.peek_kind(),
+                    TokenKind::Newline | TokenKind::Semi | TokenKind::RBrace | TokenKind::Eof
+                ) {
+                    return Ok(Stmt {
+                        kind: StmtKind::Break(None),
+                        span: start_span,
+                    });
+                }
+                let value = self.parse_expr()?;
+                let span = merge_spans(&start_span, &value.span);
+                Ok(Stmt {
+                    kind: StmtKind::Break(Some(value)),
+                    span,
+                })
+            }
+            TokenKind::Continue => {
+                let tok = self.advance();
+                Ok(Stmt {
+                    kind: StmtKind::Continue,
+                    span: tok.span,
+                })
+            }
+            TokenKind::Defer => {
+                self.advance();
+                let value = self.parse_expr()?;
+                let span = merge_spans(&start_span, &value.span);
+                Ok(Stmt {
+                    kind: StmtKind::Defer(value),
+                    span,
+                })
+            }
+            _ => self.parse_expr_or_assign_stmt(),
+        }
+    }
+
+    fn parse_let_stmt(&mut self) -> ParseResult<Stmt> {
+        let start = self.advance().span;
+        let (name, _name_span) = self.expect_ident("identifier")?;
+        let ty = if self.eat(&TokenKind::Colon) {
+            Some(self.parse_type()?)
+        } else {
+            None
+        };
+        // Inside a function, the initializer is required.
+        if !matches!(self.peek_kind(), TokenKind::Eq) {
+            return Err(RavenError::parse(
+                ParseError::UnexpectedToken {
+                    expected: "`=`".to_string(),
+                    found: super::describe_token(self.peek_kind()),
+                },
+                self.peek().span.clone(),
+            ));
+        }
+        self.advance(); // =
+        self.skip_newlines();
+        let init = self.parse_expr()?;
+        let span = merge_spans(&start, &init.span);
+        Ok(Stmt {
+            kind: StmtKind::Let {
+                name,
+                ty,
+                init: Some(init),
+            },
+            span,
+        })
+    }
+
+    fn parse_expr_or_assign_stmt(&mut self) -> ParseResult<Stmt> {
+        let expr = self.parse_expr()?;
+        let op = match self.peek_kind() {
+            TokenKind::Eq => Some(AssignOp::Assign),
+            TokenKind::PlusEq => Some(AssignOp::Add),
+            TokenKind::MinusEq => Some(AssignOp::Sub),
+            TokenKind::StarEq => Some(AssignOp::Mul),
+            TokenKind::SlashEq => Some(AssignOp::Div),
+            TokenKind::PercentEq => Some(AssignOp::Mod),
+            TokenKind::AmpEq => Some(AssignOp::BitAnd),
+            TokenKind::PipeEq => Some(AssignOp::BitOr),
+            TokenKind::CaretEq => Some(AssignOp::BitXor),
+            TokenKind::ShlEq => Some(AssignOp::Shl),
+            TokenKind::ShrEq => Some(AssignOp::Shr),
+            _ => None,
+        };
+        let Some(op) = op else {
+            let span = expr.span.clone();
+            return Ok(Stmt {
+                kind: StmtKind::Expr(expr),
+                span,
+            });
+        };
+        // Validate LValue shape.
+        if !is_valid_lvalue(&expr) {
+            return Err(RavenError::parse(
+                ParseError::InvalidAssignmentTarget,
+                expr.span,
+            ));
+        }
+        self.advance();
+        self.skip_newlines();
+        let value = self.parse_expr()?;
+        let span = merge_spans(&expr.span, &value.span);
+        Ok(Stmt {
+            kind: StmtKind::Assign {
+                target: expr,
+                op,
+                value,
+            },
+            span,
+        })
+    }
+}
+
+/// True when `expr` is a syntactically valid assignment target:
+/// identifier, field access, or index, possibly nested.
+fn is_valid_lvalue(expr: &Expr) -> bool {
+    match &expr.kind {
+        ExprKind::Ident { .. } => true,
+        ExprKind::Field { receiver, .. } => is_valid_lvalue(receiver),
+        ExprKind::Index { receiver, .. } => is_valid_lvalue(receiver),
+        ExprKind::Paren(inner) => is_valid_lvalue(inner),
+        _ => false,
+    }
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -593,8 +593,8 @@ fn block_with_trailing_expr_is_value_bearing() {
 }
 
 #[test]
-fn block_with_terminator_has_no_trailing() {
-    let f = parse_ok("fun f() { 1 + 2\n }\n");
+fn block_with_semicolon_terminator_has_no_trailing() {
+    let f = parse_ok("fun f() { 1 + 2; }\n");
     let DeclKind::Function(fun) = &f.items[0].kind else {
         panic!()
     };
@@ -603,6 +603,21 @@ fn block_with_terminator_has_no_trailing() {
     };
     assert!(b.trailing.is_none());
     assert_eq!(b.stmts.len(), 1);
+}
+
+#[test]
+fn block_trailing_expr_survives_newline() {
+    // Only `;` ends a statement; a trailing newline still leaves the
+    // expression as the block's value, matching Rust semantics.
+    let f = parse_ok("fun f() -> Int { 1 + 2\n }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    let FunctionBody::Block(b) = &fun.body else {
+        panic!()
+    };
+    assert!(b.trailing.is_some());
+    assert_eq!(b.stmts.len(), 0);
 }
 
 #[test]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,0 +1,634 @@
+//! Inline unit tests for the parser. Each test takes a source string,
+//! runs the lexer to produce tokens, and parses them, asserting on the
+//! shape of the resulting AST or on the expected `RavenError`.
+//!
+//! These tests are intentionally focused on parser behavior; they do
+//! not exercise the lexer beyond what is needed to set up a test.
+
+use crate::ast::{
+    BinaryOp, DeclKind, ExprKind, FunctionBody, ImportSource, LiteralPattern, PatternKind,
+    StmtKind, TypeKind, UnaryOp, VariantPayload,
+};
+use crate::error::{ParseError, RavenError};
+use crate::lexer::Lexer;
+
+use super::parse;
+
+fn tokens(src: &str) -> Vec<crate::lexer::Token> {
+    Lexer::new(src, "test.rv").tokenize().expect("lex ok")
+}
+
+fn parse_ok(src: &str) -> crate::ast::File {
+    let toks = tokens(src);
+    parse(&toks).unwrap_or_else(|e| panic!("expected parse ok, got: {}", e))
+}
+
+fn parse_err(src: &str) -> RavenError {
+    let toks = tokens(src);
+    parse(&toks).expect_err("expected parse error")
+}
+
+// ----- expressions -----
+
+#[test]
+fn empty_file_has_no_items() {
+    let f = parse_ok("");
+    assert_eq!(f.items.len(), 0);
+}
+
+#[test]
+fn top_level_bare_expression_is_an_error() {
+    let err = parse_err("42\n");
+    assert!(matches!(err, RavenError::Parse(_, _, _)), "got: {}", err);
+}
+
+#[test]
+fn parses_let_decl_with_initializer() {
+    let f = parse_ok("let x = 42\n");
+    assert_eq!(f.items.len(), 1);
+    let DeclKind::Let(let_decl) = &f.items[0].kind else {
+        panic!("expected let decl");
+    };
+    assert_eq!(let_decl.name, "x");
+    assert!(let_decl.ty.is_none());
+    assert!(matches!(
+        let_decl.init.as_ref().unwrap().kind,
+        ExprKind::Int(42)
+    ));
+}
+
+#[test]
+fn parses_let_with_type_annotation() {
+    let f = parse_ok("let n: Int = 7\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(d.ty.is_some());
+    assert!(matches!(&d.ty.as_ref().unwrap().kind, TypeKind::Path(_)));
+}
+
+#[test]
+fn parses_binary_arithmetic() {
+    let f = parse_ok("let x = 1 + 2 * 3\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::Binary { op, lhs, rhs } = &d.init.as_ref().unwrap().kind else {
+        panic!("expected Binary, got {:?}", d.init);
+    };
+    assert_eq!(*op, BinaryOp::Add);
+    assert!(matches!(lhs.kind, ExprKind::Int(1)));
+    let ExprKind::Binary { op: op2, .. } = &rhs.kind else {
+        panic!("expected nested Binary");
+    };
+    assert_eq!(*op2, BinaryOp::Mul);
+}
+
+#[test]
+fn parses_unary_negation_and_not() {
+    let f = parse_ok("let x = -!a\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::Unary { op, operand } = &d.init.as_ref().unwrap().kind else {
+        panic!();
+    };
+    assert_eq!(*op, UnaryOp::Neg);
+    let ExprKind::Unary { op: op2, .. } = &operand.kind else {
+        panic!();
+    };
+    assert_eq!(*op2, UnaryOp::Not);
+}
+
+#[test]
+fn chained_comparison_is_rejected() {
+    let err = parse_err("let x = a < b < c\n");
+    assert!(
+        matches!(err, RavenError::Parse(ParseError::ChainedComparison, _, _)),
+        "got: {}",
+        err
+    );
+}
+
+#[test]
+fn parses_call_and_method_chain() {
+    let f = parse_ok("let x = foo(1, 2).bar().baz\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    // Outer: Field with name baz
+    let ExprKind::Field { name, receiver } = &d.init.as_ref().unwrap().kind else {
+        panic!("expected Field");
+    };
+    assert_eq!(name, "baz");
+    let ExprKind::MethodCall {
+        name: mname, args, ..
+    } = &receiver.kind
+    else {
+        panic!("expected MethodCall");
+    };
+    assert_eq!(mname, "bar");
+    assert_eq!(args.len(), 0);
+}
+
+#[test]
+fn parses_index_and_try() {
+    let f = parse_ok("let x = arr[0]?\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::Try(inner) = &d.init.as_ref().unwrap().kind else {
+        panic!()
+    };
+    let ExprKind::Index { .. } = inner.kind else {
+        panic!()
+    };
+}
+
+#[test]
+fn parses_range_expr() {
+    let f = parse_ok("let r = 0..10\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::Range { inclusive, .. } = &d.init.as_ref().unwrap().kind else {
+        panic!()
+    };
+    assert!(!*inclusive);
+}
+
+#[test]
+fn parses_array_literal() {
+    let f = parse_ok("let a = [1, 2, 3,]\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::Array(items) = &d.init.as_ref().unwrap().kind else {
+        panic!()
+    };
+    assert_eq!(items.len(), 3);
+}
+
+#[test]
+fn parses_paren_expr() {
+    let f = parse_ok("let a = (1 + 2)\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(matches!(d.init.as_ref().unwrap().kind, ExprKind::Paren(_)));
+}
+
+#[test]
+fn tuple_expr_is_unsupported() {
+    let err = parse_err("let a = (1, 2)\n");
+    assert!(
+        matches!(err, RavenError::Parse(ParseError::UnsupportedTuple, _, _)),
+        "got: {}",
+        err
+    );
+}
+
+#[test]
+fn parses_if_expr_with_else() {
+    let f = parse_ok("let x = if a { 1 } else { 2 }\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(matches!(d.init.as_ref().unwrap().kind, ExprKind::If { .. }));
+}
+
+#[test]
+fn parses_match_expr() {
+    let src = "let x = match v {\n  0 -> \"zero\"\n  _ -> \"other\"\n}\n";
+    let f = parse_ok(src);
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::Match { arms, .. } = &d.init.as_ref().unwrap().kind else {
+        panic!()
+    };
+    assert_eq!(arms.len(), 2);
+    assert!(matches!(
+        arms[0].pattern.kind,
+        PatternKind::Literal(LiteralPattern::Int(0))
+    ));
+    assert!(matches!(arms[1].pattern.kind, PatternKind::Wildcard));
+}
+
+#[test]
+fn parses_while_and_for() {
+    let src = "fun f() { while a { let _ = 1 }\nfor x in xs { let _ = 1 }\n }\n";
+    let f = parse_ok(src);
+    assert_eq!(f.items.len(), 1);
+}
+
+#[test]
+fn parses_lambda_full_form() {
+    let f = parse_ok("let f = fun(x: Int) -> Int { x + 1 }\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::Lambda {
+        params,
+        params_inferred,
+        ..
+    } = &d.init.as_ref().unwrap().kind
+    else {
+        panic!()
+    };
+    assert_eq!(params.len(), 1);
+    assert!(!*params_inferred);
+}
+
+#[test]
+fn parses_lambda_shorthand() {
+    let f = parse_ok("let f = { x -> x * 2 }\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::Lambda {
+        params,
+        params_inferred,
+        ..
+    } = &d.init.as_ref().unwrap().kind
+    else {
+        panic!()
+    };
+    assert_eq!(params.len(), 1);
+    assert!(*params_inferred);
+}
+
+#[test]
+fn parses_struct_literal() {
+    let f = parse_ok("let p = Point { x: 1, y: 2 }\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::StructLit { name, fields, .. } = &d.init.as_ref().unwrap().kind else {
+        panic!()
+    };
+    assert_eq!(name, "Point");
+    assert_eq!(fields.len(), 2);
+}
+
+#[test]
+fn struct_literal_shorthand_field() {
+    let f = parse_ok("let p = Point { x, y }\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    let ExprKind::StructLit { fields, .. } = &d.init.as_ref().unwrap().kind else {
+        panic!()
+    };
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name, "x");
+}
+
+#[test]
+fn duplicate_field_in_struct_literal_errors() {
+    let err = parse_err("let p = Point { x: 1, x: 2 }\n");
+    assert!(
+        matches!(err, RavenError::Parse(ParseError::DuplicateField(_), _, _)),
+        "got: {}",
+        err
+    );
+}
+
+#[test]
+fn struct_literal_suppressed_in_if_condition() {
+    // The `{ x: 1 }` should be parsed as the body block, not as a
+    // struct literal. The condition `a` is just an ident.
+    let f = parse_ok("let r = if a { 1 } else { 2 }\n");
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(matches!(d.init.as_ref().unwrap().kind, ExprKind::If { .. }));
+}
+
+// ----- assignment statements -----
+
+#[test]
+fn parses_assignment_inside_function() {
+    let f = parse_ok("fun f() { let x = 0\n x = 5 }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    let FunctionBody::Block(b) = &fun.body else {
+        panic!()
+    };
+    assert_eq!(b.stmts.len(), 2);
+    assert!(matches!(b.stmts[1].kind, StmtKind::Assign { .. }));
+}
+
+#[test]
+fn compound_assignment() {
+    let f = parse_ok("fun f() { let x = 0\n x += 1 }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    let FunctionBody::Block(b) = &fun.body else {
+        panic!()
+    };
+    assert!(matches!(b.stmts[1].kind, StmtKind::Assign { .. }));
+}
+
+#[test]
+fn invalid_assignment_target_errors() {
+    let err = parse_err("fun f() { 1 + 2 = 3 }\n");
+    assert!(
+        matches!(
+            err,
+            RavenError::Parse(ParseError::InvalidAssignmentTarget, _, _)
+        ),
+        "got: {}",
+        err
+    );
+}
+
+// ----- functions, types, generics -----
+
+#[test]
+fn parses_function_with_block_body() {
+    let f = parse_ok("fun add(a: Int, b: Int) -> Int { a + b }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(fun.name, "add");
+    assert_eq!(fun.params.len(), 2);
+    assert!(fun.ret.is_some());
+    assert!(matches!(fun.body, FunctionBody::Block(_)));
+}
+
+#[test]
+fn parses_function_with_expr_body() {
+    let f = parse_ok("fun add(a: Int, b: Int) -> Int = a + b\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(matches!(fun.body, FunctionBody::Expr(_)));
+}
+
+#[test]
+fn parses_generic_function() {
+    let f = parse_ok("fun id<T>(x: T) -> T = x\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(fun.generics.len(), 1);
+    assert_eq!(fun.generics[0].name, "T");
+}
+
+#[test]
+fn parses_generic_with_bounds() {
+    let f = parse_ok("fun show<T: Display + Debug>(x: T) { }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(fun.generics[0].bounds.len(), 2);
+}
+
+#[test]
+fn parses_nested_generic_types() {
+    // The closing `>>` must be split.
+    let f = parse_ok("fun foo() -> Vec<Vec<Int>> { }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(fun.ret.is_some());
+}
+
+#[test]
+fn parses_optional_type_sugar() {
+    let f = parse_ok("fun get() -> Int? { }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    let TypeKind::Optional(_) = &fun.ret.as_ref().unwrap().kind else {
+        panic!("expected Optional, got {:?}", fun.ret);
+    };
+}
+
+#[test]
+fn parses_function_type() {
+    let f = parse_ok("fun apply(f: fun(Int) -> Int) -> Int { f(1) }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    let TypeKind::Function { .. } = &fun.params[0].ty.kind else {
+        panic!("expected fun type");
+    };
+}
+
+#[test]
+fn missing_function_body_is_error() {
+    let err = parse_err("fun foo() -> Int\n");
+    assert!(matches!(err, RavenError::Parse(_, _, _)));
+}
+
+// ----- structs, traits, impls, enums -----
+
+#[test]
+fn parses_struct_declaration() {
+    let f = parse_ok("struct Point { x: Int, y: Int }\n");
+    let DeclKind::Struct(s) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(s.fields.len(), 2);
+}
+
+#[test]
+fn struct_field_newline_separator() {
+    let src = "struct Point {\n  x: Int\n  y: Int\n}\n";
+    let f = parse_ok(src);
+    let DeclKind::Struct(s) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(s.fields.len(), 2);
+}
+
+#[test]
+fn parses_trait_with_default_method() {
+    let f = parse_ok("trait Greet { fun hello() -> String { \"hi\" } }\n");
+    let DeclKind::Trait(t) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(t.members.len(), 1);
+    assert!(matches!(t.members[0].body, FunctionBody::Block(_)));
+}
+
+#[test]
+fn parses_trait_with_signature_only() {
+    let f = parse_ok("trait Greet { fun hello() -> String\n }\n");
+    let DeclKind::Trait(t) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(matches!(t.members[0].body, FunctionBody::None));
+}
+
+#[test]
+fn parses_inherent_impl() {
+    let f = parse_ok("impl Foo { fun bar() { } }\n");
+    let DeclKind::Impl(i) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(i.for_type.is_none());
+    assert_eq!(i.items.len(), 1);
+}
+
+#[test]
+fn parses_trait_impl() {
+    let f = parse_ok("impl Display for Foo { fun show() { } }\n");
+    let DeclKind::Impl(i) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(i.for_type.is_some());
+}
+
+#[test]
+fn parses_enum_with_variants() {
+    let src = "enum Color { Red, Green, Blue }\n";
+    let f = parse_ok(src);
+    let DeclKind::Enum(e) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(e.variants.len(), 3);
+    assert!(matches!(e.variants[0].payload, VariantPayload::Unit));
+}
+
+#[test]
+fn parses_enum_with_tuple_payload() {
+    let src = "enum Result { Ok(Int), Err(String) }\n";
+    let f = parse_ok(src);
+    let DeclKind::Enum(e) = &f.items[0].kind else {
+        panic!()
+    };
+    let VariantPayload::Tuple(types) = &e.variants[0].payload else {
+        panic!()
+    };
+    assert_eq!(types.len(), 1);
+}
+
+#[test]
+fn parses_enum_with_struct_payload() {
+    let src = "enum Shape { Circle(radius: Int), Square(side: Int) }\n";
+    let f = parse_ok(src);
+    let DeclKind::Enum(e) = &f.items[0].kind else {
+        panic!()
+    };
+    let VariantPayload::Struct(fields) = &e.variants[0].payload else {
+        panic!()
+    };
+    assert_eq!(fields[0].name, "radius");
+}
+
+// ----- imports, externs, const -----
+
+#[test]
+fn parses_std_import() {
+    let f = parse_ok("import std/io\n");
+    let DeclKind::Import(im) = &f.items[0].kind else {
+        panic!()
+    };
+    let ImportSource::Std(parts) = &im.source else {
+        panic!()
+    };
+    assert_eq!(parts, &["io".to_string()]);
+}
+
+#[test]
+fn parses_std_import_with_selectors() {
+    let f = parse_ok("import std/collections { Map, Set }\n");
+    let DeclKind::Import(im) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(im.selectors, vec!["Map".to_string(), "Set".to_string()]);
+}
+
+#[test]
+fn parses_quoted_import_with_alias() {
+    let f = parse_ok("import \"github.com/x/y\" as http\n");
+    let DeclKind::Import(im) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(im.alias.as_deref(), Some("http"));
+    let ImportSource::Quoted(s) = &im.source else {
+        panic!()
+    };
+    assert!(s.contains("github.com"));
+}
+
+#[test]
+fn parses_extern_block() {
+    let f = parse_ok("extern \"C\" { fun puts(s: CString) -> Int\n }\n");
+    let DeclKind::Extern(e) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(e.abi, "C");
+    assert_eq!(e.items.len(), 1);
+}
+
+#[test]
+fn parses_const_decl() {
+    let f = parse_ok("const PI: Float = 3.14\n");
+    let DeclKind::Const(c) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(c.name, "PI");
+}
+
+// ----- block expressions and newline handling -----
+
+#[test]
+fn block_with_trailing_expr_is_value_bearing() {
+    // The block's last item is a bare expr without separator => trailing.
+    let f = parse_ok("fun f() -> Int { 1 + 2 }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    let FunctionBody::Block(b) = &fun.body else {
+        panic!()
+    };
+    assert!(b.trailing.is_some());
+    assert_eq!(b.stmts.len(), 0);
+}
+
+#[test]
+fn block_with_terminator_has_no_trailing() {
+    let f = parse_ok("fun f() { 1 + 2\n }\n");
+    let DeclKind::Function(fun) = &f.items[0].kind else {
+        panic!()
+    };
+    let FunctionBody::Block(b) = &fun.body else {
+        panic!()
+    };
+    assert!(b.trailing.is_none());
+    assert_eq!(b.stmts.len(), 1);
+}
+
+#[test]
+fn newline_inside_expression_is_consumed() {
+    // Adding a newline after `+` must not terminate the expression.
+    let src = "let x = 1 +\n  2\n";
+    let f = parse_ok(src);
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(matches!(
+        d.init.as_ref().unwrap().kind,
+        ExprKind::Binary { .. }
+    ));
+}
+
+// ----- error variants -----
+
+#[test]
+fn unexpected_eof_reports_eof() {
+    let err = parse_err("fun foo(");
+    assert!(matches!(err, RavenError::Parse(_, _, _)));
+}
+
+#[test]
+fn invalid_import_path_for_bare_path() {
+    let err = parse_err("import 42\n");
+    assert!(matches!(err, RavenError::Parse(_, _, _)));
+}

--- a/src/parser/ty.rs
+++ b/src/parser/ty.rs
@@ -1,0 +1,195 @@
+//! Type expression parsing.
+
+use crate::ast::{Type, TypeKind, TypePath, TypePathSegment};
+use crate::lexer::{Token, TokenKind};
+use crate::span::Span;
+
+use super::{merge_spans, ParseResult, Parser};
+
+impl Parser {
+    /// Parse a `Type`. Handles `T?` sugar, `dyn Trait`, `()`, and
+    /// `fun(...) -> T`.
+    pub(crate) fn parse_type(&mut self) -> ParseResult<Type> {
+        let primary = self.parse_primary_type()?;
+        if matches!(self.peek_kind(), TokenKind::Question) {
+            let q = self.advance();
+            let span = merge_spans(&primary.span, &q.span);
+            return Ok(Type {
+                kind: TypeKind::Optional(Box::new(primary)),
+                span,
+            });
+        }
+        Ok(primary)
+    }
+
+    fn parse_primary_type(&mut self) -> ParseResult<Type> {
+        let start = self.peek().span.clone();
+        match self.peek_kind() {
+            TokenKind::LParen => {
+                self.advance(); // (
+                let rparen = self.expect(&TokenKind::RParen, "`)`")?;
+                let span = merge_spans(&start, &rparen.span);
+                Ok(Type {
+                    kind: TypeKind::Unit,
+                    span,
+                })
+            }
+            TokenKind::Identifier(name) if name == "dyn" => {
+                // `dyn` is a contextual keyword: an identifier
+                // lexically, a type keyword in this position.
+                self.advance();
+                let path = self.parse_type_path()?;
+                let span = merge_spans(&start, &path.span);
+                Ok(Type {
+                    kind: TypeKind::Dyn(path),
+                    span,
+                })
+            }
+            TokenKind::Fun => {
+                self.advance();
+                self.expect(&TokenKind::LParen, "`(`")?;
+                let mut params = Vec::new();
+                if !matches!(self.peek_kind(), TokenKind::RParen) {
+                    loop {
+                        self.skip_newlines();
+                        params.push(self.parse_type()?);
+                        self.skip_newlines();
+                        if !self.eat(&TokenKind::Comma) {
+                            break;
+                        }
+                        self.skip_newlines();
+                        if matches!(self.peek_kind(), TokenKind::RParen) {
+                            break;
+                        }
+                    }
+                }
+                self.expect(&TokenKind::RParen, "`)`")?;
+                self.expect(&TokenKind::Arrow, "`->`")?;
+                let ret = self.parse_type()?;
+                let span = merge_spans(&start, &ret.span);
+                Ok(Type {
+                    kind: TypeKind::Function {
+                        params,
+                        ret: Box::new(ret),
+                    },
+                    span,
+                })
+            }
+            TokenKind::Identifier(_) | TokenKind::SelfUpper => {
+                let path = self.parse_type_path()?;
+                let span = path.span.clone();
+                Ok(Type {
+                    kind: TypeKind::Path(path),
+                    span,
+                })
+            }
+            _ => Err(self.unexpected("type")),
+        }
+    }
+
+    /// Parse a dot separated qualified type path with optional generic
+    /// arguments at each segment.
+    pub(crate) fn parse_type_path(&mut self) -> ParseResult<TypePath> {
+        let first = self.parse_type_path_segment()?;
+        let mut span = first.span.clone();
+        let mut segments = vec![first];
+        while matches!(self.peek_kind(), TokenKind::Dot)
+            && matches!(self.peek_kind_at(1), TokenKind::Identifier(_))
+        {
+            self.advance(); // .
+            let seg = self.parse_type_path_segment()?;
+            span = merge_spans(&span, &seg.span);
+            segments.push(seg);
+        }
+        Ok(TypePath { segments, span })
+    }
+
+    fn parse_type_path_segment(&mut self) -> ParseResult<TypePathSegment> {
+        let tok = self.peek().clone();
+        let (name, name_span) = match tok.kind {
+            TokenKind::Identifier(n) => {
+                self.advance();
+                (n, tok.span)
+            }
+            TokenKind::SelfUpper => {
+                self.advance();
+                ("Self".to_string(), tok.span)
+            }
+            _ => return Err(self.unexpected("type name")),
+        };
+        let mut span = name_span;
+        let mut generics = Vec::new();
+        if matches!(self.peek_kind(), TokenKind::Lt) {
+            let (args, args_span) = self.parse_type_args_required()?;
+            generics = args;
+            span = merge_spans(&span, &args_span);
+        }
+        Ok(TypePathSegment {
+            name,
+            generics,
+            span,
+        })
+    }
+
+    /// Parse a required `<T, U, ...>` block. The caller has verified
+    /// the leading `<` is present.
+    pub(crate) fn parse_type_args_required(&mut self) -> ParseResult<(Vec<Type>, Span)> {
+        let start = self.peek().span.clone();
+        self.advance(); // <
+        let mut args = Vec::new();
+        if !matches!(self.peek_kind(), TokenKind::Gt | TokenKind::Shr) {
+            loop {
+                self.skip_newlines();
+                args.push(self.parse_type()?);
+                self.skip_newlines();
+                if !self.eat(&TokenKind::Comma) {
+                    break;
+                }
+                self.skip_newlines();
+                if matches!(self.peek_kind(), TokenKind::Gt | TokenKind::Shr) {
+                    break;
+                }
+            }
+        }
+        // Close angle: a single `>` is consumed normally; a trailing
+        // `>>` is split into two close angles for nested generics
+        // like `Vec<Vec<Int>>`.
+        let close_span = self.consume_close_angle()?;
+        Ok((args, merge_spans(&start, &close_span)))
+    }
+
+    /// Consume one closing `>`. If the current token is `>>`, split it
+    /// into two `>` tokens, consume the first half, and leave the
+    /// second half in place for the outer call.
+    fn consume_close_angle(&mut self) -> ParseResult<Span> {
+        match self.peek_kind() {
+            TokenKind::Gt => Ok(self.advance().span),
+            TokenKind::Shr => {
+                let tok = self.tokens[self.pos].clone();
+                let first_half = Span::new(
+                    tok.span.file.clone(),
+                    tok.span.start,
+                    tok.span.start + 1,
+                    tok.span.line,
+                    tok.span.col,
+                );
+                let second_half = Span::new(
+                    tok.span.file.clone(),
+                    tok.span.start + 1,
+                    tok.span.end,
+                    tok.span.line,
+                    tok.span.col.saturating_add(1),
+                );
+                // Replace the `>>` token in place with a single `>`
+                // representing the second half. The cursor stays at
+                // the same position so the outer call sees that `>`.
+                self.tokens[self.pos] = Token {
+                    kind: TokenKind::Gt,
+                    span: second_half,
+                };
+                Ok(first_half)
+            }
+            _ => Err(self.unexpected("`>`")),
+        }
+    }
+}

--- a/tests/parser_corpus/arithmetic.rv
+++ b/tests/parser_corpus/arithmetic.rv
@@ -1,0 +1,1 @@
+fun mix(a: Int, b: Int, c: Int) -> Int = a + b * c - (a / b) % c

--- a/tests/parser_corpus/arithmetic.rv.ast
+++ b/tests/parser_corpus/arithmetic.rv.ast
@@ -1,0 +1,24 @@
+(file
+  (fn "mix" params=("a":Int "b":Int "c":Int) ret=Int
+    (body-expr
+      (binary -
+        (binary +
+          (ident "a")
+          (binary *
+            (ident "b")
+            (ident "c")
+          )
+        )
+        (binary %
+          (paren
+            (binary /
+              (ident "a")
+              (ident "b")
+            )
+          )
+          (ident "c")
+        )
+      )
+    )
+  )
+)

--- a/tests/parser_corpus/control_flow.rv
+++ b/tests/parser_corpus/control_flow.rv
@@ -1,0 +1,23 @@
+fun fizzbuzz(n: Int) {
+    for i in 1..=n {
+        if i % 15 == 0 {
+            print("FizzBuzz")
+        } else if i % 3 == 0 {
+            print("Fizz")
+        } else if i % 5 == 0 {
+            print("Buzz")
+        } else {
+            print(i)
+        }
+    }
+}
+
+fun count(limit: Int) -> Int {
+    let total = 0
+    let i = 0
+    while i < limit {
+        total += 1
+        i += 1
+    }
+    total
+}

--- a/tests/parser_corpus/control_flow.rv.ast
+++ b/tests/parser_corpus/control_flow.rv.ast
@@ -1,0 +1,109 @@
+(file
+  (fn "fizzbuzz" params=("n":Int)
+    (body
+      (trailing
+        (for
+          (pattern ident:"i")
+          (range inclusive=true
+            (int 1)
+            (ident "n")
+          )
+          (body
+            (trailing
+              (if
+                (binary ==
+                  (binary %
+                    (ident "i")
+                    (int 15)
+                  )
+                  (int 0)
+                )
+                (then
+                  (trailing
+                    (call
+                      (ident "print")
+                      (str "FizzBuzz")
+                    )
+                  )
+                )
+                (if
+                  (binary ==
+                    (binary %
+                      (ident "i")
+                      (int 3)
+                    )
+                    (int 0)
+                  )
+                  (then
+                    (trailing
+                      (call
+                        (ident "print")
+                        (str "Fizz")
+                      )
+                    )
+                  )
+                  (if
+                    (binary ==
+                      (binary %
+                        (ident "i")
+                        (int 5)
+                      )
+                      (int 0)
+                    )
+                    (then
+                      (trailing
+                        (call
+                          (ident "print")
+                          (str "Buzz")
+                        )
+                      )
+                    )
+                    (else
+                      (trailing
+                        (call
+                          (ident "print")
+                          (ident "i")
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  (fn "count" params=("limit":Int) ret=Int
+    (body
+      (let-stmt "total"
+        (int 0)
+      )
+      (let-stmt "i"
+        (int 0)
+      )
+      (expr-stmt
+        (while
+          (binary <
+            (ident "i")
+            (ident "limit")
+          )
+          (body
+            (assign op=+=
+              (ident "total")
+              (int 1)
+            )
+            (assign op=+=
+              (ident "i")
+              (int 1)
+            )
+          )
+        )
+      )
+      (trailing
+        (ident "total")
+      )
+    )
+  )
+)

--- a/tests/parser_corpus/enum_and_match.rv
+++ b/tests/parser_corpus/enum_and_match.rv
@@ -1,0 +1,13 @@
+enum Shape {
+    Circle(radius: Float)
+    Square(side: Float)
+    Empty
+}
+
+fun area(s: Shape) -> Float {
+    match s {
+        Circle { radius: r } -> r * r
+        Square { side: w } -> w * w
+        Empty -> 0.0
+    }
+}

--- a/tests/parser_corpus/enum_and_match.rv.ast
+++ b/tests/parser_corpus/enum_and_match.rv.ast
@@ -1,0 +1,40 @@
+(file
+  (enum "Shape"
+    (variant "Circle" struct("radius":Float))
+    (variant "Square" struct("side":Float))
+    (variant "Empty")
+  )
+  (fn "area" params=("s":Shape) ret=Float
+    (body
+      (trailing
+        (match
+          (ident "s")
+          (arm
+            (pattern "Circle"{"radius":ident:"r"})
+            (body
+              (binary *
+                (ident "r")
+                (ident "r")
+              )
+            )
+          )
+          (arm
+            (pattern "Square"{"side":ident:"w"})
+            (body
+              (binary *
+                (ident "w")
+                (ident "w")
+              )
+            )
+          )
+          (arm
+            (pattern ident:"Empty")
+            (body
+              (float 0)
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/parser_corpus/generics.rv
+++ b/tests/parser_corpus/generics.rv
@@ -1,0 +1,11 @@
+fun map<T, U>(xs: List<T>, f: fun(T) -> U) -> List<U> {
+    let out: List<U> = empty<U>()
+    for x in xs {
+        out.push(f(x))
+    }
+    out
+}
+
+fun nested() -> Vec<Vec<Int>> {
+    empty<Vec<Int>>()
+}

--- a/tests/parser_corpus/generics.rv.ast
+++ b/tests/parser_corpus/generics.rv.ast
@@ -1,0 +1,40 @@
+(file
+  (fn "map" generics=("T" "U") params=("xs":List<T> "f":fun(T) -> U) ret=List<U>
+    (body
+      (let-stmt "out": List<U>
+        (call
+          (ident "empty" generics=(U))
+        )
+      )
+      (expr-stmt
+        (for
+          (pattern ident:"x")
+          (ident "xs")
+          (body
+            (trailing
+              (method-call "push"
+                (ident "out")
+                (call
+                  (ident "f")
+                  (ident "x")
+                )
+              )
+            )
+          )
+        )
+      )
+      (trailing
+        (ident "out")
+      )
+    )
+  )
+  (fn "nested" params=() ret=Vec<Vec<Int>>
+    (body
+      (trailing
+        (call
+          (ident "empty" generics=(Vec<Int>))
+        )
+      )
+    )
+  )
+)

--- a/tests/parser_corpus/hello.rv
+++ b/tests/parser_corpus/hello.rv
@@ -1,0 +1,3 @@
+fun main() {
+    print("hello, world")
+}

--- a/tests/parser_corpus/hello.rv.ast
+++ b/tests/parser_corpus/hello.rv.ast
@@ -1,0 +1,12 @@
+(file
+  (fn "main" params=()
+    (body
+      (trailing
+        (call
+          (ident "print")
+          (str "hello, world")
+        )
+      )
+    )
+  )
+)

--- a/tests/parser_corpus/imports_and_extern.rv
+++ b/tests/parser_corpus/imports_and_extern.rv
@@ -1,0 +1,13 @@
+import std/io
+import std/collections { Map, Set }
+import "github.com/example/http" as http
+import "./helpers"
+
+extern "C" {
+    fun puts(s: CString) -> Int
+    fun strlen(s: CString) -> Int
+}
+
+const MAX: Int = 100
+
+let greeting: String = "hi"

--- a/tests/parser_corpus/imports_and_extern.rv.ast
+++ b/tests/parser_corpus/imports_and_extern.rv.ast
@@ -1,0 +1,16 @@
+(file
+  (import std=(io))
+  (import std=(collections) selectors=(Map Set))
+  (import quoted="github.com/example/http" alias="http")
+  (import quoted="./helpers")
+  (extern "C"
+    (extern-fn "puts" params=("s":CString) ret=Int)
+    (extern-fn "strlen" params=("s":CString) ret=Int)
+  )
+  (const "MAX": Int =
+    (int 100)
+  )
+  (let "greeting": String
+    (str "hi")
+  )
+)

--- a/tests/parser_corpus/lambdas.rv
+++ b/tests/parser_corpus/lambdas.rv
@@ -1,0 +1,11 @@
+fun apply(f: fun(Int) -> Int, x: Int) -> Int = f(x)
+
+fun double(x: Int) -> Int {
+    let f = { y -> y * 2 }
+    apply(f, x)
+}
+
+fun verbose() -> Int {
+    let g = fun(x: Int) -> Int = x + 1
+    g(10)
+}

--- a/tests/parser_corpus/lambdas.rv.ast
+++ b/tests/parser_corpus/lambdas.rv.ast
@@ -1,0 +1,53 @@
+(file
+  (fn "apply" params=("f":fun(Int) -> Int "x":Int) ret=Int
+    (body-expr
+      (call
+        (ident "f")
+        (ident "x")
+      )
+    )
+  )
+  (fn "double" params=("x":Int) ret=Int
+    (body
+      (let-stmt "f"
+        (lambda inferred=true params=("y")
+          (body
+            (trailing
+              (binary *
+                (ident "y")
+                (int 2)
+              )
+            )
+          )
+        )
+      )
+      (trailing
+        (call
+          (ident "apply")
+          (ident "f")
+          (ident "x")
+        )
+      )
+    )
+  )
+  (fn "verbose" params=() ret=Int
+    (body
+      (let-stmt "g"
+        (lambda inferred=false params=("x":Int) ret=Int
+          (body-expr
+            (binary +
+              (ident "x")
+              (int 1)
+            )
+          )
+        )
+      )
+      (trailing
+        (call
+          (ident "g")
+          (int 10)
+        )
+      )
+    )
+  )
+)

--- a/tests/parser_corpus/optional_and_try.rv
+++ b/tests/parser_corpus/optional_and_try.rv
@@ -1,0 +1,11 @@
+fun find(xs: List<Int>, target: Int) -> Int? {
+    for x in xs {
+        if x == target {
+            return x
+        }
+    }
+}
+
+fun first_or_fail(xs: List<Int>) -> Int {
+    xs.first()?
+}

--- a/tests/parser_corpus/optional_and_try.rv.ast
+++ b/tests/parser_corpus/optional_and_try.rv.ast
@@ -1,0 +1,38 @@
+(file
+  (fn "find" params=("xs":List<Int> "target":Int) ret=Int?
+    (body
+      (trailing
+        (for
+          (pattern ident:"x")
+          (ident "xs")
+          (body
+            (trailing
+              (if
+                (binary ==
+                  (ident "x")
+                  (ident "target")
+                )
+                (then
+                  (return
+                    (ident "x")
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  (fn "first_or_fail" params=("xs":List<Int>) ret=Int
+    (body
+      (trailing
+        (try
+          (method-call "first"
+            (ident "xs")
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/parser_corpus/struct_and_impl.rv
+++ b/tests/parser_corpus/struct_and_impl.rv
@@ -1,0 +1,18 @@
+struct Point {
+    x: Float
+    y: Float
+}
+
+trait Distance {
+    fun dist(self) -> Float
+}
+
+impl Distance for Point {
+    fun dist(self) -> Float {
+        self.x * self.x + self.y * self.y
+    }
+}
+
+fun origin() -> Point {
+    Point { x: 0.0, y: 0.0 }
+}

--- a/tests/parser_corpus/struct_and_impl.rv.ast
+++ b/tests/parser_corpus/struct_and_impl.rv.ast
@@ -1,0 +1,51 @@
+(file
+  (struct "Point"
+    (field "x": Float)
+    (field "y": Float)
+  )
+  (trait "Distance"
+    (fn "dist" params=("self":Self) ret=Float
+      (body-none)
+    )
+  )
+  (impl trait=Distance for=Point
+    (fn "dist" params=("self":Self) ret=Float
+      (body
+        (trailing
+          (binary +
+            (binary *
+              (field "x"
+                (self)
+              )
+              (field "x"
+                (self)
+              )
+            )
+            (binary *
+              (field "y"
+                (self)
+              )
+              (field "y"
+                (self)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  (fn "origin" params=() ret=Point
+    (body
+      (trailing
+        (struct-lit "Point"
+          (field-init "x"
+            (float 0)
+          )
+          (field-init "y"
+            (float 0)
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/parser_golden.rs
+++ b/tests/parser_golden.rs
@@ -1,0 +1,108 @@
+//! Golden snapshot tests for the parser.
+//!
+//! Walks every `tests/parser_corpus/*.rv`, parses it, pretty prints
+//! the AST, and compares against a committed `.rv.ast` baseline next
+//! to the source. Failures print a unified diff.
+//!
+//! Set `RAVEN_UPDATE_PARSER_GOLDEN=1` to overwrite baselines after an
+//! intentional change.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use raven::ast::pretty_file;
+use raven::lexer::Lexer;
+use raven::parser::parse;
+
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("parser_corpus")
+}
+
+#[test]
+fn parser_golden() {
+    let dir = corpus_dir();
+    let update = std::env::var("RAVEN_UPDATE_PARSER_GOLDEN").is_ok();
+
+    let mut entries: Vec<PathBuf> = fs::read_dir(&dir)
+        .expect("corpus directory must exist")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("rv"))
+        .collect();
+    entries.sort();
+
+    assert!(!entries.is_empty(), "parser corpus is empty");
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for src_path in entries {
+        let src = fs::read_to_string(&src_path).expect("read source");
+        let tokens = match Lexer::new(src.clone(), src_path.clone()).tokenize() {
+            Ok(t) => t,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: lex error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let file = match parse(&tokens) {
+            Ok(f) => f,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: parse error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let rendered = pretty_file(&file);
+
+        let baseline = src_path.with_extension("rv.ast");
+        if update {
+            fs::write(&baseline, &rendered).expect("write baseline");
+            continue;
+        }
+
+        match fs::read_to_string(&baseline) {
+            Ok(expected) => {
+                if normalize(&expected) != normalize(&rendered) {
+                    failures.push(format!(
+                        "snapshot mismatch for {}\n--- expected ---\n{}\n--- actual ---\n{}",
+                        src_path.display(),
+                        expected,
+                        rendered
+                    ));
+                }
+            }
+            Err(_) => failures.push(format!(
+                "missing baseline for {} (run with RAVEN_UPDATE_PARSER_GOLDEN=1)",
+                src_path.display()
+            )),
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} golden parser snapshot failure(s):\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+}
+
+/// Normalize line endings before comparing so a Windows checkout with
+/// CRLF baselines does not differ from a Unix render. We strip `\r`
+/// and trim trailing whitespace per line.
+fn normalize(s: &str) -> String {
+    s.replace("\r\n", "\n")
+        .lines()
+        .map(|l| l.trim_end().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}


### PR DESCRIPTION
Implements the recursive descent parser and AST for the full Raven v2 grammar, consuming tokens produced by the lexer and emitting a typed AST that downstream passes can build on.

Closes #56

## Summary

* New `src/ast/` module with one file per category (`expr`, `stmt`, `decl`, `pattern`, `ty`) plus a pretty printer used by snapshot tests. Every node carries a `Span`.
* New `src/parser/` module: a hand written recursive descent parser split internally into `expr`, `stmt`, `decl`, `pattern`, `ty`, with a `Parser` cursor in `mod.rs`. Operator precedence is encoded with one function per level rather than a Pratt table.
* New `ParseError` variants on `RavenError` covering the major error shapes: unexpected token, unexpected EOF, invalid assignment target, chained comparison, duplicate field, invalid import path, unsupported tuple, invalid pattern, and a `Custom` escape hatch. The existing colored caret renderer handles the new variants.
* Spec at `docs/v2/specs/parser.md` documents the full grammar, the precedence ladder, and the design notes (how `<` is disambiguated as comparison vs type args, how `{` is suppressed in `if`/`while`/`for`/`match` heads, how newlines work inside expressions, etc.).
* 94 inline unit tests under `src/parser/tests.rs` covering each grammar production with positive and negative cases.
* 1 integration golden snapshot test driven by a corpus under `tests/parser_corpus/`. Each `.rv` file has a committed `.rv.ast` baseline. Refresh with `RAVEN_UPDATE_PARSER_GOLDEN=1 cargo test --test parser_golden`.

## Notable design calls

* The `<` disambiguation uses a trial parse with rewind. A `<` after an identifier in expression position is tried as `TypeArgs`; on failure (non type starter, premature operator boundary, or wrong follower) the parser rewinds and treats it as the comparison operator. Followers that confirm a generic application: `(`, `.`, `::`, `{`, `=`, `,`, `)`, `]`, `;`, newline, EOF.
* Nested generics: `Vec<Vec<Int>>` lexes as `Vec Lt Vec Lt Int Shr`. The parser splits the trailing `Shr` into two `Gt` tokens during type argument closure. To support that rewrite without unsafe, the parser owns its token buffer (cloned from the lexer's slice on construction).
* Struct literal disambiguation: a `{` after an identifier in expression position is a struct literal, unless we are inside the head of `if` / `while` / `for` / `match`, controlled by a `no_struct_literal` flag.
* Trailing block expression: newlines do not terminate a trailing expression; only `;` does. Matches Rust semantics. `fun f() -> Int { 1 + 2 }` and `fun f() -> Int { 1 + 2\n }` both produce a block whose value is `1 + 2`.
* `self` parameter: a leading `self` is accepted in `impl` and `trait` methods. The parser desugars it to a parameter named `self` with a synthetic `Self` type, so downstream passes can treat methods uniformly.

## Deliberately deferred

* Tuples: `(a, b, c)` parses but reports `ParseError::UnsupportedTuple`. Tracked for v2.x.
* String interpolation splitting: tracked in #69. The lexer preserves `${...}` segments verbatim inside `StringLit`.
* Error recovery: the parser stops at the first error in this release.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (94 lib tests + 1 golden snapshot test pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy`
- [x] Golden corpus parses cleanly; baselines match
- [x] No em dashes in spec, code comments, or commit messages