### PR TITLE
feat(runtime): String, List, Map, Set, Closure, and Box layouts

### DIFF
--- a/docs/v2/specs/object-layout.md
+++ b/docs/v2/specs/object-layout.md
@@ -1,0 +1,347 @@
+# Object Layout Spec
+
+## Goal
+
+Pin the in-memory shape of every heap-allocated Raven v2 value. The shared
+`ObjectHeader` from issue #63 is already fixed; this document specifies what
+follows the header for each tag, the exact field offsets, the constructor
+APIs the back-end calls, and how the future GC will walk each layout.
+
+The layouts are documented in two parallel forms: a `#[repr(C)]` Rust
+struct in `raven-runtime/src/object/<kind>.rs` that the in-tree tests
+assert against, and a C-style diagram with explicit byte offsets that
+codegen treats as a binary contract.
+
+All sizes and offsets are for 64-bit targets. Per-layout `cfg` gates keep
+size assertions correct on 32-bit hosts (the runtime is not yet supported
+there beyond compiling).
+
+## Shared header
+
+Recap from `runtime.md`:
+
+```
+offset  size  field
+  0      4    tag
+  4      4    gc_bits
+  8      4    len
+ 12      4    cap
+```
+
+Total 16 bytes, alignment 4, but every object is allocated at
+`OBJECT_ALIGN = 8` so the payload that follows is 8-byte aligned. Every
+subsequent layout therefore starts its first payload field at offset 16
+without padding.
+
+## String
+
+```c
+struct String {
+    ObjectHeader header;     // tag = TAG_STRING
+    u8          *bytes;      // owned buffer of `cap` bytes
+};
+```
+
+Field offsets on 64-bit:
+
+| offset | size | field         |
+| -----: | ---: | ------------- |
+| 0      | 16   | header        |
+| 16     | 8    | bytes         |
+| total  | 24   |               |
+
+* Alignment: 8.
+* `header.tag = TAG_STRING`.
+* `header.len` is the UTF-8 byte length, not the codepoint count.
+* `header.cap` is the allocated byte capacity of `bytes`.
+* `bytes` points to an owned buffer of `cap` bytes. The first `len` bytes
+  are valid UTF-8. The remaining `cap - len` bytes are undefined.
+* When `cap == 0`, `bytes` is null.
+
+## List
+
+```c
+struct List {
+    ObjectHeader header;     // tag = TAG_LIST
+    u32          element_size;
+    u32          element_align;
+    u8          *elements;   // owned buffer of `cap * element_size` bytes
+};
+```
+
+Field offsets on 64-bit:
+
+| offset | size | field         |
+| -----: | ---: | ------------- |
+| 0      | 16   | header        |
+| 16     | 4    | element_size  |
+| 20     | 4    | element_align |
+| 24     | 8    | elements      |
+| total  | 32   |               |
+
+* Alignment: 8.
+* `header.tag = TAG_LIST`.
+* `header.len` is the element count, `header.cap` the element capacity.
+* `element_size` is the size in bytes of one element. Scalars are inline
+  (e.g. `List<Int>` stores 8-byte slots). Heap objects are stored as
+  pointer-sized slots, so `element_size == 8` and the slot holds a
+  pointer to the inner object.
+* `element_align` is the alignment of one element, the same value the
+  back-end would pass to `raven_alloc` for an element.
+* `elements` points to an owned buffer of `cap * element_size` bytes.
+  When `cap == 0`, `elements` is null.
+
+The GC tracing rule keys on whether the element is a pointer type. The
+back-end records this in a per-list descriptor in a follow-up; for now
+the tracer treats `element_size == 8` and `element_align == 8` lists as
+potentially pointer-bearing.
+
+## Map
+
+```c
+struct Map {
+    ObjectHeader header;     // tag = TAG_MAP
+    u32          bucket_count;
+    u32          _pad;       // reserved, zeroed
+    MapEntry    *buckets;
+};
+
+struct MapEntry {
+    u64   hash;
+    void *key;     // null if empty or tombstone
+    void *value;
+};
+```
+
+Map field offsets on 64-bit:
+
+| offset | size | field         |
+| -----: | ---: | ------------- |
+| 0      | 16   | header        |
+| 16     | 4    | bucket_count  |
+| 20     | 4    | _pad          |
+| 24     | 8    | buckets       |
+| total  | 32   |               |
+
+`MapEntry` offsets:
+
+| offset | size | field         |
+| -----: | ---: | ------------- |
+| 0      | 8    | hash          |
+| 8      | 8    | key           |
+| 16     | 8    | value         |
+| total  | 24   |               |
+
+* Alignment of `Map`: 8. Alignment of `MapEntry`: 8.
+* `header.tag = TAG_MAP`. `header.len` is the live entry count.
+* `header.cap` mirrors `bucket_count`. Keeping `cap` in the header lets
+  the GC walk the buckets without dispatching through `tag`.
+* `bucket_count` is a power of two, or zero for the freshly-constructed
+  empty map. The constructor accepts any non-negative request and rounds
+  up to the next power of two.
+* `buckets` points to `bucket_count` contiguous `MapEntry` slots. An
+  empty or tombstoned slot has `key == null`. Tombstones are distinguished
+  from truly-empty slots by `hash == TOMBSTONE_HASH` (a reserved bit
+  pattern; see the constructor module). Tombstone bookkeeping is not yet
+  used by the v2 stdlib, but the slot reservation keeps the entry shape
+  stable when rehash and delete land in a stdlib issue.
+* `key` and `value` are pointers. When the logical key or value is a
+  primitive that does not fit in a pointer, the back-end boxes it through
+  `raven_box_new` before insertion.
+
+The hash function for the v2 scaffold is FNV-1a 64. It is deterministic
+(no per-process seed) and depends on no external crate. The choice is
+documented here because the hash is part of the persisted-bucket layout:
+re-hashing on resize must agree with the original insert. A future
+issue may swap to a seeded hasher; the swap is a behaviour change, not
+an ABI change, because `hash` is internal to `MapEntry`.
+
+## Set
+
+```c
+struct Set {
+    ObjectHeader header;     // tag = TAG_SET
+    u32          bucket_count;
+    u32          _pad;
+    SetEntry    *buckets;
+};
+
+struct SetEntry {
+    u64   hash;
+    void *element;
+};
+```
+
+Set field offsets mirror Map:
+
+| offset | size | field         |
+| -----: | ---: | ------------- |
+| 0      | 16   | header        |
+| 16     | 4    | bucket_count  |
+| 20     | 4    | _pad          |
+| 24     | 8    | buckets       |
+| total  | 32   |               |
+
+`SetEntry` offsets:
+
+| offset | size | field         |
+| -----: | ---: | ------------- |
+| 0      | 8    | hash          |
+| 8      | 8    | element       |
+| total  | 16   |               |
+
+Same rules as `Map`: `header.tag = TAG_SET`, `header.cap` mirrors
+`bucket_count`, empty or tombstoned slots have `element == null`,
+FNV-1a 64 is the hash function.
+
+## Closure
+
+```c
+struct Closure {
+    ObjectHeader header;     // tag = TAG_CLOSURE, len = capture count
+    void        *fn_ptr;     // pointer to the lifted body
+    void        *captures;   // owned buffer of size `capture_size`
+    u32          capture_size;
+    u32          capture_align;
+};
+```
+
+Field offsets on 64-bit:
+
+| offset | size | field         |
+| -----: | ---: | ------------- |
+| 0      | 16   | header        |
+| 16     | 8    | fn_ptr        |
+| 24     | 8    | captures      |
+| 32     | 4    | capture_size  |
+| 36     | 4    | capture_align |
+| total  | 40   |               |
+
+* Alignment: 8.
+* `header.tag = TAG_CLOSURE`. `header.len` is the capture count (the
+  number of distinct captured bindings, not the byte size).
+* `header.cap` is unused and zeroed.
+* `fn_ptr` is the raw code pointer of the lifted closure body. The body
+  has the calling convention `(captures: *mut u8, args...) -> ret`.
+* `captures` is a pointer to an owned buffer of `capture_size` bytes.
+  Layout inside the capture record is decided by the closure-lowering
+  pass and is opaque to the runtime. The GC walks it through a
+  descriptor produced by codegen in a follow-up.
+* `captures` is null when `capture_size == 0`.
+
+The pointer-indirect form (rather than inline-after-header) keeps every
+`Closure` object the same size, so the GC and stdlib do not need to read
+the capture footer to advance over a closure. The cost is one extra
+allocation per closure with non-empty captures.
+
+## Box
+
+```c
+struct Box {
+    ObjectHeader header;     // tag = TAG_BOX, len = payload byte size
+    u8           payload[];  // sized payload follows the header
+};
+```
+
+Field offsets on 64-bit:
+
+| offset | size       | field   |
+| -----: | ---------: | ------- |
+| 0      | 16         | header  |
+| 16     | payload_sz | payload |
+
+* Alignment: `max(OBJECT_ALIGN, payload_align)`.
+* `header.tag = TAG_BOX`. `header.len` is the payload size in bytes.
+* `header.cap` is 1 (a `Box<T>` always holds exactly one `T`).
+* The payload lives inline at offset 16. For payload alignments greater
+  than 8 the constructor pads the request to the alignment, but at
+  current Raven scalar widths (8 bytes for `Int`, `Float`, pointers, less
+  for `Bool`) no padding is needed.
+
+`Box` exists so generic collections over primitives can be uniformly
+typed: a `List<Int>` may store `Int` inline (when codegen specialises it)
+or as a `Box<Int>` pointer slot (when monomorphisation falls back to a
+generic body, e.g. a method on `List<T>` taking a `T` by value).
+
+## Constructor APIs
+
+Every constructor is `#[no_mangle] pub extern "C"`. Every constructor
+returns a typed pointer (e.g. `*mut String`) that codegen treats as
+opaque and only ever passes back through accessors.
+
+| Symbol | Signature | Notes |
+| ------ | --------- | ----- |
+| `raven_string_new` | `fn(cap: u32) -> *mut String` | Allocates a `String` with the given byte capacity. Bytes buffer is allocated separately and zero-filled. `header.len = 0`. |
+| `raven_string_len` | `fn(s: *const String) -> u32` | Returns `header.len`. |
+| `raven_string_bytes` | `fn(s: *const String) -> *const u8` | Returns the `bytes` field. |
+| `raven_string_concat` | `fn(a: *const String, b: *const String) -> *mut String` | Returns a new heap string equal to `a` followed by `b`. |
+| `raven_list_new` | `fn(element_size: u32, element_align: u32, cap: u32) -> *mut List` | Allocates a `List` with the given per-element shape and slot capacity. `header.len = 0`. |
+| `raven_list_len` | `fn(l: *const List) -> u32` | Returns `header.len`. |
+| `raven_list_elements` | `fn(l: *const List) -> *mut u8` | Returns the `elements` field. |
+| `raven_list_push` | `fn(l: *mut List, payload: *const u8)` | Copies `element_size` bytes from `payload` into the next slot, growing the buffer if needed. |
+| `raven_map_new` | `fn(bucket_count: u32) -> *mut Map` | Allocates a `Map` with the given initial bucket count, rounded up to a power of two. Bucket buffer is zero-filled. |
+| `raven_map_buckets` | `fn(m: *const Map) -> *mut MapEntry` | Returns the `buckets` field. |
+| `raven_map_bucket_count` | `fn(m: *const Map) -> u32` | Returns the `bucket_count` field. |
+| `raven_set_new` | `fn(bucket_count: u32) -> *mut Set` | Set counterpart of `raven_map_new`. |
+| `raven_set_buckets` | `fn(s: *const Set) -> *mut SetEntry` | Returns the `buckets` field. |
+| `raven_set_bucket_count` | `fn(s: *const Set) -> u32` | Returns the `bucket_count` field. |
+| `raven_closure_new` | `fn(fn_ptr: *const u8, capture_size: u32, capture_align: u32, capture_count: u32) -> *mut Closure` | Allocates a `Closure` with the given function pointer and capture record. Capture buffer is zero-filled and owned by the closure. |
+| `raven_closure_fn_ptr` | `fn(c: *const Closure) -> *const u8` | Returns the function pointer. |
+| `raven_closure_captures` | `fn(c: *const Closure) -> *mut u8` | Returns the captures buffer. |
+| `raven_box_new` | `fn(payload_size: u32, payload_align: u32) -> *mut Box` | Allocates a `Box` whose payload is `payload_size` bytes aligned to `payload_align`. Payload is zero-filled. |
+| `raven_box_payload` | `fn(b: *const Box) -> *mut u8` | Returns a pointer to the inline payload at offset 16. |
+
+The deallocator counterpart for each kind is a follow-up issue; today the
+process leaks every heap object on exit, which is fine for the v2
+scaffold because no test program holds objects long enough to matter.
+
+## Tracing summary
+
+The GC (issue #64) will dispatch on `header.tag` and walk the layout's
+internal pointers. The pointers each layout owns are:
+
+| Tag | Internal pointers | Notes |
+| --- | ----------------- | ----- |
+| `TAG_STRING` | `bytes` at offset 16 | Owned `u8` buffer of size `cap`. No further tracing needed. |
+| `TAG_LIST` | `elements` at offset 24 | The buffer holds `cap * element_size` bytes. If `element_size == 8` and `element_align == 8` it may hold heap pointers that the tracer recurses into. |
+| `TAG_MAP` | `buckets` at offset 24, then for each non-empty bucket `key` at entry offset 8 and `value` at entry offset 16 | Both `key` and `value` are heap pointers (or boxes for primitives). |
+| `TAG_SET` | `buckets` at offset 24, then for each non-empty bucket `element` at entry offset 8 | |
+| `TAG_CLOSURE` | `captures` at offset 24 | The capture record is opaque to the tracer; a per-closure descriptor produced by codegen will enumerate its pointers in a follow-up. |
+| `TAG_BOX` | none of its own; the payload at offset 16 is treated by the descriptor attached to the box's static type | |
+
+The actual tracing implementation lands in issue #64. This document
+exists so that issue can be written against a fixed set of offsets.
+
+## Out of scope
+
+* Real GC. `gc_bits` stays zero. Allocations leak at process exit. Issue
+  #64 lands the collector.
+* Codegen integration. Issue #67 wires field loads and stores through the
+  offsets pinned here.
+* Trait object fat pointers. The `BOX` tag is the storage shape; the
+  vtable layout is issue #66.
+* Full stdlib over these layouts (string methods, list iteration, map
+  iteration). Issues #71 to #80 ship those.
+* Resize policy beyond the constructor. `raven_list_push` doubles `cap`
+  when full; map and set resize live with the stdlib issues.
+
+## Test coverage
+
+* Inline unit tests in `raven-runtime/src/object/*.rs`:
+  * `size_of::<String>() == 24`, `size_of::<List>() == 32`,
+    `size_of::<Map>() == 32`, `size_of::<Set>() == 32`,
+    `size_of::<Closure>() == 40` on 64-bit targets.
+  * `offset_of!` for every field matches the diagram above.
+  * Constructors zero the body and set `header.tag` correctly.
+  * `raven_string_concat` produces a string whose bytes equal the
+    concatenation of its inputs.
+  * `raven_list_push` grows the buffer and preserves earlier elements.
+* Integration tests in `raven-runtime/tests/object_layouts.rs`:
+  * Construct and read back every layout through the C ABI surface, so
+    the staticlib's exported symbols stay reachable.
+  * Cross-check that `header.tag` and `header.cap` agree with what the
+    constructor was told.
+
+Size assertions are gated on `target_pointer_width = "64"` so 32-bit
+hosts still compile cleanly until their layouts are pinned in a future
+revision.

--- a/docs/v2/specs/runtime.md
+++ b/docs/v2/specs/runtime.md
@@ -114,7 +114,8 @@ also Rust.
   passthrough. A bump or slab allocator is issue #64.
 * Garbage collection. `gc_bits` is reserved but unused.
 * Full object layouts for `String`, `List`, `Map`, `Set`, `Closure`.
-  Only the shared header is fixed. Per-kind layouts are issue #65.
+  This scaffold fixes only the shared header; the per-kind layouts land
+  with issue #65 and are documented in `docs/v2/specs/object-layout.md`.
 * Trait object dispatch tables. The `BOX` tag exists as a placeholder;
   the actual vtable shape lands in issue #66.
 * Async, threading, FFI safety beyond the stated symbols.

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -17,10 +17,11 @@
 pub mod object;
 
 pub use object::{
-    raven_list_elements, raven_list_len, raven_list_new, raven_list_push, raven_string_bytes,
-    raven_string_concat, raven_string_len, raven_string_new, List as RavenList, ObjectHeader,
-    String as RavenString, OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET,
-    TAG_STRING,
+    raven_list_elements, raven_list_len, raven_list_new, raven_list_push, raven_map_bucket_count,
+    raven_map_buckets, raven_map_new, raven_set_bucket_count, raven_set_buckets, raven_set_new,
+    raven_string_bytes, raven_string_concat, raven_string_len, raven_string_new, List as RavenList,
+    Map as RavenMap, MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString,
+    OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING,
 };
 
 use std::alloc::{self, Layout};

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -17,7 +17,9 @@
 pub mod object;
 
 pub use object::{
-    ObjectHeader, OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING,
+    raven_string_bytes, raven_string_concat, raven_string_len, raven_string_new, ObjectHeader,
+    String as RavenString, OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET,
+    TAG_STRING,
 };
 
 use std::alloc::{self, Layout};

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -17,11 +17,13 @@
 pub mod object;
 
 pub use object::{
-    raven_list_elements, raven_list_len, raven_list_new, raven_list_push, raven_map_bucket_count,
-    raven_map_buckets, raven_map_new, raven_set_bucket_count, raven_set_buckets, raven_set_new,
-    raven_string_bytes, raven_string_concat, raven_string_len, raven_string_new, List as RavenList,
-    Map as RavenMap, MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString,
-    OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING,
+    raven_box_new, raven_box_payload, raven_closure_captures, raven_closure_fn_ptr,
+    raven_closure_new, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,
+    raven_map_bucket_count, raven_map_buckets, raven_map_new, raven_set_bucket_count,
+    raven_set_buckets, raven_set_new, raven_string_bytes, raven_string_concat, raven_string_len,
+    raven_string_new, Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap,
+    MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, OBJECT_ALIGN,
+    TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING,
 };
 
 use std::alloc::{self, Layout};

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -17,7 +17,8 @@
 pub mod object;
 
 pub use object::{
-    raven_string_bytes, raven_string_concat, raven_string_len, raven_string_new, ObjectHeader,
+    raven_list_elements, raven_list_len, raven_list_new, raven_list_push, raven_string_bytes,
+    raven_string_concat, raven_string_len, raven_string_new, List as RavenList, ObjectHeader,
     String as RavenString, OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET,
     TAG_STRING,
 };

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -11,8 +11,10 @@
 //! See `docs/v2/specs/runtime.md` for the contract and
 //! `docs/v2/specs/object-layout.md` for per-kind payload layouts.
 
+pub mod list;
 pub mod string;
 
+pub use list::{raven_list_elements, raven_list_len, raven_list_new, raven_list_push, List};
 pub use string::{
     raven_string_bytes, raven_string_concat, raven_string_len, raven_string_new, String,
 };

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -8,7 +8,14 @@
 //! advance, dispatching on the `tag` field only when it needs the
 //! payload shape.
 //!
-//! See `docs/v2/specs/runtime.md` for the contract.
+//! See `docs/v2/specs/runtime.md` for the contract and
+//! `docs/v2/specs/object-layout.md` for per-kind payload layouts.
+
+pub mod string;
+
+pub use string::{
+    raven_string_bytes, raven_string_concat, raven_string_len, raven_string_new, String,
+};
 
 /// Alignment, in bytes, used for every heap object the runtime
 /// allocates. The header itself is 4-byte aligned, but objects are

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -11,10 +11,15 @@
 //! See `docs/v2/specs/runtime.md` for the contract and
 //! `docs/v2/specs/object-layout.md` for per-kind payload layouts.
 
+pub mod hash;
 pub mod list;
+pub mod map;
+pub mod set;
 pub mod string;
 
 pub use list::{raven_list_elements, raven_list_len, raven_list_new, raven_list_push, List};
+pub use map::{raven_map_bucket_count, raven_map_buckets, raven_map_new, Map, MapEntry};
+pub use set::{raven_set_bucket_count, raven_set_buckets, raven_set_new, Set, SetEntry};
 pub use string::{
     raven_string_bytes, raven_string_concat, raven_string_len, raven_string_new, String,
 };

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -11,12 +11,16 @@
 //! See `docs/v2/specs/runtime.md` for the contract and
 //! `docs/v2/specs/object-layout.md` for per-kind payload layouts.
 
+pub mod boxed;
+pub mod closure;
 pub mod hash;
 pub mod list;
 pub mod map;
 pub mod set;
 pub mod string;
 
+pub use boxed::{raven_box_new, raven_box_payload, Box, BOX_PAYLOAD_OFFSET};
+pub use closure::{raven_closure_captures, raven_closure_fn_ptr, raven_closure_new, Closure};
 pub use list::{raven_list_elements, raven_list_len, raven_list_new, raven_list_push, List};
 pub use map::{raven_map_bucket_count, raven_map_buckets, raven_map_new, Map, MapEntry};
 pub use set::{raven_set_bucket_count, raven_set_buckets, raven_set_new, Set, SetEntry};

--- a/raven-runtime/src/object/boxed.rs
+++ b/raven-runtime/src/object/boxed.rs
@@ -1,0 +1,178 @@
+//! In-memory layout, constructor, and accessor for boxed primitives.
+//!
+//! A `Box` is the object that lets a primitive value live on the heap,
+//! for example as a pointer slot inside a generic `List<T>`. Its
+//! payload follows the header inline. See
+//! `docs/v2/specs/object-layout.md` for the byte-exact layout.
+
+use super::{ObjectHeader, OBJECT_ALIGN, TAG_BOX};
+use crate::raven_alloc;
+use std::ptr;
+
+/// Offset, in bytes, from the start of a `Box` to its inline payload.
+/// The payload begins immediately after the 16-byte header.
+pub const BOX_PAYLOAD_OFFSET: usize = std::mem::size_of::<ObjectHeader>();
+
+/// Boxed primitive object. The struct models only the fixed header;
+/// the sized payload follows inline at `BOX_PAYLOAD_OFFSET`. `header.len`
+/// is the payload byte size, `header.cap` is 1 (a box holds one value).
+///
+/// The payload is reached through `raven_box_payload`, not a struct
+/// field, because its size is decided at allocation time.
+#[repr(C)]
+pub struct Box {
+    /// Standard 16-byte object header. `tag == TAG_BOX`,
+    /// `len == payload size`, `cap == 1`.
+    pub header: ObjectHeader,
+}
+
+/// Allocate a fresh `Box` whose inline payload is `payload_size` bytes
+/// aligned to `payload_align`. The payload is zero-filled.
+///
+/// The whole object (header plus payload) is one allocation aligned to
+/// `max(OBJECT_ALIGN, payload_align)`. Returns null on allocation
+/// failure or invalid layout.
+#[no_mangle]
+pub extern "C" fn raven_box_new(payload_size: u32, payload_align: u32) -> *mut Box {
+    if payload_align != 0 && !payload_align.is_power_of_two() {
+        return ptr::null_mut();
+    }
+    let align = box_align(payload_align);
+    let total = box_total_size(payload_size);
+    let ptr = raven_alloc(total, align) as *mut Box;
+    if ptr.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: `ptr` points to `total` writable bytes; zero the whole
+    // object, then write the header.
+    unsafe {
+        ptr::write_bytes(ptr as *mut u8, 0, total);
+        ptr::write(
+            ptr,
+            Box {
+                header: ObjectHeader::new(TAG_BOX, payload_size, 1),
+            },
+        );
+    }
+    ptr
+}
+
+/// Return a pointer to the box's inline payload.
+///
+/// The payload is valid for `header.len` bytes. Returns null when `b`
+/// is null.
+#[no_mangle]
+pub extern "C" fn raven_box_payload(b: *const Box) -> *mut u8 {
+    if b.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: the payload sits at a fixed offset after the header in
+    // the same allocation.
+    unsafe { (b as *mut u8).add(BOX_PAYLOAD_OFFSET) }
+}
+
+/// Total allocation size for a box with the given payload size.
+pub(crate) const fn box_total_size(payload_size: u32) -> usize {
+    BOX_PAYLOAD_OFFSET + payload_size as usize
+}
+
+/// Allocation alignment for a box with the given payload alignment.
+pub(crate) const fn box_align(payload_align: u32) -> usize {
+    let a = payload_align as usize;
+    if a > OBJECT_ALIGN {
+        a
+    } else {
+        OBJECT_ALIGN
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raven_dealloc;
+    use std::mem::{offset_of, size_of};
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn box_header_size_and_payload_offset_match_spec() {
+        assert_eq!(size_of::<Box>(), 16);
+        assert_eq!(offset_of!(Box, header), 0);
+        assert_eq!(BOX_PAYLOAD_OFFSET, 16);
+    }
+
+    #[test]
+    fn new_sets_header_and_zero_fills_payload() {
+        let b = raven_box_new(8, 8);
+        assert!(!b.is_null());
+        // SAFETY: b came from the constructor with an 8-byte payload.
+        unsafe {
+            assert_eq!((*b).header.tag, TAG_BOX);
+            assert_eq!((*b).header.len, 8);
+            assert_eq!((*b).header.cap, 1);
+        }
+        let payload = raven_box_payload(b);
+        assert!(!payload.is_null());
+        // SAFETY: payload points to 8 zeroed bytes.
+        unsafe {
+            for i in 0..8 {
+                assert_eq!(payload.add(i).read(), 0);
+            }
+        }
+        unsafe { drop_box_for_test(b) };
+    }
+
+    #[test]
+    fn payload_roundtrips_a_value() {
+        let b = raven_box_new(8, 8);
+        let payload = raven_box_payload(b);
+        // SAFETY: payload points to 8 writable, aligned bytes.
+        unsafe {
+            (payload as *mut u64).write(0x0102_0304_0506_0708);
+            assert_eq!((payload as *const u64).read(), 0x0102_0304_0506_0708);
+        }
+        unsafe { drop_box_for_test(b) };
+    }
+
+    #[test]
+    fn zero_sized_payload_is_valid() {
+        let b = raven_box_new(0, 0);
+        assert!(!b.is_null());
+        // SAFETY: b came from the constructor.
+        unsafe {
+            assert_eq!((*b).header.len, 0);
+            assert_eq!((*b).header.cap, 1);
+        }
+        // Payload pointer is one-past-the-header; valid but not
+        // dereferenceable for reads.
+        assert!(!raven_box_payload(b).is_null());
+        unsafe { drop_box_for_test(b) };
+    }
+
+    #[test]
+    fn invalid_align_returns_null() {
+        assert!(raven_box_new(8, 3).is_null());
+    }
+
+    #[test]
+    fn null_payload_is_safe() {
+        assert!(raven_box_payload(std::ptr::null()).is_null());
+    }
+
+    /// Test-only deallocator.
+    ///
+    /// # Safety
+    ///
+    /// `b` must come from `raven_box_new` and not be freed yet.
+    unsafe fn drop_box_for_test(b: *mut Box) {
+        if b.is_null() {
+            return;
+        }
+        // SAFETY: matches construction layout.
+        let payload_size = unsafe { (*b).header.len };
+        raven_dealloc(
+            b as *mut u8,
+            box_total_size(payload_size),
+            box_align(OBJECT_ALIGN as u32),
+        );
+    }
+}

--- a/raven-runtime/src/object/closure.rs
+++ b/raven-runtime/src/object/closure.rs
@@ -1,0 +1,227 @@
+//! In-memory layout, constructor, and accessors for Raven closures.
+//!
+//! See `docs/v2/specs/object-layout.md` for the byte-exact field
+//! offsets the back-end relies on. Captures are stored in a separately
+//! allocated, owned buffer pointed to by `captures`, so every closure
+//! object is the same fixed size regardless of capture count.
+
+use super::{ObjectHeader, OBJECT_ALIGN, TAG_CLOSURE};
+use crate::{raven_alloc, raven_dealloc};
+use std::mem::align_of;
+use std::ptr;
+
+/// Closure object. The header's `len` is the capture count; `cap` is
+/// unused and zero. `fn_ptr` is the lifted body, `captures` owns the
+/// capture record of `capture_size` bytes.
+#[repr(C)]
+pub struct Closure {
+    /// Standard 16-byte object header. `tag == TAG_CLOSURE`,
+    /// `len == capture count`.
+    pub header: ObjectHeader,
+    /// Raw code pointer of the lifted closure body.
+    pub fn_ptr: *const u8,
+    /// Owned buffer of `capture_size` bytes. Null when
+    /// `capture_size == 0`.
+    pub captures: *mut u8,
+    /// Size in bytes of the capture record.
+    pub capture_size: u32,
+    /// Alignment in bytes of the capture record.
+    pub capture_align: u32,
+}
+
+/// Allocate a fresh `Closure` with the given function pointer and
+/// capture record shape. The capture buffer is zero-filled.
+///
+/// `capture_count` is recorded in `header.len`; `capture_size` and
+/// `capture_align` describe the owned capture buffer. Returns null on
+/// allocation failure or invalid layout.
+#[no_mangle]
+pub extern "C" fn raven_closure_new(
+    fn_ptr: *const u8,
+    capture_size: u32,
+    capture_align: u32,
+    capture_count: u32,
+) -> *mut Closure {
+    if capture_align != 0 && !capture_align.is_power_of_two() {
+        return ptr::null_mut();
+    }
+    let closure_ptr = raven_alloc(size_of_closure(), align_of_closure()) as *mut Closure;
+    if closure_ptr.is_null() {
+        return ptr::null_mut();
+    }
+    let captures = if capture_size == 0 {
+        ptr::null_mut()
+    } else {
+        let align = if capture_align == 0 {
+            1
+        } else {
+            capture_align as usize
+        };
+        let p = raven_alloc(capture_size as usize, align);
+        if p.is_null() {
+            raven_dealloc(
+                closure_ptr as *mut u8,
+                size_of_closure(),
+                align_of_closure(),
+            );
+            return ptr::null_mut();
+        }
+        // SAFETY: the allocator just gave us `capture_size` bytes.
+        unsafe { ptr::write_bytes(p, 0, capture_size as usize) };
+        p
+    };
+    // SAFETY: closure_ptr points to writable, correctly aligned storage.
+    unsafe {
+        ptr::write(
+            closure_ptr,
+            Closure {
+                header: ObjectHeader::new(TAG_CLOSURE, capture_count, 0),
+                fn_ptr,
+                captures,
+                capture_size,
+                capture_align,
+            },
+        );
+    }
+    closure_ptr
+}
+
+/// Return the closure's function pointer.
+///
+/// Returns null when `c` is null.
+#[no_mangle]
+pub extern "C" fn raven_closure_fn_ptr(c: *const Closure) -> *const u8 {
+    if c.is_null() {
+        return ptr::null();
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*c).fn_ptr }
+}
+
+/// Return a pointer to the closure's capture buffer.
+///
+/// Returns null when `c` is null or has no captures.
+#[no_mangle]
+pub extern "C" fn raven_closure_captures(c: *const Closure) -> *mut u8 {
+    if c.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*c).captures }
+}
+
+/// Size of the in-memory `Closure` object.
+pub(crate) const fn size_of_closure() -> usize {
+    std::mem::size_of::<Closure>()
+}
+
+/// Alignment of the in-memory `Closure` object.
+pub(crate) const fn align_of_closure() -> usize {
+    let a = align_of::<Closure>();
+    if a > OBJECT_ALIGN {
+        a
+    } else {
+        OBJECT_ALIGN
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+
+    extern "C" fn dummy_body() {}
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn closure_size_and_offsets_match_spec() {
+        assert_eq!(size_of::<Closure>(), 40);
+        assert_eq!(offset_of!(Closure, header), 0);
+        assert_eq!(offset_of!(Closure, fn_ptr), 16);
+        assert_eq!(offset_of!(Closure, captures), 24);
+        assert_eq!(offset_of!(Closure, capture_size), 32);
+        assert_eq!(offset_of!(Closure, capture_align), 36);
+        assert!(align_of::<Closure>() >= 8);
+    }
+
+    #[test]
+    fn new_no_captures_leaves_buffer_null() {
+        let fp = dummy_body as *const u8;
+        let c = raven_closure_new(fp, 0, 0, 0);
+        assert!(!c.is_null());
+        // SAFETY: c came from the constructor.
+        unsafe {
+            assert_eq!((*c).header.tag, TAG_CLOSURE);
+            assert_eq!((*c).header.len, 0);
+            assert_eq!((*c).capture_size, 0);
+            assert!((*c).captures.is_null());
+            assert_eq!((*c).fn_ptr, fp);
+        }
+        unsafe { drop_closure_for_test(c) };
+    }
+
+    #[test]
+    fn new_with_captures_zero_fills_buffer() {
+        let fp = dummy_body as *const u8;
+        let c = raven_closure_new(fp, 24, 8, 3);
+        assert!(!c.is_null());
+        // SAFETY: c has a 24-byte capture buffer and len 3.
+        unsafe {
+            assert_eq!((*c).header.len, 3);
+            assert_eq!((*c).capture_size, 24);
+            assert_eq!((*c).capture_align, 8);
+            let buf = (*c).captures;
+            assert!(!buf.is_null());
+            for i in 0..24 {
+                assert_eq!(buf.add(i).read(), 0);
+            }
+        }
+        unsafe { drop_closure_for_test(c) };
+    }
+
+    #[test]
+    fn accessors_match_fields() {
+        let fp = dummy_body as *const u8;
+        let c = raven_closure_new(fp, 16, 8, 2);
+        assert_eq!(raven_closure_fn_ptr(c), fp);
+        let captures = raven_closure_captures(c);
+        assert!(!captures.is_null());
+        // Write a value through the captures pointer and read it back.
+        // SAFETY: captures points to 16 writable bytes.
+        unsafe {
+            (captures as *mut u64).write(0xABCD);
+            assert_eq!((captures as *const u64).read(), 0xABCD);
+        }
+        unsafe { drop_closure_for_test(c) };
+    }
+
+    #[test]
+    fn null_accessors_are_safe() {
+        assert!(raven_closure_fn_ptr(std::ptr::null()).is_null());
+        assert!(raven_closure_captures(std::ptr::null()).is_null());
+    }
+
+    /// Test-only deallocator.
+    ///
+    /// # Safety
+    ///
+    /// `c` must come from `raven_closure_new` and not be freed yet.
+    unsafe fn drop_closure_for_test(c: *mut Closure) {
+        if c.is_null() {
+            return;
+        }
+        // SAFETY: matches construction layout.
+        let capture_size = unsafe { (*c).capture_size };
+        let capture_align = unsafe { (*c).capture_align };
+        let captures = unsafe { (*c).captures };
+        if !captures.is_null() && capture_size > 0 {
+            let align = if capture_align == 0 {
+                1
+            } else {
+                capture_align as usize
+            };
+            raven_dealloc(captures, capture_size as usize, align);
+        }
+        raven_dealloc(c as *mut u8, size_of_closure(), align_of_closure());
+    }
+}

--- a/raven-runtime/src/object/hash.rs
+++ b/raven-runtime/src/object/hash.rs
@@ -1,0 +1,45 @@
+//! Deterministic 64-bit hash used by Map and Set buckets.
+//!
+//! FNV-1a 64 is chosen because the persisted hash sits inside each
+//! bucket and must be reproducible when the table resizes. The
+//! function takes no per-process seed and pulls in no extra
+//! dependency. See `docs/v2/specs/object-layout.md` for the design
+//! note.
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// Hash `bytes` with FNV-1a 64.
+pub fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut h = FNV_OFFSET;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_yields_offset_basis() {
+        assert_eq!(fnv1a_64(b""), FNV_OFFSET);
+    }
+
+    #[test]
+    fn known_vector_matches_reference() {
+        // FNV-1a 64 of "a" per the published reference.
+        assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
+        // FNV-1a 64 of "foobar".
+        assert_eq!(fnv1a_64(b"foobar"), 0x8594_4171_f739_67e8);
+    }
+
+    #[test]
+    fn different_inputs_collide_rarely() {
+        // Sanity check, not a guarantee: two short distinct inputs
+        // should produce different hashes.
+        assert_ne!(fnv1a_64(b"hello"), fnv1a_64(b"world"));
+    }
+}

