### PR TITLE
fix: clean clippy --all-targets and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Lint
-      run: cargo clippy
+      run: cargo clippy --workspace --all-targets
 
   build:
     runs-on: ubuntu-latest

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -95,8 +95,8 @@ fn integer_literals_in_all_four_bases_with_underscores() {
 
 #[test]
 fn float_literals_with_and_without_exponent() {
-    let toks = lex("3.14 1.0e10 6.022e-23 1E+3 1e10");
-    let expected = [3.14_f64, 1.0e10, 6.022e-23, 1.0e3, 1.0e10];
+    let toks = lex("3.25 1.0e10 6.022e-23 1E+3 1e10");
+    let expected = [3.25_f64, 1.0e10, 6.022e-23, 1.0e3, 1.0e10];
     let nums: Vec<f64> = toks
         .iter()
         .filter_map(|t| match t.kind {

--- a/src/resolve/tests.rs
+++ b/src/resolve/tests.rs
@@ -5,8 +5,6 @@
 //! coverage section. Module local tests (scope mechanics, item
 //! collection, import resolution) live next to their modules.
 
-#![cfg(test)]
-
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
A lexer test asserted on the float literal `3.14`, which clippy reads as an approximate `f64::consts::PI` and denies by default. The lint only appears under `--all-targets` (it lives in a test target), and the CI lint job was running bare `cargo clippy`, which checks only lib and bin targets. So `cargo clippy --all-targets` failed locally while CI stayed green.

This change:

- Swaps the test literal `3.14` for `3.25`, which exercises the same multi-digit-fraction parse path without tripping `approx_constant`.
- Removes a redundant inner `#![cfg(test)]` from `src/resolve/tests.rs` (the module is already gated by `#[cfg(test)] mod tests;`), clearing a `duplicated_attributes` warning.
- Widens the CI lint step to `cargo clippy --workspace --all-targets` so test-target and runtime-crate lints are caught going forward.

## Test plan

- [x] `cargo clippy --workspace --all-targets` clean (no errors, no warnings)
- [x] `cargo test` 247 lib tests plus all golden suites pass
- [x] `cargo fmt --check` clean
