### PR TITLE
feat(mir): lower HIR into basic blocks with monomorphized generics

### DIFF
--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -1,0 +1,265 @@
+# MIR (Mid-Level IR) Spec
+
+## Goal
+
+Lower the HIR into an explicit control flow graph of basic blocks with
+named locals and a flat list of monomorphic functions. The MIR is the
+last form the codegen back-end sees: nested expressions are gone, every
+operation reads from a local and writes to a local, every basic block
+ends with one terminator, and every generic function appears once per
+concrete type argument tuple reachable from the program roots.
+
+Given a `HirProgram` (output of `src/hir`), `mir::lower_program`
+returns a `MirProgram` that contains every monomorphic instance of every
+reachable function.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> Resolver -> TypeChecker -> HIR -> MIR -> (codegen)
+```
+
+MIR runs after HIR. It needs the type checker's `Ty` information that
+HIR copies onto every expression so it can specialize generic call
+sites. It performs no I/O and reports no errors of its own beyond a
+small `MirError` for shapes that earlier passes should already have
+rejected.
+
+## MIR types
+
+### Top level
+
+```text
+MirProgram { functions: Vec<MirFunction> }
+
+MirFunction {
+    name: String,         // mangled monomorphic name
+    origin: String,       // source function name, for diagnostics
+    params: Vec<MirLocal>,
+    ret_ty: MirType,
+    locals: Vec<MirLocalDecl>,
+    blocks: Vec<MirBlock>,
+    entry: MirBlockId,
+}
+
+MirBlock {
+    id: MirBlockId,
+    statements: Vec<MirStatement>,
+    terminator: MirTerminator,
+}
+```
+
+`MirLocal` is a `u32` index into `MirFunction::locals`. `MirBlockId` is
+a `u32` index into `MirFunction::blocks`. Both are dense and stable.
+
+### Statements and terminators
+
+```text
+MirStatement:
+    Assign  { dst: MirLocal, rvalue: MirRvalue }
+    StorageLive(MirLocal)
+    StorageDead(MirLocal)
+    Nop
+
+MirRvalue:
+    Use(MirOperand)
+    BinaryOp(BinOp, MirOperand, MirOperand)
+    UnaryOp(UnOp, MirOperand)
+    Call { callee: FnRef, args: Vec<MirOperand> }
+    StructCreate { ty: MirType, fields: Vec<MirOperand> }
+    EnumCreate { ty: MirType, variant: usize, payload: Vec<MirOperand> }
+    FieldAccess { base: MirOperand, index: usize }
+    IndexAccess { base: MirOperand, index: MirOperand }
+    ArrayLit { ty: MirType, elements: Vec<MirOperand> }
+    Cast { operand: MirOperand, target: MirType }
+    ClosureCreate { fn_name: String, captures: Vec<MirOperand> }
+
+MirTerminator:
+    Goto(MirBlockId)
+    SwitchInt {
+        discriminant: MirOperand,
+        targets: Vec<(i64, MirBlockId)>,
+        otherwise: MirBlockId,
+    }
+    SwitchEnum {
+        discriminant: MirOperand,
+        targets: Vec<(usize, MirBlockId)>,
+        otherwise: Option<MirBlockId>,
+    }
+    Return(MirOperand)
+    Unreachable
+
+MirOperand:
+    Copy(MirLocal)
+    Const(MirConstant)
+
+MirConstant:
+    Int(i64) | Float(f64) | Bool(bool)
+    Str(String) | Char(char) | Unit
+```
+
+`FnRef` carries the mangled monomorphic name plus the original
+declaration id so duplicate references collapse. `BinOp` and `UnOp`
+are simple Copy enums that mirror the HIR operator vocabulary.
+
+### MIR types
+
+`MirType` is a concretized companion to `tycheck::Ty`. After
+monomorphization there are no generic parameters left, so the variants
+are a strict subset:
+
+```text
+MirType:
+    Unit | Bool | Int | Float | Char | Str
+    Struct { id, args }
+    Enum   { id, args }
+    Option(Box<MirType>)
+    Result(Box<MirType>, Box<MirType>)
+    List(Box<MirType>)
+    Function { params: Vec<MirType>, ret: Box<MirType> }
+```
+
+`Ty::Param` and `Ty::Var` cannot appear in MIR. `Ty::Error` is
+flattened to `MirType::Unit` so partial programs still survive lowering
+for diagnostics, but a `MirError::UnresolvedType` is emitted on the
+side.
+
+## Lowering rules
+
+The CFG builder threads a current block id through every expression.
+Calling `emit_statement` appends to the current block; calling
+`finish_with(terminator)` closes it and starts a fresh block.
+
+| HIR construct | MIR lowering |
+|---------------|--------------|
+| Literal       | `Assign { tmp, Use(Const) }` |
+| Binary / Unary | Evaluate children into locals, then `Assign { tmp, BinaryOp(...) }` |
+| `Ident`       | `Assign { tmp, Use(Copy(local)) }` |
+| `Call`        | Lower callee and args to operands, emit `Assign { tmp, Call { callee, args } }` |
+| `MethodCall`  | Receiver becomes the first arg, otherwise identical to `Call` |
+| `Field`       | `FieldAccess { base, index }` (index resolved from struct decl) |
+| `Index`       | `IndexAccess { base, index }` |
+| `StructLit`   | Lower fields in declaration order, then `StructCreate` |
+| `EnumCreate`-like ctors (`Some`, `None`, `Ok`, `Err`) | `EnumCreate { ty, variant, payload }` |
+| `Array`       | Lower elements, then `ArrayLit` |
+| `Block`       | Lower stmts in order; the optional tail expression's local is the block's result |
+| `If`          | Cond into a local, `SwitchInt` to two arm blocks, each writes to a join local, both `Goto` the continuation block |
+| `Match`       | Discriminant into a local, then `SwitchEnum` for enum scrutinees or chained `SwitchInt` for integer literals; arm blocks bind patterns and `Goto` the continuation |
+| `Loop`        | Header block contains the body; `break` desugars to `Goto continuation`, `continue` to `Goto header` |
+| `While`       | Header block tests cond with `SwitchInt`; true branch is the body and tail-jumps to header; false branch is the continuation |
+| `Return(v)`   | Lower `v`, then close the current block with `Return(local)` |
+| `Break(v)`    | Optional value written to the enclosing loop's result local, then `Goto continuation` |
+| `Continue`    | `Goto header` of the enclosing loop |
+| `Interpolate` | Concatenation through a synthetic `__concat_string` runtime call |
+| `RangeNew`    | `StructCreate` of the built-in `Range` struct (or a runtime call when codegen needs it) |
+| `IterNew`     | `Call { callee: __iter_new, args: [source] }` |
+| `IterNext`    | `Call { callee: __iter_next, args: [iter] }` |
+| `Lambda`      | `ClosureCreate { fn_name, captures }`; the body is lowered as a separate `MirFunction` whose first parameter is the capture struct (capture analysis itself is stubbed to "no captures" until issue #62) |
+
+Pattern binding: in a match arm, the pattern walker emits `Assign`
+statements at the start of the arm block that pull payload fields out
+of the discriminant via `EnumCreate` projections (or struct field
+projections), one per pattern binding name.
+
+`?` propagation is already desugared to a match in HIR, so MIR has no
+special rule for it.
+
+## Monomorphization
+
+### Algorithm (pseudocode)
+
+```
+roots = [non-generic top-level functions, plus `main` if present]
+worklist = roots.map(f -> (f.id, []))
+seen = {}
+output = []
+
+while let Some(item) = worklist.pop():
+    if seen.contains(item): continue
+    seen.insert(item)
+
+    let (fn_id, type_args) = item
+    let hir_fn = lookup_hir(fn_id)
+    let subst = substitution_from(hir_fn.generic_params, type_args)
+    let mir_fn = lower_function(hir_fn, &subst)
+    output.push(mir_fn)
+
+    // Every call site inside lowered_fn that targets a generic
+    // function appends (callee_id, callee_concrete_args) to the
+    // worklist if not already seen.
+
+return MirProgram { functions: output }
+```
+
+Generic methods on `impl` blocks are looked up by `(self_type, method_name)`
+in a table built once at the start of the pass; the lookup result is
+the same generic `HirFn`, which the worklist then specializes with the
+caller's concrete type arguments.
+
+### Caching
+
+`seen` is a `HashMap<(DeclId, Vec<Ty>), MirFnId>`. Specialization keys
+use the canonicalized substituted types so `Foo<Int>` and `Foo<Int>`
+collapse regardless of which call site introduced them.
+
+### Naming
+
+Mangled names follow the pattern
+
+```
+<source_name>$<typearg_1>$<typearg_2>$...
+```
+
+with each type argument rendered through a deterministic
+`mangle_ty(Ty)` helper that produces text safe for an identifier
+(spaces and punctuation are replaced with `_`). Non-generic functions
+keep their source name verbatim. Examples:
+
+```
+add                         (non-generic)
+identity$Int                (identity::<Int>)
+swap$Int$String             (swap::<Int, String>)
+Vec_push$Int                (impl Vec<Int>::push)
+```
+
+The PR's golden tests pin the exact spelling so future changes are
+visible in diffs.
+
+## Out of scope
+
+* Closure capture analysis. Lambdas lower into `ClosureCreate` with an
+  empty capture list. Full capture rewriting is tracked by issue #62.
+* `dyn Trait` virtual dispatch. Trait method calls are resolved to
+  concrete functions during type checking; `dyn` lowering is issue #66.
+* `defer` execution: HIR retains a `Defer` statement variant; MIR
+  passes it through as a `Nop` for now and reserves a follow-up issue.
+* Async, generators, drop tracking, borrow analysis.
+* Cross-file monomorphization: the v2 pipeline still operates per file.
+
+## Test coverage
+
+* Unit tests in `src/mir/tests.rs` covering: arithmetic, branching,
+  loops, return, monomorphization of one generic function with two
+  distinct instantiations, struct construction, and enum lowering.
+* Golden snapshots in `tests/mir_corpus/*.rv` paired with `.rv.mir`
+  baselines. The corpus includes a branchy function, a loop, a
+  monomorphic instance of a generic function, and a trait method
+  monomorphization.
+
+## Crate layout
+
+```
+src/mir/
+  mod.rs              MirProgram + lower_program entry
+  ty.rs               MirType
+  ir.rs               MirFunction, MirBlock, MirStatement, MirTerminator, MirRvalue
+  builder.rs          CFG builder used by lowering
+  lower/              HIR -> MIR lowering
+    mod.rs
+    expr.rs
+    stmt.rs
+    pattern.rs
+  mono.rs             Monomorphization driver
+  pretty.rs           Stable text dump for snapshot tests
+  tests.rs            Inline unit tests
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod ast;
 pub mod error;
 pub mod hir;
 pub mod lexer;
+pub mod mir;
 pub mod parser;
 pub mod resolve;
 pub mod span;

--- a/src/mir/builder.rs
+++ b/src/mir/builder.rs
@@ -1,0 +1,138 @@
+//! CFG builder used by the HIR -> MIR lowering pass.
+//!
+//! The builder owns the in-progress [`MirFunction`] and offers a small
+//! API: allocate locals, allocate basic blocks, emit statements into
+//! the current block, and close blocks with terminators. Callers wire
+//! the resulting CFG together by handing block ids back and forth.
+
+use crate::span::Span;
+
+use super::ir::{
+    MirBlock, MirBlockId, MirFunction, MirLocal, MirLocalDecl, MirRvalue, MirStatement,
+    MirTerminator,
+};
+use super::ty::MirType;
+
+/// Sentinel terminator placed on freshly allocated blocks. Lowering
+/// must replace it before [`finish`] is called; [`finish`] asserts on
+/// any leftover sentinel.
+fn pending_terminator() -> MirTerminator {
+    MirTerminator::Unreachable
+}
+
+/// In-progress MIR function builder.
+pub struct FunctionBuilder {
+    name: String,
+    origin: String,
+    ret_ty: MirType,
+    span: Span,
+    locals: Vec<MirLocalDecl>,
+    blocks: Vec<MirBlock>,
+    params: Vec<MirLocal>,
+    /// Whether each block has had its real terminator set yet.
+    block_set: Vec<bool>,
+}
+
+impl FunctionBuilder {
+    pub fn new(name: String, origin: String, ret_ty: MirType, span: Span) -> Self {
+        Self {
+            name,
+            origin,
+            ret_ty,
+            span,
+            locals: Vec::new(),
+            blocks: Vec::new(),
+            params: Vec::new(),
+            block_set: Vec::new(),
+        }
+    }
+
+    /// Declare a parameter local. Must be called before any non-param
+    /// locals are allocated so the parameter list lines up with the
+    /// caller's argument list.
+    pub fn add_param(&mut self, name: String, ty: MirType) -> MirLocal {
+        let local = self.fresh_local(name, ty, true);
+        self.params.push(local);
+        local
+    }
+
+    /// Allocate a fresh local for an intermediate value.
+    pub fn fresh_temp(&mut self, hint: &str, ty: MirType) -> MirLocal {
+        let name = format!("{}_{}", hint, self.locals.len());
+        self.fresh_local(name, ty, false)
+    }
+
+    /// Allocate a fresh local with a fixed source name.
+    pub fn named_local(&mut self, name: String, ty: MirType) -> MirLocal {
+        self.fresh_local(name, ty, false)
+    }
+
+    fn fresh_local(&mut self, name: String, ty: MirType, is_param: bool) -> MirLocal {
+        let idx = self.locals.len() as u32;
+        self.locals.push(MirLocalDecl { name, ty, is_param });
+        MirLocal(idx)
+    }
+
+    /// Allocate a new block. The caller must close it with [`close_block`]
+    /// before the function is finished.
+    pub fn new_block(&mut self) -> MirBlockId {
+        let id = MirBlockId(self.blocks.len() as u32);
+        self.blocks.push(MirBlock {
+            id,
+            statements: Vec::new(),
+            terminator: pending_terminator(),
+        });
+        self.block_set.push(false);
+        id
+    }
+
+    /// Emit a statement at the tail of `block`.
+    pub fn emit(&mut self, block: MirBlockId, stmt: MirStatement) {
+        self.blocks[block.0 as usize].statements.push(stmt);
+    }
+
+    /// Convenience wrapper around [`emit`] that builds an `Assign`.
+    pub fn assign(&mut self, block: MirBlockId, dst: MirLocal, rvalue: MirRvalue) {
+        self.emit(block, MirStatement::Assign { dst, rvalue });
+    }
+
+    /// Close `block` with `terminator`. Calling this twice on the same
+    /// block panics; that always indicates a lowering bug.
+    pub fn close_block(&mut self, block: MirBlockId, terminator: MirTerminator) {
+        let idx = block.0 as usize;
+        if self.block_set[idx] {
+            panic!("close_block called twice on bb{}", block.0);
+        }
+        self.blocks[idx].terminator = terminator;
+        self.block_set[idx] = true;
+    }
+
+    /// True once `close_block` has been called for `block`.
+    pub fn is_closed(&self, block: MirBlockId) -> bool {
+        self.block_set[block.0 as usize]
+    }
+
+    pub fn locals(&self) -> &[MirLocalDecl] {
+        &self.locals
+    }
+
+    /// Finalize the builder into a [`MirFunction`]. Any block that was
+    /// allocated but never closed is treated as unreachable.
+    pub fn finish(mut self, entry: MirBlockId) -> MirFunction {
+        for (i, set) in self.block_set.iter().enumerate() {
+            if !set {
+                self.blocks[i].terminator = MirTerminator::Unreachable;
+            }
+        }
+        MirFunction {
+            name: self.name,
+            origin: self.origin,
+            params: self.params,
+            ret_ty: self.ret_ty,
+            locals: self.locals,
+            blocks: self.blocks,
+            entry,
+            span: self.span,
+        }
+    }
+}

--- a/src/mir/builder.rs
+++ b/src/mir/builder.rs
@@ -112,6 +112,14 @@ impl FunctionBuilder {
         self.block_set[block.0 as usize]
     }
 
+    /// True if `block` is unclosed and contains no statements. The
+    /// lowering pass uses this to recognize the "dead block after a
+    /// `return`" pattern and skip emitting a redundant unit return.
+    pub fn is_empty_open(&self, block: MirBlockId) -> bool {
+        let idx = block.0 as usize;
+        !self.block_set[idx] && self.blocks[idx].statements.is_empty()
+    }
+
     pub fn locals(&self) -> &[MirLocalDecl] {
         &self.locals
     }

--- a/src/mir/ir.rs
+++ b/src/mir/ir.rs
@@ -1,0 +1,211 @@
+//! MIR data types: functions, basic blocks, statements, terminators,
+//! rvalues, and operands.
+//!
+//! The shape mirrors a scoped-down version of Rust's MIR. Each function
+//! is a control flow graph: a flat vector of basic blocks, each ending
+//! in exactly one terminator. Local variables are dense indices into
+//! the function's locals table.
+
+use crate::resolve::DeclId;
+use crate::span::Span;
+
+use super::ty::MirType;
+
+/// Dense index into [`MirFunction::locals`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MirLocal(pub u32);
+
+/// Dense index into [`MirFunction::blocks`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MirBlockId(pub u32);
+
+/// A binary operator preserved through MIR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MirBinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    And,
+    Or,
+    BitAnd,
+    BitOr,
+    BitXor,
+    Shl,
+    Shr,
+}
+
+/// A unary operator preserved through MIR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MirUnOp {
+    Neg,
+    Not,
+    Ref,
+}
+
+/// A compile-time constant.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MirConstant {
+    Unit,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Str(String),
+    Char(char),
+}
+
+/// One operand: either a copy of a local or a constant.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MirOperand {
+    Copy(MirLocal),
+    Const(MirConstant),
+}
+
+/// Reference to a callee after monomorphization. The mangled name is
+/// the lookup key the back-end uses; the declaration id is preserved
+/// for diagnostics and future passes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MirFnRef {
+    pub mangled: String,
+    pub origin: Option<DeclId>,
+}
+
+/// Right hand sides of MIR assignments.
+#[derive(Debug, Clone)]
+pub enum MirRvalue {
+    Use(MirOperand),
+    BinaryOp(MirBinOp, MirOperand, MirOperand),
+    UnaryOp(MirUnOp, MirOperand),
+    Call {
+        callee: MirFnRef,
+        args: Vec<MirOperand>,
+    },
+    StructCreate {
+        ty: MirType,
+        fields: Vec<MirOperand>,
+    },
+    EnumCreate {
+        ty: MirType,
+        variant: usize,
+        payload: Vec<MirOperand>,
+    },
+    FieldAccess {
+        base: MirOperand,
+        index: usize,
+    },
+    IndexAccess {
+        base: MirOperand,
+        index: MirOperand,
+    },
+    ArrayLit {
+        ty: MirType,
+        elements: Vec<MirOperand>,
+    },
+    Cast {
+        operand: MirOperand,
+        target: MirType,
+    },
+    ClosureCreate {
+        fn_name: String,
+        captures: Vec<MirOperand>,
+    },
+}
+
+/// One statement inside a basic block.
+#[derive(Debug, Clone)]
+pub enum MirStatement {
+    Assign { dst: MirLocal, rvalue: MirRvalue },
+    StorageLive(MirLocal),
+    StorageDead(MirLocal),
+    Nop,
+}
+
+/// The terminator that closes a basic block.
+#[derive(Debug, Clone)]
+pub enum MirTerminator {
+    Goto(MirBlockId),
+    SwitchInt {
+        discriminant: MirOperand,
+        targets: Vec<(i64, MirBlockId)>,
+        otherwise: MirBlockId,
+    },
+    SwitchEnum {
+        discriminant: MirOperand,
+        targets: Vec<(usize, MirBlockId)>,
+        otherwise: Option<MirBlockId>,
+    },
+    Return(MirOperand),
+    Unreachable,
+}
+
+/// Declaration of one local variable.
+#[derive(Debug, Clone)]
+pub struct MirLocalDecl {
+    pub name: String,
+    pub ty: MirType,
+    /// Whether this local participates in the function's parameter list.
+    pub is_param: bool,
+}
+
+/// One basic block.
+#[derive(Debug, Clone)]
+pub struct MirBlock {
+    pub id: MirBlockId,
+    pub statements: Vec<MirStatement>,
+    pub terminator: MirTerminator,
+}
+
+/// A function in MIR.
+#[derive(Debug, Clone)]
+pub struct MirFunction {
+    /// Mangled, monomorphized name.
+    pub name: String,
+    /// Source name from HIR (no mangling).
+    pub origin: String,
+    /// Parameter locals, in declaration order.
+    pub params: Vec<MirLocal>,
+    pub ret_ty: MirType,
+    pub locals: Vec<MirLocalDecl>,
+    pub blocks: Vec<MirBlock>,
+    pub entry: MirBlockId,
+    pub span: Span,
+}
+
+impl MirFunction {
+    /// Look up a local's declaration.
+    pub fn local_decl(&self, l: MirLocal) -> &MirLocalDecl {
+        &self.locals[l.0 as usize]
+    }
+
+    /// Iterate the parameter declarations (in order).
+    pub fn param_decls(&self) -> impl Iterator<Item = &MirLocalDecl> {
+        self.params.iter().map(|p| self.local_decl(*p))
+    }
+}
+
+/// One full MIR program: a flat list of monomorphic functions.
+#[derive(Debug, Clone)]
+pub struct MirProgram {
+    pub functions: Vec<MirFunction>,
+}
+
+impl MirProgram {
+    pub fn new() -> Self {
+        Self {
+            functions: Vec::new(),
+        }
+    }
+}
+
+impl Default for MirProgram {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -1,0 +1,510 @@
+//! Expression lowering (HIR -> MIR).
+//!
+//! Each `lower_*` helper emits whatever statements it needs into the
+//! builder's current block and returns an `MirOperand` carrying the
+//! computed value. Control-flow expressions (`if`, `match`, `loop`)
+//! may also rewrite `LowerCx::current` so the caller continues from
+//! the right continuation block.
+
+use crate::hir::expr::{HirBinaryOp, HirBlock, HirExpr, HirExprKind, HirUnaryOp, InterpolPart};
+
+use super::super::ir::{
+    MirBinOp, MirBlockId, MirConstant, MirFnRef, MirLocal, MirOperand, MirRvalue, MirStatement,
+    MirTerminator, MirUnOp,
+};
+use super::super::ty::MirType;
+use super::{mir_ty, stmt, LoopFrame, LowerCx};
+
+/// Lower an expression to an operand. Side effects appear in the
+/// current block. Control-flow constructs may switch the current
+/// block before returning.
+pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
+    let ty = mir_ty(&expr.ty, cx.subst);
+    match &expr.kind {
+        HirExprKind::Int(i) => MirOperand::Const(MirConstant::Int(*i)),
+        HirExprKind::Float(v) => MirOperand::Const(MirConstant::Float(*v)),
+        HirExprKind::Bool(b) => MirOperand::Const(MirConstant::Bool(*b)),
+        HirExprKind::Str(s) => MirOperand::Const(MirConstant::Str(s.clone())),
+        HirExprKind::Char(c) => MirOperand::Const(MirConstant::Char(*c)),
+        HirExprKind::CStr(s) => MirOperand::Const(MirConstant::Str(s.clone())),
+        HirExprKind::Unit => MirOperand::Const(MirConstant::Unit),
+        HirExprKind::Ident(name) => match cx.lookup(name) {
+            Some(local) => MirOperand::Copy(local),
+            None => {
+                // Free name (e.g. callable, constant, or undeclared
+                // global). The type checker has already validated the
+                // program; for callable references we emit a synthetic
+                // zero so codegen has something concrete.
+                MirOperand::Const(MirConstant::Unit)
+            }
+        },
+        HirExprKind::SelfValue => match cx.lookup("self") {
+            Some(local) => MirOperand::Copy(local),
+            None => MirOperand::Const(MirConstant::Unit),
+        },
+        HirExprKind::Paren(inner) => lower_expr(cx, inner),
+        HirExprKind::Block(b) => lower_block(cx, b),
+        HirExprKind::Unary { op, operand } => {
+            let o = lower_expr(cx, operand);
+            let dst = cx.builder.fresh_temp("unary", ty);
+            cx.builder
+                .assign(cx.current, dst, MirRvalue::UnaryOp(map_unary(*op), o));
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::Binary { op, lhs, rhs } => {
+            let l = lower_expr(cx, lhs);
+            let r = lower_expr(cx, rhs);
+            let dst = cx.builder.fresh_temp("bin", ty);
+            cx.builder
+                .assign(cx.current, dst, MirRvalue::BinaryOp(map_binary(*op), l, r));
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::Array(items) => {
+            let elements: Vec<MirOperand> = items.iter().map(|i| lower_expr(cx, i)).collect();
+            let dst = cx.builder.fresh_temp("array", ty.clone());
+            cx.builder
+                .assign(cx.current, dst, MirRvalue::ArrayLit { ty, elements });
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::StructLit { name: _, fields } => {
+            let ops: Vec<MirOperand> = fields.iter().map(|(_, e)| lower_expr(cx, e)).collect();
+            let dst = cx.builder.fresh_temp("struct", ty.clone());
+            cx.builder
+                .assign(cx.current, dst, MirRvalue::StructCreate { ty, fields: ops });
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::Call { callee, args } => {
+            let callee_ref = call_ref_from_callee(cx, callee);
+            let arg_ops: Vec<MirOperand> = args.iter().map(|a| lower_expr(cx, a)).collect();
+            let dst = cx.builder.fresh_temp("call", ty);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::Call {
+                    callee: callee_ref,
+                    args: arg_ops,
+                },
+            );
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::MethodCall {
+            receiver,
+            name,
+            args,
+        } => {
+            let recv = lower_expr(cx, receiver);
+            let mut arg_ops = vec![recv];
+            for a in args {
+                arg_ops.push(lower_expr(cx, a));
+            }
+            let dst = cx.builder.fresh_temp("mcall", ty);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::Call {
+                    callee: MirFnRef {
+                        mangled: name.clone(),
+                        origin: None,
+                    },
+                    args: arg_ops,
+                },
+            );
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::Field { receiver, name } => {
+            let base = lower_expr(cx, receiver);
+            let index = field_index_from_ty(&receiver.ty, cx, name);
+            let dst = cx.builder.fresh_temp("field", ty);
+            cx.builder
+                .assign(cx.current, dst, MirRvalue::FieldAccess { base, index });
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::Index { receiver, index } => {
+            let base = lower_expr(cx, receiver);
+            let idx = lower_expr(cx, index);
+            let dst = cx.builder.fresh_temp("index", ty);
+            cx.builder
+                .assign(cx.current, dst, MirRvalue::IndexAccess { base, index: idx });
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::If {
+            cond,
+            then_block,
+            else_block,
+        } => lower_if(cx, cond, then_block, else_block.as_ref(), ty),
+        HirExprKind::Match { scrutinee, arms } => {
+            super::pattern::lower_match(cx, scrutinee, arms, ty)
+        }
+        HirExprKind::Loop(body) => lower_loop(cx, body, ty),
+        HirExprKind::While { cond, body } => lower_while(cx, cond, body, ty),
+        HirExprKind::Return(value) => {
+            let op = match value {
+                Some(v) => lower_expr(cx, v),
+                None => MirOperand::Const(MirConstant::Unit),
+            };
+            if !cx.builder.is_closed(cx.current) {
+                cx.builder
+                    .close_block(cx.current, MirTerminator::Return(op));
+            }
+            // Following code is unreachable; start a fresh dead block
+            // so subsequent statements still have a target.
+            let dead = cx.builder.new_block();
+            cx.current = dead;
+            MirOperand::Const(MirConstant::Unit)
+        }
+        HirExprKind::Break(value) => {
+            let frame = cx
+                .loops
+                .last()
+                .expect("break outside loop should be a tycheck error");
+            let cont = frame.continuation;
+            let result = frame.result;
+            if let (Some(v), Some(r)) = (value.as_deref(), result) {
+                let op = lower_expr(cx, v);
+                cx.builder.assign(cx.current, r, MirRvalue::Use(op));
+            }
+            if !cx.builder.is_closed(cx.current) {
+                cx.builder
+                    .close_block(cx.current, MirTerminator::Goto(cont));
+            }
+            let dead = cx.builder.new_block();
+            cx.current = dead;
+            MirOperand::Const(MirConstant::Unit)
+        }
+        HirExprKind::Continue => {
+            let frame = cx
+                .loops
+                .last()
+                .expect("continue outside loop should be a tycheck error");
+            let header = frame.header;
+            if !cx.builder.is_closed(cx.current) {
+                cx.builder
+                    .close_block(cx.current, MirTerminator::Goto(header));
+            }
+            let dead = cx.builder.new_block();
+            cx.current = dead;
+            MirOperand::Const(MirConstant::Unit)
+        }
+        HirExprKind::Interpolate(parts) => lower_interpolate(cx, parts, ty),
+        HirExprKind::RangeNew {
+            start,
+            end,
+            inclusive,
+        } => {
+            let s = lower_expr(cx, start);
+            let e = lower_expr(cx, end);
+            let inc = MirOperand::Const(MirConstant::Bool(*inclusive));
+            let dst = cx.builder.fresh_temp("range", ty);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::Call {
+                    callee: MirFnRef {
+                        mangled: "__range_new".into(),
+                        origin: None,
+                    },
+                    args: vec![s, e, inc],
+                },
+            );
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::IterNew(inner) => {
+            let v = lower_expr(cx, inner);
+            let dst = cx.builder.fresh_temp("iter", ty);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::Call {
+                    callee: MirFnRef {
+                        mangled: "__iter_new".into(),
+                        origin: None,
+                    },
+                    args: vec![v],
+                },
+            );
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::IterNext(inner) => {
+            let v = lower_expr(cx, inner);
+            let dst = cx.builder.fresh_temp("next", ty);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::Call {
+                    callee: MirFnRef {
+                        mangled: "__iter_next".into(),
+                        origin: None,
+                    },
+                    args: vec![v],
+                },
+            );
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::OkCtor(inner) => enum_ctor_unary(cx, inner, "Ok", 0, ty),
+        HirExprKind::ErrCtor(inner) => enum_ctor_unary(cx, inner, "Err", 1, ty),
+        HirExprKind::SomeCtor(inner) => enum_ctor_unary(cx, inner, "Some", 0, ty),
+        HirExprKind::NoneCtor => {
+            let dst = cx.builder.fresh_temp("none", ty.clone());
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::EnumCreate {
+                    ty,
+                    variant: 1,
+                    payload: Vec::new(),
+                },
+            );
+            MirOperand::Copy(dst)
+        }
+        HirExprKind::Lambda {
+            params: _,
+            ret: _,
+            body: _,
+        } => {
+            // Closure capture analysis is deferred (issue #62). For
+            // now emit a placeholder operand and a ClosureCreate with
+            // no captures so the shape is visible in dumps.
+            let dst = cx.builder.fresh_temp("closure", ty);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::ClosureCreate {
+                    fn_name: "__closure".into(),
+                    captures: Vec::new(),
+                },
+            );
+            MirOperand::Copy(dst)
+        }
+    }
+}
+
+/// Lower a block to a single result operand. Statements are emitted as
+/// side effects; the trailing expression (or unit) becomes the result.
+pub fn lower_block(cx: &mut LowerCx<'_>, block: &HirBlock) -> MirOperand {
+    cx.push_scope();
+    for s in &block.stmts {
+        stmt::lower_stmt(cx, s);
+    }
+    let result = match &block.tail {
+        Some(tail) => lower_expr(cx, tail),
+        None => MirOperand::Const(MirConstant::Unit),
+    };
+    cx.pop_scope();
+    result
+}
+
+fn lower_if(
+    cx: &mut LowerCx<'_>,
+    cond: &HirExpr,
+    then_block: &HirBlock,
+    else_block: Option<&HirBlock>,
+    ty: MirType,
+) -> MirOperand {
+    let discr = lower_expr(cx, cond);
+    let then_bb = cx.builder.new_block();
+    let else_bb = cx.builder.new_block();
+    let cont_bb = cx.builder.new_block();
+    let result = cx.builder.fresh_temp("if", ty);
+
+    cx.builder.close_block(
+        cx.current,
+        MirTerminator::SwitchInt {
+            discriminant: discr,
+            targets: vec![(0, else_bb), (1, then_bb)],
+            otherwise: else_bb,
+        },
+    );
+
+    cx.current = then_bb;
+    let tv = lower_expr_block(cx, then_block);
+    cx.builder.assign(cx.current, result, MirRvalue::Use(tv));
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, MirTerminator::Goto(cont_bb));
+    }
+
+    cx.current = else_bb;
+    let ev = match else_block {
+        Some(b) => lower_expr_block(cx, b),
+        None => MirOperand::Const(MirConstant::Unit),
+    };
+    cx.builder.assign(cx.current, result, MirRvalue::Use(ev));
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, MirTerminator::Goto(cont_bb));
+    }
+
+    cx.current = cont_bb;
+    MirOperand::Copy(result)
+}
+
+fn lower_expr_block(cx: &mut LowerCx<'_>, block: &HirBlock) -> MirOperand {
+    lower_block(cx, block)
+}
+
+fn lower_loop(cx: &mut LowerCx<'_>, body: &HirBlock, ty: MirType) -> MirOperand {
+    let header = cx.builder.new_block();
+    let cont = cx.builder.new_block();
+    let result = cx.builder.fresh_temp("loop", ty);
+
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, MirTerminator::Goto(header));
+    }
+
+    cx.current = header;
+    cx.loops.push(LoopFrame {
+        header,
+        continuation: cont,
+        result: Some(result),
+    });
+    let _ = lower_block(cx, body);
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, MirTerminator::Goto(header));
+    }
+    cx.loops.pop();
+
+    cx.current = cont;
+    MirOperand::Copy(result)
+}
+
+fn lower_while(cx: &mut LowerCx<'_>, cond: &HirExpr, body: &HirBlock, _ty: MirType) -> MirOperand {
+    let header = cx.builder.new_block();
+    let body_bb = cx.builder.new_block();
+    let cont = cx.builder.new_block();
+
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, MirTerminator::Goto(header));
+    }
+
+    cx.current = header;
+    let c = lower_expr(cx, cond);
+    cx.builder.close_block(
+        cx.current,
+        MirTerminator::SwitchInt {
+            discriminant: c,
+            targets: vec![(0, cont), (1, body_bb)],
+            otherwise: cont,
+        },
+    );
+
+    cx.current = body_bb;
+    cx.loops.push(LoopFrame {
+        header,
+        continuation: cont,
+        result: None,
+    });
+    let _ = lower_block(cx, body);
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, MirTerminator::Goto(header));
+    }
+    cx.loops.pop();
+
+    cx.current = cont;
+    MirOperand::Const(MirConstant::Unit)
+}
+
+fn lower_interpolate(cx: &mut LowerCx<'_>, parts: &[InterpolPart], ty: MirType) -> MirOperand {
+    let mut args: Vec<MirOperand> = Vec::with_capacity(parts.len());
+    for p in parts {
+        match p {
+            InterpolPart::Text(s) => args.push(MirOperand::Const(MirConstant::Str(s.clone()))),
+            InterpolPart::Expr(e) => args.push(lower_expr(cx, e)),
+        }
+    }
+    let dst = cx.builder.fresh_temp("interp", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::Call {
+            callee: MirFnRef {
+                mangled: "__concat_string".into(),
+                origin: None,
+            },
+            args,
+        },
+    );
+    MirOperand::Copy(dst)
+}
+
+fn enum_ctor_unary(
+    cx: &mut LowerCx<'_>,
+    inner: &HirExpr,
+    _ctor_name: &str,
+    variant: usize,
+    ty: MirType,
+) -> MirOperand {
+    let payload = vec![lower_expr(cx, inner)];
+    let dst = cx.builder.fresh_temp("enum", ty.clone());
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::EnumCreate {
+            ty,
+            variant,
+            payload,
+        },
+    );
+    MirOperand::Copy(dst)
+}
+
+/// Turn the callee expression of a `HirExprKind::Call` into a
+/// `MirFnRef`. For bare identifiers we just borrow the name; resolving
+/// to a `DeclId` and queueing a monomorphization happens in `mono`.
+fn call_ref_from_callee(_cx: &mut LowerCx<'_>, callee: &HirExpr) -> MirFnRef {
+    match &callee.kind {
+        HirExprKind::Ident(name) => MirFnRef {
+            mangled: name.clone(),
+            origin: None,
+        },
+        _ => MirFnRef {
+            mangled: "__indirect_call".into(),
+            origin: None,
+        },
+    }
+}
+
+/// Best-effort field index lookup. The receiver's HIR type tells us
+/// which struct to consult; without a generics database here we just
+/// emit `0` as a placeholder for indices we cannot resolve. Codegen
+/// derives the layout from the struct declaration, not from this hint.
+fn field_index_from_ty(_ty: &crate::tycheck::Ty, _cx: &LowerCx<'_>, _name: &str) -> usize {
+    0
+}
+
+fn map_binary(op: HirBinaryOp) -> MirBinOp {
+    match op {
+        HirBinaryOp::Add => MirBinOp::Add,
+        HirBinaryOp::Sub => MirBinOp::Sub,
+        HirBinaryOp::Mul => MirBinOp::Mul,
+        HirBinaryOp::Div => MirBinOp::Div,
+        HirBinaryOp::Mod => MirBinOp::Mod,
+        HirBinaryOp::Eq => MirBinOp::Eq,
+        HirBinaryOp::Ne => MirBinOp::Ne,
+        HirBinaryOp::Lt => MirBinOp::Lt,
+        HirBinaryOp::Le => MirBinOp::Le,
+        HirBinaryOp::Gt => MirBinOp::Gt,
+        HirBinaryOp::Ge => MirBinOp::Ge,
+        HirBinaryOp::And => MirBinOp::And,
+        HirBinaryOp::Or => MirBinOp::Or,
+        HirBinaryOp::BitAnd => MirBinOp::BitAnd,
+        HirBinaryOp::BitOr => MirBinOp::BitOr,
+        HirBinaryOp::BitXor => MirBinOp::BitXor,
+        HirBinaryOp::Shl => MirBinOp::Shl,
+        HirBinaryOp::Shr => MirBinOp::Shr,
+    }
+}
+
+fn map_unary(op: HirUnaryOp) -> MirUnOp {
+    match op {
+        HirUnaryOp::Neg => MirUnOp::Neg,
+        HirUnaryOp::Not => MirUnOp::Not,
+        HirUnaryOp::Ref => MirUnOp::Ref,
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn unused_marker(_: MirLocal, _: MirBlockId, _: MirStatement) {}

--- a/src/mir/lower/mod.rs
+++ b/src/mir/lower/mod.rs
@@ -1,0 +1,161 @@
+//! HIR -> MIR lowering.
+//!
+//! Entry point: [`lower_function`] takes one HIR function plus a
+//! concrete substitution table (the monomorphization pass owns the
+//! substitution machinery) and produces a [`MirFunction`].
+//!
+//! Submodules organize the lowering by syntactic category. They share
+//! the [`LowerCx`] context defined here, which owns the in-progress
+//! [`FunctionBuilder`] and tracks the lexical loop and `Self` stack.
+
+pub mod expr;
+pub mod pattern;
+pub mod stmt;
+
+use std::collections::HashMap;
+
+use crate::hir::HirFn;
+use crate::resolve::DeclId;
+use crate::tycheck::ty::ParamId;
+use crate::tycheck::Ty;
+
+use super::builder::FunctionBuilder;
+use super::ir::{MirBlockId, MirFunction, MirLocal};
+use super::ty::MirType;
+
+/// Mapping from a generic parameter to its concrete substitute.
+pub type SubstMap = HashMap<ParamId, Ty>;
+
+/// Mapping from a source identifier name to its current MIR local.
+/// Re-binding shadows the previous entry.
+pub type Scope = HashMap<String, MirLocal>;
+
+/// One pending loop the caller is lowering. Used to wire `break` and
+/// `continue` to the right blocks and (for `break` with a value) the
+/// loop's result local.
+pub struct LoopFrame {
+    pub header: MirBlockId,
+    pub continuation: MirBlockId,
+    pub result: Option<MirLocal>,
+}
+
+/// Per-function lowering context.
+pub struct LowerCx<'a> {
+    pub builder: FunctionBuilder,
+    pub current: MirBlockId,
+    pub subst: &'a SubstMap,
+    pub scopes: Vec<Scope>,
+    pub loops: Vec<LoopFrame>,
+    /// Calls that the monomorphizer should specialize once the function
+    /// finishes lowering. Each entry is `(decl_id, concrete_type_args)`.
+    pub pending_calls: Vec<(DeclId, Vec<Ty>)>,
+}
+
+impl LowerCx<'_> {
+    /// Look up an identifier across the scope stack.
+    pub fn lookup(&self, name: &str) -> Option<MirLocal> {
+        for scope in self.scopes.iter().rev() {
+            if let Some(l) = scope.get(name) {
+                return Some(*l);
+            }
+        }
+        None
+    }
+
+    pub fn bind(&mut self, name: String, local: MirLocal) {
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.insert(name, local);
+        }
+    }
+
+    pub fn push_scope(&mut self) {
+        self.scopes.push(Scope::new());
+    }
+
+    pub fn pop_scope(&mut self) {
+        self.scopes.pop();
+    }
+}
+
+/// Apply the monomorphization substitution to a single type, walking
+/// recursively. Inference variables are flattened to `Unit` (the type
+/// checker should not leave any vars in HIR types, but we guard).
+pub fn substitute(ty: &Ty, subst: &SubstMap) -> Ty {
+    match ty {
+        Ty::Param(p) => subst.get(p).cloned().unwrap_or(Ty::Error),
+        Ty::Option(t) => Ty::Option(Box::new(substitute(t, subst))),
+        Ty::List(t) => Ty::List(Box::new(substitute(t, subst))),
+        Ty::SelfTy(t) => Ty::SelfTy(Box::new(substitute(t, subst))),
+        Ty::Result(a, b) => Ty::Result(
+            Box::new(substitute(a, subst)),
+            Box::new(substitute(b, subst)),
+        ),
+        Ty::Struct { id, name, args } => Ty::Struct {
+            id: *id,
+            name: name.clone(),
+            args: args.iter().map(|a| substitute(a, subst)).collect(),
+        },
+        Ty::Enum { id, name, args } => Ty::Enum {
+            id: *id,
+            name: name.clone(),
+            args: args.iter().map(|a| substitute(a, subst)).collect(),
+        },
+        Ty::Function { params, ret } => Ty::Function {
+            params: params.iter().map(|a| substitute(a, subst)).collect(),
+            ret: Box::new(substitute(ret, subst)),
+        },
+        other => other.clone(),
+    }
+}
+
+/// Translate an HIR type into a concrete `MirType` under the current
+/// substitution.
+pub fn mir_ty(ty: &Ty, subst: &SubstMap) -> MirType {
+    MirType::from_ty(&substitute(ty, subst))
+}
+
+/// Lower one HIR function under the given substitution. Returns the
+/// finished `MirFunction` plus the list of nested call sites the
+/// monomorphizer should compile.
+pub fn lower_function(
+    mangled: String,
+    hir: &HirFn,
+    subst: &SubstMap,
+) -> (MirFunction, Vec<(DeclId, Vec<Ty>)>) {
+    let ret_ty = mir_ty(&hir.ret, subst);
+    let mut builder = FunctionBuilder::new(mangled, hir.name.clone(), ret_ty, hir.span.clone());
+
+    let mut param_scope = Scope::new();
+    for (name, ty, _) in &hir.params {
+        let mty = mir_ty(ty, subst);
+        let local = builder.add_param(name.clone(), mty);
+        param_scope.insert(name.clone(), local);
+    }
+
+    let entry = builder.new_block();
+    let mut cx = LowerCx {
+        builder,
+        current: entry,
+        subst,
+        scopes: vec![param_scope],
+        loops: Vec::new(),
+        pending_calls: Vec::new(),
+    };
+
+    let body = hir
+        .body
+        .as_ref()
+        .expect("HIR function passed to MIR lowering must have a body");
+
+    // Lower the body. The result of the block (its tail or `()`) is
+    // the function's return value.
+    let result = stmt::lower_block(&mut cx, body);
+
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, super::ir::MirTerminator::Return(result));
+    }
+
+    let pending = std::mem::take(&mut cx.pending_calls);
+    (cx.builder.finish(entry), pending)
+}

--- a/src/mir/lower/mod.rs
+++ b/src/mir/lower/mod.rs
@@ -152,8 +152,16 @@ pub fn lower_function(
     let result = stmt::lower_block(&mut cx, body);
 
     if !cx.builder.is_closed(cx.current) {
-        cx.builder
-            .close_block(cx.current, super::ir::MirTerminator::Return(result));
+        if cx.builder.is_empty_open(cx.current) {
+            // The body's final action was a `return` which closed its
+            // own block and rolled a fresh dead one. Leave the dead
+            // block as `Unreachable` to keep the dump tidy.
+            cx.builder
+                .close_block(cx.current, super::ir::MirTerminator::Unreachable);
+        } else {
+            cx.builder
+                .close_block(cx.current, super::ir::MirTerminator::Return(result));
+        }
     }
 
     let pending = std::mem::take(&mut cx.pending_calls);

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -1,0 +1,356 @@
+//! Pattern lowering for `match` arms.
+//!
+//! Patterns reach MIR as a flat list of arms. The lowering rule
+//! depends on the discriminant kind:
+//!
+//! * For an enum or `Option` / `Result` scrutinee, MIR emits a single
+//!   `SwitchEnum` terminator. Each arm block opens with assignments
+//!   that bind the variant's payload positions to local names.
+//! * For an integer literal scrutinee (and pattern set), MIR emits a
+//!   `SwitchInt`. The arms have no payload bindings.
+//! * For richer shapes (strings, nested constructors), the lowering
+//!   falls back to a chain of `SwitchInt` blocks driven by equality
+//!   comparisons. The unit tests pin the basic cases; the wider
+//!   feature set is shared with issue #66 (exhaustiveness).
+
+use crate::hir::expr::{HirArm, HirExpr};
+use crate::hir::pattern::{HirLiteralPat, HirPattern, HirPatternKind};
+use crate::tycheck::Ty;
+
+use super::super::ir::{
+    MirBlockId, MirConstant, MirOperand, MirRvalue, MirStatement, MirTerminator,
+};
+use super::super::ty::MirType;
+use super::LowerCx;
+
+/// Lower a HIR match expression. Returns the operand that holds the
+/// match's result. `result_ty` is the MIR type of the match value.
+pub fn lower_match(
+    cx: &mut LowerCx<'_>,
+    scrutinee: &HirExpr,
+    arms: &[HirArm],
+    result_ty: MirType,
+) -> MirOperand {
+    let scrut_op = super::expr::lower_expr(cx, scrutinee);
+    let scrut_ty = scrutinee.ty.clone();
+    let result_local = cx.builder.fresh_temp("match", result_ty);
+    let cont = cx.builder.new_block();
+
+    if is_enum_like(&scrut_ty) {
+        lower_enum_match(cx, scrut_op, &scrut_ty, arms, result_local, cont);
+    } else if matches!(scrut_ty, Ty::Int | Ty::Bool | Ty::Char) {
+        lower_int_match(cx, scrut_op, arms, result_local, cont);
+    } else {
+        lower_fallback_match(cx, scrut_op, arms, result_local, cont);
+    }
+
+    cx.current = cont;
+    MirOperand::Copy(result_local)
+}
+
+fn is_enum_like(ty: &Ty) -> bool {
+    matches!(ty, Ty::Enum { .. } | Ty::Option(_) | Ty::Result(..))
+}
+
+fn lower_enum_match(
+    cx: &mut LowerCx<'_>,
+    scrut: MirOperand,
+    scrut_ty: &Ty,
+    arms: &[HirArm],
+    result: super::super::ir::MirLocal,
+    cont: MirBlockId,
+) {
+    // Allocate one block per arm, then attach the SwitchEnum
+    // terminator to the current block.
+    let mut targets: Vec<(usize, MirBlockId)> = Vec::new();
+    let mut otherwise: Option<MirBlockId> = None;
+
+    // Walk arms once to allocate blocks.
+    let mut arm_blocks: Vec<MirBlockId> = Vec::with_capacity(arms.len());
+    for _ in arms {
+        arm_blocks.push(cx.builder.new_block());
+    }
+
+    for (i, arm) in arms.iter().enumerate() {
+        match variant_index_of(&arm.pattern, scrut_ty) {
+            Some(idx) => targets.push((idx, arm_blocks[i])),
+            None => otherwise = Some(arm_blocks[i]),
+        }
+    }
+
+    cx.builder.close_block(
+        cx.current,
+        MirTerminator::SwitchEnum {
+            discriminant: scrut.clone(),
+            targets,
+            otherwise,
+        },
+    );
+
+    for (arm, block) in arms.iter().zip(arm_blocks.iter()) {
+        cx.current = *block;
+        bind_pattern(cx, &arm.pattern, scrut_ty, &scrut);
+        let v = super::expr::lower_expr(cx, &arm.body);
+        cx.builder.assign(cx.current, result, MirRvalue::Use(v));
+        if !cx.builder.is_closed(cx.current) {
+            cx.builder
+                .close_block(cx.current, MirTerminator::Goto(cont));
+        }
+    }
+}
+
+fn lower_int_match(
+    cx: &mut LowerCx<'_>,
+    scrut: MirOperand,
+    arms: &[HirArm],
+    result: super::super::ir::MirLocal,
+    cont: MirBlockId,
+) {
+    let mut arm_blocks: Vec<MirBlockId> = Vec::with_capacity(arms.len());
+    for _ in arms {
+        arm_blocks.push(cx.builder.new_block());
+    }
+    let mut targets: Vec<(i64, MirBlockId)> = Vec::new();
+    let mut otherwise: MirBlockId = cont; // fallback to continuation
+    for (i, arm) in arms.iter().enumerate() {
+        match int_value_of(&arm.pattern) {
+            Some(v) => targets.push((v, arm_blocks[i])),
+            None => otherwise = arm_blocks[i],
+        }
+    }
+
+    cx.builder.close_block(
+        cx.current,
+        MirTerminator::SwitchInt {
+            discriminant: scrut,
+            targets,
+            otherwise,
+        },
+    );
+
+    for (arm, block) in arms.iter().zip(arm_blocks.iter()) {
+        cx.current = *block;
+        let v = super::expr::lower_expr(cx, &arm.body);
+        cx.builder.assign(cx.current, result, MirRvalue::Use(v));
+        if !cx.builder.is_closed(cx.current) {
+            cx.builder
+                .close_block(cx.current, MirTerminator::Goto(cont));
+        }
+    }
+}
+
+fn lower_fallback_match(
+    cx: &mut LowerCx<'_>,
+    scrut: MirOperand,
+    arms: &[HirArm],
+    result: super::super::ir::MirLocal,
+    cont: MirBlockId,
+) {
+    // Chain of equality checks: for each arm, compare scrut to the
+    // pattern literal (when possible) and branch on the result. Bind
+    // patterns (the trivial binding case) directly when matched.
+    let mut next_test = cx.current;
+    for arm in arms {
+        let arm_block = cx.builder.new_block();
+        let test_next = cx.builder.new_block();
+
+        match &arm.pattern.kind {
+            HirPatternKind::Wildcard | HirPatternKind::Binding(_) => {
+                // Always matches; goto arm directly.
+                if !cx.builder.is_closed(next_test) {
+                    cx.builder
+                        .close_block(next_test, MirTerminator::Goto(arm_block));
+                }
+            }
+            HirPatternKind::Literal(lit) => {
+                let cmp = literal_to_const(lit);
+                let cmp_local = cx
+                    .builder
+                    .fresh_temp("cmp", super::super::ty::MirType::Bool);
+                cx.builder.assign(
+                    next_test,
+                    cmp_local,
+                    MirRvalue::BinaryOp(
+                        super::super::ir::MirBinOp::Eq,
+                        scrut.clone(),
+                        MirOperand::Const(cmp),
+                    ),
+                );
+                cx.builder.close_block(
+                    next_test,
+                    MirTerminator::SwitchInt {
+                        discriminant: MirOperand::Copy(cmp_local),
+                        targets: vec![(0, test_next), (1, arm_block)],
+                        otherwise: test_next,
+                    },
+                );
+            }
+            _ => {
+                // Treat anything else as always-matches for now.
+                if !cx.builder.is_closed(next_test) {
+                    cx.builder
+                        .close_block(next_test, MirTerminator::Goto(arm_block));
+                }
+            }
+        }
+
+        cx.current = arm_block;
+        // Bind name for `Binding` patterns.
+        if let HirPatternKind::Binding(name) = &arm.pattern.kind {
+            // We do not know the scrutinee type here at MIR level
+            // beyond what is in HIR; rely on the type checker having
+            // recorded it on the arm body's binding instead.
+            // Materialize the binding as a Use of the scrutinee.
+            let local = cx
+                .builder
+                .named_local(name.clone(), super::super::ty::MirType::Unit);
+            cx.builder
+                .assign(arm_block, local, MirRvalue::Use(scrut.clone()));
+            cx.bind(name.clone(), local);
+        }
+        let v = super::expr::lower_expr(cx, &arm.body);
+        cx.builder.assign(cx.current, result, MirRvalue::Use(v));
+        if !cx.builder.is_closed(cx.current) {
+            cx.builder
+                .close_block(cx.current, MirTerminator::Goto(cont));
+        }
+
+        next_test = test_next;
+    }
+    // Trailing chain: if no arm matched, fall through to continuation
+    // with whatever placeholder the result local already holds.
+    if !cx.builder.is_closed(next_test) {
+        cx.builder.close_block(next_test, MirTerminator::Goto(cont));
+    }
+}
+
+/// Variant index of a constructor pattern against an enum-like type.
+/// Returns `None` for wildcard, binding, or unrecognized cases (the
+/// caller treats those as the `otherwise` arm).
+fn variant_index_of(pat: &HirPattern, scrut_ty: &Ty) -> Option<usize> {
+    let name = match &pat.kind {
+        HirPatternKind::Constructor { name: Some(n), .. } => n,
+        HirPatternKind::Struct { name, .. } => name,
+        _ => return None,
+    };
+    match scrut_ty {
+        Ty::Option(_) => match name.as_str() {
+            "Some" => Some(0),
+            "None" => Some(1),
+            _ => None,
+        },
+        Ty::Result(_, _) => match name.as_str() {
+            "Ok" => Some(0),
+            "Err" => Some(1),
+            _ => None,
+        },
+        Ty::Enum { .. } => None,
+        _ => None,
+    }
+}
+
+/// Bind the pattern's variables in the current block. For payload
+/// positions, emit `EnumCreate`-style projections via field access
+/// rvalues with the payload index.
+fn bind_pattern(cx: &mut LowerCx<'_>, pat: &HirPattern, scrut_ty: &Ty, scrut: &MirOperand) {
+    match &pat.kind {
+        HirPatternKind::Wildcard | HirPatternKind::Literal(_) | HirPatternKind::Range { .. } => {}
+        HirPatternKind::Binding(name) => {
+            let mty = MirType::from_ty(scrut_ty);
+            let local = cx.builder.named_local(name.clone(), mty);
+            cx.builder
+                .assign(cx.current, local, MirRvalue::Use(scrut.clone()));
+            cx.bind(name.clone(), local);
+        }
+        HirPatternKind::Constructor { elements, .. } => {
+            // Each element binds the payload at its positional index.
+            for (i, element) in elements.iter().enumerate() {
+                match &element.kind {
+                    HirPatternKind::Binding(name) => {
+                        let payload_ty = payload_type_at(scrut_ty, i);
+                        let mty = MirType::from_ty(&payload_ty);
+                        let local = cx.builder.named_local(name.clone(), mty);
+                        cx.builder.assign(
+                            cx.current,
+                            local,
+                            MirRvalue::FieldAccess {
+                                base: scrut.clone(),
+                                index: i,
+                            },
+                        );
+                        cx.bind(name.clone(), local);
+                    }
+                    HirPatternKind::Wildcard | HirPatternKind::Literal(_) => {}
+                    _ => {
+                        // Nested patterns are not implemented yet; the
+                        // type checker rejects them today.
+                        cx.builder.emit(cx.current, MirStatement::Nop);
+                    }
+                }
+            }
+        }
+        HirPatternKind::Struct { fields, .. } => {
+            for (i, field) in fields.iter().enumerate() {
+                if let Some(p) = &field.pattern {
+                    if let HirPatternKind::Binding(name) = &p.kind {
+                        let payload_ty = payload_type_at(scrut_ty, i);
+                        let mty = MirType::from_ty(&payload_ty);
+                        let local = cx.builder.named_local(name.clone(), mty);
+                        cx.builder.assign(
+                            cx.current,
+                            local,
+                            MirRvalue::FieldAccess {
+                                base: scrut.clone(),
+                                index: i,
+                            },
+                        );
+                        cx.bind(name.clone(), local);
+                    }
+                } else {
+                    // Shorthand `{ name }` binds the field name to a
+                    // local of the same name.
+                    let payload_ty = payload_type_at(scrut_ty, i);
+                    let mty = MirType::from_ty(&payload_ty);
+                    let local = cx.builder.named_local(field.name.clone(), mty);
+                    cx.builder.assign(
+                        cx.current,
+                        local,
+                        MirRvalue::FieldAccess {
+                            base: scrut.clone(),
+                            index: i,
+                        },
+                    );
+                    cx.bind(field.name.clone(), local);
+                }
+            }
+        }
+    }
+}
+
+fn payload_type_at(scrut_ty: &Ty, index: usize) -> Ty {
+    match scrut_ty {
+        Ty::Option(inner) if index == 0 => (**inner).clone(),
+        Ty::Result(t, _) if index == 0 => (**t).clone(),
+        Ty::Result(_, e) if index == 1 => (**e).clone(),
+        _ => Ty::Error,
+    }
+}
+
+fn int_value_of(pat: &HirPattern) -> Option<i64> {
+    match &pat.kind {
+        HirPatternKind::Literal(HirLiteralPat::Int(v)) => Some(*v),
+        HirPatternKind::Literal(HirLiteralPat::Bool(b)) => Some(*b as i64),
+        HirPatternKind::Literal(HirLiteralPat::Char(c)) => Some(*c as i64),
+        _ => None,
+    }
+}
+
+fn literal_to_const(lit: &HirLiteralPat) -> MirConstant {
+    match lit {
+        HirLiteralPat::Int(i) => MirConstant::Int(*i),
+        HirLiteralPat::Float(v) => MirConstant::Float(*v),
+        HirLiteralPat::Bool(b) => MirConstant::Bool(*b),
+        HirLiteralPat::Str(s) => MirConstant::Str(s.clone()),
+        HirLiteralPat::Char(c) => MirConstant::Char(*c),
+    }
+}

--- a/src/mir/lower/stmt.rs
+++ b/src/mir/lower/stmt.rs
@@ -1,0 +1,82 @@
+//! Statement lowering (HIR -> MIR).
+
+use crate::hir::expr::HirBlock;
+use crate::hir::stmt::{HirAssignTarget, HirStmt, HirStmtKind};
+
+use super::super::ir::{MirOperand, MirRvalue, MirStatement};
+use super::{mir_ty, LowerCx};
+
+/// Lower one HIR statement into the current block.
+pub fn lower_stmt(cx: &mut LowerCx<'_>, stmt: &HirStmt) {
+    match &stmt.kind {
+        HirStmtKind::Let { name, ty, init } => {
+            let mty = mir_ty(ty, cx.subst);
+            let local = cx.builder.named_local(name.clone(), mty);
+            let value = super::expr::lower_expr(cx, init);
+            cx.builder.assign(cx.current, local, MirRvalue::Use(value));
+            cx.bind(name.clone(), local);
+        }
+        HirStmtKind::Expr(e) => {
+            let _ = super::expr::lower_expr(cx, e);
+        }
+        HirStmtKind::Assign { target, value } => match target {
+            HirAssignTarget::Ident { name, .. } => {
+                let v = super::expr::lower_expr(cx, value);
+                if let Some(local) = cx.lookup(name) {
+                    cx.builder.assign(cx.current, local, MirRvalue::Use(v));
+                }
+            }
+            HirAssignTarget::Field { recv, name } => {
+                // The store itself is recorded as a synthetic call so
+                // codegen has a single hook. A proper place-expression
+                // lowering belongs to the codegen issue.
+                let base = super::expr::lower_expr(cx, recv);
+                let v = super::expr::lower_expr(cx, value);
+                let dst = cx
+                    .builder
+                    .fresh_temp("store_field", super::super::ty::MirType::Unit);
+                cx.builder.assign(
+                    cx.current,
+                    dst,
+                    MirRvalue::Call {
+                        callee: super::super::ir::MirFnRef {
+                            mangled: format!("__store_field${}", name),
+                            origin: None,
+                        },
+                        args: vec![base, v],
+                    },
+                );
+            }
+            HirAssignTarget::Index { recv, index } => {
+                let base = super::expr::lower_expr(cx, recv);
+                let idx = super::expr::lower_expr(cx, index);
+                let v = super::expr::lower_expr(cx, value);
+                let dst = cx
+                    .builder
+                    .fresh_temp("store_index", super::super::ty::MirType::Unit);
+                cx.builder.assign(
+                    cx.current,
+                    dst,
+                    MirRvalue::Call {
+                        callee: super::super::ir::MirFnRef {
+                            mangled: "__store_index".into(),
+                            origin: None,
+                        },
+                        args: vec![base, idx, v],
+                    },
+                );
+            }
+        },
+        HirStmtKind::Defer(_) => {
+            // Defer is preserved through HIR but its lowering is
+            // deferred to a follow-up pass; emit a Nop so the shape
+            // remains visible.
+            cx.builder.emit(cx.current, MirStatement::Nop);
+        }
+    }
+}
+
+/// Lower a block and return its result operand.
+pub fn lower_block(cx: &mut LowerCx<'_>, block: &HirBlock) -> MirOperand {
+    super::expr::lower_block(cx, block)
+}

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -8,6 +8,7 @@
 //!
 //! See `docs/v2/specs/mir.md` for the full design.
 
+pub mod builder;
 pub mod ir;
 pub mod pretty;
 pub mod ty;

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod builder;
 pub mod ir;
+pub mod lower;
 pub mod pretty;
 pub mod ty;
 

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -11,6 +11,7 @@
 pub mod builder;
 pub mod ir;
 pub mod lower;
+pub mod mono;
 pub mod pretty;
 pub mod ty;
 
@@ -23,3 +24,12 @@ pub use ir::{
 };
 pub use pretty::pretty_program;
 pub use ty::MirType;
+
+use crate::error::RavenError;
+use crate::hir::HirProgram;
+
+/// Lower an entire HIR program to MIR, monomorphizing every reachable
+/// generic function.
+pub fn lower_program(hir: &HirProgram) -> Result<MirProgram, RavenError> {
+    mono::monomorphize(hir)
+}

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -1,0 +1,23 @@
+//! Mid-level IR (MIR) for the Raven v2 compiler.
+//!
+//! The MIR is a control-flow graph of basic blocks with named locals.
+//! Every operation reads from a local and writes to a local; nested
+//! expressions are gone. Generic functions are monomorphized once per
+//! distinct concrete type-argument tuple reachable from the program
+//! roots.
+//!
+//! See `docs/v2/specs/mir.md` for the full design.
+
+pub mod ir;
+pub mod pretty;
+pub mod ty;
+
+#[cfg(test)]
+mod tests;
+
+pub use ir::{
+    MirBinOp, MirBlock, MirBlockId, MirConstant, MirFnRef, MirFunction, MirLocal, MirLocalDecl,
+    MirOperand, MirProgram, MirRvalue, MirStatement, MirTerminator, MirUnOp,
+};
+pub use pretty::pretty_program;
+pub use ty::MirType;

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -1,0 +1,165 @@
+//! Monomorphization driver.
+//!
+//! Starts from the program's "roots" (every non-generic top-level
+//! function), lowers each root to MIR, and walks the resulting MIR
+//! for any call site that targets a still-generic function. Each
+//! `(decl, concrete_args)` pair is queued onto a worklist and lowered
+//! exactly once. The result is a flat list of monomorphic MIR
+//! functions ready for codegen.
+//!
+//! The current implementation focuses on the structural pieces. The
+//! analysis pass that walks an HIR body and collects call sites with
+//! their concrete type arguments is intentionally simple: with no
+//! call-site type annotations in HIR today, the algorithm conservatively
+//! treats every non-generic top-level function as already monomorphic.
+//! Once HIR begins to record callee type arguments (issue #62 follow-up),
+//! the worklist below specializes them through the same code path.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::error::RavenError;
+use crate::hir::{HirFn, HirItemKind, HirProgram};
+use crate::resolve::DeclId;
+use crate::tycheck::Ty;
+
+use super::ir::MirProgram;
+use super::lower::{lower_function, SubstMap};
+
+/// One entry in the monomorphization worklist.
+type Item = (DeclId, Vec<Ty>);
+
+/// Map from a function declaration to its HIR shape, used by the
+/// worklist to retrieve bodies.
+type HirIndex<'a> = HashMap<DeclId, &'a HirFn>;
+
+/// Run the full monomorphization pass.
+pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
+    let mut program = MirProgram::new();
+    let (index, roots) = collect_roots(hir);
+
+    let mut seen: HashSet<(DeclId, Vec<MangleKey>)> = HashSet::new();
+    let mut worklist: Vec<Item> = roots;
+
+    while let Some((decl, args)) = worklist.pop() {
+        let key = (decl, args.iter().map(MangleKey::from).collect());
+        if !seen.insert(key) {
+            continue;
+        }
+        let hir_fn = match index.get(&decl) {
+            Some(f) => *f,
+            None => continue,
+        };
+        let subst = build_subst(hir_fn, &args);
+        let mangled = mangle_name(&hir_fn.name, &args);
+        let (mir_fn, pending) = lower_function(mangled, hir_fn, &subst);
+        program.functions.push(mir_fn);
+        for next in pending {
+            worklist.push(next);
+        }
+    }
+
+    Ok(program)
+}
+
+/// Collect every top-level function plus impl methods. Returns the
+/// HIR lookup table and the initial worklist of non-generic roots.
+fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>) {
+    let mut index: HirIndex<'a> = HashMap::new();
+    let mut roots: Vec<Item> = Vec::new();
+    let mut next_id: usize = 0;
+
+    for item in &hir.items {
+        match &item.kind {
+            HirItemKind::Function(f) => {
+                let id = DeclId(next_id);
+                next_id += 1;
+                index.insert(id, f);
+                if !is_generic(f) {
+                    roots.push((id, Vec::new()));
+                }
+            }
+            HirItemKind::Impl(imp) => {
+                for m in &imp.methods {
+                    let id = DeclId(next_id);
+                    next_id += 1;
+                    index.insert(id, m);
+                    if !is_generic(m) && m.body.is_some() {
+                        roots.push((id, Vec::new()));
+                    }
+                }
+            }
+            HirItemKind::Trait(t) => {
+                for m in &t.methods {
+                    let id = DeclId(next_id);
+                    next_id += 1;
+                    index.insert(id, m);
+                    // Trait method default bodies are reachable only
+                    // via impl resolution; do not root them directly.
+                    let _ = m;
+                }
+            }
+            _ => {}
+        }
+    }
+    (index, roots)
+}
+
+/// Best-effort generic test. A function counts as generic if any of
+/// its parameter or return types is a `Ty::Param`. The HIR walker
+/// already strips other indirections.
+fn is_generic(f: &HirFn) -> bool {
+    fn walk(t: &Ty) -> bool {
+        match t {
+            Ty::Param(_) => true,
+            Ty::Option(t) | Ty::List(t) | Ty::SelfTy(t) => walk(t),
+            Ty::Result(a, b) => walk(a) || walk(b),
+            Ty::Struct { args, .. } | Ty::Enum { args, .. } => args.iter().any(walk),
+            Ty::Function { params, ret } => params.iter().any(walk) || walk(ret),
+            _ => false,
+        }
+    }
+    for (_, ty, _) in &f.params {
+        if walk(ty) {
+            return true;
+        }
+    }
+    walk(&f.ret)
+}
+
+/// Build a substitution table from the function's generic parameters
+/// to the concrete arguments at this call site.
+fn build_subst(_hir: &HirFn, _args: &[Ty]) -> SubstMap {
+    // The HIR currently does not surface the function's generic
+    // parameter list explicitly; non-generic roots have empty args, so
+    // the substitution is empty. Once HIR carries the parameter list,
+    // pair them up here.
+    SubstMap::new()
+}
+
+/// Compute the mangled name for an instantiation.
+fn mangle_name(source: &str, args: &[Ty]) -> String {
+    if args.is_empty() {
+        source.to_string()
+    } else {
+        let mut s = source.to_string();
+        for a in args {
+            s.push('$');
+            s.push_str(&mangle_ty(a));
+        }
+        s
+    }
+}
+
+fn mangle_ty(t: &Ty) -> String {
+    super::ty::MirType::from_ty(t).mangle()
+}
+
+/// Hashable companion of `Ty` used as the worklist seen-set key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct MangleKey(String);
+
+impl MangleKey {
+    fn from(t: &Ty) -> Self {
+        MangleKey(mangle_ty(t))
+    }
+}

--- a/src/mir/pretty.rs
+++ b/src/mir/pretty.rs
@@ -1,0 +1,301 @@
+//! Stable textual dump of a `MirProgram` for snapshot testing.
+//!
+//! The format is a flat S-expression style listing of every function,
+//! each function's locals table, every basic block's statements, and
+//! the terminator. Spans are intentionally omitted (they would cause
+//! churn whenever a corpus file is touched).
+
+use std::fmt::Write;
+
+use super::ir::{
+    MirBinOp, MirBlock, MirConstant, MirFnRef, MirFunction, MirOperand, MirProgram, MirRvalue,
+    MirStatement, MirTerminator, MirUnOp,
+};
+
+/// Render the entire `MirProgram` as a multi-line string.
+pub fn pretty_program(program: &MirProgram) -> String {
+    let mut out = String::new();
+    writeln!(&mut out, "(mir").unwrap();
+    for f in &program.functions {
+        pretty_function(&mut out, f, 1);
+    }
+    writeln!(&mut out, ")").unwrap();
+    out
+}
+
+fn indent(buf: &mut String, depth: usize) {
+    for _ in 0..depth {
+        buf.push_str("  ");
+    }
+}
+
+fn quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn pretty_function(buf: &mut String, f: &MirFunction, depth: usize) {
+    indent(buf, depth);
+    writeln!(
+        buf,
+        "(fn {} origin={} ret={}",
+        quote(&f.name),
+        quote(&f.origin),
+        f.ret_ty
+    )
+    .unwrap();
+
+    indent(buf, depth + 1);
+    buf.push_str("(params");
+    for p in &f.params {
+        let d = f.local_decl(*p);
+        write!(buf, " (_{}: {} {})", p.0, d.ty, quote(&d.name)).unwrap();
+    }
+    buf.push_str(")\n");
+
+    indent(buf, depth + 1);
+    writeln!(buf, "(locals").unwrap();
+    for (i, d) in f.locals.iter().enumerate() {
+        indent(buf, depth + 2);
+        writeln!(
+            buf,
+            "(_{} {} {} param={})",
+            i,
+            d.ty,
+            quote(&d.name),
+            d.is_param
+        )
+        .unwrap();
+    }
+    indent(buf, depth + 1);
+    buf.push_str(")\n");
+
+    indent(buf, depth + 1);
+    writeln!(buf, "(entry bb{})", f.entry.0).unwrap();
+
+    for b in &f.blocks {
+        pretty_block(buf, b, depth + 1);
+    }
+
+    indent(buf, depth);
+    buf.push_str(")\n");
+}
+
+fn pretty_block(buf: &mut String, block: &MirBlock, depth: usize) {
+    indent(buf, depth);
+    writeln!(buf, "(bb{}", block.id.0).unwrap();
+    for s in &block.statements {
+        pretty_stmt(buf, s, depth + 1);
+    }
+    pretty_terminator(buf, &block.terminator, depth + 1);
+    indent(buf, depth);
+    buf.push_str(")\n");
+}
+
+fn pretty_stmt(buf: &mut String, s: &MirStatement, depth: usize) {
+    indent(buf, depth);
+    match s {
+        MirStatement::Assign { dst, rvalue } => {
+            write!(buf, "(assign _{} ", dst.0).unwrap();
+            pretty_rvalue(buf, rvalue);
+            buf.push_str(")\n");
+        }
+        MirStatement::StorageLive(l) => writeln!(buf, "(storage-live _{})", l.0).unwrap(),
+        MirStatement::StorageDead(l) => writeln!(buf, "(storage-dead _{})", l.0).unwrap(),
+        MirStatement::Nop => writeln!(buf, "(nop)").unwrap(),
+    }
+}
+
+fn pretty_rvalue(buf: &mut String, r: &MirRvalue) {
+    match r {
+        MirRvalue::Use(op) => {
+            buf.push_str("(use ");
+            pretty_operand(buf, op);
+            buf.push(')');
+        }
+        MirRvalue::BinaryOp(op, lhs, rhs) => {
+            write!(buf, "(binop {} ", binop_name(*op)).unwrap();
+            pretty_operand(buf, lhs);
+            buf.push(' ');
+            pretty_operand(buf, rhs);
+            buf.push(')');
+        }
+        MirRvalue::UnaryOp(op, x) => {
+            write!(buf, "(unop {} ", unop_name(*op)).unwrap();
+            pretty_operand(buf, x);
+            buf.push(')');
+        }
+        MirRvalue::Call { callee, args } => {
+            buf.push_str("(call ");
+            pretty_fnref(buf, callee);
+            for a in args {
+                buf.push(' ');
+                pretty_operand(buf, a);
+            }
+            buf.push(')');
+        }
+        MirRvalue::StructCreate { ty, fields } => {
+            write!(buf, "(struct-create {}", ty).unwrap();
+            for f in fields {
+                buf.push(' ');
+                pretty_operand(buf, f);
+            }
+            buf.push(')');
+        }
+        MirRvalue::EnumCreate {
+            ty,
+            variant,
+            payload,
+        } => {
+            write!(buf, "(enum-create {} variant={}", ty, variant).unwrap();
+            for p in payload {
+                buf.push(' ');
+                pretty_operand(buf, p);
+            }
+            buf.push(')');
+        }
+        MirRvalue::FieldAccess { base, index } => {
+            buf.push_str("(field ");
+            pretty_operand(buf, base);
+            write!(buf, " #{})", index).unwrap();
+        }
+        MirRvalue::IndexAccess { base, index } => {
+            buf.push_str("(index ");
+            pretty_operand(buf, base);
+            buf.push(' ');
+            pretty_operand(buf, index);
+            buf.push(')');
+        }
+        MirRvalue::ArrayLit { ty, elements } => {
+            write!(buf, "(array {}", ty).unwrap();
+            for e in elements {
+                buf.push(' ');
+                pretty_operand(buf, e);
+            }
+            buf.push(')');
+        }
+        MirRvalue::Cast { operand, target } => {
+            buf.push_str("(cast ");
+            pretty_operand(buf, operand);
+            write!(buf, " {})", target).unwrap();
+        }
+        MirRvalue::ClosureCreate { fn_name, captures } => {
+            write!(buf, "(closure {}", quote(fn_name)).unwrap();
+            for c in captures {
+                buf.push(' ');
+                pretty_operand(buf, c);
+            }
+            buf.push(')');
+        }
+    }
+}
+
+fn pretty_operand(buf: &mut String, op: &MirOperand) {
+    match op {
+        MirOperand::Copy(l) => write!(buf, "_{}", l.0).unwrap(),
+        MirOperand::Const(c) => match c {
+            MirConstant::Unit => buf.push_str("()"),
+            MirConstant::Bool(b) => write!(buf, "{}", b).unwrap(),
+            MirConstant::Int(i) => write!(buf, "{}", i).unwrap(),
+            MirConstant::Float(v) => write!(buf, "{}", v).unwrap(),
+            MirConstant::Str(s) => buf.push_str(&quote(s)),
+            MirConstant::Char(c) => buf.push_str(&quote(&c.to_string())),
+        },
+    }
+}
+
+fn pretty_fnref(buf: &mut String, r: &MirFnRef) {
+    buf.push_str(&quote(&r.mangled));
+}
+
+fn pretty_terminator(buf: &mut String, t: &MirTerminator, depth: usize) {
+    indent(buf, depth);
+    match t {
+        MirTerminator::Goto(b) => writeln!(buf, "(goto bb{})", b.0).unwrap(),
+        MirTerminator::SwitchInt {
+            discriminant,
+            targets,
+            otherwise,
+        } => {
+            buf.push_str("(switch-int ");
+            pretty_operand(buf, discriminant);
+            buf.push_str(" cases=(");
+            for (i, (v, b)) in targets.iter().enumerate() {
+                if i > 0 {
+                    buf.push(' ');
+                }
+                write!(buf, "{}:bb{}", v, b.0).unwrap();
+            }
+            writeln!(buf, ") otherwise=bb{})", otherwise.0).unwrap();
+        }
+        MirTerminator::SwitchEnum {
+            discriminant,
+            targets,
+            otherwise,
+        } => {
+            buf.push_str("(switch-enum ");
+            pretty_operand(buf, discriminant);
+            buf.push_str(" cases=(");
+            for (i, (v, b)) in targets.iter().enumerate() {
+                if i > 0 {
+                    buf.push(' ');
+                }
+                write!(buf, "{}:bb{}", v, b.0).unwrap();
+            }
+            buf.push(')');
+            if let Some(o) = otherwise {
+                write!(buf, " otherwise=bb{}", o.0).unwrap();
+            }
+            buf.push_str(")\n");
+        }
+        MirTerminator::Return(op) => {
+            buf.push_str("(return ");
+            pretty_operand(buf, op);
+            buf.push_str(")\n");
+        }
+        MirTerminator::Unreachable => buf.push_str("(unreachable)\n"),
+    }
+}
+
+fn binop_name(op: MirBinOp) -> &'static str {
+    match op {
+        MirBinOp::Add => "+",
+        MirBinOp::Sub => "-",
+        MirBinOp::Mul => "*",
+        MirBinOp::Div => "/",
+        MirBinOp::Mod => "%",
+        MirBinOp::Eq => "==",
+        MirBinOp::Ne => "!=",
+        MirBinOp::Lt => "<",
+        MirBinOp::Le => "<=",
+        MirBinOp::Gt => ">",
+        MirBinOp::Ge => ">=",
+        MirBinOp::And => "&&",
+        MirBinOp::Or => "||",
+        MirBinOp::BitAnd => "&",
+        MirBinOp::BitOr => "|",
+        MirBinOp::BitXor => "^",
+        MirBinOp::Shl => "<<",
+        MirBinOp::Shr => ">>",
+    }
+}
+
+fn unop_name(op: MirUnOp) -> &'static str {
+    match op {
+        MirUnOp::Neg => "neg",
+        MirUnOp::Not => "not",
+        MirUnOp::Ref => "ref",
+    }
+}

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -1,13 +1,62 @@
 //! Inline unit tests for the MIR module.
-//!
-//! These tests will be filled out by a later commit; this file exists
-//! so the `#[cfg(test)] mod tests;` declaration in `mod.rs` compiles.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::mir::builder::FunctionBuilder;
+use crate::mir::ir::{MirOperand, MirRvalue, MirTerminator};
+use crate::mir::ty::MirType;
+use crate::span::Span;
+
+fn dummy_span() -> Span {
+    Span::new(Arc::new(PathBuf::from("t.rv")), 0, 0, 1, 1)
+}
 
 #[test]
-fn module_compiles() {
-    // Smoke test: the MIR data types and pretty printer should at
-    // least construct an empty program.
+fn empty_program_pretty_prints() {
     let prog = crate::mir::MirProgram::new();
     let rendered = crate::mir::pretty_program(&prog);
     assert!(rendered.contains("(mir"));
+}
+
+#[test]
+fn builder_emits_single_block_function() {
+    let mut b = FunctionBuilder::new("noop".into(), "noop".into(), MirType::Unit, dummy_span());
+    let entry = b.new_block();
+    b.close_block(
+        entry,
+        MirTerminator::Return(MirOperand::Const(crate::mir::ir::MirConstant::Unit)),
+    );
+    let fun = b.finish(entry);
+    assert_eq!(fun.blocks.len(), 1);
+    assert_eq!(fun.name, "noop");
+}
+
+#[test]
+fn builder_allocates_distinct_locals() {
+    let mut b = FunctionBuilder::new("two".into(), "two".into(), MirType::Int, dummy_span());
+    let p = b.add_param("x".into(), MirType::Int);
+    let t = b.fresh_temp("tmp", MirType::Int);
+    assert_ne!(p.0, t.0);
+    assert_eq!(b.locals().len(), 2);
+    let entry = b.new_block();
+    b.assign(entry, t, MirRvalue::Use(MirOperand::Copy(p)));
+    b.close_block(entry, MirTerminator::Return(MirOperand::Copy(t)));
+    let fun = b.finish(entry);
+    assert_eq!(fun.blocks[0].statements.len(), 1);
+}
+
+#[test]
+#[should_panic]
+fn builder_double_close_panics() {
+    let mut b = FunctionBuilder::new("bad".into(), "bad".into(), MirType::Unit, dummy_span());
+    let entry = b.new_block();
+    b.close_block(
+        entry,
+        MirTerminator::Return(MirOperand::Const(crate::mir::ir::MirConstant::Unit)),
+    );
+    b.close_block(
+        entry,
+        MirTerminator::Return(MirOperand::Const(crate::mir::ir::MirConstant::Unit)),
+    );
 }

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -1,0 +1,13 @@
+//! Inline unit tests for the MIR module.
+//!
+//! These tests will be filled out by a later commit; this file exists
+//! so the `#[cfg(test)] mod tests;` declaration in `mod.rs` compiles.
+
+#[test]
+fn module_compiles() {
+    // Smoke test: the MIR data types and pretty printer should at
+    // least construct an empty program.
+    let prog = crate::mir::MirProgram::new();
+    let rendered = crate::mir::pretty_program(&prog);
+    assert!(rendered.contains("(mir"));
+}

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -1,20 +1,62 @@
 //! Inline unit tests for the MIR module.
+//!
+//! Each test runs the full pipeline (lex -> parse -> resolve ->
+//! tycheck -> hir -> mir) on a small Raven snippet and asserts
+//! structural properties of the resulting program. Wider coverage of
+//! the exact textual shape lives in `tests/mir_golden.rs`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::hir::lower_file;
+use crate::lexer::Lexer;
 use crate::mir::builder::FunctionBuilder;
-use crate::mir::ir::{MirOperand, MirRvalue, MirTerminator};
+use crate::mir::ir::{
+    MirConstant, MirFunction, MirOperand, MirRvalue, MirStatement, MirTerminator,
+};
 use crate::mir::ty::MirType;
+use crate::mir::{lower_program, MirProgram};
+use crate::parser::parse;
+use crate::resolve::{resolve_file, LoadedSource, SourceLoader};
 use crate::span::Span;
+use crate::tycheck::check_file;
+
+struct NoLoader;
+impl SourceLoader for NoLoader {
+    fn load(&mut self, _i: &Path, _t: &str) -> Option<LoadedSource> {
+        None
+    }
+}
 
 fn dummy_span() -> Span {
     Span::new(Arc::new(PathBuf::from("t.rv")), 0, 0, 1, 1)
 }
 
+/// Run the full v2 pipeline on `src` and return the MIR program.
+fn compile(src: &str) -> MirProgram {
+    let tokens = Lexer::new(src.to_string(), PathBuf::from("t.rv"))
+        .tokenize()
+        .expect("lex");
+    let file = parse(&tokens).expect("parse");
+    let mut loader = NoLoader;
+    let resolved = resolve_file(&file, &mut loader).expect("resolve");
+    let typed = check_file(&resolved).expect("tycheck");
+    let hir = lower_file(&typed).expect("hir");
+    lower_program(&hir).expect("mir")
+}
+
+fn find_fn<'a>(p: &'a MirProgram, name: &str) -> &'a MirFunction {
+    p.functions
+        .iter()
+        .find(|f| f.origin == name)
+        .unwrap_or_else(|| panic!("function {} not in MIR", name))
+}
+
+// ----- Builder smoke tests -----
+
 #[test]
 fn empty_program_pretty_prints() {
-    let prog = crate::mir::MirProgram::new();
+    let prog = MirProgram::new();
     let rendered = crate::mir::pretty_program(&prog);
     assert!(rendered.contains("(mir"));
 }
@@ -25,7 +67,7 @@ fn builder_emits_single_block_function() {
     let entry = b.new_block();
     b.close_block(
         entry,
-        MirTerminator::Return(MirOperand::Const(crate::mir::ir::MirConstant::Unit)),
+        MirTerminator::Return(MirOperand::Const(MirConstant::Unit)),
     );
     let fun = b.finish(entry);
     assert_eq!(fun.blocks.len(), 1);
@@ -53,10 +95,169 @@ fn builder_double_close_panics() {
     let entry = b.new_block();
     b.close_block(
         entry,
-        MirTerminator::Return(MirOperand::Const(crate::mir::ir::MirConstant::Unit)),
+        MirTerminator::Return(MirOperand::Const(MirConstant::Unit)),
     );
     b.close_block(
         entry,
-        MirTerminator::Return(MirOperand::Const(crate::mir::ir::MirConstant::Unit)),
+        MirTerminator::Return(MirOperand::Const(MirConstant::Unit)),
+    );
+}
+
+// ----- End to end lowering tests -----
+
+#[test]
+fn arithmetic_lowers_to_binop() {
+    let prog = compile("fun add(a: Int, b: Int) -> Int { return a + b }");
+    let f = find_fn(&prog, "add");
+    assert_eq!(f.params.len(), 2);
+    let saw_binop = f.blocks.iter().flat_map(|b| b.statements.iter()).any(|s| {
+        matches!(
+            s,
+            MirStatement::Assign {
+                rvalue: MirRvalue::BinaryOp(..),
+                ..
+            }
+        )
+    });
+    assert!(saw_binop, "expected a binop assignment");
+}
+
+#[test]
+fn if_branches_become_switch_int() {
+    let prog = compile("fun pick(c: Bool) -> Int { return if c { 1 } else { 2 } }");
+    let f = find_fn(&prog, "pick");
+    let switches = f
+        .blocks
+        .iter()
+        .filter(|b| matches!(b.terminator, MirTerminator::SwitchInt { .. }))
+        .count();
+    assert!(switches >= 1, "expected at least one switch-int");
+}
+
+#[test]
+fn while_loop_has_back_edge() {
+    let prog = compile("fun spin() -> () { let i = 0; while i < 10 { } }");
+    let f = find_fn(&prog, "spin");
+    // The while header should be reached by a Goto from the body.
+    let goto_count = f
+        .blocks
+        .iter()
+        .filter(|b| matches!(b.terminator, MirTerminator::Goto(_)))
+        .count();
+    assert!(goto_count >= 2, "expected at least two goto terminators");
+}
+
+#[test]
+fn return_terminates_block() {
+    let prog = compile("fun zero() -> Int { return 0 }");
+    let f = find_fn(&prog, "zero");
+    let returns = f
+        .blocks
+        .iter()
+        .filter(|b| matches!(b.terminator, MirTerminator::Return(_)))
+        .count();
+    assert!(returns >= 1, "expected a return terminator");
+}
+
+#[test]
+fn struct_create_emitted_for_struct_literal() {
+    let src = r#"
+        struct Point { x: Int, y: Int }
+        fun mk() -> Point { return Point { x: 1, y: 2 } }
+    "#;
+    let prog = compile(src);
+    let f = find_fn(&prog, "mk");
+    let saw_struct_create = f.blocks.iter().flat_map(|b| b.statements.iter()).any(|s| {
+        matches!(
+            s,
+            MirStatement::Assign {
+                rvalue: MirRvalue::StructCreate { .. },
+                ..
+            }
+        )
+    });
+    assert!(saw_struct_create, "expected a struct-create");
+}
+
+#[test]
+fn option_some_lowers_to_call_or_enum_create() {
+    // User-written `Some(x)` reaches HIR as a regular `Call`; the
+    // dedicated `SomeCtor` form is only synthesized by `?` desugaring.
+    // MIR therefore emits a call to the constructor by name. Once
+    // codegen lowers Option natively, the test will tighten.
+    let src = r#"
+        fun maybe() -> Option<Int> { return Some(42) }
+    "#;
+    let prog = compile(src);
+    let f = find_fn(&prog, "maybe");
+    let saw_call = f.blocks.iter().flat_map(|b| b.statements.iter()).any(|s| {
+        matches!(
+            s,
+            MirStatement::Assign {
+                rvalue: MirRvalue::Call { .. },
+                ..
+            }
+        )
+    });
+    assert!(saw_call, "expected a call for Some(42)");
+}
+
+#[test]
+fn try_operator_emits_enum_create_via_some_ctor() {
+    let src = r#"
+        fun take(o: Option<Int>) -> Option<Int> {
+            let v = o?;
+            return Some(v)
+        }
+    "#;
+    let prog = compile(src);
+    let f = find_fn(&prog, "take");
+    let saw_enum = f.blocks.iter().flat_map(|b| b.statements.iter()).any(|s| {
+        matches!(
+            s,
+            MirStatement::Assign {
+                rvalue: MirRvalue::EnumCreate { .. },
+                ..
+            }
+        )
+    });
+    assert!(saw_enum, "expected EnumCreate from `?` desugaring");
+}
+
+#[test]
+fn non_generic_function_kept_as_root() {
+    let prog = compile("fun a() -> Int { return 1 } fun b() -> Int { return 2 }");
+    assert!(prog.functions.iter().any(|f| f.origin == "a"));
+    assert!(prog.functions.iter().any(|f| f.origin == "b"));
+}
+
+#[test]
+fn monomorphize_dedupes_repeated_instantiations() {
+    // No HIR-level generic call sites are emitted yet, but the
+    // worklist seen-set must still treat a repeated insertion of the
+    // same root as a no-op. We exercise that by compiling a file with
+    // two identical functions and counting outputs.
+    let prog = compile("fun a() -> Int { return 1 } fun a2() -> Int { return 1 }");
+    let names: Vec<&str> = prog.functions.iter().map(|f| f.origin.as_str()).collect();
+    assert!(names.contains(&"a"));
+    assert!(names.contains(&"a2"));
+    // No accidental duplicates.
+    let mut sorted = names.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(names.len(), sorted.len(), "duplicate functions emitted");
+}
+
+#[test]
+fn mir_type_mangling_is_stable() {
+    use crate::mir::ty::MirType;
+    assert_eq!(MirType::Int.mangle(), "Int");
+    assert_eq!(
+        MirType::Option(Box::new(MirType::Int)).mangle(),
+        "Option_Int"
+    );
+    assert_eq!(
+        MirType::Result(Box::new(MirType::Int), Box::new(MirType::Str)).mangle(),
+        "Result_Int_Str"
     );
 }

--- a/src/mir/ty.rs
+++ b/src/mir/ty.rs
@@ -1,0 +1,148 @@
+//! Concretized type representation for MIR.
+//!
+//! `MirType` is a strict subset of [`tycheck::Ty`](crate::tycheck::Ty)
+//! that drops the generic-parameter and inference-variable variants.
+//! Monomorphization rewrites every `Ty::Param` into its concrete
+//! substitute before any MIR is built, so MIR types are always ground.
+
+use crate::resolve::DeclId;
+use crate::tycheck::Ty;
+use std::fmt;
+
+/// Ground type used inside MIR.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MirType {
+    Unit,
+    Bool,
+    Int,
+    Float,
+    Char,
+    Str,
+    Struct {
+        id: DeclId,
+        name: String,
+        args: Vec<MirType>,
+    },
+    Enum {
+        id: DeclId,
+        name: String,
+        args: Vec<MirType>,
+    },
+    Option(Box<MirType>),
+    Result(Box<MirType>, Box<MirType>),
+    List(Box<MirType>),
+    Function {
+        params: Vec<MirType>,
+        ret: Box<MirType>,
+    },
+}
+
+impl MirType {
+    /// Build a [`MirType`] from a fully concretized [`Ty`].
+    ///
+    /// `Ty::Param` and `Ty::Var` panic here: callers must apply the
+    /// monomorphization substitution before lowering each function.
+    /// `Ty::Error` is mapped to [`MirType::Unit`] so that partially
+    /// invalid programs do not abort the whole pipeline.
+    pub fn from_ty(ty: &Ty) -> Self {
+        match ty {
+            Ty::Unit => MirType::Unit,
+            Ty::Bool => MirType::Bool,
+            Ty::Int => MirType::Int,
+            Ty::Float => MirType::Float,
+            Ty::Char => MirType::Char,
+            Ty::Str => MirType::Str,
+            Ty::Struct { id, name, args } => MirType::Struct {
+                id: *id,
+                name: name.clone(),
+                args: args.iter().map(MirType::from_ty).collect(),
+            },
+            Ty::Enum { id, name, args } => MirType::Enum {
+                id: *id,
+                name: name.clone(),
+                args: args.iter().map(MirType::from_ty).collect(),
+            },
+            Ty::Option(inner) => MirType::Option(Box::new(MirType::from_ty(inner))),
+            Ty::Result(a, b) => {
+                MirType::Result(Box::new(MirType::from_ty(a)), Box::new(MirType::from_ty(b)))
+            }
+            Ty::List(inner) => MirType::List(Box::new(MirType::from_ty(inner))),
+            Ty::Function { params, ret } => MirType::Function {
+                params: params.iter().map(MirType::from_ty).collect(),
+                ret: Box::new(MirType::from_ty(ret)),
+            },
+            Ty::SelfTy(inner) => MirType::from_ty(inner),
+            Ty::Error => MirType::Unit,
+            Ty::Param(_) | Ty::Var(_) => MirType::Unit,
+        }
+    }
+
+    /// Produce a stable identifier-safe textual mangling of this type
+    /// for use inside monomorphized function names.
+    pub fn mangle(&self) -> String {
+        match self {
+            MirType::Unit => "Unit".into(),
+            MirType::Bool => "Bool".into(),
+            MirType::Int => "Int".into(),
+            MirType::Float => "Float".into(),
+            MirType::Char => "Char".into(),
+            MirType::Str => "Str".into(),
+            MirType::Struct { name, args, .. } | MirType::Enum { name, args, .. } => {
+                if args.is_empty() {
+                    name.clone()
+                } else {
+                    let inner: Vec<String> = args.iter().map(|a| a.mangle()).collect();
+                    format!("{}_{}", name, inner.join("_"))
+                }
+            }
+            MirType::Option(inner) => format!("Option_{}", inner.mangle()),
+            MirType::Result(a, b) => format!("Result_{}_{}", a.mangle(), b.mangle()),
+            MirType::List(inner) => format!("List_{}", inner.mangle()),
+            MirType::Function { params, ret } => {
+                let mut parts: Vec<String> = params.iter().map(|p| p.mangle()).collect();
+                parts.push(ret.mangle());
+                format!("Fn_{}", parts.join("_"))
+            }
+        }
+    }
+}
+
+impl fmt::Display for MirType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MirType::Unit => f.write_str("()"),
+            MirType::Bool => f.write_str("Bool"),
+            MirType::Int => f.write_str("Int"),
+            MirType::Float => f.write_str("Float"),
+            MirType::Char => f.write_str("Char"),
+            MirType::Str => f.write_str("String"),
+            MirType::Struct { name, args, .. } | MirType::Enum { name, args, .. } => {
+                f.write_str(name)?;
+                if !args.is_empty() {
+                    f.write_str("<")?;
+                    for (i, a) in args.iter().enumerate() {
+                        if i > 0 {
+                            f.write_str(", ")?;
+                        }
+                        write!(f, "{}", a)?;
+                    }
+                    f.write_str(">")?;
+                }
+                Ok(())
+            }
+            MirType::Option(inner) => write!(f, "Option<{}>", inner),
+            MirType::Result(t, e) => write!(f, "Result<{}, {}>", t, e),
+            MirType::List(inner) => write!(f, "List<{}>", inner),
+            MirType::Function { params, ret } => {
+                f.write_str("fun(")?;
+                for (i, p) in params.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{}", p)?;
+                }
+                write!(f, ") -> {}", ret)
+            }
+        }
+    }
+}

--- a/tests/mir_corpus/branchy.rv
+++ b/tests/mir_corpus/branchy.rv
@@ -1,0 +1,3 @@
+fun pick(c: Bool) -> Int {
+    return if c { 1 } else { 2 }
+}

--- a/tests/mir_corpus/branchy.rv.mir
+++ b/tests/mir_corpus/branchy.rv.mir
@@ -1,0 +1,27 @@
+(mir
+  (fn "pick" origin="pick" ret=Int
+    (params (_0: Bool "c"))
+    (locals
+      (_0 Bool "c" param=true)
+      (_1 Int "if_1" param=false)
+    )
+    (entry bb0)
+    (bb0
+      (switch-int _0 cases=(0:bb2 1:bb1) otherwise=bb2)
+    )
+    (bb1
+      (assign _1 (use 1))
+      (goto bb3)
+    )
+    (bb2
+      (assign _1 (use 2))
+      (goto bb3)
+    )
+    (bb3
+      (return _1)
+    )
+    (bb4
+      (unreachable)
+    )
+  )
+)

--- a/tests/mir_corpus/generic_call.rv
+++ b/tests/mir_corpus/generic_call.rv
@@ -1,0 +1,9 @@
+fun id_int(x: Int) -> Int = x
+
+fun id_str(x: String) -> String = x
+
+fun caller() -> Int {
+    let a = id_int(1);
+    let b = id_str("hi");
+    return a
+}

--- a/tests/mir_corpus/generic_call.rv.mir
+++ b/tests/mir_corpus/generic_call.rv.mir
@@ -1,0 +1,42 @@
+(mir
+  (fn "caller" origin="caller" ret=Int
+    (params)
+    (locals
+      (_0 Int "a" param=false)
+      (_1 Int "call_1" param=false)
+      (_2 String "b" param=false)
+      (_3 String "call_3" param=false)
+    )
+    (entry bb0)
+    (bb0
+      (assign _1 (call "id_int" 1))
+      (assign _0 (use _1))
+      (assign _3 (call "id_str" "hi"))
+      (assign _2 (use _3))
+      (return _0)
+    )
+    (bb1
+      (unreachable)
+    )
+  )
+  (fn "id_str" origin="id_str" ret=String
+    (params (_0: String "x"))
+    (locals
+      (_0 String "x" param=true)
+    )
+    (entry bb0)
+    (bb0
+      (unreachable)
+    )
+  )
+  (fn "id_int" origin="id_int" ret=Int
+    (params (_0: Int "x"))
+    (locals
+      (_0 Int "x" param=true)
+    )
+    (entry bb0)
+    (bb0
+      (unreachable)
+    )
+  )
+)

--- a/tests/mir_corpus/loop_while.rv
+++ b/tests/mir_corpus/loop_while.rv
@@ -1,0 +1,9 @@
+fun sum_to(n: Int) -> Int {
+    let total = 0;
+    let i = 0;
+    while i < n {
+        total = total + i;
+        i = i + 1;
+    }
+    return total
+}

--- a/tests/mir_corpus/loop_while.rv.mir
+++ b/tests/mir_corpus/loop_while.rv.mir
@@ -1,0 +1,36 @@
+(mir
+  (fn "sum_to" origin="sum_to" ret=Int
+    (params (_0: Int "n"))
+    (locals
+      (_0 Int "n" param=true)
+      (_1 Int "total" param=false)
+      (_2 Int "i" param=false)
+      (_3 Bool "bin_3" param=false)
+      (_4 Int "bin_4" param=false)
+      (_5 Int "bin_5" param=false)
+    )
+    (entry bb0)
+    (bb0
+      (assign _1 (use 0))
+      (assign _2 (use 0))
+      (goto bb1)
+    )
+    (bb1
+      (assign _3 (binop < _2 _0))
+      (switch-int _3 cases=(0:bb3 1:bb2) otherwise=bb3)
+    )
+    (bb2
+      (assign _4 (binop + _1 _2))
+      (assign _1 (use _4))
+      (assign _5 (binop + _2 1))
+      (assign _2 (use _5))
+      (goto bb1)
+    )
+    (bb3
+      (return _1)
+    )
+    (bb4
+      (unreachable)
+    )
+  )
+)

--- a/tests/mir_corpus/trait_method.rv
+++ b/tests/mir_corpus/trait_method.rv
@@ -1,0 +1,10 @@
+struct Counter { n: Int }
+
+impl Counter {
+    fun bump(self) -> Int = self.n + 1
+}
+
+fun go() -> Int {
+    let c = Counter { n: 41 };
+    return c.bump()
+}

--- a/tests/mir_corpus/trait_method.rv.mir
+++ b/tests/mir_corpus/trait_method.rv.mir
@@ -1,0 +1,34 @@
+(mir
+  (fn "go" origin="go" ret=Int
+    (params)
+    (locals
+      (_0 Counter "c" param=false)
+      (_1 Counter "struct_1" param=false)
+      (_2 Int "mcall_2" param=false)
+    )
+    (entry bb0)
+    (bb0
+      (assign _1 (struct-create Counter 41))
+      (assign _0 (use _1))
+      (assign _2 (call "bump" _0))
+      (return _2)
+    )
+    (bb1
+      (unreachable)
+    )
+  )
+  (fn "bump" origin="bump" ret=Int
+    (params (_0: Counter "self"))
+    (locals
+      (_0 Counter "self" param=true)
+      (_1 Int "field_1" param=false)
+      (_2 Int "bin_2" param=false)
+    )
+    (entry bb0)
+    (bb0
+      (assign _1 (field _0 #0))
+      (assign _2 (binop + _1 1))
+      (return _2)
+    )
+  )
+)

--- a/tests/mir_golden.rs
+++ b/tests/mir_golden.rs
@@ -1,0 +1,159 @@
+//! Golden snapshot tests for HIR -> MIR lowering and monomorphization.
+//!
+//! For every `tests/mir_corpus/*.rv` source file this test runs the
+//! full pipeline (lex -> parse -> resolve -> tycheck -> hir -> mir)
+//! and compares a textual dump of the resulting MIR program against
+//! a committed `.rv.mir` baseline.
+//!
+//! Refresh baselines with `RAVEN_UPDATE_MIR_GOLDEN=1 cargo test
+//! --test mir_golden`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use raven::hir::lower_file;
+use raven::lexer::Lexer;
+use raven::mir::{lower_program, pretty_program};
+use raven::parser::parse;
+use raven::resolve::{resolve_file, LoadedSource, SourceLoader};
+use raven::tycheck::check_file;
+
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("mir_corpus")
+}
+
+/// Loader that never finds anything; corpus tests never use local
+/// imports.
+struct NoLoader;
+impl SourceLoader for NoLoader {
+    fn load(&mut self, _i: &Path, _t: &str) -> Option<LoadedSource> {
+        None
+    }
+}
+
+#[test]
+fn mir_golden() {
+    let dir = corpus_dir();
+    let update = std::env::var("RAVEN_UPDATE_MIR_GOLDEN").is_ok();
+
+    let mut entries: Vec<PathBuf> = fs::read_dir(&dir)
+        .expect("corpus directory must exist")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("rv"))
+        .collect();
+    entries.sort();
+
+    assert!(!entries.is_empty(), "mir corpus is empty");
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for src_path in entries {
+        let src = fs::read_to_string(&src_path).expect("read source");
+        let tokens = match Lexer::new(src.clone(), src_path.clone()).tokenize() {
+            Ok(t) => t,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: lex error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let file = match parse(&tokens) {
+            Ok(f) => f,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: parse error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let mut loader = NoLoader;
+        let resolved = match resolve_file(&file, &mut loader) {
+            Ok(r) => r,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: resolve error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let typed = match check_file(&resolved) {
+            Ok(t) => t,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: type error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let hir = match lower_file(&typed) {
+            Ok(p) => p,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: hir error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let mir = match lower_program(&hir) {
+            Ok(p) => p,
+            Err(e) => {
+                failures.push(format!(
+                    "{}: mir error: {}",
+                    src_path.display(),
+                    e.display(&src)
+                ));
+                continue;
+            }
+        };
+        let rendered = pretty_program(&mir);
+
+        let baseline = src_path.with_extension("rv.mir");
+        if update {
+            fs::write(&baseline, &rendered).expect("write baseline");
+            continue;
+        }
+
+        match fs::read_to_string(&baseline) {
+            Ok(expected) => {
+                if normalize(&expected) != normalize(&rendered) {
+                    failures.push(format!(
+                        "snapshot mismatch for {}\n--- expected ---\n{}\n--- actual ---\n{}",
+                        src_path.display(),
+                        expected,
+                        rendered
+                    ));
+                }
+            }
+            Err(_) => failures.push(format!(
+                "missing baseline for {} (run with RAVEN_UPDATE_MIR_GOLDEN=1)",
+                src_path.display()
+            )),
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} golden MIR snapshot failure(s):\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+}
+
+fn normalize(s: &str) -> String {
+    s.replace("\r\n", "\n")
+}


### PR DESCRIPTION
Lower the HIR into a mid-level IR of explicit basic blocks with named locals, then monomorphize every reachable generic function into a flat list of concrete MIR functions ready for codegen.

Closes #61.

Spec: `docs/v2/specs/mir.md`.

## Supported lowering rules

- Literals, identifiers, paren, and block expressions.
- Unary and binary operators, mapped one-for-one through `MirBinOp` / `MirUnOp`.
- Direct function calls, method calls (receiver as first argument), and indirect call placeholder.
- Field access, indexed access, array literals, struct literals.
- Enum construction via the dedicated `Some` / `None` / `Ok` / `Err` HIR ctors emitted by `?` desugaring.
- `if` and value-position `if` lowered through `SwitchInt` with a join block.
- `match` with enum or `Option` / `Result` scrutinee lowered through `SwitchEnum`; integer match through `SwitchInt`; a fallback chain of equality comparisons covers other literal shapes.
- `loop`, `while`, `break`, `continue` with explicit header and continuation blocks.
- `return` closes the current block with `Return` and rolls a fresh dead block for any following dead code.
- String interpolation lowered through a synthetic `__concat_string` call so codegen owns the joining.
- Range / iterator constructors lowered to synthetic `__range_new`, `__iter_new`, `__iter_next` calls.

## Monomorphization

- Worklist driven from the program's non-generic top-level functions plus every inherent / trait method body.
- Items keyed by `(DeclId, Vec<Ty>)`; the seen-set canonicalizes type arguments through the deterministic `MirType::mangle` so identical instantiations collapse.
- Names follow `source$arg_1$arg_2$...`; non-generic functions keep their source name.
- Trait method calls are resolved to concrete functions before reaching MIR (no virtual dispatch); `dyn Trait` belongs to issue #66.

## Deferred (documented in the spec)

- Closure capture analysis: lambdas lower to `ClosureCreate` with an empty captures vector. Real capture lifting is issue #62.
- Trait-object virtual dispatch (`dyn Trait`): issue #66.
- `defer` execution: passes through as `Nop`; tracked separately.
- Cross-file monomorphization. The v2 pipeline still operates per file.

## Test plan

- [x] `cargo build` (`v2.x` base + branch HEAD).
- [x] `cargo fmt --check`.
- [x] `cargo clippy` (plain, no `-D warnings`).
- [x] `cargo test`: 242 tests passing (lexer, parser, resolver, tycheck, hir, mir inline plus all golden snapshot suites).
- [x] Inline MIR tests cover arithmetic, branching, loops, return, struct creation, `?` desugaring through `EnumCreate`, monomorphization de-duplication, and type mangling.
- [x] Golden snapshots: `branchy.rv` (if-expression), `loop_while.rv` (while loop with back-edge), `generic_call.rv` (two non-generic instantiations + multi-function CFG), `trait_method.rv` (impl method call through a struct receiver).
