### PR TITLE
feat(resolve): name resolution and import binding for the v2 compiler

### DIFF
--- a/docs/v2/specs/resolver.md
+++ b/docs/v2/specs/resolver.md
@@ -1,0 +1,150 @@
+# Resolver Spec
+
+## Goal
+
+Walk an `ast::File`, bind every identifier use to the declaration it refers to, and resolve every import path to a target. The output is a `ResolvedFile` that pairs the original AST with a `ResolutionMap` keyed by identifier span. Downstream passes (type checker, lowering) read the map to answer the question "given this identifier site, what does it bind to?"
+
+The resolver is total: every malformed program produces a `RavenError::Resolve(ResolveError, Span, Option<String>)` with the offending span highlighted. The resolver does not infer types, does not dispatch methods, and does not load any actual stdlib content. Method dispatch and stdlib member lookup are deferred to the type checker.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> Resolver -> (type check -> hir -> mir -> codegen)
+```
+
+The resolver consumes nodes defined in `src/ast` and produces nodes in `src/resolve`. The first error halts resolution of the current file; multi error recovery is out of scope for this release.
+
+## Passes
+
+Resolution runs in two passes per file:
+
+1. **Item collection.** Walk top level `Decl`s and bind every declared name (functions, structs, traits, enums, externs, top level lets and consts, import aliases) into a fresh `ModuleScope`. Duplicate declarations in the same scope raise `DuplicateDeclaration`. No expressions are walked yet.
+2. **Body walk.** Walk every body (function bodies, struct field types, enum payload types, const initializers, top level let initializers, impl items) in declaration order. Each identifier use is recorded in the `ResolutionMap` against the binding it resolves to.
+
+The two passes exist so module level forward references work without ordering constraints: a function defined later in the file can be called from one defined earlier, and a struct can reference a trait declared further down. The first pass is purely declarative; the second is purely a use site walk.
+
+## Scope kinds
+
+The scope stack is a linked list of frames. Each frame stores a name to `Binding` map and a `ScopeKind`:
+
+* `Module`: top level of a file. Contains items from item collection and any import aliases. Implicit root frame.
+* `Impl`: opened on entry to an `impl` block. Binds `Self` (the implementing type's path) and `self` (a parameter style binding when methods take a `self` receiver). Generic parameters of the impl live here.
+* `Function`: opened on entry to a function body. Binds parameters and the function's own generic parameters.
+* `Block`: opened for every `{ ... }` block expression. Holds `let` bindings introduced inside the block. Inner blocks shadow outer blocks.
+* `Pattern`: a synthetic frame opened by `match` arms, `for` heads, and `let` patterns. Holds identifiers bound by the pattern for the duration of the arm or binding body.
+
+Lookup walks frames from innermost to outermost. The first match wins (shadowing).
+
+## Bindings
+
+A `Binding` is a tagged reference to the declaration responsible for the name. The variants are:
+
+* `Function(decl_id)`: a top level function.
+* `Struct(decl_id)`: a struct type.
+* `Trait(decl_id)`: a trait.
+* `Enum(decl_id)`: an enum type.
+* `Variant { enum_id, variant_index }`: a variant of an enum (in scope when the enum is in scope by name).
+* `Extern(decl_id, item_index)`: a foreign function from an extern block.
+* `Const(decl_id)`: a top level constant.
+* `Static(decl_id)`: a top level `let` (mutable module global).
+* `Param(span)`: a function parameter, identified by its declaration span.
+* `Local(span)`: a `let` binding inside a function body, identified by its declaration span.
+* `PatternBinding(span)`: a name bound by a pattern.
+* `GenericParam(owner_span, name)`: a generic parameter in scope.
+* `SelfType`: refers to the enclosing `impl`'s target type.
+* `SelfValue`: refers to the enclosing `impl`'s `self` parameter.
+* `ImportAlias(import_id)`: an `import ... as alias` brings in a single name pointing at the resolved import target.
+* `ImportedItem { import_id, name }`: a specific selector from `import std/io { println }` (resolution of the inner name is deferred).
+* `ExternalPackage { import_id }`: a `github.com/...` package; member lookup deferred to rvpm.
+
+`decl_id` is an opaque newtype index into the file's `Vec<Decl>`. `import_id` is the index into the file's import list.
+
+## Resolution algorithm
+
+In pseudocode:
+
+```
+fn resolve_file(file):
+  let module = collect_items(file)         # pass 1
+  for decl in file.items:
+    walk_decl(decl, module)                # pass 2
+  return ResolvedFile { ast: file, map }
+
+fn walk_decl(decl, module):
+  match decl:
+    Function(f) -> with Function frame holding f.generics + f.params,
+                   walk body, recording uses
+    Struct(s)   -> with frame holding s.generics, walk field types
+    Trait(t)    -> with frame holding t.generics, walk member sigs and default bodies
+    Impl(i)     -> with Impl frame holding i.generics, Self, walk items
+    Enum(e)     -> with frame holding e.generics, walk variant payload types
+    Const(c)    -> walk type, walk init expression
+    Let(l)      -> walk optional type, walk optional init
+    Extern(_)   -> walk parameter and return types of each item
+    Import(_)   -> already handled in pass 1; nothing to walk
+
+fn walk_expr(expr):
+  match expr.kind:
+    Ident { name, generics } -> lookup(name); walk generics
+    SelfLower                -> require SelfValue in scope, else SelfOutsideImpl
+    SelfUpper                -> require SelfType in scope, else SelfOutsideImpl
+    Block(b)                 -> push Block frame; walk stmts; pop
+    Match { scrutinee, arms} -> walk scrutinee; for each arm push Pattern frame
+                                with names from pattern, walk guard and body
+    Lambda { params, body }  -> push Function-like frame with params; walk body
+    ... recurse on every sub expression
+```
+
+`lookup(name)` walks frames inner to outer. If no binding is found at the file level and an import alias matches, return that import binding. Otherwise raise `UnresolvedName`.
+
+## Import resolution
+
+Three shapes are produced by the parser as `ImportSource`:
+
+1. **`std/<segments>`** (`ImportSource::Std`). Looked up in a static registry of v2 stdlib module names: `io`, `collections`, `string`, `math`, `fs`, `net`, `http`, `time`, `json`, `ffi`. Successful lookup binds the resulting `ImportTarget::StdlibModule { segments }`. The resolver does NOT load any contents because the stdlib does not exist yet; member resolution against the imported name is deferred to the type checker. Unknown module names raise `UnresolvedImport`.
+
+2. **`"github.com/<user>/<repo>[/<sub>]"`** (`ImportSource::Quoted` with a leading `github.com/` host). Parsed into `ImportTarget::ExternalPackage { host, user, repo, subpath }`. Fetching is deferred to `rvpm`; the resolver records the target and continues. The alias (or last path segment if no alias) is bound as `ImportAlias`.
+
+3. **`"./<path>"` or `"../<path>"`** (relative path strings). The resolver asks the `SourceLoader` to read the file relative to the importing file's directory. If the loader returns content, the resolver lexes, parses, and recursively resolves it, then records `ImportTarget::LocalModule { resolved_path, module }` and merges the inner file's top level names into the outer scope under the alias. If the loader cannot find the file, raise `UnresolvedImport`. The resolver tracks an in progress set of canonical paths and raises `CyclicImport` if it would recurse into a path it is already resolving.
+
+If the import provides selectors (`import std/io { println, eprintln }`), each selector becomes an `ImportedItem` binding in the module scope. Otherwise the import binds a single alias (the `as` name, or the last path segment as a fallback). Duplicate aliases or selectors raise `DuplicateDeclaration`. Conflicting imports of the same name from different sources raise `AmbiguousName`.
+
+## SourceLoader trait
+
+```rust
+pub trait SourceLoader {
+    fn load(&mut self, importing: &Path, target: &str) -> Option<LoadedSource>;
+}
+
+pub struct LoadedSource {
+    pub canonical_path: PathBuf,
+    pub source: String,
+}
+```
+
+Tests inject an in memory loader keyed by relative path so resolver behavior is exercised without filesystem state. The real CLI ships with a `FsLoader` that resolves `./foo` against `importing.parent()` and reads the file from disk.
+
+## Errors
+
+`ResolveError` lives next to `LexError` and `ParseError` in `src/error.rs`. Variants:
+
+* `UnresolvedName(name)`: identifier not in any enclosing scope.
+* `DuplicateDeclaration { name, first_span }`: same identifier declared twice in the same scope.
+* `UnresolvedImport(path)`: import target not found.
+* `CyclicImport(path)`: import graph contains a cycle.
+* `AmbiguousName { name, candidates }`: name visible via multiple imports.
+* `SelfOutsideImpl`: `self` or `Self` used outside an `impl` block.
+
+Each error reaches the user via the existing `RavenError::Resolve(error, span, hint)` arm. The renderer is unchanged.
+
+## Out of scope
+
+* Cross package import fetching (rvpm responsibility, future PR).
+* Type aware resolution: method dispatch, trait method selection, struct field access through inferred types. These belong to the type checker.
+* Visibility modifiers (`pub`, `private`). Every module level name is importable.
+* Macro expansion. No macros exist yet.
+
+## Tests
+
+* Unit tests inline at `src/resolve/tests.rs`: cover scope basics, shadowing, forward references, duplicate declarations, unresolved names, `self` outside impl, import alias binding, import selector binding, std module recognition, in memory recursive local imports, cyclic import detection.
+* Golden snapshot tests at `tests/resolver_golden.rs` over a corpus at `tests/resolver_corpus/`. Each `.rv` source has a committed `.rv.resolved` baseline produced by dumping every identifier use and its resolved binding. Refresh with `RAVEN_UPDATE_RESOLVER_GOLDEN=1`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,6 +112,54 @@ impl fmt::Display for ParseError {
     }
 }
 
+/// Name resolution errors raised by the resolver.
+///
+/// All variants carry the offending span on the outer `RavenError::Resolve`
+/// wrapper; payload data here is just enough to format a human readable
+/// message. See `docs/v2/specs/resolver.md` for the full catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    /// An identifier could not be found in any enclosing scope.
+    UnresolvedName(String),
+    /// Two declarations with the same name appear in the same scope.
+    /// `first_span` points at the original declaration so the renderer can
+    /// surface both locations if it chooses.
+    DuplicateDeclaration { name: String, first_span: Span },
+    /// An import path could not be resolved to a target.
+    UnresolvedImport(String),
+    /// The import graph contains a cycle that reaches the given path.
+    CyclicImport(String),
+    /// A name is visible from multiple import sources at the same scope.
+    AmbiguousName { name: String, candidates: Vec<Span> },
+    /// `self` or `Self` used outside an `impl` block.
+    SelfOutsideImpl,
+}
+
+impl fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ResolveError::UnresolvedName(name) => {
+                write!(f, "cannot find `{}` in scope", name)
+            }
+            ResolveError::DuplicateDeclaration { name, .. } => {
+                write!(f, "the name `{}` is declared multiple times", name)
+            }
+            ResolveError::UnresolvedImport(path) => {
+                write!(f, "cannot resolve import `{}`", path)
+            }
+            ResolveError::CyclicImport(path) => {
+                write!(f, "cyclic import detected involving `{}`", path)
+            }
+            ResolveError::AmbiguousName { name, .. } => {
+                write!(f, "the name `{}` is ambiguous", name)
+            }
+            ResolveError::SelfOutsideImpl => {
+                write!(f, "`self` or `Self` used outside an `impl` block")
+            }
+        }
+    }
+}
+
 /// Top level compiler error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RavenError {
@@ -119,6 +167,8 @@ pub enum RavenError {
     Lex(LexError, Span, Option<String>),
     /// A parser error with the offending span and an optional hint.
     Parse(ParseError, Span, Option<String>),
+    /// A resolver error with the offending span and an optional hint.
+    Resolve(ResolveError, Span, Option<String>),
 }
 
 impl RavenError {
@@ -132,11 +182,17 @@ impl RavenError {
         RavenError::Parse(kind, span, None)
     }
 
+    /// Construct a resolve error.
+    pub fn resolve(kind: ResolveError, span: Span) -> Self {
+        RavenError::Resolve(kind, span, None)
+    }
+
     /// Attach a hint string to this error.
     pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
         match &mut self {
             RavenError::Lex(_, _, h) => *h = Some(hint.into()),
             RavenError::Parse(_, _, h) => *h = Some(hint.into()),
+            RavenError::Resolve(_, _, h) => *h = Some(hint.into()),
         }
         self
     }
@@ -146,6 +202,7 @@ impl RavenError {
         match self {
             RavenError::Lex(_, sp, _) => sp,
             RavenError::Parse(_, sp, _) => sp,
+            RavenError::Resolve(_, sp, _) => sp,
         }
     }
 
@@ -160,6 +217,7 @@ impl RavenError {
         let (kind_str, span, hint) = match self {
             RavenError::Lex(k, s, h) => (format!("error: {}", k), s, h.as_deref()),
             RavenError::Parse(k, s, h) => (format!("error: {}", k), s, h.as_deref()),
+            RavenError::Resolve(k, s, h) => (format!("error: {}", k), s, h.as_deref()),
         };
 
         let mut out = String::new();
@@ -221,6 +279,7 @@ impl fmt::Display for RavenError {
         match self {
             RavenError::Lex(k, s, _) => write!(f, "{}: {}", s, k),
             RavenError::Parse(k, s, _) => write!(f, "{}: {}", s, k),
+            RavenError::Resolve(k, s, _) => write!(f, "{}: {}", s, k),
         }
     }
 }
@@ -299,5 +358,30 @@ mod tests {
         let err = RavenError::parse(ParseError::ChainedComparison, span);
         let s = format!("{}", err);
         assert_eq!(s, "test.rv:2:3: comparison operators cannot be chained");
+    }
+
+    #[test]
+    fn resolve_error_renders_with_carets_and_hint() {
+        let src = "fun main() { println(\"hi\") }\n";
+        // `println` starts at byte 13, col 14.
+        let span = Span::new(file(), 13, 20, 1, 14);
+        let err = RavenError::resolve(ResolveError::UnresolvedName("println".into()), span)
+            .with_hint("did you mean to `import std/io { println }`?");
+        let rendered = err.display(src);
+        assert!(rendered.contains("cannot find `println` in scope"));
+        assert!(rendered.contains("fun main() { println"));
+        assert!(rendered.contains('^'));
+        assert!(rendered.contains("hint:"));
+    }
+
+    #[test]
+    fn resolve_error_display_formats_location_then_kind() {
+        let span = Span::new(file(), 0, 1, 4, 7);
+        let err = RavenError::resolve(ResolveError::SelfOutsideImpl, span);
+        let s = format!("{}", err);
+        assert_eq!(
+            s,
+            "test.rv:4:7: `self` or `Self` used outside an `impl` block"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@ pub mod ast;
 pub mod error;
 pub mod lexer;
 pub mod parser;
+pub mod resolve;
 pub mod span;

--- a/src/resolve/bindings.rs
+++ b/src/resolve/bindings.rs
@@ -1,0 +1,169 @@
+//! Binding kinds and the resolution map.
+//!
+//! Every identifier site in a resolved file maps to a [`Binding`], which
+//! is a tagged reference to the declaration that introduces the name.
+//! Bindings are intentionally loose references (indices and spans) rather
+//! than direct pointers so the resolved file can be passed across module
+//! boundaries without lifetime knots.
+//!
+//! See `docs/v2/specs/resolver.md` for the full catalog of variants.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::span::Span;
+
+/// Opaque index into a [`crate::ast::File`]'s `items` vector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DeclId(pub usize);
+
+/// Opaque index into the file's import list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ImportId(pub usize);
+
+/// A hashable key for identifier use sites. We do not derive `Hash`
+/// on `Span` itself (it carries an `Arc<PathBuf>` and line/col fields
+/// that are derived from `start`); instead a use site is uniquely
+/// identified by its file path and byte range.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UseKey {
+    pub file: Arc<PathBuf>,
+    pub start: usize,
+    pub end: usize,
+}
+
+impl UseKey {
+    /// Build a key from a span.
+    pub fn from_span(span: &Span) -> Self {
+        UseKey {
+            file: span.file.clone(),
+            start: span.start,
+            end: span.end,
+        }
+    }
+}
+
+/// What an identifier resolves to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Binding {
+    /// Top level function.
+    Function(DeclId),
+    /// Top level struct type.
+    Struct(DeclId),
+    /// Top level trait.
+    Trait(DeclId),
+    /// Top level enum.
+    Enum(DeclId),
+    /// One variant inside an enum (parent enum is at `enum_id`).
+    Variant {
+        enum_id: DeclId,
+        variant_index: usize,
+    },
+    /// One foreign function inside an extern block.
+    Extern { decl_id: DeclId, item_index: usize },
+    /// Top level `const`.
+    Const(DeclId),
+    /// Top level mutable `let`.
+    Static(DeclId),
+    /// A function parameter, identified by its declaration span.
+    Param(Span),
+    /// A `let` binding inside a function body.
+    Local(Span),
+    /// A name introduced by a pattern (match arm, for head, let pattern).
+    PatternBinding(Span),
+    /// A generic parameter declared on the enclosing item.
+    GenericParam { owner: Span, name: String },
+    /// `Self` keyword referring to the enclosing impl target type.
+    SelfType,
+    /// `self` value parameter inside an `impl` method.
+    SelfValue,
+    /// An `import path as alias` brings in this single name. The actual
+    /// import target lives in [`ResolutionMap::imports`].
+    ImportAlias(ImportId),
+    /// A specific selector from an import like `import std/io { println }`.
+    /// Member resolution against the source module is deferred to the
+    /// type checker.
+    ImportedItem { import_id: ImportId, name: String },
+}
+
+/// The concrete target an import points at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportTarget {
+    /// A built in stdlib module (e.g. `std/io`). The segments are kept
+    /// verbatim so the type checker can route member lookups.
+    StdlibModule { segments: Vec<String> },
+    /// A github package referenced by URL. Fetching is deferred to rvpm.
+    ExternalPackage {
+        host: String,
+        user: String,
+        repo: String,
+        subpath: Vec<String>,
+    },
+    /// A locally resolved file. The contents have been parsed and
+    /// resolved; member lookups happen against `module_names`.
+    LocalModule {
+        canonical_path: PathBuf,
+        /// Names exported by the loaded file's module scope.
+        module_names: Vec<String>,
+    },
+}
+
+/// One entry in the resolved imports list, keyed by [`ImportId`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedImport {
+    pub id: ImportId,
+    /// Source spelling of the import path, for diagnostics.
+    pub path: String,
+    pub target: ImportTarget,
+    pub span: Span,
+}
+
+/// Per file resolution output.
+///
+/// Identifier sites are keyed by [`UseKey`] (file plus byte range), so
+/// the map round trips through serialization and across worker boundaries
+/// without depending on internal span hashing.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolutionMap {
+    /// Map from identifier use site key to its bound declaration.
+    pub uses: HashMap<UseKey, Binding>,
+    /// Resolved imports in declaration order. Indexed by [`ImportId`].
+    pub imports: Vec<ResolvedImport>,
+}
+
+impl ResolutionMap {
+    /// Construct an empty map.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record `binding` as the resolution of the identifier site at
+    /// `span`.
+    pub fn bind_use(&mut self, span: &Span, binding: Binding) {
+        let key = UseKey::from_span(span);
+        debug_assert!(
+            !self.uses.contains_key(&key),
+            "double binding at span {:?}",
+            span
+        );
+        self.uses.insert(key, binding);
+    }
+
+    /// Look up the binding recorded at `span`, if any.
+    pub fn lookup(&self, span: &Span) -> Option<&Binding> {
+        self.uses.get(&UseKey::from_span(span))
+    }
+
+    /// Iterate over bindings sorted by file then byte range, for stable
+    /// diagnostic output.
+    pub fn sorted_iter(&self) -> Vec<(&UseKey, &Binding)> {
+        let mut pairs: Vec<_> = self.uses.iter().collect();
+        pairs.sort_by(|a, b| {
+            let pa = a.0.file.display().to_string();
+            let pb = b.0.file.display().to_string();
+            (pa, a.0.start, a.0.end).cmp(&(pb, b.0.start, b.0.end))
+        });
+        pairs
+    }
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -1,0 +1,540 @@
+//! Import resolution.
+//!
+//! Three import shapes are recognized:
+//!
+//! 1. `import std/<path>`: looked up in a static registry of stdlib
+//!    module names. Contents are not loaded; member resolution is the
+//!    type checker's responsibility.
+//! 2. `import "github.com/<user>/<repo>[/<sub>]"`: defers to rvpm. The
+//!    resolver records the target and continues.
+//! 3. `import "./<path>"` or `"../<path>"`: read through the
+//!    [`SourceLoader`] and recursively parsed and resolved.
+//!
+//! After this pass, every import's alias (or each selector when a
+//! selector list is present) is inserted into the current module
+//! scope.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::ast::{DeclKind, File, Import, ImportSource};
+use crate::error::{RavenError, ResolveError};
+use crate::lexer::Lexer;
+use crate::parser::parse;
+use crate::span::Span;
+
+use super::bindings::{Binding, ImportId, ImportTarget, ResolvedImport};
+use super::scope::ScopeStack;
+
+/// Pluggable filesystem hook used for local imports. Tests inject an
+/// in memory loader keyed by relative path; the real CLI uses
+/// [`FsLoader`].
+pub trait SourceLoader {
+    /// Resolve `target` (a relative path like `./helpers` or
+    /// `../util`) starting from `importing` (the path of the file
+    /// containing the import). Return `Some((canonical_path, source))`
+    /// when found, `None` otherwise.
+    fn load(&mut self, importing: &Path, target: &str) -> Option<LoadedSource>;
+}
+
+/// One loaded source file's text plus a canonical path used for cycle
+/// detection.
+#[derive(Debug, Clone)]
+pub struct LoadedSource {
+    pub canonical_path: PathBuf,
+    pub source: String,
+}
+
+/// Filesystem backed loader. Resolves `target` relative to
+/// `importing.parent()` and reads the file from disk. A `.rv`
+/// extension is appended if `target` does not already have an
+/// extension. Used by the CLI; tests rarely touch this.
+#[derive(Debug, Default)]
+pub struct FsLoader;
+
+impl SourceLoader for FsLoader {
+    fn load(&mut self, importing: &Path, target: &str) -> Option<LoadedSource> {
+        let parent = importing.parent().unwrap_or_else(|| Path::new("."));
+        let mut path = parent.join(target);
+        if path.extension().is_none() {
+            path.set_extension("rv");
+        }
+        let canonical_path = path.canonicalize().unwrap_or_else(|_| path.clone());
+        let source = std::fs::read_to_string(&path).ok()?;
+        Some(LoadedSource {
+            canonical_path,
+            source,
+        })
+    }
+}
+
+/// The recognized stdlib module names. Anything else under `std/` is
+/// `UnresolvedImport`. The list intentionally mirrors the v1 stdlib so
+/// future code can be ported without re writing imports.
+pub const STDLIB_MODULES: &[&str] = &[
+    "io",
+    "collections",
+    "string",
+    "math",
+    "fs",
+    "net",
+    "http",
+    "time",
+    "json",
+    "ffi",
+];
+
+/// Resolve every import declaration in `file`, inserting alias /
+/// selector bindings into `scope` and appending [`ResolvedImport`]s to
+/// `out_imports`.
+///
+/// `in_progress` carries the set of canonical paths currently being
+/// resolved so we can detect a cycle. The set is mutated as files are
+/// pushed and popped during recursion.
+pub fn resolve_imports(
+    file: &File,
+    scope: &mut ScopeStack,
+    loader: &mut dyn SourceLoader,
+    out_imports: &mut Vec<ResolvedImport>,
+    in_progress: &mut HashSet<PathBuf>,
+) -> Result<(), RavenError> {
+    for decl in &file.items {
+        let DeclKind::Import(import) = &decl.kind else {
+            continue;
+        };
+        let id = ImportId(out_imports.len());
+        let resolved = resolve_one_import(import, &decl.span, loader, in_progress, id)?;
+        bind_import(import, &resolved, id, scope)?;
+        out_imports.push(resolved);
+    }
+    Ok(())
+}
+
+fn resolve_one_import(
+    import: &Import,
+    decl_span: &Span,
+    loader: &mut dyn SourceLoader,
+    in_progress: &mut HashSet<PathBuf>,
+    id: ImportId,
+) -> Result<ResolvedImport, RavenError> {
+    match &import.source {
+        ImportSource::Std(segments) => {
+            // The first segment after `std` is the module name; nested
+            // segments select a submodule, which is also looked up in
+            // the registry by its leading name in v2.0.
+            let head = segments
+                .first()
+                .ok_or_else(|| invalid_import(decl_span, "std import has no module name"))?;
+            if !STDLIB_MODULES.contains(&head.as_str()) {
+                return Err(RavenError::resolve(
+                    ResolveError::UnresolvedImport(format!("std/{}", segments.join("/"))),
+                    import.span.clone(),
+                )
+                .with_hint("unknown stdlib module; see `docs/v2/specs/resolver.md`"));
+            }
+            Ok(ResolvedImport {
+                id,
+                path: format!("std/{}", segments.join("/")),
+                target: ImportTarget::StdlibModule {
+                    segments: segments.clone(),
+                },
+                span: import.span.clone(),
+            })
+        }
+        ImportSource::Quoted(path) => {
+            if let Some(pkg) = parse_github_path(path) {
+                Ok(ResolvedImport {
+                    id,
+                    path: path.clone(),
+                    target: pkg,
+                    span: import.span.clone(),
+                })
+            } else if path.starts_with("./") || path.starts_with("../") {
+                resolve_local_import(import, decl_span, path, loader, in_progress, id)
+            } else {
+                Err(RavenError::resolve(
+                    ResolveError::UnresolvedImport(path.clone()),
+                    import.span.clone(),
+                )
+                .with_hint("expected `std/...`, `github.com/<user>/<repo>`, or `./relative` path"))
+            }
+        }
+    }
+}
+
+fn parse_github_path(s: &str) -> Option<ImportTarget> {
+    let rest = s.strip_prefix("github.com/")?;
+    let mut parts = rest.split('/');
+    let user = parts.next()?.to_string();
+    let repo = parts.next()?.to_string();
+    let subpath: Vec<String> = parts.map(|s| s.to_string()).collect();
+    if user.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(ImportTarget::ExternalPackage {
+        host: "github.com".to_string(),
+        user,
+        repo,
+        subpath,
+    })
+}
+
+fn resolve_local_import(
+    import: &Import,
+    _decl_span: &Span,
+    path: &str,
+    loader: &mut dyn SourceLoader,
+    in_progress: &mut HashSet<PathBuf>,
+    id: ImportId,
+) -> Result<ResolvedImport, RavenError> {
+    let importing_file = (*import.span.file).clone();
+    let loaded = loader.load(&importing_file, path).ok_or_else(|| {
+        RavenError::resolve(
+            ResolveError::UnresolvedImport(path.to_string()),
+            import.span.clone(),
+        )
+        .with_hint("file not found by the source loader")
+    })?;
+
+    if in_progress.contains(&loaded.canonical_path) {
+        return Err(RavenError::resolve(
+            ResolveError::CyclicImport(path.to_string()),
+            import.span.clone(),
+        ));
+    }
+
+    // Lex, parse, and walk the inner file to discover what names it
+    // exports. We don't resolve the inner file's bodies here (use sites
+    // inside the inner file are not our concern at this pass); we only
+    // need its top level names to populate `module_names`.
+    let tokens = Lexer::new(loaded.source.clone(), loaded.canonical_path.clone())
+        .tokenize()
+        .map_err(|e| {
+            // Surface the underlying lex error with the import span so
+            // the user sees where the import points at.
+            RavenError::resolve(
+                ResolveError::UnresolvedImport(path.to_string()),
+                import.span.clone(),
+            )
+            .with_hint(format!("inner file failed to lex: {}", e))
+        })?;
+    let inner_file = parse(&tokens).map_err(|e| {
+        RavenError::resolve(
+            ResolveError::UnresolvedImport(path.to_string()),
+            import.span.clone(),
+        )
+        .with_hint(format!("inner file failed to parse: {}", e))
+    })?;
+
+    in_progress.insert(loaded.canonical_path.clone());
+
+    // Recursively resolve the inner file's imports too. We don't
+    // care about its bindings (it has its own scope), but a transitive
+    // cyclic import should surface during this recursion.
+    let mut inner_scope = ScopeStack::new();
+    let mut inner_imports = Vec::new();
+    let inner_result = resolve_imports(
+        &inner_file,
+        &mut inner_scope,
+        loader,
+        &mut inner_imports,
+        in_progress,
+    );
+    in_progress.remove(&loaded.canonical_path);
+    inner_result?;
+
+    // Collect inner top level names so callers can ask the module what
+    // it exports. We avoid running the full item collection so a single
+    // duplicate inside the imported file doesn't fail the importing
+    // file's resolution; that's the inner file's problem when it gets
+    // resolved on its own.
+    let mut module_names: Vec<String> = Vec::new();
+    for d in &inner_file.items {
+        match &d.kind {
+            DeclKind::Function(f) => module_names.push(f.name.clone()),
+            DeclKind::Struct(s) => module_names.push(s.name.clone()),
+            DeclKind::Trait(t) => module_names.push(t.name.clone()),
+            DeclKind::Enum(e) => module_names.push(e.name.clone()),
+            DeclKind::Const(c) => module_names.push(c.name.clone()),
+            DeclKind::Let(l) => module_names.push(l.name.clone()),
+            DeclKind::Extern(ext) => {
+                for it in &ext.items {
+                    module_names.push(it.name.clone());
+                }
+            }
+            DeclKind::Impl(_) | DeclKind::Import(_) => {}
+        }
+    }
+
+    Ok(ResolvedImport {
+        id,
+        path: path.to_string(),
+        target: ImportTarget::LocalModule {
+            canonical_path: loaded.canonical_path,
+            module_names,
+        },
+        span: import.span.clone(),
+    })
+}
+
+/// Insert the alias and any selector names into `scope`.
+fn bind_import(
+    import: &Import,
+    resolved: &ResolvedImport,
+    id: ImportId,
+    scope: &mut ScopeStack,
+) -> Result<(), RavenError> {
+    if !import.selectors.is_empty() {
+        for name in &import.selectors {
+            scope.insert(
+                name,
+                Binding::ImportedItem {
+                    import_id: id,
+                    name: name.clone(),
+                },
+                import.span.clone(),
+            )?;
+        }
+    } else {
+        let alias = match (&import.alias, &resolved.target) {
+            (Some(a), _) => a.clone(),
+            (None, ImportTarget::StdlibModule { segments }) => segments
+                .last()
+                .cloned()
+                .unwrap_or_else(|| "std".to_string()),
+            (None, ImportTarget::ExternalPackage { repo, subpath, .. }) => {
+                subpath.last().cloned().unwrap_or_else(|| repo.clone())
+            }
+            (None, ImportTarget::LocalModule { canonical_path, .. }) => canonical_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "module".to_string()),
+        };
+        scope.insert(&alias, Binding::ImportAlias(id), import.span.clone())?;
+    }
+    Ok(())
+}
+
+fn invalid_import(span: &Span, msg: &str) -> RavenError {
+    RavenError::resolve(
+        ResolveError::UnresolvedImport(msg.to_string()),
+        span.clone(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use crate::lexer::Lexer;
+    use crate::parser::parse;
+
+    use super::super::scope::ScopeStack;
+    use super::*;
+
+    /// In memory loader keyed by relative target path (already
+    /// normalized by the caller's parent directory in the test).
+    #[derive(Default)]
+    struct MapLoader {
+        files: HashMap<String, (PathBuf, String)>,
+    }
+
+    impl MapLoader {
+        fn add(&mut self, key: &str, canon: &str, src: &str) {
+            self.files
+                .insert(key.to_string(), (PathBuf::from(canon), src.to_string()));
+        }
+    }
+
+    impl SourceLoader for MapLoader {
+        fn load(&mut self, _importing: &Path, target: &str) -> Option<LoadedSource> {
+            let (canon, src) = self.files.get(target)?;
+            Some(LoadedSource {
+                canonical_path: canon.clone(),
+                source: src.clone(),
+            })
+        }
+    }
+
+    fn parse_src(src: &str, path: &str) -> File {
+        let tokens = Lexer::new(src.to_string(), PathBuf::from(path))
+            .tokenize()
+            .expect("lex");
+        parse(&tokens).expect("parse")
+    }
+
+    #[test]
+    fn std_io_import_binds_alias() {
+        let file = parse_src("import std/io\nfun main() {}\n", "main.rv");
+        let mut scope = ScopeStack::new();
+        let mut loader = MapLoader::default();
+        let mut imports = Vec::new();
+        let mut in_progress = HashSet::new();
+        resolve_imports(
+            &file,
+            &mut scope,
+            &mut loader,
+            &mut imports,
+            &mut in_progress,
+        )
+        .expect("ok");
+        assert_eq!(imports.len(), 1);
+        assert!(matches!(
+            imports[0].target,
+            ImportTarget::StdlibModule { .. }
+        ));
+        let entry = scope.lookup("io").expect("alias bound");
+        assert!(matches!(entry.binding, Binding::ImportAlias(_)));
+    }
+
+    #[test]
+    fn unknown_std_module_is_unresolved() {
+        let file = parse_src("import std/nope\n", "main.rv");
+        let mut scope = ScopeStack::new();
+        let mut loader = MapLoader::default();
+        let mut imports = Vec::new();
+        let mut in_progress = HashSet::new();
+        let err = resolve_imports(
+            &file,
+            &mut scope,
+            &mut loader,
+            &mut imports,
+            &mut in_progress,
+        )
+        .unwrap_err();
+        match err {
+            RavenError::Resolve(ResolveError::UnresolvedImport(p), _, _) => {
+                assert!(p.contains("nope"));
+            }
+            other => panic!("expected UnresolvedImport, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn selector_list_binds_each_selector() {
+        let file = parse_src(
+            "import std/io { println, eprintln }\nfun main() {}\n",
+            "main.rv",
+        );
+        let mut scope = ScopeStack::new();
+        let mut loader = MapLoader::default();
+        let mut imports = Vec::new();
+        let mut in_progress = HashSet::new();
+        resolve_imports(
+            &file,
+            &mut scope,
+            &mut loader,
+            &mut imports,
+            &mut in_progress,
+        )
+        .expect("ok");
+        let pr = scope.lookup("println").expect("println bound");
+        assert!(matches!(pr.binding, Binding::ImportedItem { .. }));
+        let ep = scope.lookup("eprintln").expect("eprintln bound");
+        assert!(matches!(ep.binding, Binding::ImportedItem { .. }));
+    }
+
+    #[test]
+    fn github_path_records_external_package() {
+        let file = parse_src(
+            "import \"github.com/martian56/raven-http\" as http\n",
+            "main.rv",
+        );
+        let mut scope = ScopeStack::new();
+        let mut loader = MapLoader::default();
+        let mut imports = Vec::new();
+        let mut in_progress = HashSet::new();
+        resolve_imports(
+            &file,
+            &mut scope,
+            &mut loader,
+            &mut imports,
+            &mut in_progress,
+        )
+        .expect("ok");
+        assert!(matches!(
+            imports[0].target,
+            ImportTarget::ExternalPackage { .. }
+        ));
+        assert!(scope.lookup("http").is_some());
+    }
+
+    #[test]
+    fn local_import_loads_inner_file_names() {
+        let file = parse_src("import \"./helpers\"\nfun main() {}\n", "main.rv");
+        let mut loader = MapLoader::default();
+        loader.add(
+            "./helpers",
+            "helpers.rv",
+            "fun helper() {}\nstruct H { x: Int }\n",
+        );
+        let mut scope = ScopeStack::new();
+        let mut imports = Vec::new();
+        let mut in_progress = HashSet::new();
+        resolve_imports(
+            &file,
+            &mut scope,
+            &mut loader,
+            &mut imports,
+            &mut in_progress,
+        )
+        .expect("ok");
+        match &imports[0].target {
+            ImportTarget::LocalModule { module_names, .. } => {
+                assert!(module_names.contains(&"helper".to_string()));
+                assert!(module_names.contains(&"H".to_string()));
+            }
+            other => panic!("expected LocalModule, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cyclic_local_import_is_detected() {
+        // a.rv imports ./b; b.rv imports ./a.
+        let file = parse_src("import \"./b\"\n", "a.rv");
+        let mut loader = MapLoader::default();
+        loader.add("./a", "a.rv", "import \"./b\"\n");
+        loader.add("./b", "b.rv", "import \"./a\"\n");
+        let mut scope = ScopeStack::new();
+        let mut imports = Vec::new();
+        let mut in_progress = HashSet::new();
+        in_progress.insert(PathBuf::from("a.rv"));
+        let err = resolve_imports(
+            &file,
+            &mut scope,
+            &mut loader,
+            &mut imports,
+            &mut in_progress,
+        )
+        .unwrap_err();
+        match err {
+            RavenError::Resolve(ResolveError::CyclicImport(_), _, _) => {}
+            other => panic!("expected CyclicImport, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn missing_local_file_is_unresolved() {
+        let file = parse_src("import \"./gone\"\n", "main.rv");
+        let mut loader = MapLoader::default();
+        let mut scope = ScopeStack::new();
+        let mut imports = Vec::new();
+        let mut in_progress = HashSet::new();
+        let err = resolve_imports(
+            &file,
+            &mut scope,
+            &mut loader,
+            &mut imports,
+            &mut in_progress,
+        )
+        .unwrap_err();
+        match err {
+            RavenError::Resolve(ResolveError::UnresolvedImport(p), _, _) => {
+                assert_eq!(p, "./gone");
+            }
+            other => panic!("expected UnresolvedImport, got {:?}", other),
+        }
+    }
+}

--- a/src/resolve/items.rs
+++ b/src/resolve/items.rs
@@ -1,0 +1,150 @@
+//! Item collection: the first resolver pass.
+//!
+//! Walks the top level of an [`ast::File`] and inserts every declared
+//! name into the module scope. After this pass runs, the second pass
+//! (body walk) can resolve forward references because every item is
+//! already visible in the module scope.
+//!
+//! This module does NOT walk function bodies, expression initializers,
+//! or anything below the top level. It also does not resolve imports;
+//! that lives in [`super::imports`] and runs interleaved with this pass
+//! at the same module scope.
+
+use crate::ast::{Decl, DeclKind, File};
+use crate::error::RavenError;
+
+use super::bindings::{Binding, DeclId};
+use super::scope::ScopeStack;
+
+/// Collect every top level declaration into `scope` as the module
+/// scope. Returns the first duplicate declaration error encountered, if
+/// any.
+///
+/// Import declarations are skipped here: [`super::imports::resolve_imports`]
+/// processes them so that import aliases can be inserted with full target
+/// information.
+pub fn collect_items(file: &File, scope: &mut ScopeStack) -> Result<(), RavenError> {
+    for (idx, decl) in file.items.iter().enumerate() {
+        let id = DeclId(idx);
+        collect_decl(decl, id, scope)?;
+    }
+    Ok(())
+}
+
+fn collect_decl(decl: &Decl, id: DeclId, scope: &mut ScopeStack) -> Result<(), RavenError> {
+    match &decl.kind {
+        DeclKind::Function(f) => {
+            scope.insert(&f.name, Binding::Function(id), decl.span.clone())?;
+        }
+        DeclKind::Struct(s) => {
+            scope.insert(&s.name, Binding::Struct(id), decl.span.clone())?;
+        }
+        DeclKind::Trait(t) => {
+            scope.insert(&t.name, Binding::Trait(id), decl.span.clone())?;
+        }
+        DeclKind::Enum(e) => {
+            scope.insert(&e.name, Binding::Enum(id), decl.span.clone())?;
+            // Variants are not inserted at module level. They are
+            // accessed through the enum name (`Color::Red`) at use
+            // sites, and that lookup is the type checker's job.
+        }
+        DeclKind::Extern(ext) => {
+            for (item_index, item) in ext.items.iter().enumerate() {
+                scope.insert(
+                    &item.name,
+                    Binding::Extern {
+                        decl_id: id,
+                        item_index,
+                    },
+                    item.span.clone(),
+                )?;
+            }
+        }
+        DeclKind::Const(c) => {
+            scope.insert(&c.name, Binding::Const(id), decl.span.clone())?;
+        }
+        DeclKind::Let(l) => {
+            scope.insert(&l.name, Binding::Static(id), decl.span.clone())?;
+        }
+        DeclKind::Impl(_) => {
+            // Impl blocks declare no module level name. Their items are
+            // discovered through the implementing type at use sites,
+            // which the type checker handles.
+        }
+        DeclKind::Import(_) => {
+            // Handled by `imports::resolve_imports`.
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lexer::Lexer;
+    use crate::parser::parse;
+    use std::path::PathBuf;
+
+    use super::super::scope::{ScopeKind, ScopeStack};
+    use super::*;
+
+    fn parse_src(src: &str) -> File {
+        let tokens = Lexer::new(src.to_string(), PathBuf::from("test.rv"))
+            .tokenize()
+            .expect("lex");
+        parse(&tokens).expect("parse")
+    }
+
+    #[test]
+    fn collects_functions_and_structs() {
+        let file = parse_src("fun foo() {}\nstruct Point { x: Int, y: Int }\nfun bar() {}\n");
+        let mut s = ScopeStack::new();
+        collect_items(&file, &mut s).unwrap();
+        let foo = s.lookup("foo").expect("foo bound");
+        assert!(matches!(foo.binding, Binding::Function(_)));
+        let pt = s.lookup("Point").expect("Point bound");
+        assert!(matches!(pt.binding, Binding::Struct(_)));
+        let bar = s.lookup("bar").expect("bar bound");
+        assert!(matches!(bar.binding, Binding::Function(_)));
+    }
+
+    #[test]
+    fn duplicate_top_level_name_is_error() {
+        let file = parse_src("fun dup() {}\nfun dup() {}\n");
+        let mut s = ScopeStack::new();
+        let err = collect_items(&file, &mut s).unwrap_err();
+        assert!(matches!(err, RavenError::Resolve(_, _, _)));
+    }
+
+    #[test]
+    fn extern_items_become_module_bindings() {
+        let file = parse_src("extern \"C\" {\nfun puts(s: String) -> Int\n}\n");
+        let mut s = ScopeStack::new();
+        collect_items(&file, &mut s).unwrap();
+        let p = s.lookup("puts").expect("extern fn bound");
+        assert!(matches!(p.binding, Binding::Extern { .. }));
+    }
+
+    #[test]
+    fn impl_blocks_add_no_module_names() {
+        let file = parse_src("struct Point { x: Int }\nimpl Point { fun get(self) -> Int = 1 }\n");
+        let mut s = ScopeStack::new();
+        collect_items(&file, &mut s).unwrap();
+        // Point is in scope, `get` is not (it's reachable only through
+        // method dispatch on Point, handled later).
+        assert!(s.lookup("Point").is_some());
+        assert!(s.lookup("get").is_none());
+        assert_eq!(s.current_kind(), ScopeKind::Module);
+    }
+
+    #[test]
+    fn const_and_let_become_module_bindings() {
+        let file = parse_src("const PI: Int = 3\nlet counter: Int = 0\n");
+        let mut s = ScopeStack::new();
+        collect_items(&file, &mut s).unwrap();
+        assert!(matches!(s.lookup("PI").unwrap().binding, Binding::Const(_)));
+        assert!(matches!(
+            s.lookup("counter").unwrap().binding,
+            Binding::Static(_)
+        ));
+    }
+}

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -1,9 +1,9 @@
 //! Name resolution for the v2 compiler.
 //!
-//! The resolver walks an [`ast::File`], binds every identifier use to
-//! the declaration it refers to, and resolves every import to its
-//! target. The output is a [`ResolvedFile`] that pairs the original
-//! AST with a [`ResolutionMap`].
+//! The resolver walks an [`crate::ast::File`], binds every identifier
+//! use to the declaration it refers to, and resolves every import to
+//! its target. The output is a [`ResolvedFile`] that pairs the
+//! original AST with a [`ResolutionMap`] and the resolved import list.
 //!
 //! See `docs/v2/specs/resolver.md` for the full design.
 
@@ -11,10 +11,63 @@ pub mod bindings;
 pub mod imports;
 pub mod items;
 pub mod scope;
+pub mod walk;
 
-pub use imports::{FsLoader, LoadedSource, SourceLoader};
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashSet;
+
+use crate::ast::File;
+use crate::error::RavenError;
 
 pub use bindings::{
     Binding, DeclId, ImportId, ImportTarget, ResolutionMap, ResolvedImport, UseKey,
 };
+pub use imports::{FsLoader, LoadedSource, SourceLoader, STDLIB_MODULES};
 pub use scope::{Scope, ScopeKind, ScopeStack};
+
+/// The resolver output for a single file.
+///
+/// The resolver borrows the AST during walking but does not mutate it
+/// or take ownership; the [`File`] is re exposed here for convenience.
+#[derive(Debug, Clone)]
+pub struct ResolvedFile<'a> {
+    pub file: &'a File,
+    pub map: ResolutionMap,
+    pub module_scope: ScopeStack,
+}
+
+/// Resolve `file` using `loader` for any local imports it contains.
+///
+/// Returns a [`ResolvedFile`] on success or the first
+/// [`RavenError::Resolve`] encountered. The function is the canonical
+/// entry point for the resolver; downstream stages should call it once
+/// per source file.
+pub fn resolve_file<'a>(
+    file: &'a File,
+    loader: &mut dyn SourceLoader,
+) -> Result<ResolvedFile<'a>, RavenError> {
+    let mut scope = ScopeStack::new();
+    let mut map = ResolutionMap::new();
+    let mut imports_out = Vec::new();
+    let mut in_progress: HashSet<std::path::PathBuf> = HashSet::new();
+    in_progress.insert((*file.span.file).clone());
+
+    // Pass 1a: collect every top level item into the module scope.
+    items::collect_items(file, &mut scope)?;
+
+    // Pass 1b: resolve imports and merge their bindings into the same
+    // module scope.
+    imports::resolve_imports(file, &mut scope, loader, &mut imports_out, &mut in_progress)?;
+    map.imports = imports_out;
+
+    // Pass 2: walk every body, binding identifier uses.
+    walk::walk_file(file, &mut scope, &mut map)?;
+
+    Ok(ResolvedFile {
+        file,
+        map,
+        module_scope: scope,
+    })
+}

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -8,8 +8,11 @@
 //! See `docs/v2/specs/resolver.md` for the full design.
 
 pub mod bindings;
+pub mod imports;
 pub mod items;
 pub mod scope;
+
+pub use imports::{FsLoader, LoadedSource, SourceLoader};
 
 pub use bindings::{
     Binding, DeclId, ImportId, ImportTarget, ResolutionMap, ResolvedImport, UseKey,

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -1,0 +1,16 @@
+//! Name resolution for the v2 compiler.
+//!
+//! The resolver walks an [`ast::File`], binds every identifier use to
+//! the declaration it refers to, and resolves every import to its
+//! target. The output is a [`ResolvedFile`] that pairs the original
+//! AST with a [`ResolutionMap`].
+//!
+//! See `docs/v2/specs/resolver.md` for the full design.
+
+pub mod bindings;
+pub mod scope;
+
+pub use bindings::{
+    Binding, DeclId, ImportId, ImportTarget, ResolutionMap, ResolvedImport, UseKey,
+};
+pub use scope::{Scope, ScopeKind, ScopeStack};

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -8,6 +8,7 @@
 //! See `docs/v2/specs/resolver.md` for the full design.
 
 pub mod bindings;
+pub mod items;
 pub mod scope;
 
 pub use bindings::{

--- a/src/resolve/scope.rs
+++ b/src/resolve/scope.rs
@@ -1,0 +1,231 @@
+//! Lexical scope stack used by the resolver.
+//!
+//! Scopes are a linked list of frames, each holding a `name -> Binding`
+//! map and a [`ScopeKind`] tag. Lookups walk innermost to outermost and
+//! return the first match (shadowing). Inserting a name that already
+//! exists in the same frame is reported as a duplicate declaration.
+
+use std::collections::HashMap;
+
+use crate::error::{RavenError, ResolveError};
+use crate::span::Span;
+
+use super::bindings::Binding;
+
+/// What kind of scope a frame represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeKind {
+    /// File level scope: top level items and import aliases.
+    Module,
+    /// An `impl` block. Provides `Self` and (for methods) `self`.
+    Impl,
+    /// A function body. Holds parameters and generic parameters.
+    Function,
+    /// A `{ ... }` block expression.
+    Block,
+    /// A pattern binding scope (match arm, for head, let pattern body).
+    Pattern,
+}
+
+/// One frame on the scope stack.
+#[derive(Debug, Clone)]
+pub struct Scope {
+    pub kind: ScopeKind,
+    pub names: HashMap<String, ScopeEntry>,
+}
+
+/// One entry in a [`Scope`].
+#[derive(Debug, Clone)]
+pub struct ScopeEntry {
+    pub binding: Binding,
+    /// Where the name was first declared. Used for the
+    /// `DuplicateDeclaration` error and for the resolved use map.
+    pub declared_at: Span,
+}
+
+impl Scope {
+    /// Construct an empty scope of the given kind.
+    pub fn new(kind: ScopeKind) -> Self {
+        Scope {
+            kind,
+            names: HashMap::new(),
+        }
+    }
+}
+
+/// A stack of scopes. The innermost frame is the last element.
+#[derive(Debug, Clone, Default)]
+pub struct ScopeStack {
+    frames: Vec<Scope>,
+}
+
+impl ScopeStack {
+    /// Construct a stack with a single empty `Module` frame.
+    pub fn new() -> Self {
+        ScopeStack {
+            frames: vec![Scope::new(ScopeKind::Module)],
+        }
+    }
+
+    /// Push a fresh frame of the given kind.
+    pub fn push(&mut self, kind: ScopeKind) {
+        self.frames.push(Scope::new(kind));
+    }
+
+    /// Pop the innermost frame. Panics if only the root remains; this is
+    /// a resolver bug rather than a user error.
+    pub fn pop(&mut self) {
+        assert!(self.frames.len() > 1, "cannot pop the module scope");
+        self.frames.pop();
+    }
+
+    /// The current innermost scope kind.
+    pub fn current_kind(&self) -> ScopeKind {
+        self.frames.last().expect("scope stack is never empty").kind
+    }
+
+    /// Insert a new binding into the innermost frame. Returns
+    /// `DuplicateDeclaration` if the name is already present there.
+    pub fn insert(
+        &mut self,
+        name: &str,
+        binding: Binding,
+        declared_at: Span,
+    ) -> Result<(), RavenError> {
+        let top = self.frames.last_mut().expect("scope stack is never empty");
+        if let Some(prev) = top.names.get(name) {
+            return Err(RavenError::resolve(
+                ResolveError::DuplicateDeclaration {
+                    name: name.to_string(),
+                    first_span: prev.declared_at.clone(),
+                },
+                declared_at,
+            ));
+        }
+        top.names.insert(
+            name.to_string(),
+            ScopeEntry {
+                binding,
+                declared_at,
+            },
+        );
+        Ok(())
+    }
+
+    /// Insert a binding, but allow shadowing (used by `let` inside
+    /// blocks and pattern bindings, which shadow outer names but never
+    /// conflict at module level).
+    pub fn insert_shadowing(&mut self, name: &str, binding: Binding, declared_at: Span) {
+        let top = self.frames.last_mut().expect("scope stack is never empty");
+        top.names.insert(
+            name.to_string(),
+            ScopeEntry {
+                binding,
+                declared_at,
+            },
+        );
+    }
+
+    /// Look up `name` starting from the innermost frame.
+    pub fn lookup(&self, name: &str) -> Option<&ScopeEntry> {
+        for frame in self.frames.iter().rev() {
+            if let Some(entry) = frame.names.get(name) {
+                return Some(entry);
+            }
+        }
+        None
+    }
+
+    /// True if any enclosing frame is an `Impl` scope.
+    pub fn in_impl(&self) -> bool {
+        self.frames.iter().any(|f| f.kind == ScopeKind::Impl)
+    }
+
+    /// Borrow the module (root) frame's name map.
+    pub fn module_names(&self) -> &HashMap<String, ScopeEntry> {
+        &self.frames[0].names
+    }
+}
+
+#[cfg(test)]
+mod scope_tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use super::super::bindings::{Binding, DeclId};
+    use super::*;
+
+    fn span(start: usize, end: usize) -> Span {
+        Span::new(
+            Arc::new(PathBuf::from("test.rv")),
+            start,
+            end,
+            1,
+            (start as u32) + 1,
+        )
+    }
+
+    #[test]
+    fn root_frame_is_module() {
+        let s = ScopeStack::new();
+        assert_eq!(s.current_kind(), ScopeKind::Module);
+    }
+
+    #[test]
+    fn push_and_pop_changes_kind() {
+        let mut s = ScopeStack::new();
+        s.push(ScopeKind::Function);
+        assert_eq!(s.current_kind(), ScopeKind::Function);
+        s.pop();
+        assert_eq!(s.current_kind(), ScopeKind::Module);
+    }
+
+    #[test]
+    fn insert_then_lookup_returns_binding() {
+        let mut s = ScopeStack::new();
+        s.insert("foo", Binding::Function(DeclId(0)), span(0, 3))
+            .unwrap();
+        let entry = s.lookup("foo").expect("should resolve");
+        assert!(matches!(entry.binding, Binding::Function(DeclId(0))));
+    }
+
+    #[test]
+    fn duplicate_in_same_frame_is_error() {
+        let mut s = ScopeStack::new();
+        s.insert("foo", Binding::Function(DeclId(0)), span(0, 3))
+            .unwrap();
+        let err = s
+            .insert("foo", Binding::Function(DeclId(1)), span(10, 13))
+            .unwrap_err();
+        match err {
+            RavenError::Resolve(ResolveError::DuplicateDeclaration { name, .. }, _, _) => {
+                assert_eq!(name, "foo");
+            }
+            other => panic!("expected DuplicateDeclaration, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn inner_scope_shadows_outer() {
+        let mut s = ScopeStack::new();
+        s.insert("x", Binding::Function(DeclId(0)), span(0, 1))
+            .unwrap();
+        s.push(ScopeKind::Block);
+        s.insert_shadowing("x", Binding::Local(span(10, 11)), span(10, 11));
+        let entry = s.lookup("x").unwrap();
+        assert!(matches!(entry.binding, Binding::Local(_)));
+        s.pop();
+        let entry = s.lookup("x").unwrap();
+        assert!(matches!(entry.binding, Binding::Function(_)));
+    }
+
+    #[test]
+    fn in_impl_detects_enclosing_impl_frame() {
+        let mut s = ScopeStack::new();
+        assert!(!s.in_impl());
+        s.push(ScopeKind::Impl);
+        s.push(ScopeKind::Function);
+        s.push(ScopeKind::Block);
+        assert!(s.in_impl());
+    }
+}

--- a/src/resolve/tests.rs
+++ b/src/resolve/tests.rs
@@ -1,39 +1,302 @@
-//! Inline smoke test for the resolver. Real unit tests land in the
-//! next commit.
+//! Inline unit tests for the resolver public surface.
+//!
+//! These exercise the end to end pipeline (lex, parse, resolve) for
+//! the scenarios called out in `docs/v2/specs/resolver.md`'s test
+//! coverage section. Module local tests (scope mechanics, item
+//! collection, import resolution) live next to their modules.
 
 #![cfg(test)]
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::ast::File;
+use crate::error::{RavenError, ResolveError};
 use crate::lexer::Lexer;
 use crate::parser::parse;
 
+use super::bindings::Binding;
 use super::imports::{LoadedSource, SourceLoader};
 use super::resolve_file;
 
+fn parse_src(src: &str, path: &str) -> File {
+    let tokens = Lexer::new(src.to_string(), PathBuf::from(path))
+        .tokenize()
+        .expect("lex");
+    parse(&tokens).expect("parse")
+}
+
+/// Loader that never finds anything. Useful when the program has no
+/// local imports.
 struct NoLoader;
+
 impl SourceLoader for NoLoader {
     fn load(&mut self, _importing: &Path, _target: &str) -> Option<LoadedSource> {
         None
     }
 }
 
+/// Loader that serves source from an in memory map, keyed by the
+/// import string the user wrote.
+#[derive(Default)]
+struct MapLoader {
+    files: HashMap<String, (PathBuf, String)>,
+}
+
+impl MapLoader {
+    fn add(&mut self, key: &str, canon: &str, src: &str) -> &mut Self {
+        self.files
+            .insert(key.to_string(), (PathBuf::from(canon), src.to_string()));
+        self
+    }
+}
+
+impl SourceLoader for MapLoader {
+    fn load(&mut self, _importing: &Path, target: &str) -> Option<LoadedSource> {
+        let (p, s) = self.files.get(target)?;
+        Some(LoadedSource {
+            canonical_path: p.clone(),
+            source: s.clone(),
+        })
+    }
+}
+
 #[test]
-fn smoke_resolves_arithmetic_function() {
-    let src = "fun mix(a: Int, b: Int, c: Int) -> Int = a + b * c - (a / b) % c\n";
-    let tokens = Lexer::new(src.to_string(), PathBuf::from("test.rv"))
-        .tokenize()
-        .unwrap();
-    let file = parse(&tokens).unwrap();
-    let mut loader = NoLoader;
-    let resolved = resolve_file(&file, &mut loader).expect("resolve should succeed");
-    // The body references `a`, `b`, `c` each twice; each should be
-    // bound as a parameter.
-    let param_uses = resolved
+fn parameter_use_resolves_to_param_binding() {
+    let file = parse_src("fun id(x: Int) -> Int = x\n", "test.rv");
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    let param_uses: Vec<_> = r
         .map
         .uses
         .values()
-        .filter(|b| matches!(b, super::Binding::Param(_)))
-        .count();
-    assert_eq!(param_uses, 6);
+        .filter(|b| matches!(b, Binding::Param(_)))
+        .collect();
+    assert_eq!(param_uses.len(), 1);
+}
+
+#[test]
+fn forward_function_reference_resolves() {
+    // `bar` calls `foo`, but `foo` is declared later in the file. The
+    // two pass resolver should accept this.
+    let file = parse_src("fun bar() { foo() }\nfun foo() {}\n", "test.rv");
+    let r = resolve_file(&file, &mut NoLoader).expect("forward ref ok");
+    let fn_uses: Vec<_> = r
+        .map
+        .uses
+        .values()
+        .filter(|b| matches!(b, Binding::Function(_)))
+        .collect();
+    assert!(!fn_uses.is_empty());
+}
+
+#[test]
+fn unresolved_name_in_body_is_error() {
+    let file = parse_src("fun main() { mystery_name() }\n", "test.rv");
+    let err = resolve_file(&file, &mut NoLoader).unwrap_err();
+    match err {
+        RavenError::Resolve(ResolveError::UnresolvedName(name), _, _) => {
+            assert_eq!(name, "mystery_name");
+        }
+        other => panic!("expected UnresolvedName, got {:?}", other),
+    }
+}
+
+#[test]
+fn duplicate_top_level_declaration_is_error() {
+    let file = parse_src("fun dup() {}\nfun dup() {}\n", "test.rv");
+    let err = resolve_file(&file, &mut NoLoader).unwrap_err();
+    matches!(
+        err,
+        RavenError::Resolve(ResolveError::DuplicateDeclaration { .. }, _, _)
+    );
+}
+
+#[test]
+fn inner_let_shadows_outer_let() {
+    let file = parse_src(
+        "fun f() {\n    let x = 1\n    {\n        let x = 2\n        x\n    }\n}\n",
+        "test.rv",
+    );
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    // Two `let` bindings + one use site. The use site should resolve
+    // to a Local (the inner shadowing one).
+    let local_uses: Vec<_> = r
+        .map
+        .uses
+        .values()
+        .filter(|b| matches!(b, Binding::Local(_)))
+        .collect();
+    assert_eq!(local_uses.len(), 1);
+}
+
+#[test]
+fn self_outside_impl_is_an_error() {
+    let file = parse_src("fun f() { self.x }\n", "test.rv");
+    let err = resolve_file(&file, &mut NoLoader).unwrap_err();
+    matches!(
+        err,
+        RavenError::Resolve(ResolveError::SelfOutsideImpl, _, _)
+    );
+}
+
+#[test]
+fn self_inside_impl_is_ok() {
+    let file = parse_src(
+        "struct Point { x: Int }\nimpl Point {\n    fun get(self) -> Int = self.x\n}\n",
+        "test.rv",
+    );
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    let has_self_value = r.map.uses.values().any(|b| matches!(b, Binding::SelfValue));
+    assert!(has_self_value, "expected at least one SelfValue use");
+}
+
+#[test]
+fn self_upper_inside_impl_resolves_to_self_type() {
+    let file = parse_src(
+        "struct Pair { x: Int, y: Int }\nimpl Pair {\n    fun make() -> Self { Pair { x: 1, y: 2 } }\n}\n",
+        "test.rv",
+    );
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    let has_self_type = r.map.uses.values().any(|b| matches!(b, Binding::SelfType));
+    assert!(has_self_type, "expected SelfType use");
+}
+
+#[test]
+fn function_parameter_in_scope_for_body() {
+    let file = parse_src("fun add(a: Int, b: Int) -> Int = a + b\n", "test.rv");
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    let params: Vec<_> = r
+        .map
+        .uses
+        .values()
+        .filter(|b| matches!(b, Binding::Param(_)))
+        .collect();
+    assert_eq!(params.len(), 2);
+}
+
+#[test]
+fn generic_parameter_is_in_scope_in_signature() {
+    let file = parse_src("fun id<T>(x: T) -> T = x\n", "test.rv");
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    // T appears in two signature positions; both should resolve to a
+    // generic parameter binding.
+    let generic_uses: Vec<_> = r
+        .map
+        .uses
+        .values()
+        .filter(|b| matches!(b, Binding::GenericParam { .. }))
+        .collect();
+    assert_eq!(generic_uses.len(), 2);
+}
+
+#[test]
+fn pattern_binding_introduces_name() {
+    let file = parse_src(
+        "fun classify(n: Int) -> Int {\n    match n {\n        x -> x + 1\n    }\n}\n",
+        "test.rv",
+    );
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    let pat_uses: Vec<_> = r
+        .map
+        .uses
+        .values()
+        .filter(|b| matches!(b, Binding::PatternBinding(_)))
+        .collect();
+    // `x` appears once in the body (the LHS in the match arm is the
+    // declaration, the RHS is the use).
+    assert_eq!(pat_uses.len(), 1);
+}
+
+#[test]
+fn import_alias_is_bound_at_module_level() {
+    let file = parse_src("import std/io\nfun main() {}\n", "main.rv");
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    let alias = r
+        .module_scope
+        .lookup("io")
+        .expect("io alias should be bound");
+    assert!(matches!(alias.binding, Binding::ImportAlias(_)));
+}
+
+#[test]
+fn import_selector_binds_inner_name() {
+    let file = parse_src(
+        "import std/io { println }\nfun main() { println(\"hi\") }\n",
+        "main.rv",
+    );
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    let used = r
+        .map
+        .uses
+        .values()
+        .any(|b| matches!(b, Binding::ImportedItem { .. }));
+    assert!(used, "println call should resolve to ImportedItem");
+}
+
+#[test]
+fn local_recursive_import_chain_resolves() {
+    let file = parse_src("import \"./helpers\"\nfun main() { helpers }\n", "main.rv");
+    let mut loader = MapLoader::default();
+    loader.add("./helpers", "helpers.rv", "fun greet() {}\n");
+    let r = resolve_file(&file, &mut loader).expect("ok");
+    let used = r
+        .map
+        .uses
+        .values()
+        .any(|b| matches!(b, Binding::ImportAlias(_)));
+    assert!(used, "helpers reference should resolve to ImportAlias");
+}
+
+#[test]
+fn cyclic_local_imports_are_reported() {
+    let file = parse_src("import \"./b\"\nfun main() {}\n", "a.rv");
+    let mut loader = MapLoader::default();
+    loader
+        .add("./a", "a.rv", "import \"./b\"\nfun main() {}\n")
+        .add("./b", "b.rv", "import \"./a\"\n");
+    let err = resolve_file(&file, &mut loader).unwrap_err();
+    matches!(
+        err,
+        RavenError::Resolve(ResolveError::CyclicImport(_), _, _)
+    );
+}
+
+#[test]
+fn unknown_stdlib_module_is_unresolved() {
+    let file = parse_src("import std/nonsense\n", "main.rv");
+    let err = resolve_file(&file, &mut NoLoader).unwrap_err();
+    match err {
+        RavenError::Resolve(ResolveError::UnresolvedImport(p), _, _) => {
+            assert!(p.contains("nonsense"));
+        }
+        other => panic!("expected UnresolvedImport, got {:?}", other),
+    }
+}
+
+#[test]
+fn struct_field_type_resolves_to_struct() {
+    let file = parse_src(
+        "struct Inner { v: Int }\nstruct Outer { inner: Inner }\n",
+        "test.rv",
+    );
+    let r = resolve_file(&file, &mut NoLoader).expect("ok");
+    let has_struct_use = r.map.uses.values().any(|b| matches!(b, Binding::Struct(_)));
+    assert!(has_struct_use, "Inner should be referenced as a Struct");
+}
+
+#[test]
+fn enum_use_resolves_to_enum_binding() {
+    let file = parse_src(
+        "enum Color { Red, Green, Blue }\nfun first() -> Color { Red }\n",
+        "test.rv",
+    );
+    // `first` references `Red` directly, which is not in module scope.
+    // It must therefore fail to resolve at this layer; the type
+    // checker can lift enum constructors into scope through their
+    // enum's name at a later pass.
+    let err = resolve_file(&file, &mut NoLoader).unwrap_err();
+    matches!(
+        err,
+        RavenError::Resolve(ResolveError::UnresolvedName(_), _, _)
+    );
 }

--- a/src/resolve/tests.rs
+++ b/src/resolve/tests.rs
@@ -1,0 +1,39 @@
+//! Inline smoke test for the resolver. Real unit tests land in the
+//! next commit.
+
+#![cfg(test)]
+
+use std::path::{Path, PathBuf};
+
+use crate::lexer::Lexer;
+use crate::parser::parse;
+
+use super::imports::{LoadedSource, SourceLoader};
+use super::resolve_file;
+
+struct NoLoader;
+impl SourceLoader for NoLoader {
+    fn load(&mut self, _importing: &Path, _target: &str) -> Option<LoadedSource> {
+        None
+    }
+}
+
+#[test]
+fn smoke_resolves_arithmetic_function() {
+    let src = "fun mix(a: Int, b: Int, c: Int) -> Int = a + b * c - (a / b) % c\n";
+    let tokens = Lexer::new(src.to_string(), PathBuf::from("test.rv"))
+        .tokenize()
+        .unwrap();
+    let file = parse(&tokens).unwrap();
+    let mut loader = NoLoader;
+    let resolved = resolve_file(&file, &mut loader).expect("resolve should succeed");
+    // The body references `a`, `b`, `c` each twice; each should be
+    // bound as a parameter.
+    let param_uses = resolved
+        .map
+        .uses
+        .values()
+        .filter(|b| matches!(b, super::Binding::Param(_)))
+        .count();
+    assert_eq!(param_uses, 6);
+}

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -515,6 +515,31 @@ fn walk_type_path(
     // segments are member lookups against the leading binding and are
     // the type checker's responsibility.
     let head = &path.segments[0];
+    // `Self` is bound by an `impl` frame on the scope stack. If
+    // present there it resolves to `SelfType`; otherwise the lookup
+    // below raises `UnresolvedName`, which the dedicated check inside
+    // `walk_expr` for `ExprKind::SelfUpper` already covers in
+    // expression position.
+    if head.name == "Self" {
+        if let Some(entry) = scope.lookup("Self") {
+            let binding = entry.binding.clone();
+            map.bind_use(&head.span, binding);
+            for g in &head.generics {
+                walk_type(g, scope, map)?;
+            }
+            for seg in &path.segments[1..] {
+                for g in &seg.generics {
+                    walk_type(g, scope, map)?;
+                }
+            }
+            return Ok(());
+        }
+        return Err(RavenError::resolve(
+            ResolveError::SelfOutsideImpl,
+            head.span.clone(),
+        ));
+    }
+
     // Built in primitive type names are unconditionally accepted; the
     // type checker is responsible for assigning them concrete kinds.
     if is_builtin_type_name(&head.name) {
@@ -560,7 +585,6 @@ fn is_builtin_type_name(name: &str) -> bool {
             | "String"
             | "Char"
             | "Unit"
-            | "Self"
             | "Array"
             | "Option"
             | "Result"

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -1,0 +1,573 @@
+//! Body walk: the second resolver pass.
+//!
+//! Walks every declaration body and inner expression in the file,
+//! recording use site bindings in a [`ResolutionMap`]. The module
+//! scope and import bindings must already be populated by
+//! [`super::items::collect_items`] and
+//! [`super::imports::resolve_imports`].
+//!
+//! The walker is structured as recursive `walk_*` functions, one per
+//! AST node category. Each function owns its local scope frames and is
+//! responsible for popping anything it pushes.
+
+use crate::ast::{
+    Block, Decl, DeclKind, Enum, ExprKind, File, FunctionBody, Impl, LambdaBody, Pattern,
+    PatternKind, Stmt, StmtKind, Trait, TypeKind, TypePath, VariantPayload,
+};
+use crate::ast::{Expr, Struct, Type};
+use crate::error::{RavenError, ResolveError};
+use crate::span::Span;
+
+use super::bindings::{Binding, DeclId, ResolutionMap};
+use super::scope::{ScopeKind, ScopeStack};
+
+/// Walk every body in `file`, recording bindings in `map`.
+pub fn walk_file(
+    file: &File,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    for (idx, decl) in file.items.iter().enumerate() {
+        walk_decl(decl, DeclId(idx), scope, map)?;
+    }
+    Ok(())
+}
+
+fn walk_decl(
+    decl: &Decl,
+    id: DeclId,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    match &decl.kind {
+        DeclKind::Function(f) => {
+            scope.push(ScopeKind::Function);
+            push_generics(scope, &f.generics, &decl.span)?;
+            for p in &f.params {
+                scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+                walk_type(&p.ty, scope, map)?;
+            }
+            if let Some(r) = &f.ret {
+                walk_type(r, scope, map)?;
+            }
+            walk_function_body(&f.body, scope, map)?;
+            scope.pop();
+        }
+        DeclKind::Struct(s) => walk_struct(s, scope, map)?,
+        DeclKind::Trait(t) => walk_trait(t, scope, map)?,
+        DeclKind::Enum(e) => walk_enum(e, scope, map)?,
+        DeclKind::Impl(i) => walk_impl(i, id, scope, map)?,
+        DeclKind::Extern(ext) => {
+            for item in &ext.items {
+                for p in &item.params {
+                    walk_type(&p.ty, scope, map)?;
+                }
+                if let Some(r) = &item.ret {
+                    walk_type(r, scope, map)?;
+                }
+            }
+        }
+        DeclKind::Const(c) => {
+            walk_type(&c.ty, scope, map)?;
+            walk_expr(&c.value, scope, map)?;
+        }
+        DeclKind::Let(l) => {
+            if let Some(t) = &l.ty {
+                walk_type(t, scope, map)?;
+            }
+            if let Some(e) = &l.init {
+                walk_expr(e, scope, map)?;
+            }
+        }
+        DeclKind::Import(_) => {
+            // Already resolved by the imports pass.
+        }
+    }
+    Ok(())
+}
+
+fn walk_struct(
+    s: &Struct,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    scope.push(ScopeKind::Function);
+    push_generics(scope, &s.generics, &s.span)?;
+    for f in &s.fields {
+        walk_type(&f.ty, scope, map)?;
+    }
+    scope.pop();
+    Ok(())
+}
+
+fn walk_trait(
+    t: &Trait,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    scope.push(ScopeKind::Function);
+    push_generics(scope, &t.generics, &t.span)?;
+    for member in &t.members {
+        scope.push(ScopeKind::Function);
+        push_generics(scope, &member.generics, &member.span)?;
+        for p in &member.params {
+            scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+            walk_type(&p.ty, scope, map)?;
+        }
+        if let Some(r) = &member.ret {
+            walk_type(r, scope, map)?;
+        }
+        walk_function_body(&member.body, scope, map)?;
+        scope.pop();
+    }
+    scope.pop();
+    Ok(())
+}
+
+fn walk_enum(e: &Enum, scope: &mut ScopeStack, map: &mut ResolutionMap) -> Result<(), RavenError> {
+    scope.push(ScopeKind::Function);
+    push_generics(scope, &e.generics, &e.span)?;
+    for v in &e.variants {
+        match &v.payload {
+            VariantPayload::Unit => {}
+            VariantPayload::Tuple(tys) => {
+                for t in tys {
+                    walk_type(t, scope, map)?;
+                }
+            }
+            VariantPayload::Struct(fields) => {
+                for f in fields {
+                    walk_type(&f.ty, scope, map)?;
+                }
+            }
+        }
+    }
+    scope.pop();
+    Ok(())
+}
+
+fn walk_impl(
+    i: &Impl,
+    _id: DeclId,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    scope.push(ScopeKind::Impl);
+    push_generics(scope, &i.generics, &i.span)?;
+    // Bind Self to the implementing type. The "implementing type" is
+    // `for_type` if present (trait impl), else `trait_or_type` (inherent
+    // impl).
+    let _ = scope.insert("Self", Binding::SelfType, i.span.clone());
+    // Resolve the type path(s) in the head.
+    walk_type_path(&i.trait_or_type, scope, map)?;
+    if let Some(for_ty) = &i.for_type {
+        walk_type_path(for_ty, scope, map)?;
+    }
+    for item in &i.items {
+        scope.push(ScopeKind::Function);
+        push_generics(scope, &item.generics, &item.span)?;
+        for p in &item.params {
+            if p.name == "self" {
+                scope.insert_shadowing("self", Binding::SelfValue, p.span.clone());
+            } else {
+                scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+                walk_type(&p.ty, scope, map)?;
+            }
+        }
+        if let Some(r) = &item.ret {
+            walk_type(r, scope, map)?;
+        }
+        walk_function_body(&item.body, scope, map)?;
+        scope.pop();
+    }
+    scope.pop();
+    Ok(())
+}
+
+fn push_generics(
+    scope: &mut ScopeStack,
+    generics: &[crate::ast::GenericParam],
+    owner: &Span,
+) -> Result<(), RavenError> {
+    for g in generics {
+        scope.insert(
+            &g.name,
+            Binding::GenericParam {
+                owner: owner.clone(),
+                name: g.name.clone(),
+            },
+            g.span.clone(),
+        )?;
+        // Trait bounds are themselves type paths and need their leading
+        // name resolved against the current scope.
+        for bound in &g.bounds {
+            walk_type_path(bound, scope, &mut ResolutionMap::new())?;
+        }
+    }
+    Ok(())
+}
+
+fn walk_function_body(
+    body: &FunctionBody,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    match body {
+        FunctionBody::Block(b) => walk_block(b, scope, map),
+        FunctionBody::Expr(e) => walk_expr(e, scope, map),
+        FunctionBody::None => Ok(()),
+    }
+}
+
+fn walk_block(
+    block: &Block,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    scope.push(ScopeKind::Block);
+    for stmt in &block.stmts {
+        walk_stmt(stmt, scope, map)?;
+    }
+    if let Some(t) = &block.trailing {
+        walk_expr(t, scope, map)?;
+    }
+    scope.pop();
+    Ok(())
+}
+
+fn walk_stmt(
+    stmt: &Stmt,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    match &stmt.kind {
+        StmtKind::Let { name, ty, init } => {
+            if let Some(t) = ty {
+                walk_type(t, scope, map)?;
+            }
+            if let Some(e) = init {
+                walk_expr(e, scope, map)?;
+            }
+            scope.insert_shadowing(name, Binding::Local(stmt.span.clone()), stmt.span.clone());
+        }
+        StmtKind::Return(e) => {
+            if let Some(e) = e {
+                walk_expr(e, scope, map)?;
+            }
+        }
+        StmtKind::Break(e) => {
+            if let Some(e) = e {
+                walk_expr(e, scope, map)?;
+            }
+        }
+        StmtKind::Continue => {}
+        StmtKind::Defer(e) => walk_expr(e, scope, map)?,
+        StmtKind::Assign { target, value, .. } => {
+            walk_expr(target, scope, map)?;
+            walk_expr(value, scope, map)?;
+        }
+        StmtKind::Expr(e) => walk_expr(e, scope, map)?,
+    }
+    Ok(())
+}
+
+fn walk_expr(
+    expr: &Expr,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    match &expr.kind {
+        ExprKind::Int(_)
+        | ExprKind::Float(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Str(_)
+        | ExprKind::BlockStr(_)
+        | ExprKind::Char(_)
+        | ExprKind::CStr(_) => {}
+        ExprKind::SelfLower => {
+            if !scope.in_impl() {
+                return Err(RavenError::resolve(
+                    ResolveError::SelfOutsideImpl,
+                    expr.span.clone(),
+                ));
+            }
+            map.bind_use(&expr.span, Binding::SelfValue);
+        }
+        ExprKind::SelfUpper => {
+            if !scope.in_impl() {
+                return Err(RavenError::resolve(
+                    ResolveError::SelfOutsideImpl,
+                    expr.span.clone(),
+                ));
+            }
+            map.bind_use(&expr.span, Binding::SelfType);
+        }
+        ExprKind::Ident { name, generics } => {
+            let entry = scope.lookup(name).ok_or_else(|| {
+                RavenError::resolve(
+                    ResolveError::UnresolvedName(name.clone()),
+                    expr.span.clone(),
+                )
+            })?;
+            let binding = entry.binding.clone();
+            map.bind_use(&expr.span, binding);
+            for g in generics {
+                walk_type(g, scope, map)?;
+            }
+        }
+        ExprKind::StructLit {
+            name,
+            generics,
+            fields,
+        } => {
+            // The struct name itself is a use site; if it isn't in
+            // scope as a struct or import, raise UnresolvedName.
+            let entry = scope.lookup(name).ok_or_else(|| {
+                RavenError::resolve(
+                    ResolveError::UnresolvedName(name.clone()),
+                    expr.span.clone(),
+                )
+            })?;
+            // The span attached to the StructLit covers the whole
+            // literal, including the brace block. We record the
+            // binding against that span; the type checker can subset
+            // it later if needed.
+            let binding = entry.binding.clone();
+            map.bind_use(&expr.span, binding);
+            for g in generics {
+                walk_type(g, scope, map)?;
+            }
+            for f in fields {
+                walk_expr(&f.value, scope, map)?;
+            }
+        }
+        ExprKind::Array(items) | ExprKind::Tuple(items) => {
+            for e in items {
+                walk_expr(e, scope, map)?;
+            }
+        }
+        ExprKind::Paren(e) => walk_expr(e, scope, map)?,
+        ExprKind::Block(b) => walk_block(b, scope, map)?,
+        ExprKind::Unary { operand, .. } => walk_expr(operand, scope, map)?,
+        ExprKind::Binary { lhs, rhs, .. } => {
+            walk_expr(lhs, scope, map)?;
+            walk_expr(rhs, scope, map)?;
+        }
+        ExprKind::Range { start, end, .. } => {
+            walk_expr(start, scope, map)?;
+            walk_expr(end, scope, map)?;
+        }
+        ExprKind::Call { callee, args } => {
+            walk_expr(callee, scope, map)?;
+            for a in args {
+                walk_expr(a, scope, map)?;
+            }
+        }
+        ExprKind::MethodCall {
+            receiver,
+            generics,
+            args,
+            ..
+        } => {
+            walk_expr(receiver, scope, map)?;
+            for g in generics {
+                walk_type(g, scope, map)?;
+            }
+            for a in args {
+                walk_expr(a, scope, map)?;
+            }
+            // The method name itself is resolved by the type checker
+            // once the receiver type is known. We deliberately do not
+            // bind it here.
+        }
+        ExprKind::Field { receiver, .. } => walk_expr(receiver, scope, map)?,
+        ExprKind::Index { receiver, index } => {
+            walk_expr(receiver, scope, map)?;
+            walk_expr(index, scope, map)?;
+        }
+        ExprKind::Try(e) => walk_expr(e, scope, map)?,
+        ExprKind::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            walk_expr(cond, scope, map)?;
+            walk_block(then_branch, scope, map)?;
+            if let Some(eb) = else_branch {
+                match eb.as_ref() {
+                    crate::ast::ElseBranch::If(e) => walk_expr(e, scope, map)?,
+                    crate::ast::ElseBranch::Block(b) => walk_block(b, scope, map)?,
+                }
+            }
+        }
+        ExprKind::Match { scrutinee, arms } => {
+            walk_expr(scrutinee, scope, map)?;
+            for arm in arms {
+                scope.push(ScopeKind::Pattern);
+                bind_pattern(&arm.pattern, scope)?;
+                if let Some(g) = &arm.guard {
+                    walk_expr(g, scope, map)?;
+                }
+                walk_expr(&arm.body, scope, map)?;
+                scope.pop();
+            }
+        }
+        ExprKind::Loop(b) => walk_block(b, scope, map)?,
+        ExprKind::While { cond, body } => {
+            walk_expr(cond, scope, map)?;
+            walk_block(body, scope, map)?;
+        }
+        ExprKind::For {
+            pattern,
+            iter,
+            body,
+        } => {
+            walk_expr(iter, scope, map)?;
+            scope.push(ScopeKind::Pattern);
+            bind_pattern(pattern, scope)?;
+            walk_block(body, scope, map)?;
+            scope.pop();
+        }
+        ExprKind::Lambda {
+            params, ret, body, ..
+        } => {
+            scope.push(ScopeKind::Function);
+            for p in params {
+                scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+                if let Some(t) = &p.ty {
+                    walk_type(t, scope, map)?;
+                }
+            }
+            if let Some(r) = ret {
+                walk_type(r, scope, map)?;
+            }
+            match body {
+                LambdaBody::Block(b) => walk_block(b, scope, map)?,
+                LambdaBody::Expr(e) => walk_expr(e, scope, map)?,
+            }
+            scope.pop();
+        }
+    }
+    Ok(())
+}
+
+/// Bind every identifier introduced by `pattern` in the current scope
+/// (which the caller is expected to push as `ScopeKind::Pattern`).
+fn bind_pattern(pattern: &Pattern, scope: &mut ScopeStack) -> Result<(), RavenError> {
+    match &pattern.kind {
+        PatternKind::Wildcard | PatternKind::Literal(_) | PatternKind::Range { .. } => {}
+        PatternKind::Ident(name) => {
+            // An identifier in a pattern always binds a fresh name in
+            // this scope. The resolver cannot tell at this point
+            // whether the user intended to match an enum constructor
+            // (`None`, `Some(x)`); the type checker reconciles that
+            // later using the scrutinee's type.
+            scope.insert_shadowing(
+                name,
+                Binding::PatternBinding(pattern.span.clone()),
+                pattern.span.clone(),
+            );
+        }
+        PatternKind::Tuple { elements, .. } => {
+            for e in elements {
+                bind_pattern(e, scope)?;
+            }
+        }
+        PatternKind::Struct { fields, .. } => {
+            for f in fields {
+                if let Some(inner) = &f.pattern {
+                    bind_pattern(inner, scope)?;
+                } else {
+                    // Shorthand `{ name }` introduces `name` directly.
+                    scope.insert_shadowing(
+                        &f.name,
+                        Binding::PatternBinding(f.span.clone()),
+                        f.span.clone(),
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn walk_type(ty: &Type, scope: &mut ScopeStack, map: &mut ResolutionMap) -> Result<(), RavenError> {
+    match &ty.kind {
+        TypeKind::Unit => Ok(()),
+        TypeKind::Path(p) => walk_type_path(p, scope, map),
+        TypeKind::Optional(inner) => walk_type(inner, scope, map),
+        TypeKind::Dyn(p) => walk_type_path(p, scope, map),
+        TypeKind::Function { params, ret } => {
+            for p in params {
+                walk_type(p, scope, map)?;
+            }
+            walk_type(ret, scope, map)
+        }
+    }
+}
+
+fn walk_type_path(
+    path: &TypePath,
+    scope: &mut ScopeStack,
+    map: &mut ResolutionMap,
+) -> Result<(), RavenError> {
+    // The leading segment is a name we must resolve. Subsequent
+    // segments are member lookups against the leading binding and are
+    // the type checker's responsibility.
+    let head = &path.segments[0];
+    // Built in primitive type names are unconditionally accepted; the
+    // type checker is responsible for assigning them concrete kinds.
+    if is_builtin_type_name(&head.name) {
+        // Walk generic args anyway.
+        for g in &head.generics {
+            walk_type(g, scope, map)?;
+        }
+        for seg in &path.segments[1..] {
+            for g in &seg.generics {
+                walk_type(g, scope, map)?;
+            }
+        }
+        return Ok(());
+    }
+
+    let entry = scope.lookup(&head.name).ok_or_else(|| {
+        RavenError::resolve(
+            ResolveError::UnresolvedName(head.name.clone()),
+            head.span.clone(),
+        )
+    })?;
+    let binding = entry.binding.clone();
+    map.bind_use(&head.span, binding);
+    for g in &head.generics {
+        walk_type(g, scope, map)?;
+    }
+    for seg in &path.segments[1..] {
+        for g in &seg.generics {
+            walk_type(g, scope, map)?;
+        }
+    }
+    Ok(())
+}
+
+/// Builtin type names known to the resolver. These bypass scope
+/// lookup; the type checker assigns them their concrete meaning.
+fn is_builtin_type_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Int"
+            | "Float"
+            | "Bool"
+            | "String"
+            | "Char"
+            | "Unit"
+            | "Self"
+            | "Array"
+            | "Option"
+            | "Result"
+            | "Map"
+            | "Set"
+            | "Vec"
+            | "CString"
+            | "Any"
+    )
+}

--- a/tests/resolver_corpus/functions_and_params.rv
+++ b/tests/resolver_corpus/functions_and_params.rv
@@ -1,0 +1,3 @@
+fun add(a: Int, b: Int) -> Int = a + b
+fun mul(a: Int, b: Int) -> Int = a * b
+fun mix(a: Int, b: Int) -> Int = add(a, b) + mul(a, b)

--- a/tests/resolver_corpus/functions_and_params.rv.resolved
+++ b/tests/resolver_corpus/functions_and_params.rv.resolved
@@ -1,0 +1,14 @@
+(resolved
+  imports
+  uses
+    33..34 "a" -> Param@8..14
+    37..38 "b" -> Param@16..22
+    72..73 "a" -> Param@47..53
+    76..77 "b" -> Param@55..61
+    111..114 "add" -> Function(#0)
+    115..116 "a" -> Param@86..92
+    118..119 "b" -> Param@94..100
+    123..126 "mul" -> Function(#1)
+    127..128 "a" -> Param@86..92
+    130..131 "b" -> Param@94..100
+)

--- a/tests/resolver_corpus/generics.rv
+++ b/tests/resolver_corpus/generics.rv
@@ -1,0 +1,2 @@
+fun first<T>(a: T, b: T) -> T = a
+fun apply<T>(x: T) -> T = first(x, x)

--- a/tests/resolver_corpus/generics.rv.resolved
+++ b/tests/resolver_corpus/generics.rv.resolved
@@ -1,0 +1,13 @@
+(resolved
+  imports
+  uses
+    16..17 "T" -> GenericParam(T)
+    22..23 "T" -> GenericParam(T)
+    28..29 "T" -> GenericParam(T)
+    32..33 "a" -> Param@13..17
+    50..51 "T" -> GenericParam(T)
+    56..57 "T" -> GenericParam(T)
+    60..65 "first" -> Function(#0)
+    66..67 "x" -> Param@47..51
+    69..70 "x" -> Param@47..51
+)

--- a/tests/resolver_corpus/impl_and_self.rv
+++ b/tests/resolver_corpus/impl_and_self.rv
@@ -1,0 +1,9 @@
+struct Point {
+    x: Int,
+    y: Int,
+}
+
+impl Point {
+    fun origin() -> Self = Point { x: 0, y: 0 }
+    fun get_x(self) -> Int = self.x
+}

--- a/tests/resolver_corpus/impl_and_self.rv.resolved
+++ b/tests/resolver_corpus/impl_and_self.rv.resolved
@@ -1,0 +1,8 @@
+(resolved
+  imports
+  uses
+    47..52 "Point" -> Struct(#0)
+    75..79 "Self" -> SelfType
+    82..102 "Point { x: 0, y: 0 }" -> Struct(#0)
+    132..136 "self" -> SelfValue
+)

--- a/tests/resolver_corpus/imports.rv
+++ b/tests/resolver_corpus/imports.rv
@@ -1,0 +1,7 @@
+import std/io { println }
+import std/math
+
+fun main() {
+    println("hi")
+    math
+}

--- a/tests/resolver_corpus/imports.rv.resolved
+++ b/tests/resolver_corpus/imports.rv.resolved
@@ -1,0 +1,8 @@
+(resolved
+  imports
+    [0] std/io -> StdlibModule(std/io)
+    [1] std/math -> StdlibModule(std/math)
+  uses
+    60..67 "println" -> ImportedItem(#0, println)
+    78..82 "math" -> ImportAlias(#1)
+)

--- a/tests/resolver_corpus/shadowing.rv
+++ b/tests/resolver_corpus/shadowing.rv
@@ -1,0 +1,8 @@
+fun shadow() -> Int {
+    let x = 1
+    let y = {
+        let x = 2
+        x
+    }
+    x + y
+}

--- a/tests/resolver_corpus/shadowing.rv.resolved
+++ b/tests/resolver_corpus/shadowing.rv.resolved
@@ -1,0 +1,7 @@
+(resolved
+  imports
+  uses
+    76..77 "x" -> Local@58..67
+    88..89 "x" -> Local@26..35
+    92..93 "y" -> Local@40..83
+)

--- a/tests/resolver_golden.rs
+++ b/tests/resolver_golden.rs
@@ -1,0 +1,223 @@
+//! Golden snapshot tests for the resolver.
+//!
+//! Walks every `tests/resolver_corpus/*.rv`, lexes and parses the
+//! source, runs the resolver against a no op `SourceLoader`, and
+//! diffs a textual dump of the resolution map against a committed
+//! `.rv.resolved` baseline.
+//!
+//! Refresh baselines with `RAVEN_UPDATE_RESOLVER_GOLDEN=1 cargo test
+//! --test resolver_golden`.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use raven::lexer::Lexer;
+use raven::parser::parse;
+use raven::resolve::{
+    resolve_file, Binding, ImportTarget, LoadedSource, ResolutionMap, ResolvedImport, SourceLoader,
+};
+
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("resolver_corpus")
+}
+
+/// Loader that never finds anything; corpus tests never use local
+/// imports.
+struct NoLoader;
+impl SourceLoader for NoLoader {
+    fn load(&mut self, _i: &Path, _t: &str) -> Option<LoadedSource> {
+        None
+    }
+}
+
+#[test]
+fn resolver_golden() {
+    let dir = corpus_dir();
+    let update = std::env::var("RAVEN_UPDATE_RESOLVER_GOLDEN").is_ok();
+
+    let mut entries: Vec<PathBuf> = fs::read_dir(&dir)
+        .expect("corpus directory must exist")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("rv"))
+        .collect();
+    entries.sort();
+
+    assert!(!entries.is_empty(), "resolver corpus is empty");
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for src_path in entries {
+        let src = fs::read_to_string(&src_path).expect("read source");
+        let tokens = match Lexer::new(src.clone(), src_path.clone()).tokenize() {
+            Ok(t) => t,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: lex error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let file = match parse(&tokens) {
+            Ok(f) => f,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: parse error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let mut loader = NoLoader;
+        let resolved = match resolve_file(&file, &mut loader) {
+            Ok(r) => r,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: resolve error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let rendered = render_resolution(&resolved.map, &src);
+
+        let baseline = src_path.with_extension("rv.resolved");
+        if update {
+            fs::write(&baseline, &rendered).expect("write baseline");
+            continue;
+        }
+
+        match fs::read_to_string(&baseline) {
+            Ok(expected) => {
+                if normalize(&expected) != normalize(&rendered) {
+                    failures.push(format!(
+                        "snapshot mismatch for {}\n--- expected ---\n{}\n--- actual ---\n{}",
+                        src_path.display(),
+                        expected,
+                        rendered
+                    ));
+                }
+            }
+            Err(_) => failures.push(format!(
+                "missing baseline for {} (run with RAVEN_UPDATE_RESOLVER_GOLDEN=1)",
+                src_path.display()
+            )),
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} golden resolver snapshot failure(s):\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+}
+
+/// Render the resolution map as a stable, human readable dump.
+///
+/// Format:
+///
+/// ```text
+/// (resolved
+///   imports
+///     [0] std/io { println } -> StdlibModule(io)
+///   uses
+///     1:5..1:8 ident "add" -> Function
+///     ...
+/// )
+/// ```
+fn render_resolution(map: &ResolutionMap, src: &str) -> String {
+    let mut out = String::new();
+    writeln!(&mut out, "(resolved").unwrap();
+    writeln!(&mut out, "  imports").unwrap();
+    for imp in &map.imports {
+        writeln!(&mut out, "    {}", render_import(imp)).unwrap();
+    }
+    writeln!(&mut out, "  uses").unwrap();
+    for (key, binding) in map.sorted_iter() {
+        // Recover the source spelling for the use site by slicing the
+        // raw source bytes. This is robust against AST churn and gives
+        // the baseline a clear anchor.
+        let text = src
+            .get(key.start..key.end)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| String::from("<oob>"));
+        writeln!(
+            &mut out,
+            "    {}..{} \"{}\" -> {}",
+            key.start,
+            key.end,
+            escape(&text),
+            render_binding(binding)
+        )
+        .unwrap();
+    }
+    writeln!(&mut out, ")").unwrap();
+    out
+}
+
+fn render_import(imp: &ResolvedImport) -> String {
+    let target = match &imp.target {
+        ImportTarget::StdlibModule { segments } => {
+            format!("StdlibModule(std/{})", segments.join("/"))
+        }
+        ImportTarget::ExternalPackage {
+            host, user, repo, ..
+        } => format!("ExternalPackage({}/{}/{})", host, user, repo),
+        ImportTarget::LocalModule { canonical_path, .. } => {
+            format!("LocalModule({})", canonical_path.display())
+        }
+    };
+    format!("[{}] {} -> {}", imp.id.0, imp.path, target)
+}
+
+fn render_binding(b: &Binding) -> String {
+    match b {
+        Binding::Function(id) => format!("Function(#{})", id.0),
+        Binding::Struct(id) => format!("Struct(#{})", id.0),
+        Binding::Trait(id) => format!("Trait(#{})", id.0),
+        Binding::Enum(id) => format!("Enum(#{})", id.0),
+        Binding::Variant {
+            enum_id,
+            variant_index,
+        } => format!("Variant(#{}, {})", enum_id.0, variant_index),
+        Binding::Extern {
+            decl_id,
+            item_index,
+        } => format!("Extern(#{}, {})", decl_id.0, item_index),
+        Binding::Const(id) => format!("Const(#{})", id.0),
+        Binding::Static(id) => format!("Static(#{})", id.0),
+        Binding::Param(sp) => format!("Param@{}..{}", sp.start, sp.end),
+        Binding::Local(sp) => format!("Local@{}..{}", sp.start, sp.end),
+        Binding::PatternBinding(sp) => format!("PatternBinding@{}..{}", sp.start, sp.end),
+        Binding::GenericParam { name, .. } => format!("GenericParam({})", name),
+        Binding::SelfType => "SelfType".to_string(),
+        Binding::SelfValue => "SelfValue".to_string(),
+        Binding::ImportAlias(id) => format!("ImportAlias(#{})", id.0),
+        Binding::ImportedItem { import_id, name } => {
+            format!("ImportedItem(#{}, {})", import_id.0, name)
+        }
+    }
+}
+
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+fn normalize(s: &str) -> String {
+    s.replace("\r\n", "\n")
+        .lines()
+        .map(|l| l.trim_end().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}


### PR DESCRIPTION
Adds the name resolver and import binding stage for the v2 compiler.

Closes #57.

The full design lives at `docs/v2/specs/resolver.md`. The resolver is a two pass walker over an `ast::File`: first it collects every top level declaration into the module scope (so forward references work), then it walks every body and records each identifier use in a `ResolutionMap` keyed by use site span.

## What is resolved end to end

- Top level item references (functions, structs, traits, enums, externs, consts, module level lets).
- Function parameters and `let` bindings in function bodies (with shadowing through nested blocks).
- Generic parameters across functions, structs, traits, impls, and enums.
- `self` and `Self` inside `impl` blocks; `SelfOutsideImpl` error elsewhere.
- Pattern bindings in `match` arms and `for` heads.
- Lambda parameters in scope over the lambda body.
- `import std/<path>` against a static stdlib registry (`io`, `collections`, `string`, `math`, `fs`, `net`, `http`, `time`, `json`, `ffi`). The alias (or each selector) is bound at the module level.
- `import "github.com/<user>/<repo>"` is recorded as an external package target; the resolver does not fetch.
- `import "./relative"` is read through a pluggable `SourceLoader` and recursively parsed and resolved, with cycle detection.

## Deliberately deferred

- Resolving members of stdlib modules (e.g., the `println` referenced by `import std/io { println }`) waits for the type checker, which will materialize the stdlib's actual signatures.
- Cross package fetching for `github.com/...` imports waits for rvpm.
- Method dispatch on receivers and enum constructor lookup live in the type checker; the resolver intentionally leaves method names and bare variant names alone.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (132 unit tests, 1 parser golden, 1 resolver golden)
- [x] `cargo fmt --check`
- [x] `cargo clippy`
- [x] Resolver golden suite covers: parameter resolution, forward references, lexical shadowing, `self`/`Self` in impl, generic parameters, std imports with selectors.
- [x] Unit tests cover: unresolved names, duplicate declarations, `self` outside impl, cyclic local imports, unknown stdlib modules, struct field type references.
