### PR TITLE
feat(runtime): scaffold raven-runtime workspace crate with C ABI surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,7 @@ version = 4
 [[package]]
 name = "raven"
 version = "2.0.0-dev"
+
+[[package]]
+name = "raven-runtime"
+version = "2.0.0-dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,31 @@
-[package]
-name = "raven"
+[workspace]
+members = [".", "raven-runtime"]
+
+[workspace.package]
 version = "2.0.0-dev"
 edition = "2021"
 authors = ["martian56"]
-description = "A modern compiled programming language (v2 in development)"
 license = "MIT"
 repository = "https://github.com/martian56/raven"
+
+[package]
+name = "raven"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "A modern compiled programming language (v2 in development)"
 homepage = "https://raven.ufazien.com"
 keywords = ["programming", "language", "compiler"]
 categories = ["development-tools", "command-line-utilities"]
 
 # Packaging metadata (deb / rpm / wix) intentionally omitted while v2 is under construction.
-# It will be repopulated in Phase 11 (tooling) once the v2 stdlib and rvpm shape settle.
+# It will be repopulated alongside the v2 tooling work once the stdlib and rvpm shape settle.
 
 [dependencies]
-# Phase 0 has no dependencies. Cranelift, ureq, toml, clap etc. will be added per phase as they become needed.
+# The compiler crate has no third-party dependencies during early v2 work.
+# Cranelift, ureq, toml, clap etc. will be added per issue as they become needed.
 
 [profile.release]
 opt-level = 3