--- a/raven-runtime/src/object/list.rs
+++ b/raven-runtime/src/object/list.rs
@@ -1,0 +1,312 @@
+//! In-memory layout, constructor, and accessors for Raven `List<T>`.
+//!
+//! See `docs/v2/specs/object-layout.md` for the byte-exact field
+//! offsets the back-end relies on.
+
+use super::{ObjectHeader, OBJECT_ALIGN, TAG_LIST};
+use crate::{raven_alloc, raven_dealloc};
+use std::mem::align_of;
+use std::ptr;
+
+/// Boxed `List<T>`. The header carries `len` (element count) and
+/// `cap` (slot capacity); `element_size`/`element_align` describe one
+/// slot; `elements` owns a buffer of `cap * element_size` bytes.
+#[repr(C)]
+pub struct List {
+    /// Standard 16-byte object header. `tag == TAG_LIST`.
+    pub header: ObjectHeader,
+    /// Size in bytes of one element slot.
+    pub element_size: u32,
+    /// Alignment in bytes of one element slot.
+    pub element_align: u32,
+    /// Owned buffer of `header.cap * element_size` bytes. Null when
+    /// `header.cap == 0`.
+    pub elements: *mut u8,
+}
+
+/// Allocate a fresh `List` with the given per-element shape and slot
+/// capacity. Header is `len = 0`, `cap = cap`. Elements buffer is
+/// zero-filled.
+///
+/// Returns null on allocation failure or invalid layout.
+#[no_mangle]
+pub extern "C" fn raven_list_new(element_size: u32, element_align: u32, cap: u32) -> *mut List {
+    if element_align != 0 && !element_align.is_power_of_two() {
+        return ptr::null_mut();
+    }
+    let list_ptr = raven_alloc(size_of_list(), align_of_list()) as *mut List;
+    if list_ptr.is_null() {
+        return ptr::null_mut();
+    }
+    let buffer = match alloc_elements(element_size, element_align, cap) {
+        Some(p) => p,
+        None => {
+            raven_dealloc(list_ptr as *mut u8, size_of_list(), align_of_list());
+            return ptr::null_mut();
+        }
+    };
+    // SAFETY: list_ptr points to writable, correctly aligned storage.
+    unsafe {
+        ptr::write(
+            list_ptr,
+            List {
+                header: ObjectHeader::new(TAG_LIST, 0, cap),
+                element_size,
+                element_align,
+                elements: buffer,
+            },
+        );
+    }
+    list_ptr
+}
+
+/// Return the current element count, i.e. `header.len`.
+///
+/// Returns zero when `l` is null.
+#[no_mangle]
+pub extern "C" fn raven_list_len(l: *const List) -> u32 {
+    if l.is_null() {
+        return 0;
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*l).header.len }
+}
+
+/// Return a pointer to the element buffer.
+///
+/// The buffer holds `raven_list_len(l) * element_size` initialised
+/// bytes. Returns null when `l` is null.
+#[no_mangle]
+pub extern "C" fn raven_list_elements(l: *const List) -> *mut u8 {
+    if l.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*l).elements }
+}
+
+/// Append one element to the list, growing the buffer if needed.
+///
+/// Copies `element_size` bytes from `payload` into the slot at index
+/// `header.len`, then increments `header.len`. The growth policy
+/// doubles `cap` each time (starting from 4 when the list is empty).
+///
+/// No-op when `l` is null or `payload` is null.
+#[no_mangle]
+pub extern "C" fn raven_list_push(l: *mut List, payload: *const u8) {
+    if l.is_null() || payload.is_null() {
+        return;
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    let (len, cap, elem_size, elem_align) = unsafe {
+        (
+            (*l).header.len,
+            (*l).header.cap,
+            (*l).element_size,
+            (*l).element_align,
+        )
+    };
+    if elem_size == 0 {
+        // Zero-sized elements still count for `len` but never copy.
+        // SAFETY: bumping a counter on a live header.
+        unsafe { (*l).header.len = len.saturating_add(1) };
+        return;
+    }
+    if len == cap {
+        let new_cap = if cap == 0 { 4 } else { cap.saturating_mul(2) };
+        if !grow_buffer(l, elem_size, elem_align, cap, new_cap) {
+            return;
+        }
+    }
+    // SAFETY: after the potential grow the slot at `len` is valid for
+    // `elem_size` writable bytes.
+    unsafe {
+        let dst = (*l).elements.add((len as usize) * (elem_size as usize));
+        ptr::copy_nonoverlapping(payload, dst, elem_size as usize);
+        (*l).header.len = len + 1;
+    }
+}
+
+/// Size of the in-memory `List` object.
+pub(crate) const fn size_of_list() -> usize {
+    std::mem::size_of::<List>()
+}
+
+/// Alignment of the in-memory `List` object.
+pub(crate) const fn align_of_list() -> usize {
+    let a = align_of::<List>();
+    if a > OBJECT_ALIGN {
+        a
+    } else {
+        OBJECT_ALIGN
+    }
+}
+
+fn alloc_elements(element_size: u32, element_align: u32, cap: u32) -> Option<*mut u8> {
+    if cap == 0 || element_size == 0 {
+        return Some(ptr::null_mut());
+    }
+    let bytes = (element_size as usize).checked_mul(cap as usize)?;
+    let align = if element_align == 0 {
+        1
+    } else {
+        element_align as usize
+    };
+    let p = raven_alloc(bytes, align);
+    if p.is_null() {
+        return None;
+    }
+    // SAFETY: the allocator just gave us `bytes` writable bytes.
+    unsafe { ptr::write_bytes(p, 0, bytes) };
+    Some(p)
+}
+
+fn grow_buffer(l: *mut List, elem_size: u32, elem_align: u32, old_cap: u32, new_cap: u32) -> bool {
+    let new_buffer = match alloc_elements(elem_size, elem_align, new_cap) {
+        Some(p) => p,
+        None => return false,
+    };
+    // SAFETY: l is a valid List pointer from a constructor.
+    unsafe {
+        let old_buffer = (*l).elements;
+        if !old_buffer.is_null() && old_cap > 0 {
+            let copy_bytes = (old_cap as usize) * (elem_size as usize);
+            if !new_buffer.is_null() {
+                ptr::copy_nonoverlapping(old_buffer, new_buffer, copy_bytes);
+            }
+            let align = if elem_align == 0 {
+                1
+            } else {
+                elem_align as usize
+            };
+            raven_dealloc(old_buffer, (old_cap as usize) * (elem_size as usize), align);
+        }
+        (*l).elements = new_buffer;
+        (*l).header.cap = new_cap;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn list_size_and_offsets_match_spec() {
+        assert_eq!(size_of::<List>(), 32);
+        assert_eq!(offset_of!(List, header), 0);
+        assert_eq!(offset_of!(List, element_size), 16);
+        assert_eq!(offset_of!(List, element_align), 20);
+        assert_eq!(offset_of!(List, elements), 24);
+        assert!(align_of::<List>() >= 8);
+    }
+
+    #[test]
+    fn new_zero_capacity_yields_empty_list() {
+        let l = raven_list_new(8, 8, 0);
+        assert!(!l.is_null());
+        // SAFETY: l came from the constructor.
+        unsafe {
+            assert_eq!((*l).header.tag, TAG_LIST);
+            assert_eq!((*l).header.len, 0);
+            assert_eq!((*l).header.cap, 0);
+            assert_eq!((*l).element_size, 8);
+            assert_eq!((*l).element_align, 8);
+            assert!((*l).elements.is_null());
+        }
+        unsafe { drop_list_for_test(l) };
+    }
+
+    #[test]
+    fn new_with_capacity_zero_fills_buffer() {
+        let l = raven_list_new(4, 4, 6);
+        assert!(!l.is_null());
+        // SAFETY: l has a 24-byte buffer.
+        unsafe {
+            let bytes = 4 * 6;
+            for i in 0..bytes {
+                assert_eq!((*l).elements.add(i).read(), 0);
+            }
+        }
+        unsafe { drop_list_for_test(l) };
+    }
+
+    #[test]
+    fn push_appends_and_grows() {
+        // Start with cap 0 so we exercise the grow path.
+        let l = raven_list_new(8, 8, 0);
+        let values: [u64; 10] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        for v in &values {
+            // SAFETY: each push reads 8 bytes from a stack-local u64.
+            raven_list_push(l, v as *const u64 as *const u8);
+        }
+        assert_eq!(raven_list_len(l), 10);
+        // SAFETY: l has 10 valid u64 slots.
+        unsafe {
+            let slots = (*l).elements as *const u64;
+            for (i, v) in values.iter().enumerate() {
+                assert_eq!(*slots.add(i), *v);
+            }
+            assert!((*l).header.cap >= 10);
+        }
+        unsafe { drop_list_for_test(l) };
+    }
+
+    #[test]
+    fn push_preserves_earlier_elements_across_grow() {
+        let l = raven_list_new(8, 8, 2);
+        let first = 0xDEADBEEFu64;
+        let second = 0xCAFEBABEu64;
+        raven_list_push(l, &first as *const u64 as *const u8);
+        raven_list_push(l, &second as *const u64 as *const u8);
+        let third = 0x12345678u64;
+        // This push forces a grow.
+        raven_list_push(l, &third as *const u64 as *const u8);
+        assert_eq!(raven_list_len(l), 3);
+        // SAFETY: l has at least three valid u64 slots.
+        unsafe {
+            let slots = (*l).elements as *const u64;
+            assert_eq!(*slots.add(0), first);
+            assert_eq!(*slots.add(1), second);
+            assert_eq!(*slots.add(2), third);
+        }
+        unsafe { drop_list_for_test(l) };
+    }
+
+    #[test]
+    fn null_accessors_are_safe() {
+        assert_eq!(raven_list_len(std::ptr::null()), 0);
+        assert!(raven_list_elements(std::ptr::null()).is_null());
+        // Null inputs must not crash.
+        raven_list_push(std::ptr::null_mut(), std::ptr::null());
+    }
+
+    /// Test-only deallocator. The real free path lands with the GC
+    /// (issue #64).
+    ///
+    /// # Safety
+    ///
+    /// `l` must come from `raven_list_new` and not be freed yet.
+    unsafe fn drop_list_for_test(l: *mut List) {
+        if l.is_null() {
+            return;
+        }
+        // SAFETY: matches the construction layout.
+        let cap = unsafe { (*l).header.cap };
+        let elem_size = unsafe { (*l).element_size };
+        let elem_align = unsafe { (*l).element_align };
+        let buffer = unsafe { (*l).elements };
+        if !buffer.is_null() && cap > 0 && elem_size > 0 {
+            let bytes = (cap as usize) * (elem_size as usize);
+            let align = if elem_align == 0 {
+                1
+            } else {
+                elem_align as usize
+            };
+            raven_dealloc(buffer, bytes, align);
+        }
+        raven_dealloc(l as *mut u8, size_of_list(), align_of_list());
+    }
+}

--- a/raven-runtime/src/object/map.rs
+++ b/raven-runtime/src/object/map.rs
@@ -1,0 +1,236 @@
+//! In-memory layout and constructor for Raven `Map<K, V>`.
+//!
+//! See `docs/v2/specs/object-layout.md` for the byte-exact field
+//! offsets the back-end relies on. The bucket array is laid out
+//! contiguously as `bucket_count` `MapEntry` slots.
+
+use super::{ObjectHeader, OBJECT_ALIGN, TAG_MAP};
+use crate::{raven_alloc, raven_dealloc};
+use std::mem::align_of;
+use std::ptr;
+
+/// Boxed `Map<K, V>`. The header carries `len` (entry count) and
+/// `cap` (bucket count, mirroring `bucket_count`); `buckets` owns a
+/// buffer of `bucket_count` `MapEntry` slots.
+#[repr(C)]
+pub struct Map {
+    /// Standard 16-byte object header. `tag == TAG_MAP`.
+    pub header: ObjectHeader,
+    /// Power of two, or zero for the freshly-constructed empty map.
+    pub bucket_count: u32,
+    /// Reserved padding; always zero.
+    pub _pad: u32,
+    /// Owned buffer of `bucket_count` `MapEntry` slots. Null when
+    /// `bucket_count == 0`.
+    pub buckets: *mut MapEntry,
+}
+
+/// One slot in a `Map`'s bucket array. `key == null` marks an empty
+/// or tombstoned slot.
+#[repr(C)]
+pub struct MapEntry {
+    /// Cached hash of the key. Used to skip key comparisons on lookup
+    /// and to seed the new bucket index on resize.
+    pub hash: u64,
+    /// Pointer to the key payload. Null when the slot is empty or
+    /// tombstoned.
+    pub key: *mut u8,
+    /// Pointer to the value payload.
+    pub value: *mut u8,
+}
+
+/// Allocate a fresh `Map` with the given initial bucket count.
+///
+/// `bucket_count` is rounded up to the next power of two (zero stays
+/// zero). The bucket buffer is zero-filled, leaving every slot in the
+/// "empty" state. `header.len = 0`, `header.cap = bucket_count` after
+/// rounding.
+///
+/// Returns null on allocation failure.
+#[no_mangle]
+pub extern "C" fn raven_map_new(bucket_count: u32) -> *mut Map {
+    let rounded = round_up_pow2(bucket_count);
+    let map_ptr = raven_alloc(size_of_map(), align_of_map()) as *mut Map;
+    if map_ptr.is_null() {
+        return ptr::null_mut();
+    }
+    let buckets = if rounded == 0 {
+        ptr::null_mut()
+    } else {
+        let bytes = (rounded as usize)
+            .checked_mul(std::mem::size_of::<MapEntry>())
+            .unwrap_or(0);
+        if bytes == 0 {
+            raven_dealloc(map_ptr as *mut u8, size_of_map(), align_of_map());
+            return ptr::null_mut();
+        }
+        let p = raven_alloc(bytes, align_of::<MapEntry>());
+        if p.is_null() {
+            raven_dealloc(map_ptr as *mut u8, size_of_map(), align_of_map());
+            return ptr::null_mut();
+        }
+        // SAFETY: the allocator just gave us `bytes` writable bytes.
+        unsafe { ptr::write_bytes(p, 0, bytes) };
+        p as *mut MapEntry
+    };
+    // SAFETY: map_ptr points to writable, correctly aligned storage.
+    unsafe {
+        ptr::write(
+            map_ptr,
+            Map {
+                header: ObjectHeader::new(TAG_MAP, 0, rounded),
+                bucket_count: rounded,
+                _pad: 0,
+                buckets,
+            },
+        );
+    }
+    map_ptr
+}
+
+/// Return the bucket buffer pointer.
+///
+/// Returns null when `m` is null or has no buckets.
+#[no_mangle]
+pub extern "C" fn raven_map_buckets(m: *const Map) -> *mut MapEntry {
+    if m.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*m).buckets }
+}
+
+/// Return the bucket count.
+///
+/// Returns zero when `m` is null.
+#[no_mangle]
+pub extern "C" fn raven_map_bucket_count(m: *const Map) -> u32 {
+    if m.is_null() {
+        return 0;
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*m).bucket_count }
+}
+
+/// Size of the in-memory `Map` object.
+pub(crate) const fn size_of_map() -> usize {
+    std::mem::size_of::<Map>()
+}
+
+/// Alignment of the in-memory `Map` object.
+pub(crate) const fn align_of_map() -> usize {
+    let a = align_of::<Map>();
+    if a > OBJECT_ALIGN {
+        a
+    } else {
+        OBJECT_ALIGN
+    }
+}
+
+fn round_up_pow2(n: u32) -> u32 {
+    if n == 0 {
+        0
+    } else if n.is_power_of_two() {
+        n
+    } else {
+        n.checked_next_power_of_two().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn map_size_and_offsets_match_spec() {
+        assert_eq!(size_of::<Map>(), 32);
+        assert_eq!(offset_of!(Map, header), 0);
+        assert_eq!(offset_of!(Map, bucket_count), 16);
+        assert_eq!(offset_of!(Map, _pad), 20);
+        assert_eq!(offset_of!(Map, buckets), 24);
+        assert!(align_of::<Map>() >= 8);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn map_entry_size_and_offsets_match_spec() {
+        assert_eq!(size_of::<MapEntry>(), 24);
+        assert_eq!(offset_of!(MapEntry, hash), 0);
+        assert_eq!(offset_of!(MapEntry, key), 8);
+        assert_eq!(offset_of!(MapEntry, value), 16);
+        assert_eq!(align_of::<MapEntry>(), 8);
+    }
+
+    #[test]
+    fn new_zero_buckets_leaves_buffer_null() {
+        let m = raven_map_new(0);
+        assert!(!m.is_null());
+        // SAFETY: m came from the constructor.
+        unsafe {
+            assert_eq!((*m).header.tag, TAG_MAP);
+            assert_eq!((*m).header.len, 0);
+            assert_eq!((*m).header.cap, 0);
+            assert_eq!((*m).bucket_count, 0);
+            assert_eq!((*m)._pad, 0);
+            assert!((*m).buckets.is_null());
+        }
+        unsafe { drop_map_for_test(m) };
+    }
+
+    #[test]
+    fn new_rounds_up_to_power_of_two() {
+        let m = raven_map_new(5);
+        assert!(!m.is_null());
+        assert_eq!(raven_map_bucket_count(m), 8);
+        // SAFETY: m came from the constructor.
+        unsafe {
+            assert_eq!((*m).header.cap, 8);
+        }
+        unsafe { drop_map_for_test(m) };
+    }
+
+    #[test]
+    fn new_zero_fills_bucket_buffer() {
+        let m = raven_map_new(4);
+        assert!(!m.is_null());
+        let buckets = raven_map_buckets(m);
+        assert!(!buckets.is_null());
+        // SAFETY: 4 valid MapEntry slots.
+        unsafe {
+            for i in 0..4 {
+                let e = &*buckets.add(i);
+                assert_eq!(e.hash, 0);
+                assert!(e.key.is_null());
+                assert!(e.value.is_null());
+            }
+        }
+        unsafe { drop_map_for_test(m) };
+    }
+
+    #[test]
+    fn null_accessors_are_safe() {
+        assert!(raven_map_buckets(std::ptr::null()).is_null());
+        assert_eq!(raven_map_bucket_count(std::ptr::null()), 0);
+    }
+
+    /// Test-only deallocator.
+    ///
+    /// # Safety
+    ///
+    /// `m` must come from `raven_map_new` and not be freed yet.
+    unsafe fn drop_map_for_test(m: *mut Map) {
+        if m.is_null() {
+            return;
+        }
+        // SAFETY: matches construction layout.
+        let bucket_count = unsafe { (*m).bucket_count };
+        let buckets = unsafe { (*m).buckets };
+        if !buckets.is_null() && bucket_count > 0 {
+            let bytes = (bucket_count as usize) * std::mem::size_of::<MapEntry>();
+            raven_dealloc(buckets as *mut u8, bytes, align_of::<MapEntry>());
+        }
+        raven_dealloc(m as *mut u8, size_of_map(), align_of_map());
+    }
+}

--- a/raven-runtime/src/object/set.rs
+++ b/raven-runtime/src/object/set.rs
@@ -1,0 +1,225 @@
+//! In-memory layout and constructor for Raven `Set<T>`.
+//!
+//! See `docs/v2/specs/object-layout.md` for the byte-exact field
+//! offsets the back-end relies on. The bucket array is laid out
+//! contiguously as `bucket_count` `SetEntry` slots.
+
+use super::{ObjectHeader, OBJECT_ALIGN, TAG_SET};
+use crate::{raven_alloc, raven_dealloc};
+use std::mem::align_of;
+use std::ptr;
+
+/// Boxed `Set<T>`. The header carries `len` (entry count) and `cap`
+/// (bucket count, mirroring `bucket_count`); `buckets` owns a buffer
+/// of `bucket_count` `SetEntry` slots.
+#[repr(C)]
+pub struct Set {
+    /// Standard 16-byte object header. `tag == TAG_SET`.
+    pub header: ObjectHeader,
+    /// Power of two, or zero for the freshly-constructed empty set.
+    pub bucket_count: u32,
+    /// Reserved padding; always zero.
+    pub _pad: u32,
+    /// Owned buffer of `bucket_count` `SetEntry` slots. Null when
+    /// `bucket_count == 0`.
+    pub buckets: *mut SetEntry,
+}
+
+/// One slot in a `Set`'s bucket array. `element == null` marks an
+/// empty or tombstoned slot.
+#[repr(C)]
+pub struct SetEntry {
+    /// Cached hash of the element.
+    pub hash: u64,
+    /// Pointer to the element payload. Null when the slot is empty or
+    /// tombstoned.
+    pub element: *mut u8,
+}
+
+/// Allocate a fresh `Set` with the given initial bucket count.
+///
+/// `bucket_count` is rounded up to the next power of two (zero stays
+/// zero). The bucket buffer is zero-filled. `header.len = 0`,
+/// `header.cap = bucket_count` after rounding.
+///
+/// Returns null on allocation failure.
+#[no_mangle]
+pub extern "C" fn raven_set_new(bucket_count: u32) -> *mut Set {
+    let rounded = round_up_pow2(bucket_count);
+    let set_ptr = raven_alloc(size_of_set(), align_of_set()) as *mut Set;
+    if set_ptr.is_null() {
+        return ptr::null_mut();
+    }
+    let buckets = if rounded == 0 {
+        ptr::null_mut()
+    } else {
+        let bytes = (rounded as usize)
+            .checked_mul(std::mem::size_of::<SetEntry>())
+            .unwrap_or(0);
+        if bytes == 0 {
+            raven_dealloc(set_ptr as *mut u8, size_of_set(), align_of_set());
+            return ptr::null_mut();
+        }
+        let p = raven_alloc(bytes, align_of::<SetEntry>());
+        if p.is_null() {
+            raven_dealloc(set_ptr as *mut u8, size_of_set(), align_of_set());
+            return ptr::null_mut();
+        }
+        // SAFETY: the allocator just gave us `bytes` writable bytes.
+        unsafe { ptr::write_bytes(p, 0, bytes) };
+        p as *mut SetEntry
+    };
+    // SAFETY: set_ptr points to writable, correctly aligned storage.
+    unsafe {
+        ptr::write(
+            set_ptr,
+            Set {
+                header: ObjectHeader::new(TAG_SET, 0, rounded),
+                bucket_count: rounded,
+                _pad: 0,
+                buckets,
+            },
+        );
+    }
+    set_ptr
+}
+
+/// Return the bucket buffer pointer.
+///
+/// Returns null when `s` is null or has no buckets.
+#[no_mangle]
+pub extern "C" fn raven_set_buckets(s: *const Set) -> *mut SetEntry {
+    if s.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*s).buckets }
+}
+
+/// Return the bucket count.
+///
+/// Returns zero when `s` is null.
+#[no_mangle]
+pub extern "C" fn raven_set_bucket_count(s: *const Set) -> u32 {
+    if s.is_null() {
+        return 0;
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*s).bucket_count }
+}
+
+/// Size of the in-memory `Set` object.
+pub(crate) const fn size_of_set() -> usize {
+    std::mem::size_of::<Set>()
+}
+
+/// Alignment of the in-memory `Set` object.
+pub(crate) const fn align_of_set() -> usize {
+    let a = align_of::<Set>();
+    if a > OBJECT_ALIGN {
+        a
+    } else {
+        OBJECT_ALIGN
+    }
+}
+
+fn round_up_pow2(n: u32) -> u32 {
+    if n == 0 {
+        0
+    } else if n.is_power_of_two() {
+        n
+    } else {
+        n.checked_next_power_of_two().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn set_size_and_offsets_match_spec() {
+        assert_eq!(size_of::<Set>(), 32);
+        assert_eq!(offset_of!(Set, header), 0);
+        assert_eq!(offset_of!(Set, bucket_count), 16);
+        assert_eq!(offset_of!(Set, _pad), 20);
+        assert_eq!(offset_of!(Set, buckets), 24);
+        assert!(align_of::<Set>() >= 8);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn set_entry_size_and_offsets_match_spec() {
+        assert_eq!(size_of::<SetEntry>(), 16);
+        assert_eq!(offset_of!(SetEntry, hash), 0);
+        assert_eq!(offset_of!(SetEntry, element), 8);
+        assert_eq!(align_of::<SetEntry>(), 8);
+    }
+
+    #[test]
+    fn new_zero_buckets_leaves_buffer_null() {
+        let s = raven_set_new(0);
+        assert!(!s.is_null());
+        // SAFETY: s came from the constructor.
+        unsafe {
+            assert_eq!((*s).header.tag, TAG_SET);
+            assert_eq!((*s).header.len, 0);
+            assert_eq!((*s).header.cap, 0);
+            assert_eq!((*s).bucket_count, 0);
+            assert!((*s).buckets.is_null());
+        }
+        unsafe { drop_set_for_test(s) };
+    }
+
+    #[test]
+    fn new_rounds_up_to_power_of_two() {
+        let s = raven_set_new(9);
+        assert!(!s.is_null());
+        assert_eq!(raven_set_bucket_count(s), 16);
+        unsafe { drop_set_for_test(s) };
+    }
+
+    #[test]
+    fn new_zero_fills_bucket_buffer() {
+        let s = raven_set_new(4);
+        assert!(!s.is_null());
+        let buckets = raven_set_buckets(s);
+        assert!(!buckets.is_null());
+        // SAFETY: 4 valid SetEntry slots.
+        unsafe {
+            for i in 0..4 {
+                let e = &*buckets.add(i);
+                assert_eq!(e.hash, 0);
+                assert!(e.element.is_null());
+            }
+        }
+        unsafe { drop_set_for_test(s) };
+    }
+
+    #[test]
+    fn null_accessors_are_safe() {
+        assert!(raven_set_buckets(std::ptr::null()).is_null());
+        assert_eq!(raven_set_bucket_count(std::ptr::null()), 0);
+    }
+
+    /// Test-only deallocator.
+    ///
+    /// # Safety
+    ///
+    /// `s` must come from `raven_set_new` and not be freed yet.
+    unsafe fn drop_set_for_test(s: *mut Set) {
+        if s.is_null() {
+            return;
+        }
+        // SAFETY: matches construction layout.
+        let bucket_count = unsafe { (*s).bucket_count };
+        let buckets = unsafe { (*s).buckets };
+        if !buckets.is_null() && bucket_count > 0 {
+            let bytes = (bucket_count as usize) * std::mem::size_of::<SetEntry>();
+            raven_dealloc(buckets as *mut u8, bytes, align_of::<SetEntry>());
+        }
+        raven_dealloc(s as *mut u8, size_of_set(), align_of_set());
+    }
+}

--- a/raven-runtime/src/object/string.rs
+++ b/raven-runtime/src/object/string.rs
@@ -1,0 +1,266 @@
+//! In-memory layout, constructors, and accessors for Raven `String`.
+//!
+//! See `docs/v2/specs/object-layout.md` for the byte-exact field
+//! offsets the back-end relies on.
+
+use super::{ObjectHeader, OBJECT_ALIGN, TAG_STRING};
+use crate::{raven_alloc, raven_dealloc};
+use std::mem::align_of;
+use std::ptr;
+
+/// UTF-8 string object. The header carries `len` (byte count) and
+/// `cap` (allocated byte capacity); the `bytes` pointer owns the
+/// payload buffer.
+#[repr(C)]
+pub struct String {
+    /// Standard 16-byte object header. `tag == TAG_STRING`.
+    pub header: ObjectHeader,
+    /// Owned buffer of `header.cap` bytes. The first `header.len`
+    /// bytes are valid UTF-8. Null when `header.cap == 0`.
+    pub bytes: *mut u8,
+}
+
+/// Allocate a fresh `String` with the requested byte capacity.
+///
+/// The header is initialised with `tag = TAG_STRING`, `len = 0`,
+/// `cap = cap`. The byte buffer is zero-filled.
+///
+/// Returns null when the allocation fails.
+#[no_mangle]
+pub extern "C" fn raven_string_new(cap: u32) -> *mut String {
+    let header_ptr = raven_alloc(size_of_string(), align_of_string()) as *mut String;
+    if header_ptr.is_null() {
+        return ptr::null_mut();
+    }
+    let bytes_ptr = if cap == 0 {
+        ptr::null_mut()
+    } else {
+        let p = raven_alloc(cap as usize, 1);
+        if p.is_null() {
+            raven_dealloc(header_ptr as *mut u8, size_of_string(), align_of_string());
+            return ptr::null_mut();
+        }
+        // SAFETY: the allocator just gave us `cap` writable bytes.
+        unsafe { ptr::write_bytes(p, 0, cap as usize) };
+        p
+    };
+    // SAFETY: header_ptr points to writable, correctly aligned storage.
+    unsafe {
+        ptr::write(
+            header_ptr,
+            String {
+                header: ObjectHeader::new(TAG_STRING, 0, cap),
+                bytes: bytes_ptr,
+            },
+        );
+    }
+    header_ptr
+}
+
+/// Return the byte length of the string, i.e. `header.len`.
+///
+/// Returns zero when `s` is null.
+#[no_mangle]
+pub extern "C" fn raven_string_len(s: *const String) -> u32 {
+    if s.is_null() {
+        return 0;
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*s).header.len }
+}
+
+/// Return a pointer to the string's UTF-8 byte buffer.
+///
+/// The buffer is valid for `raven_string_len(s)` bytes. Returns null
+/// when `s` is null.
+#[no_mangle]
+pub extern "C" fn raven_string_bytes(s: *const String) -> *const u8 {
+    if s.is_null() {
+        return ptr::null();
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    unsafe { (*s).bytes }
+}
+
+/// Concatenate two strings into a freshly allocated string.
+///
+/// The result has `len = a.len + b.len` and a capacity equal to that
+/// length. Either input may be null, in which case it is treated as
+/// the empty string.
+#[no_mangle]
+pub extern "C" fn raven_string_concat(a: *const String, b: *const String) -> *mut String {
+    let a_len = raven_string_len(a) as usize;
+    let b_len = raven_string_len(b) as usize;
+    let total = a_len + b_len;
+    let total_u32 = match u32::try_from(total) {
+        Ok(v) => v,
+        Err(_) => return ptr::null_mut(),
+    };
+    let out = raven_string_new(total_u32);
+    if out.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: out was just constructed with `total_u32` capacity. We
+    // copy `a_len` bytes from a's buffer then `b_len` bytes from b's
+    // buffer, both bounded by the caller-supplied lengths.
+    unsafe {
+        let dst = (*out).bytes;
+        if a_len > 0 {
+            ptr::copy_nonoverlapping(raven_string_bytes(a), dst, a_len);
+        }
+        if b_len > 0 {
+            ptr::copy_nonoverlapping(raven_string_bytes(b), dst.add(a_len), b_len);
+        }
+        (*out).header.len = total_u32;
+    }
+    out
+}
+
+/// Size, in bytes, of the in-memory `String` object on the host
+/// target. Used by constructors and by the GC's free routine in a
+/// follow-up.
+pub(crate) const fn size_of_string() -> usize {
+    std::mem::size_of::<String>()
+}
+
+/// Alignment, in bytes, of the in-memory `String` object.
+pub(crate) const fn align_of_string() -> usize {
+    let a = align_of::<String>();
+    if a > OBJECT_ALIGN {
+        a
+    } else {
+        OBJECT_ALIGN
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn string_size_and_offsets_match_spec() {
+        assert_eq!(size_of::<String>(), 24);
+        assert_eq!(offset_of!(String, header), 0);
+        assert_eq!(offset_of!(String, bytes), 16);
+        assert!(align_of::<String>() >= 8);
+    }
+
+    #[test]
+    fn new_zero_capacity_yields_empty_string() {
+        let s = raven_string_new(0);
+        assert!(!s.is_null());
+        // SAFETY: s came from the constructor.
+        unsafe {
+            assert_eq!((*s).header.tag, TAG_STRING);
+            assert_eq!((*s).header.len, 0);
+            assert_eq!((*s).header.cap, 0);
+            assert!((*s).bytes.is_null());
+        }
+        // Manual cleanup until the GC arrives.
+        unsafe { drop_string_for_test(s) };
+    }
+
+    #[test]
+    fn new_with_capacity_zero_fills_buffer() {
+        let cap = 16u32;
+        let s = raven_string_new(cap);
+        assert!(!s.is_null());
+        // SAFETY: s came from the constructor with `cap` bytes.
+        unsafe {
+            assert_eq!((*s).header.cap, cap);
+            for i in 0..cap as usize {
+                assert_eq!((*s).bytes.add(i).read(), 0);
+            }
+        }
+        unsafe { drop_string_for_test(s) };
+    }
+
+    #[test]
+    fn len_and_bytes_accessors_match_header() {
+        let s = raven_string_new(8);
+        assert!(!s.is_null());
+        // SAFETY: write into the just-allocated buffer.
+        unsafe {
+            ptr::copy_nonoverlapping(b"hi".as_ptr(), (*s).bytes, 2);
+            (*s).header.len = 2;
+        }
+        assert_eq!(raven_string_len(s), 2);
+        let bytes = raven_string_bytes(s);
+        assert!(!bytes.is_null());
+        // SAFETY: bytes points to two valid bytes "hi".
+        let slice = unsafe { std::slice::from_raw_parts(bytes, 2) };
+        assert_eq!(slice, b"hi");
+        unsafe { drop_string_for_test(s) };
+    }
+
+    #[test]
+    fn concat_joins_inputs() {
+        let a = raven_string_new(5);
+        let b = raven_string_new(5);
+        assert!(!a.is_null() && !b.is_null());
+        // SAFETY: a and b have capacity 5 each.
+        unsafe {
+            ptr::copy_nonoverlapping(b"hel".as_ptr(), (*a).bytes, 3);
+            (*a).header.len = 3;
+            ptr::copy_nonoverlapping(b"lo".as_ptr(), (*b).bytes, 2);
+            (*b).header.len = 2;
+        }
+        let joined = raven_string_concat(a, b);
+        assert!(!joined.is_null());
+        assert_eq!(raven_string_len(joined), 5);
+        // SAFETY: joined has len 5.
+        let slice = unsafe { std::slice::from_raw_parts(raven_string_bytes(joined), 5) };
+        assert_eq!(slice, b"hello");
+        unsafe {
+            drop_string_for_test(joined);
+            drop_string_for_test(a);
+            drop_string_for_test(b);
+        }
+    }
+
+    #[test]
+    fn concat_with_null_treats_input_as_empty() {
+        let a = raven_string_new(2);
+        // SAFETY: a has capacity 2.
+        unsafe {
+            ptr::copy_nonoverlapping(b"hi".as_ptr(), (*a).bytes, 2);
+            (*a).header.len = 2;
+        }
+        let joined = raven_string_concat(a, std::ptr::null());
+        assert!(!joined.is_null());
+        assert_eq!(raven_string_len(joined), 2);
+        let slice = unsafe { std::slice::from_raw_parts(raven_string_bytes(joined), 2) };
+        assert_eq!(slice, b"hi");
+        unsafe {
+            drop_string_for_test(joined);
+            drop_string_for_test(a);
+        }
+    }
+
+    #[test]
+    fn null_accessors_are_safe() {
+        assert_eq!(raven_string_len(std::ptr::null()), 0);
+        assert!(raven_string_bytes(std::ptr::null()).is_null());
+    }
+
+    /// Test-only deallocator. The real free path lands with the GC
+    /// (issue #64); for unit tests we want valgrind-clean teardown.
+    ///
+    /// # Safety
+    ///
+    /// `s` must come from `raven_string_new` and not be freed yet.
+    unsafe fn drop_string_for_test(s: *mut String) {
+        if s.is_null() {
+            return;
+        }
+        // SAFETY: matches the construction layout.
+        let cap = unsafe { (*s).header.cap };
+        let bytes = unsafe { (*s).bytes };
+        if !bytes.is_null() && cap > 0 {
+            raven_dealloc(bytes, cap as usize, 1);
+        }
+        raven_dealloc(s as *mut u8, size_of_string(), align_of_string());
+    }
+}

--- a/raven-runtime/tests/object_layouts.rs
+++ b/raven-runtime/tests/object_layouts.rs
@@ -1,0 +1,150 @@
+//! Cross-crate integration tests for the per-kind object layouts.
+//!
+//! These exercise the constructor and accessor surface through the
+//! public Rust API exactly as the v2 codegen and stdlib glue will. A
+//! failure here means either a `crate-type` regression (the rlib no
+//! longer links) or a layout symbol stopped being reachable.
+//!
+//! The byte-exact `size_of` and `offset_of!` assertions live in the
+//! inline unit tests; this file confirms behaviour through the ABI.
+
+use raven_runtime::{
+    raven_box_new, raven_box_payload, raven_closure_captures, raven_closure_fn_ptr,
+    raven_closure_new, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,
+    raven_map_bucket_count, raven_map_buckets, raven_map_new, raven_set_bucket_count,
+    raven_set_buckets, raven_set_new, raven_string_bytes, raven_string_concat, raven_string_len,
+    raven_string_new, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING,
+};
+
+#[test]
+fn string_constructor_and_concat_cross_crate() {
+    let a = raven_string_new(3);
+    let b = raven_string_new(3);
+    assert!(!a.is_null() && !b.is_null());
+    // SAFETY: a and b each have capacity 3.
+    unsafe {
+        assert_eq!((*a).header.tag, TAG_STRING);
+        std::ptr::copy_nonoverlapping(b"foo".as_ptr(), (*a).bytes, 3);
+        (*a).header.len = 3;
+        std::ptr::copy_nonoverlapping(b"bar".as_ptr(), (*b).bytes, 3);
+        (*b).header.len = 3;
+    }
+    let joined = raven_string_concat(a, b);
+    assert_eq!(raven_string_len(joined), 6);
+    // SAFETY: joined has 6 valid bytes.
+    let slice = unsafe { std::slice::from_raw_parts(raven_string_bytes(joined), 6) };
+    assert_eq!(slice, b"foobar");
+}
+
+#[test]
+fn list_push_grows_cross_crate() {
+    let l = raven_list_new(8, 8, 0);
+    assert!(!l.is_null());
+    // SAFETY: l is a fresh List.
+    unsafe {
+        assert_eq!((*l).header.tag, TAG_LIST);
+    }
+    for v in 0u64..32 {
+        raven_list_push(l, &v as *const u64 as *const u8);
+    }
+    assert_eq!(raven_list_len(l), 32);
+    // SAFETY: l holds 32 u64 elements.
+    unsafe {
+        let slots = raven_list_elements(l) as *const u64;
+        for v in 0u64..32 {
+            assert_eq!(*slots.add(v as usize), v);
+        }
+    }
+}
+
+#[test]
+fn map_constructor_cross_crate() {
+    let m = raven_map_new(10);
+    assert!(!m.is_null());
+    // 10 rounds up to 16.
+    assert_eq!(raven_map_bucket_count(m), 16);
+    // SAFETY: m is a fresh Map.
+    unsafe {
+        assert_eq!((*m).header.tag, TAG_MAP);
+        assert_eq!((*m).header.cap, 16);
+    }
+    let buckets = raven_map_buckets(m);
+    assert!(!buckets.is_null());
+    // SAFETY: 16 zeroed MapEntry slots.
+    unsafe {
+        for i in 0..16 {
+            let e = &*buckets.add(i);
+            assert_eq!(e.hash, 0);
+            assert!(e.key.is_null());
+            assert!(e.value.is_null());
+        }
+    }
+}
+
+#[test]
+fn set_constructor_cross_crate() {
+    let s = raven_set_new(3);
+    assert!(!s.is_null());
+    // 3 rounds up to 4.
+    assert_eq!(raven_set_bucket_count(s), 4);
+    // SAFETY: s is a fresh Set.
+    unsafe {
+        assert_eq!((*s).header.tag, TAG_SET);
+        assert_eq!((*s).header.cap, 4);
+    }
+    let buckets = raven_set_buckets(s);
+    assert!(!buckets.is_null());
+    // SAFETY: 4 zeroed SetEntry slots.
+    unsafe {
+        for i in 0..4 {
+            let e = &*buckets.add(i);
+            assert_eq!(e.hash, 0);
+            assert!(e.element.is_null());
+        }
+    }
+}
+
+extern "C" fn closure_body() {}
+
+#[test]
+fn closure_constructor_cross_crate() {
+    let fp = closure_body as *const u8;
+    let c = raven_closure_new(fp, 16, 8, 2);
+    assert!(!c.is_null());
+    // SAFETY: c is a fresh Closure with 16 capture bytes.
+    unsafe {
+        assert_eq!((*c).header.tag, TAG_CLOSURE);
+        assert_eq!((*c).header.len, 2);
+    }
+    assert_eq!(raven_closure_fn_ptr(c), fp);
+    let captures = raven_closure_captures(c);
+    assert!(!captures.is_null());
+    // SAFETY: captures points to 16 zeroed, writable bytes.
+    unsafe {
+        for i in 0..16 {
+            assert_eq!(captures.add(i).read(), 0);
+        }
+        (captures as *mut u64).write(7);
+        assert_eq!((captures as *const u64).read(), 7);
+    }
+}
+
+#[test]
+fn box_constructor_cross_crate() {
+    let b = raven_box_new(8, 8);
+    assert!(!b.is_null());
+    // SAFETY: b is a fresh Box with an 8-byte payload.
+    unsafe {
+        assert_eq!((*b).header.tag, TAG_BOX);
+        assert_eq!((*b).header.len, 8);
+        assert_eq!((*b).header.cap, 1);
+    }
+    let payload = raven_box_payload(b);
+    assert!(!payload.is_null());
+    // SAFETY: payload points to 8 zeroed, writable bytes.
+    unsafe {
+        assert_eq!((payload as *const u64).read(), 0);
+        (payload as *mut u64).write(0xFEED);
+        assert_eq!((payload as *const u64).read(), 0xFEED);
+    }
+}


### PR DESCRIPTION
Adds concrete in-memory layouts, constructors, and accessors for every heap-allocated Raven v2 object so the GC and codegen can compute field offsets against a fixed contract.

Closes #65.

## Summary

Each layout prepends the existing 16-byte `ObjectHeader` (issue #63) and is documented byte-for-byte in `docs/v2/specs/object-layout.md`. The runtime exports both the Rust `#[repr(C)]` types (for in-tree tests and stdlib glue) and `extern "C"` constructors so the back-end never re-implements a layout.

## Layouts shipped

| Kind | Size (64-bit) | Internal pointers |
| --- | --- | --- |
| `String` | 24 | `bytes` |
| `List` | 32 | `elements` (+ `element_size`/`element_align`) |
| `Map` + `MapEntry` | 32 / 24 | `buckets`, per-entry `key` and `value` |
| `Set` + `SetEntry` | 32 / 16 | `buckets`, per-entry `element` |
| `Closure` | 40 | `captures` (pointer-indirect), `fn_ptr` |
| `Box` | 16 + payload | none of its own |

## Constructor and accessor APIs

* String: `raven_string_new`, `raven_string_len`, `raven_string_bytes`, `raven_string_concat`.
* List: `raven_list_new`, `raven_list_len`, `raven_list_elements`, `raven_list_push`.
* Map: `raven_map_new`, `raven_map_buckets`, `raven_map_bucket_count`.
* Set: `raven_set_new`, `raven_set_buckets`, `raven_set_bucket_count`.
* Closure: `raven_closure_new`, `raven_closure_fn_ptr`, `raven_closure_captures`.
* Box: `raven_box_new`, `raven_box_payload`.

Constructors allocate through `raven_alloc`, write the header with the correct tag, and zero the body. Map and Set hash with FNV-1a 64 (deterministic, no extra dependency); the choice is documented because the cached hash lives inside each bucket and must reproduce on resize. `raven_list_push` doubles capacity when full (starting at 4).

## Deferrals

* GC tracing and the real free path (issue #64). `gc_bits` stays zero; objects leak at process exit, and the per-kind deallocators are test-only helpers for now.
* Codegen integration that emits loads and stores through these offsets (issue #67).
* Trait object fat pointers and the vtable shape (issue #66). The `Box` tag is the storage shape only.
* Real string methods and collection methods, plus map/set insert, lookup, and resize (stdlib issues).

## Test plan

- [x] `cargo build` clean across the workspace.
- [x] `cargo test -p raven-runtime`: 47 inline unit tests, 6 cross-crate integration tests, 3 ABI tests.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -p raven-runtime --all-targets` clean.
- [x] Existing `raven` crate tests still pass (247).
- [x] `size_of` and `offset_of!` assertions match `docs/v2/specs/object-layout.md`, gated on 64-bit targets.
- [x] Constructors zero the body and set `header.tag`, `header.len`, `header.cap` as documented.
