### PR TITLE
fix(codegen): link with the MSVC toolchain on Windows-MSVC hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,11 +294,13 @@ dependencies = [
 name = "raven"
 version = "2.0.0-dev"
 dependencies = [
+ "cc",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -307,6 +325,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slice-group-by"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ cranelift-frontend = "0.108"
 cranelift-module = "0.108"
 cranelift-native = "0.108"
 cranelift-object = "0.108"
+# Locates the MSVC `link.exe` toolchain via the Windows registry so the
+# driver can link Cranelift's MSVC-flavor objects on windows-msvc hosts.
+cc = "1.2"
+# Supplies the host target triple to key linker selection.
+target-lexicon = "0.12"
 
 [profile.release]
 opt-level = 3

--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -163,20 +163,71 @@ raven build path/to/program.rv -o out
 The driver runs lexing, parsing, resolution, type checking, HIR
 lowering, MIR lowering, and monomorphization in order, then hands the
 `MirProgram` to `codegen::compile_to_object`. The returned `Vec<u8>` is
-written to a temporary `.o` file. The driver then invokes the system
-`cc` to link the object with the `raven-runtime` staticlib (built by
-the same Cargo invocation as the compiler). The linker is whatever `cc`
-defaults to on the host; the driver does not try to call `link.exe`
-directly on Windows so MinGW or clang are required there.
+written to a temporary `.o` file. The driver then links the object with
+the `raven-runtime` staticlib (built by the same Cargo invocation as
+the compiler) into the requested output.
 
 `compile_to_object(program, target_isa)` is also exposed for in process
 use by tests, returning the raw object bytes so a test can call the
 linker itself or inspect the object with `goblin`.
 
-If `cc` is not on the path, the smoke test that compiles and runs a
-hello world program prints a diagnostic and short circuits via
-`#[ignore]` style logic. The unit tests that only consult MIR lowering
-do not depend on `cc` at all.
+### Entry point
+
+The exported program entry is an `int main(void)` shim, not the Raven
+`main` directly. Cranelift lowers the Raven `main` under an internal
+symbol that returns whatever the function returns (unit for a typical
+program, which is no machine value at all). A C runtime starting that
+symbol as `int main()` would read an uninitialized register as the
+process exit code. The shim calls the Raven body and returns a literal
+`0`, so a successful program exits with status `0` on every host.
+
+### Linker selection
+
+Cranelift emits an object in the host's native format: an MSVC-flavor
+COFF on windows-msvc, ELF on Linux, Mach-O on macOS. The link step is
+therefore toolchain aware and keyed on the host target triple
+(`target_lexicon::Triple::host()`):
+
+* `*-windows-msvc`: the MSVC `link.exe`, located through the Windows
+  registry with `cc::windows_registry::find_tool`. The `cc` crate hands
+  back a `Command` preloaded with the SDK and CRT `LIB`, `INCLUDE`, and
+  `PATH` environment, which is why this path is preferred. The link line
+  is `/NOLOGO /OUT:<output> <object> <runtime.lib> <native system libs>
+  /SUBSYSTEM:CONSOLE`. If the registry lookup fails, the driver falls
+  back (best effort) to the Rust toolchain's bundled `rust-lld` in
+  `lld-link` flavor, located under `rustc --print sysroot`. The fallback
+  needs the SDK `LIB` paths already present in the environment because
+  `rust-lld` does not supply them.
+* `*-windows-gnu`: a `cc`/`gcc` driver, which must be a 64-bit
+  MinGW-w64. A 32-bit MinGW.org `gcc` cannot read the 64-bit object, so
+  a link failure surfaces a hint about the architecture mismatch.
+* Linux, macOS, and other Unix: the system `cc` driver, which brings the
+  system linker and its default library search paths, plus the Rust std
+  system libraries the runtime depends on (`-lpthread`, `-ldl`, `-lm`,
+  and so on).
+
+### Rust std native system libraries on MSVC
+
+The Rust staticlib references system import libraries that must appear
+on the MSVC link line, because the staticlib does not carry them. The
+exact set is captured with:
+
+```
+cargo rustc -p raven-runtime --crate-type staticlib -- --print native-static-libs
+```
+
+The `note: native-static-libs: ...` line it prints is hardcoded as a
+`const` in `linker.rs` (currently `kernel32.lib advapi32.lib ntdll.lib
+userenv.lib ws2_32.lib dbghelp.lib /defaultlib:msvcrt`, captured against
+rustc 1.85.0). The driver does not shell out to cargo at link time.
+Refresh the list the same way if the runtime crate gains native
+dependencies.
+
+If no linker is available for the host at all, the smoke test that
+compiles and runs a hello world program prints a diagnostic and short
+circuits with a successful exit. On a correctly configured host it links
+and runs the program for real and asserts the output. The unit tests
+that only consult MIR lowering do not depend on a linker.
 
 ## Out of scope (tracked by follow up issues)
 
@@ -194,10 +245,12 @@ do not depend on `cc` at all.
   constant `Int`, an arithmetic `+` lowering, an `if` with a value, a
   call between two functions, and the `print("hello")` lowering.
 * An end to end smoke test that compiles `examples/v2/hello.rv` with
-  the driver, links via `cc`, runs the resulting binary, and asserts
-  the stdout matches `Hello, Raven!\n`. The test gates itself with a
-  presence check on `cc` and emits an `eprintln!` plus an `#[ignore]`
-  if the toolchain is missing rather than failing.
+  the driver, links it with the host toolchain, runs the resulting
+  binary, and asserts the stdout matches `Hello, Raven!\n` and the exit
+  status is success. The test gates itself with a presence check on the
+  host linker and emits an `eprintln!` plus a successful exit only when
+  no linker is available at all; on a correctly configured host it links
+  and runs the program rather than skipping.
 
 ## Crate layout
 
@@ -207,6 +260,6 @@ src/codegen/
   context.rs            Per module Cranelift context, function table, string table
   function.rs           Per function lowering
   intrinsics.rs         Recognized intrinsic mangled names (print, future stdlib)
-  linker.rs             cc invocation, temp directory management
+  linker.rs             per-platform linker selection by target triple
 src/main.rs             build subcommand wired through clap minimal parsing
 ```

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -8,9 +8,10 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
-use cranelift_codegen::ir::{AbiParam, Signature};
+use cranelift_codegen::ir::{types, AbiParam, InstBuilder, Signature};
 use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::Context;
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{DataDescription, DataId, FuncId, Linkage, Module};
 use cranelift_object::{ObjectModule, ObjectProduct};
 
@@ -35,7 +36,27 @@ pub struct ModuleCx {
     strings: BTreeMap<Vec<u8>, DataId>,
     /// Counter for unique data symbol names.
     string_counter: u32,
+    /// The C entry shim and the Raven `main` it wraps, recorded during
+    /// declaration so the bodies can be emitted after every Raven
+    /// function is in the symbol table. `None` when the program has no
+    /// `main` (for example a unit test compiling a fragment).
+    main_entry: Option<MainEntry>,
 }
+
+/// The exported `main` shim plus the Raven `main` it dispatches to.
+struct MainEntry {
+    /// The exported `int main(void)` symbol the C runtime starts.
+    shim: FuncId,
+    /// The internal symbol holding the user's Raven `main` body.
+    raven_main: FuncId,
+}
+
+/// Symbol name for the user's Raven `main` body. The exported `main`
+/// the C runtime calls is a thin shim that invokes this and returns a
+/// deterministic `0` exit code, since the Raven entry point returns
+/// unit and the C runtime would otherwise read an uninitialized
+/// register as the process status.
+const RAVEN_MAIN_SYMBOL: &str = "__raven_main";
 
 impl ModuleCx {
     /// Build a fresh context wrapping `module`.
@@ -46,6 +67,7 @@ impl ModuleCx {
             runtime: HashMap::new(),
             strings: BTreeMap::new(),
             string_counter: 0,
+            main_entry: None,
         }
     }
 
@@ -116,23 +138,43 @@ impl ModuleCx {
 
     /// Declare every MIR function ahead of body emission so that calls
     /// between functions can be resolved without a fix up pass.
+    ///
+    /// The Raven `main` is declared under an internal symbol and wrapped
+    /// by an exported `int main(void)` shim. The shim is what the C
+    /// runtime starts; it calls the Raven body and returns `0`, so the
+    /// process exit code is deterministic rather than whatever the
+    /// runtime reads out of a register after a unit returning function.
     pub fn declare_functions(&mut self, program: &MirProgram) -> Result<(), CodegenError> {
         for func in &program.functions {
             let sig = self.signature_for(func)?;
-            let linkage = if func.origin == "main" {
-                Linkage::Export
-            } else {
-                Linkage::Local
-            };
-            let name = if func.origin == "main" {
-                "main".to_string()
+            let is_main = func.origin == "main";
+            let linkage = Linkage::Local;
+            let name = if is_main {
+                RAVEN_MAIN_SYMBOL.to_string()
             } else {
                 func.name.clone()
             };
             let id = self.module.declare_function(&name, linkage, &sig)?;
             self.functions.insert(func.name.clone(), id);
+            if is_main {
+                let shim = self.declare_main_shim()?;
+                self.main_entry = Some(MainEntry {
+                    shim,
+                    raven_main: id,
+                });
+            }
         }
         Ok(())
+    }
+
+    /// Declare the exported `int main(void)` C entry shim.
+    fn declare_main_shim(&mut self) -> Result<FuncId, CodegenError> {
+        let mut sig = Signature::new(self.module.target_config().default_call_conv);
+        sig.returns.push(AbiParam::new(types::I32));
+        let id = self
+            .module
+            .declare_function("main", Linkage::Export, &sig)?;
+        Ok(id)
     }
 
     /// Lower the body of every declared MIR function.
@@ -140,6 +182,47 @@ impl ModuleCx {
         for func in &program.functions {
             self.define_one(func)?;
         }
+        if self.main_entry.is_some() {
+            self.define_main_shim()?;
+        }
+        Ok(())
+    }
+
+    /// Emit the body of the `int main(void)` shim: call the Raven
+    /// `main`, discard its result, and return `0`.
+    fn define_main_shim(&mut self) -> Result<(), CodegenError> {
+        let MainEntry { shim, raven_main } = self
+            .main_entry
+            .as_ref()
+            .expect("define_main_shim called without a declared main");
+        let shim = *shim;
+        let raven_main = *raven_main;
+
+        let mut ctx = Context::new();
+        ctx.func.signature = {
+            let mut sig = Signature::new(self.module.target_config().default_call_conv);
+            sig.returns.push(AbiParam::new(types::I32));
+            sig
+        };
+
+        let callee = self.module.declare_func_in_func(raven_main, &mut ctx.func);
+        let mut builder_ctx = FunctionBuilderContext::new();
+        {
+            let mut builder = FunctionBuilder::new(&mut ctx.func, &mut builder_ctx);
+            let block = builder.create_block();
+            builder.switch_to_block(block);
+            builder.seal_block(block);
+            // The Raven `main` returns unit, so there is no result value
+            // to forward; the call is emitted purely for its effects.
+            builder.ins().call(callee, &[]);
+            let zero = builder.ins().iconst(types::I32, 0);
+            builder.ins().return_(&[zero]);
+            builder.finalize();
+        }
+
+        self.module
+            .define_function(shim, &mut ctx)
+            .map_err(|e| CodegenError::Codegen(format!("define main shim: {}", e)))?;
         Ok(())
     }
 

--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -2,18 +2,48 @@
 //!
 //! After codegen has produced a relocatable object, the driver hands
 //! it here together with the path to the runtime staticlib and the
-//! desired output path. The linker uses the system `cc` driver so
-//! that the system linker and its default lib paths come along for
-//! free.
+//! desired output path. The link step is toolchain aware: it selects a
+//! linker based on the host target triple so that the object Cranelift
+//! emitted (an MSVC-flavor COFF on windows-msvc, ELF on Linux, Mach-O
+//! on macOS) is handed to a linker that understands that format.
 //!
-//! On Windows, MinGW or clang must be on PATH because MSVC's
-//! `link.exe` does not have a `cc`-style command line. Cross platform
-//! installer packaging will smooth this out later (issue #92).
+//! * `*-windows-msvc`: the MSVC `link.exe`, located through the Windows
+//!   registry by the `cc` crate. `link.exe` is the linker rustc itself
+//!   uses on this host, and it understands the 64-bit COFF objects
+//!   Cranelift produces. A fallback to the Rust toolchain's bundled
+//!   `rust-lld` (in `lld-link` flavor) keeps the build working when the
+//!   registry lookup fails.
+//! * `*-windows-gnu`: a `cc`/`gcc` driver, which must be 64-bit
+//!   MinGW-w64. A 32-bit MinGW.org `gcc` cannot read the 64-bit object,
+//!   so a failure here surfaces a hint about the architecture mismatch.
+//! * everything else (Linux, macOS): the system `cc` driver, which
+//!   brings the system linker and its default library search paths.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use target_lexicon::{OperatingSystem, Triple};
+
 use super::CodegenError;
+
+/// Rust standard library native system libraries that the staticlib
+/// references on windows-msvc. These must appear on the MSVC link line
+/// because the staticlib does not carry them itself.
+///
+/// Captured from
+/// `cargo rustc -p raven-runtime --crate-type staticlib -- --print native-static-libs`
+/// against rustc 1.85.0 (x86_64-pc-windows-msvc). Refresh the same way
+/// if the runtime crate gains native dependencies. The trailing
+/// `/defaultlib:msvcrt` selects the C runtime and is passed verbatim.
+const MSVC_NATIVE_STATIC_LIBS: &[&str] = &[
+    "kernel32.lib",
+    "advapi32.lib",
+    "ntdll.lib",
+    "userenv.lib",
+    "ws2_32.lib",
+    "dbghelp.lib",
+    "/defaultlib:msvcrt",
+];
 
 /// Where to find the runtime staticlib produced by Cargo.
 #[derive(Debug, Clone)]
@@ -27,10 +57,25 @@ pub struct LinkOutput {
     pub binary: PathBuf,
 }
 
-/// Detect whether `cc` is available on PATH. Used by tests that need
-/// to short circuit if the toolchain is missing.
+/// Whether a usable linker is available for the host target.
+///
+/// On windows-msvc this means the MSVC `link.exe` or the bundled
+/// `rust-lld` can be located. On other hosts it means a `cc` driver is
+/// on PATH. Tests use this to skip only when no linker exists at all.
+pub fn linker_available() -> bool {
+    let triple = Triple::host();
+    if is_windows_msvc(&triple) {
+        msvc_link_tool(&host_triple_string()).is_some() || locate_rust_lld().is_some()
+    } else {
+        which_cc().is_some()
+    }
+}
+
+/// Back-compat alias: the older name reported `cc` availability. The
+/// smoke test and any external callers keep working through the new
+/// toolchain-aware check.
 pub fn cc_available() -> bool {
-    which_cc().is_some()
+    linker_available()
 }
 
 fn which_cc() -> Option<PathBuf> {
@@ -51,13 +96,188 @@ fn which_cc() -> Option<PathBuf> {
     None
 }
 
+fn is_windows_msvc(triple: &Triple) -> bool {
+    matches!(triple.operating_system, OperatingSystem::Windows)
+        && triple.environment == target_lexicon::Environment::Msvc
+}
+
+fn is_windows_gnu(triple: &Triple) -> bool {
+    matches!(triple.operating_system, OperatingSystem::Windows)
+        && matches!(
+            triple.environment,
+            target_lexicon::Environment::Gnu | target_lexicon::Environment::GnuLlvm
+        )
+}
+
+/// The host triple as the `&str` form `cc::windows_registry::find_tool`
+/// expects (for example `x86_64-pc-windows-msvc`).
+fn host_triple_string() -> String {
+    Triple::host().to_string()
+}
+
 /// Link `object_path` with `runtime` into `output`.
 ///
-/// On non Windows targets, the resulting executable is also linked
-/// against `-lpthread`, `-ldl`, and `-lm` which the Rust standard
-/// library that the runtime depends on requires. On Windows, the
-/// equivalent system libraries are added explicitly.
+/// Selects the linker by host target triple. See the module docs for
+/// the per-platform behavior.
 pub fn link(
+    object_path: &Path,
+    runtime: &RuntimeStaticLib,
+    output: &Path,
+) -> Result<LinkOutput, CodegenError> {
+    let triple = Triple::host();
+    if is_windows_msvc(&triple) {
+        link_msvc(object_path, runtime, output)
+    } else if is_windows_gnu(&triple) {
+        link_gnu(object_path, runtime, output)
+    } else {
+        link_unix(object_path, runtime, output)
+    }
+}
+
+/// Link an MSVC COFF object with the MSVC toolchain.
+///
+/// Prefers `link.exe` located through the Windows registry, because the
+/// `cc` crate hands back a `Command` preloaded with the SDK and CRT
+/// `LIB`/`PATH` environment. Falls back to the Rust toolchain's bundled
+/// `rust-lld` (best effort) when the registry lookup fails.
+fn link_msvc(
+    object_path: &Path,
+    runtime: &RuntimeStaticLib,
+    output: &Path,
+) -> Result<LinkOutput, CodegenError> {
+    let triple = host_triple_string();
+    if let Some(mut cmd) = msvc_link_tool(&triple) {
+        push_msvc_args(&mut cmd, object_path, runtime, output);
+        run_linker(cmd, "link.exe", output)
+    } else if let Some(lld) = locate_rust_lld() {
+        // Best-effort fallback. `rust-lld` in lld-link flavor speaks the
+        // same command line as `link.exe`, but it does not bring the SDK
+        // library search paths, so the LIB environment from a developer
+        // shell (or a prior `link.exe` discovery) must already be set.
+        let mut cmd = Command::new(&lld);
+        cmd.arg("-flavor").arg("link");
+        push_msvc_args(&mut cmd, object_path, runtime, output);
+        run_linker(cmd, "rust-lld", output)
+    } else {
+        Err(CodegenError::Target(
+            "no MSVC linker found: install the Visual Studio C++ build tools \
+             (for link.exe) or ensure rust-lld ships with the active toolchain"
+                .to_string(),
+        ))
+    }
+}
+
+/// Locate `link.exe` through the Windows registry and return a
+/// `Command` preloaded with the SDK and CRT environment.
+fn msvc_link_tool(triple: &str) -> Option<Command> {
+    let tool = cc::windows_registry::find_tool(triple, "link.exe")?;
+    Some(tool.to_command())
+}
+
+/// Append the common MSVC link arguments to `cmd`.
+fn push_msvc_args(
+    cmd: &mut Command,
+    object_path: &Path,
+    runtime: &RuntimeStaticLib,
+    output: &Path,
+) {
+    cmd.arg("/NOLOGO");
+    cmd.arg(format!("/OUT:{}", output.display()));
+    cmd.arg(object_path);
+    cmd.arg(&runtime.path);
+    for lib in MSVC_NATIVE_STATIC_LIBS {
+        cmd.arg(lib);
+    }
+    cmd.arg("/SUBSYSTEM:CONSOLE");
+}
+
+/// Locate `rust-lld.exe` under the active Rust toolchain sysroot.
+fn locate_rust_lld() -> Option<PathBuf> {
+    let sysroot = rustc_sysroot()?;
+    let triple = host_triple_string();
+    let p = sysroot
+        .join("lib")
+        .join("rustlib")
+        .join(&triple)
+        .join("bin")
+        .join(if cfg!(windows) {
+            "rust-lld.exe"
+        } else {
+            "rust-lld"
+        });
+    if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Query `rustc --print sysroot`.
+fn rustc_sysroot() -> Option<PathBuf> {
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let out = Command::new(rustc)
+        .arg("--print")
+        .arg("sysroot")
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+/// Link via a MinGW-w64 `gcc`/`cc` driver on windows-gnu.
+fn link_gnu(
+    object_path: &Path,
+    runtime: &RuntimeStaticLib,
+    output: &Path,
+) -> Result<LinkOutput, CodegenError> {
+    let cc = which_cc().ok_or_else(|| {
+        CodegenError::Target(
+            "no `cc`/`gcc` driver on PATH for windows-gnu linking; a 64-bit \
+             MinGW-w64 toolchain is required"
+                .to_string(),
+        )
+    })?;
+    let mut cmd = Command::new(&cc);
+    cmd.arg(object_path).arg(&runtime.path);
+    cmd.arg("-o").arg(output);
+    // Rust's std on MinGW pulls in these system libs.
+    cmd.args([
+        "-luserenv",
+        "-lbcrypt",
+        "-lws2_32",
+        "-ladvapi32",
+        "-lkernel32",
+        "-luser32",
+        "-lntdll",
+        "-lsynchronization",
+    ]);
+    let status = cmd
+        .status()
+        .map_err(|e| CodegenError::Target(format!("cc failed to launch: {}", e)))?;
+    if !status.success() {
+        return Err(CodegenError::Target(format!(
+            "cc exited with status {}. On windows-gnu the linker must be a \
+             64-bit MinGW-w64 gcc; a 32-bit MinGW.org gcc cannot read the \
+             64-bit object Cranelift emits.",
+            status
+        )));
+    }
+    Ok(LinkOutput {
+        binary: output.to_path_buf(),
+    })
+}
+
+/// Link via the system `cc` driver on Linux, macOS, and other Unix
+/// hosts. Adds the Rust std system libraries the runtime depends on.
+fn link_unix(
     object_path: &Path,
     runtime: &RuntimeStaticLib,
     output: &Path,
@@ -71,20 +291,6 @@ pub fn link(
         cmd.args(["-lpthread", "-ldl", "-lm", "-lrt", "-lgcc_s", "-lutil"]);
     } else if cfg!(target_os = "macos") {
         cmd.args(["-lpthread", "-ldl", "-lm"]);
-    } else if cfg!(windows) {
-        // Rust's std on MSVC and MinGW pulls in these system libs. The
-        // MinGW driver knows about them by default for libstd, but
-        // listing them here keeps the link line consistent.
-        cmd.args([
-            "-luserenv",
-            "-lbcrypt",
-            "-lws2_32",
-            "-ladvapi32",
-            "-lkernel32",
-            "-luser32",
-            "-lntdll",
-            "-lsynchronization",
-        ]);
     }
     let status = cmd
         .status()
@@ -93,6 +299,22 @@ pub fn link(
         return Err(CodegenError::Target(format!(
             "cc exited with status {}",
             status
+        )));
+    }
+    Ok(LinkOutput {
+        binary: output.to_path_buf(),
+    })
+}
+
+/// Run a configured linker command and map its result.
+fn run_linker(mut cmd: Command, name: &str, output: &Path) -> Result<LinkOutput, CodegenError> {
+    let status = cmd
+        .status()
+        .map_err(|e| CodegenError::Target(format!("{} failed to launch: {}", name, e)))?;
+    if !status.success() {
+        return Err(CodegenError::Target(format!(
+            "{} exited with status {}",
+            name, status
         )));
     }
     Ok(LinkOutput {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@
 //! The `build` subcommand runs the entire v2 pipeline (lex, parse,
 //! resolve, type check, HIR, MIR) and feeds the resulting `MirProgram`
 //! to the Cranelift back end. The relocatable object is then linked
-//! with the `raven-runtime` staticlib through the system `cc` driver.
+//! with the `raven-runtime` staticlib by the toolchain-aware linker
+//! (MSVC `link.exe` on windows-msvc, `cc` elsewhere).
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1,12 +1,14 @@
 //! End to end smoke test for the Cranelift back end.
 //!
 //! Compiles `examples/v2/hello.rv` with the driver, links the
-//! resulting object with the `raven-runtime` staticlib via the system
-//! `cc` driver, runs the binary, and checks that stdout matches
-//! `Hello, Raven!\n`. The test short circuits with a diagnostic on
-//! `eprintln!` and a successful exit when `cc` is unavailable or the
-//! runtime staticlib has not been built yet, so contributors without
-//! a working C toolchain do not see spurious failures.
+//! resulting object with the `raven-runtime` staticlib using the
+//! toolchain-aware linker (MSVC `link.exe` on windows-msvc, `cc`
+//! elsewhere), runs the binary, and checks that stdout matches
+//! `Hello, Raven!\n`. On a correctly configured host the test links and
+//! runs the program for real. It short circuits with a diagnostic on
+//! `eprintln!` and a successful exit only in the genuinely unsupported
+//! cases: no linker is available at all, or the runtime staticlib has
+//! not been built yet.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -22,8 +24,12 @@ use raven::tycheck::check_file;
 
 #[test]
 fn hello_world_compiles_and_runs() {
-    if !linker::cc_available() {
-        eprintln!("codegen_smoke: skipping, no `cc` driver on PATH");
+    if !linker::linker_available() {
+        eprintln!(
+            "codegen_smoke: skipping, no linker available for the host. \
+             Install the MSVC C++ build tools on windows-msvc, a 64-bit \
+             MinGW-w64 on windows-gnu, or a `cc` driver on Unix."
+        );
         return;
     }
     let runtime = match locate_runtime() {
@@ -53,18 +59,11 @@ fn hello_world_compiles_and_runs() {
     std::fs::write(&object_path, &object_bytes).expect("write object");
     let binary = tmp.join(if cfg!(windows) { "hello.exe" } else { "hello" });
 
-    match linker::link(&object_path, &runtime, &binary) {
-        Ok(_) => {}
-        Err(e) => {
-            eprintln!(
-                "codegen_smoke: skipping, linker rejected the object: {}. \
-                 This usually means the system `cc` does not match the host \
-                 architecture Cranelift targets.",
-                e
-            );
-            cleanup(&tmp);
-            return;
-        }
+    // A linker was found above, so a link failure here is a real
+    // regression on a supported host, not a reason to skip.
+    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+        cleanup(&tmp);
+        panic!("linker failed to produce an executable: {}", e);
     }
 
     let output = Command::new(&binary).output().expect("run hello binary");


### PR DESCRIPTION
## Summary

The `raven build` driver now links with a toolchain selected by the host target triple, so it produces a working native executable on windows-msvc hosts instead of failing with "File format not recognized".

Closes #105.

## Root cause

Cranelift emits an MSVC-flavor 64-bit COFF object on windows-msvc, but the driver shelled out to whatever `cc` resolved to on PATH, which on this machine is a 32-bit MinGW.org gcc whose `ld` cannot read the object. The correct linker for an MSVC object is `link.exe` (or `lld-link`), which rustc itself uses and finds through the Windows registry, not bare PATH.

## The fix

* Select the linker by host target triple (`target_lexicon::Triple::host()`). On windows-msvc, locate `link.exe` with `cc::windows_registry::find_tool`, which also supplies the SDK and CRT `LIB`/`PATH` environment. Fall back to the toolchain's bundled `rust-lld` in lld-link flavor if the registry lookup fails (best effort). Unix keeps the existing `cc` invocation; windows-gnu keeps `cc`/`gcc` with a 64-bit MinGW-w64 hint on failure.
* Pass the Rust std native system libraries on the MSVC link line, captured once from `cargo rustc -p raven-runtime --crate-type staticlib -- --print native-static-libs` and hardcoded as a `const` (the driver does not shell out to cargo at link time).
* Export an `int main(void)` shim that calls the Raven `main` and returns 0. The Raven entry returns unit, so without the shim the C runtime read an uninitialized register as the exit code and the program exited with a nondeterministic, nonzero status.

## Verification

Built `examples/v2/hello.rv` end to end with the driver and ran the result on this windows-msvc host:

```
> raven build examples/v2/hello.rv -o hello_test.exe   (exit 0)
> hello_test.exe
Hello, Raven!
exit code: 0
```

The stdout bytes were exactly `72,101,108,108,111,44,32,82,97,118,101,110,33,10`, that is `Hello, Raven!\n`, and the process exit code was 0.

The exact MSVC link command the driver builds:

```
link.exe /NOLOGO /OUT:hello_test.exe <object>.o raven_runtime.lib kernel32.lib advapi32.lib ntdll.lib userenv.lib ws2_32.lib dbghelp.lib /defaultlib:msvcrt /SUBSYSTEM:CONSOLE
```

The end-to-end smoke test now links and runs the program rather than skipping, and passes.

## Test plan

- [x] `cargo build` (workspace) clean
- [x] `cargo test --workspace` all pass (247 lib + smoke + goldens + 56 runtime)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `raven build examples/v2/hello.rv -o hello_test.exe` exits 0 and produces the executable
- [x] Running the executable prints `Hello, Raven!` and exits 0
- [x] `tests/codegen_smoke.rs` passes by running the program on this host