--- a/docs/v2/specs/runtime.md
+++ b/docs/v2/specs/runtime.md
@@ -1,0 +1,134 @@
+# Runtime Crate Spec
+
+## Goal
+
+`raven-runtime` is the small Rust crate that compiled v2 programs link
+against at run time. The compiler back-end emits machine code that calls
+into a fixed C ABI surface for heap allocation, panicking, and the few
+intrinsic operations the back-end does not want to open-code (string
+printing, eventually GC entry points). The crate is therefore the
+boundary between the static Raven world and the host operating system.
+
+This document specifies the scaffolding shape only. The crate is created
+as a workspace member, exposes its symbols, and pins object header
+constants the back-end and later GC work will both depend on. The real
+allocator and the tracing collector arrive in follow-up issues (#64 and
+#65), and trait object dispatch lands with #66.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> Resolver -> TypeChecker -> HIR -> MIR -> codegen -> object file
+                                                                                    |
+                                                                                    v
+                                                                          link with raven-runtime
+                                                                                    |
+                                                                                    v
+                                                                                executable
+```
+
+The runtime is invisible to every stage before codegen. It is also the
+only crate other than the compiler itself that ships in the workspace.
+
+## Crate layout
+
+```
+raven-runtime/
+  Cargo.toml          rlib + staticlib, no dependencies
+  src/
+    lib.rs            C ABI exports, unit tests for header layout
+    object.rs         ObjectHeader struct, tag constants, OBJECT_ALIGN
+  tests/
+    abi.rs            integration test that links the staticlib surface
+```
+
+The top-level `Cargo.toml` becomes a virtual workspace with two members:
+the existing `raven` crate (compiler) at the root, and `raven-runtime`
+under `raven-runtime/`. `[workspace.package]` carries the shared edition
+and license; each member keeps its own `[package]`.
+
+## C ABI surface
+
+Every exported symbol is `#[no_mangle] pub extern "C"`. The list is
+intentionally short. New symbols are added as later issues need them.
+
+| Symbol | Signature | Contract |
+|--------|-----------|----------|
+| `raven_alloc` | `fn(size: usize, align: usize) -> *mut u8` | Returns a fresh allocation of `size` bytes aligned to `align`. Returns null on allocation failure. The current implementation forwards to `std::alloc::alloc` with a `Layout` built from the arguments. |
+| `raven_dealloc` | `fn(ptr: *mut u8, size: usize, align: usize)` | Frees an allocation previously returned by `raven_alloc` with the same `size` and `align`. Passing a null pointer is a no-op. |
+| `raven_panic` | `fn(msg_ptr: *const u8, msg_len: usize) -> !` | Writes the UTF-8 slice `msg_ptr[..msg_len]` to standard error with a `raven panic: ` prefix and a trailing newline, then exits the process with status 101 (Rust panic code). Does not return. |
+| `raven_print_str` | `fn(ptr: *const u8, len: usize)` | Writes the UTF-8 slice to standard output without a trailing newline. |
+| `raven_println_str` | `fn(ptr: *const u8, len: usize)` | Writes the UTF-8 slice to standard output followed by a single `\n`. |
+
+All string-shaped entries take a raw pointer plus length so the codegen
+back-end does not need to know any Rust slice layout. The bytes are
+assumed valid UTF-8; the runtime does not re-validate them, mirroring
+the type-checker invariant.
+
+## Object header layout
+
+Every heap-allocated Raven object the GC walks begins with a fixed
+header:
+
+```rust
+#[repr(C)]
+pub struct ObjectHeader {
+    pub tag: u32,      // discriminator: which kind of object this is
+    pub gc_bits: u32,  // mark / colour bits reserved for the future collector
+    pub len: u32,      // logical length (string bytes, list elements, ...)
+    pub cap: u32,      // capacity in elements; 0 when not applicable
+}
+```
+
+Constraints:
+
+* `size_of::<ObjectHeader>() == 16` on every supported target.
+* `align_of::<ObjectHeader>() == 4`, but objects are allocated at
+  `OBJECT_ALIGN = 8` so the payload after the header is aligned for any
+  primitive Raven value.
+* `tag` is read by `raven_panic` (when a debug build wants to print the
+  object kind) and by the GC once it lands. The current scaffold writes
+  it once at allocation time and never inspects it.
+* `gc_bits` is reserved. The scaffold leaves it zero. Issue #64 defines
+  the bit layout.
+
+## Tag constants
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `TAG_STRING` | `0x01` | UTF-8 string. `len` is byte length, `cap` is allocated bytes. |
+| `TAG_LIST` | `0x02` | Boxed `List<T>`. `len` is element count, `cap` is allocation slots. |
+| `TAG_MAP` | `0x03` | Boxed `Map<K, V>`. `len` is entry count, `cap` is bucket count. |
+| `TAG_SET` | `0x04` | Boxed `Set<T>`. `len` is entry count, `cap` is bucket count. |
+| `TAG_CLOSURE` | `0x05` | Closure object: function pointer plus a tail of captures. |
+| `TAG_BOX` | `0x06` | Generic heap box. Reserved for trait-object payloads (#66). |
+
+Constants live in `raven-runtime/src/object.rs` and are re-exported from
+the crate root. Code generation reads them through the C ABI eventually,
+but for now the compiler imports them directly because the back-end is
+also Rust.
+
+## Out of scope for this PR
+
+* Real allocator behaviour. The current `raven_alloc` is `std::alloc`
+  passthrough. A bump or slab allocator is issue #64.
+* Garbage collection. `gc_bits` is reserved but unused.
+* Full object layouts for `String`, `List`, `Map`, `Set`, `Closure`.
+  Only the shared header is fixed. Per-kind layouts are issue #65.
+* Trait object dispatch tables. The `BOX` tag exists as a placeholder;
+  the actual vtable shape lands in issue #66.
+* Async, threading, FFI safety beyond the stated symbols.
+
+## Test coverage
+
+* Inline unit tests in `raven-runtime/src/lib.rs`:
+  * `ObjectHeader` size is 16 bytes.
+  * `ObjectHeader` alignment divides `OBJECT_ALIGN`.
+  * Round-tripping an allocation through `raven_alloc` and
+    `raven_dealloc` does not abort.
+  * `raven_println_str` accepts an empty slice without panic.
+* Integration test `raven-runtime/tests/abi.rs`:
+  * Calls the four allocation-shaped entry points across an
+    allocate-write-deallocate cycle.
+  * Verifies that the staticlib actually links from a separate crate
+    boundary (catches `crate-type` regressions).

--- a/raven-runtime/Cargo.toml
+++ b/raven-runtime/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "raven-runtime"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Runtime support library that compiled Raven programs link against"
+
+[lib]
+crate-type = ["rlib", "staticlib"]
+name = "raven_runtime"
+
+[dependencies]

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -7,9 +7,10 @@
 
 #![deny(unsafe_op_in_unsafe_fn)]
 // The ABI surface is `extern "C"` and is called from machine code
-// emitted by the back-end. The crate documents the safety contract per
-// function; marking the symbols `unsafe` would change their mangling
-// and is not what the codegen is taught to call.
+// emitted by the back-end. The safety contract for each pointer
+// argument is documented on the function itself; the symbols are not
+// marked `unsafe` because the back-end emits direct call instructions
+// and an `unsafe` qualifier would only matter for Rust callers.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![allow(clippy::missing_safety_doc)]
 
@@ -135,4 +136,71 @@ pub extern "C" fn raven_println_str(ptr: *const u8, len: usize) {
         let _ = handle.write_all(bytes);
     }
     let _ = handle.write_all(b"\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, size_of};
+
+    #[test]
+    fn object_header_is_sixteen_bytes() {
+        assert_eq!(size_of::<ObjectHeader>(), 16);
+    }
+
+    #[test]
+    fn object_header_alignment_divides_object_align() {
+        assert!(OBJECT_ALIGN.is_power_of_two());
+        assert_eq!(OBJECT_ALIGN % align_of::<ObjectHeader>(), 0);
+    }
+
+    #[test]
+    fn object_header_new_zeroes_gc_bits() {
+        let h = ObjectHeader::new(TAG_STRING, 5, 8);
+        assert_eq!(h.tag, TAG_STRING);
+        assert_eq!(h.gc_bits, 0);
+        assert_eq!(h.len, 5);
+        assert_eq!(h.cap, 8);
+    }
+
+    #[test]
+    fn tag_constants_are_distinct_and_dense() {
+        let tags = [TAG_STRING, TAG_LIST, TAG_MAP, TAG_SET, TAG_CLOSURE, TAG_BOX];
+        for (i, t) in tags.iter().enumerate() {
+            assert_eq!(*t as usize, i + 1, "tag {i} should be {}", i + 1);
+        }
+    }
+
+    #[test]
+    fn alloc_dealloc_roundtrip_succeeds() {
+        let size = 64;
+        let align = OBJECT_ALIGN;
+        let ptr = raven_alloc(size, align);
+        assert!(!ptr.is_null(), "raven_alloc returned null");
+        // Touch the memory so a miscompile or layout bug would show up
+        // under sanitizers.
+        unsafe {
+            std::ptr::write_bytes(ptr, 0xAB, size);
+        }
+        raven_dealloc(ptr, size, align);
+    }
+
+    #[test]
+    fn alloc_with_invalid_layout_returns_null() {
+        // align is not a power of two: invalid layout, must not abort.
+        let ptr = raven_alloc(8, 3);
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn dealloc_null_is_noop() {
+        raven_dealloc(std::ptr::null_mut(), 16, OBJECT_ALIGN);
+    }
+
+    #[test]
+    fn print_str_accepts_empty_slice() {
+        // Empty slices must not dereference the pointer.
+        raven_print_str(std::ptr::null(), 0);
+        raven_println_str(std::ptr::null(), 0);
+    }
 }

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1,0 +1,5 @@
+//! Runtime support crate for compiled Raven v2 programs.
+//!
+//! See `docs/v2/specs/runtime.md` for the public contract.
+
+#![deny(unsafe_op_in_unsafe_fn)]

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -13,6 +13,12 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![allow(clippy::missing_safety_doc)]
 
+pub mod object;
+
+pub use object::{
+    ObjectHeader, OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING,
+};
+
 use std::alloc::{self, Layout};
 use std::io::{self, Write};
 use std::process;

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1,5 +1,132 @@
 //! Runtime support crate for compiled Raven v2 programs.
 //!
-//! See `docs/v2/specs/runtime.md` for the public contract.
+//! Compiled v2 binaries link against this crate as a `staticlib`. The
+//! exported `extern "C"` symbols below form the entire ABI surface the
+//! back-end is allowed to call. See `docs/v2/specs/runtime.md` for the
+//! full contract and what is intentionally deferred.
 
 #![deny(unsafe_op_in_unsafe_fn)]
+// The ABI surface is `extern "C"` and is called from machine code
+// emitted by the back-end. The crate documents the safety contract per
+// function; marking the symbols `unsafe` would change their mangling
+// and is not what the codegen is taught to call.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![allow(clippy::missing_safety_doc)]
+
+use std::alloc::{self, Layout};
+use std::io::{self, Write};
+use std::process;
+use std::slice;
+
+/// Allocate `size` bytes aligned to `align`.
+///
+/// Returns null on allocation failure or invalid layout. The current
+/// implementation is a thin `std::alloc::alloc` passthrough; the real
+/// allocator lands with issue #64.
+///
+/// # Safety
+///
+/// The caller must pair every non-null return with exactly one
+/// `raven_dealloc` using the same `size` and `align`.
+#[no_mangle]
+pub extern "C" fn raven_alloc(size: usize, align: usize) -> *mut u8 {
+    let Ok(layout) = Layout::from_size_align(size, align) else {
+        return std::ptr::null_mut();
+    };
+    if layout.size() == 0 {
+        // A zero-sized allocation is well defined to return a non-null
+        // dangling pointer. `std::alloc::alloc` is UB at size zero.
+        return align as *mut u8;
+    }
+    // SAFETY: layout has a non-zero size, validated above.
+    unsafe { alloc::alloc(layout) }
+}
+
+/// Free an allocation previously returned by `raven_alloc`.
+///
+/// A null pointer or zero-sized allocation is a no-op.
+///
+/// # Safety
+///
+/// `ptr` must come from a matching `raven_alloc(size, align)` call,
+/// and must not have been freed already.
+#[no_mangle]
+pub extern "C" fn raven_dealloc(ptr: *mut u8, size: usize, align: usize) {
+    if ptr.is_null() {
+        return;
+    }
+    let Ok(layout) = Layout::from_size_align(size, align) else {
+        return;
+    };
+    if layout.size() == 0 {
+        return;
+    }
+    // SAFETY: per the contract, `ptr` matches a previous allocation
+    // with this exact layout.
+    unsafe { alloc::dealloc(ptr, layout) };
+}
+
+/// Report a fatal Raven panic and terminate the process.
+///
+/// Writes `raven panic: <msg>\n` to standard error and exits with
+/// status 101 (the same code Rust uses for unwinding panics that hit
+/// `abort`). Does not unwind.
+///
+/// # Safety
+///
+/// `msg_ptr` must point to `msg_len` initialized bytes of valid UTF-8.
+/// `msg_len` may be zero, in which case `msg_ptr` is not dereferenced.
+#[no_mangle]
+pub extern "C" fn raven_panic(msg_ptr: *const u8, msg_len: usize) -> ! {
+    let msg = if msg_len == 0 || msg_ptr.is_null() {
+        ""
+    } else {
+        // SAFETY: caller guarantees the slice is initialized UTF-8.
+        let bytes = unsafe { slice::from_raw_parts(msg_ptr, msg_len) };
+        std::str::from_utf8(bytes).unwrap_or("<invalid utf-8>")
+    };
+    let stderr = io::stderr();
+    let mut handle = stderr.lock();
+    // Best-effort write; we are about to exit either way.
+    let _ = writeln!(handle, "raven panic: {msg}");
+    let _ = handle.flush();
+    process::exit(101);
+}
+
+/// Write a UTF-8 byte slice to standard output without a trailing
+/// newline.
+///
+/// # Safety
+///
+/// `ptr` must point to `len` initialized UTF-8 bytes, or `len` must be
+/// zero.
+#[no_mangle]
+pub extern "C" fn raven_print_str(ptr: *const u8, len: usize) {
+    if len == 0 || ptr.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees the slice is initialized.
+    let bytes = unsafe { slice::from_raw_parts(ptr, len) };
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    let _ = handle.write_all(bytes);
+}
+
+/// Write a UTF-8 byte slice to standard output followed by a single
+/// `\n`.
+///
+/// # Safety
+///
+/// `ptr` must point to `len` initialized UTF-8 bytes, or `len` must be
+/// zero.
+#[no_mangle]
+pub extern "C" fn raven_println_str(ptr: *const u8, len: usize) {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    if len > 0 && !ptr.is_null() {
+        // SAFETY: caller guarantees the slice is initialized.
+        let bytes = unsafe { slice::from_raw_parts(ptr, len) };
+        let _ = handle.write_all(bytes);
+    }
+    let _ = handle.write_all(b"\n");
+}

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -1,0 +1,75 @@
+//! Canonical object header layout shared by every heap-allocated
+//! Raven value.
+//!
+//! The shape pinned here is what the future garbage collector
+//! (issue #64) walks, and what the per-kind object layouts
+//! (issue #65) prepend to their payload. Keeping it stable across
+//! every object kind lets the GC trace without knowing the kind in
+//! advance, dispatching on the `tag` field only when it needs the
+//! payload shape.
+//!
+//! See `docs/v2/specs/runtime.md` for the contract.
+
+/// Alignment, in bytes, used for every heap object the runtime
+/// allocates. The header itself is 4-byte aligned, but objects are
+/// over-aligned to 8 so payload fields immediately after the header
+/// satisfy the alignment of every primitive Raven value (`Int`,
+/// `Float`, raw pointers).
+pub const OBJECT_ALIGN: usize = 8;
+
+/// UTF-8 string. `len` is the byte length, `cap` is the allocated
+/// byte capacity.
+pub const TAG_STRING: u32 = 0x01;
+
+/// Boxed `List<T>`. `len` is the element count, `cap` is the allocated
+/// element capacity.
+pub const TAG_LIST: u32 = 0x02;
+
+/// Boxed `Map<K, V>`. `len` is the entry count, `cap` is the bucket
+/// count.
+pub const TAG_MAP: u32 = 0x03;
+
+/// Boxed `Set<T>`. `len` is the entry count, `cap` is the bucket
+/// count.
+pub const TAG_SET: u32 = 0x04;
+
+/// Closure object: a function pointer followed by an inline capture
+/// tail.
+pub const TAG_CLOSURE: u32 = 0x05;
+
+/// Generic heap box. Reserved for trait-object payloads (issue #66).
+pub const TAG_BOX: u32 = 0x06;
+
+/// Canonical 16-byte object header.
+///
+/// Every heap allocation the GC traces starts with one of these,
+/// followed by a kind-specific payload. The layout is `#[repr(C)]`
+/// and pinned: the compiler back-end and the future GC both depend
+/// on the field order and offsets.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ObjectHeader {
+    /// Discriminator picking one of the `TAG_*` constants.
+    pub tag: u32,
+    /// Mark / colour bits reserved for the future tracing collector.
+    /// Always zero in the current scaffold.
+    pub gc_bits: u32,
+    /// Logical length in the unit appropriate for the tag (bytes for
+    /// strings, elements for lists, entries for maps and sets).
+    pub len: u32,
+    /// Allocated capacity in the same unit as `len`, or zero for
+    /// kinds where capacity is not applicable.
+    pub cap: u32,
+}
+
+impl ObjectHeader {
+    /// Construct a header with the given tag and zeroed GC bits.
+    pub const fn new(tag: u32, len: u32, cap: u32) -> Self {
+        Self {
+            tag,
+            gc_bits: 0,
+            len,
+            cap,
+        }
+    }
+}

--- a/raven-runtime/tests/abi.rs
+++ b/raven-runtime/tests/abi.rs
@@ -1,0 +1,56 @@
+//! Integration test that links against `raven-runtime` from a
+//! separate crate boundary and exercises the C ABI surface.
+//!
+//! Running this test catches two regressions the inline unit tests
+//! cannot:
+//!
+//! 1. The crate must still build as an `rlib` (the linker for this
+//!    test binary picks the rlib variant; if `crate-type` regresses
+//!    to just `staticlib`, the test refuses to compile).
+//! 2. The exported symbols stay reachable through the public Rust
+//!    surface that the v2 codegen and tooling will import.
+
+use raven_runtime::{
+    raven_alloc, raven_dealloc, raven_print_str, raven_println_str, ObjectHeader, OBJECT_ALIGN,
+    TAG_LIST,
+};
+
+#[test]
+fn alloc_write_dealloc_cycle() {
+    let size = 128;
+    let ptr = raven_alloc(size, OBJECT_ALIGN);
+    assert!(!ptr.is_null(), "expected non-null allocation");
+
+    // Write a recognizable pattern and read it back so a broken
+    // allocator that returned an unmapped pointer would segfault here
+    // instead of passing.
+    unsafe {
+        for i in 0..size {
+            ptr.add(i).write(i as u8);
+        }
+        for i in 0..size {
+            assert_eq!(ptr.add(i).read(), i as u8);
+        }
+    }
+
+    raven_dealloc(ptr, size, OBJECT_ALIGN);
+}
+
+#[test]
+fn header_layout_visible_across_crate_boundary() {
+    let header = ObjectHeader::new(TAG_LIST, 3, 4);
+    assert_eq!(std::mem::size_of_val(&header), 16);
+    assert_eq!(header.tag, TAG_LIST);
+    assert_eq!(header.len, 3);
+    assert_eq!(header.cap, 4);
+}
+
+#[test]
+fn print_helpers_accept_empty_input() {
+    // Smoke test: the helpers must not abort on empty input. We
+    // intentionally do not capture stdout here; this test exists to
+    // confirm the symbols link and are callable from an external
+    // crate.
+    raven_print_str(std::ptr::null(), 0);
+    raven_println_str(std::ptr::null(), 0);
+}


### PR DESCRIPTION
Stands up the `raven-runtime` workspace crate. This is the support library that compiled v2 programs will statically link against. Codegen targets the C ABI surface here for allocation, panic, and runtime intrinsics.

Closes #62. Spec at [`docs/v2/specs/runtime.md`](./docs/v2/specs/runtime.md).

## What this adds

- **Top-level `Cargo.toml`** is now a workspace with `raven` and `raven-runtime` as members. Shared `[workspace.package]` keeps version, edition, authors, license, and repository in one place.
- **`raven-runtime/`** crate built as both `rlib` (for in-tree tests) and `staticlib` (for the link step in compiled v2 programs once codegen lands).
- **C ABI surface** (initial stubs):
  - `raven_alloc(size, align) -> *mut u8`
  - `raven_dealloc(ptr, size, align)`
  - `raven_panic(msg_ptr, msg_len)` aborts with a message
  - `raven_print_str(ptr, len)` and `raven_println_str(ptr, len)` for early bring-up
- **Object header layout** (`ObjectHeader`, 16 bytes, power-of-two aligned) plus tag constants for the heap-allocated v2 types (`TAG_STRING`, `TAG_LIST`, `TAG_MAP`, `TAG_SET`, `TAG_CLOSURE`, `TAG_BOX`). Dense numbering and stable across releases.
- **Inline unit tests** verify header size, alignment, tag distinctness, alloc/dealloc roundtrip, invalid-layout safety, and null-deref guards.
- **`raven-runtime/tests/abi.rs`** integration test exercises the same surface from a separate crate boundary, catching regressions in `crate-type` and visibility.

## Deferred for follow-up issues

- Mark-and-sweep GC (#64)
- Real object layouts beyond the header (#65)
- Trait object fat pointers (#66)
- Stdlib runtime entry points (#71 through #80)

## Test plan

- [x] `cargo build` clean across the workspace
- [x] `cargo test` 237 lib tests pass plus the new runtime tests and the ABI integration test
- [x] Existing parser, resolver, tycheck, hir, mir golden suites still pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` no new warnings
