### PR TITLE
feat(runtime): mark-and-sweep garbage collector with shadow-stack roots

### DIFF
--- a/docs/v2/specs/gc.md
+++ b/docs/v2/specs/gc.md
@@ -1,0 +1,317 @@
+# Garbage Collector Spec
+
+## Goal
+
+Give compiled Raven v2 programs automatic memory management. The
+collector reclaims every heap object the per-kind layouts in
+`object-layout.md` allocate (`String`, `List`, `Map`, `Set`, `Closure`,
+`Box`) once the running program can no longer reach it.
+
+The design target is correctness and simplicity first: a stop-the-world,
+single-threaded, tracing mark-and-sweep collector with precise roots
+supplied by a shadow stack the code generator maintains. Throughput
+optimisations (generational nurseries, incremental marking, Cranelift
+stack maps) are out of scope and are listed at the end.
+
+## Collector design
+
+The collector is a two-phase tracing mark-and-sweep:
+
+1. **Mark.** Starting from every root on the shadow stack, follow each
+   object's internal pointers (per its `tag`) and set a mark bit on
+   every object reached. Because marking traces the live object graph,
+   it reclaims cycles that reference counting would leak: object A
+   pointing at B pointing back at A is collected when neither is rooted.
+2. **Sweep.** Walk the list of every allocated object. Any object whose
+   mark bit is clear is unreachable: free its owned buffers, then free
+   the object itself. Any object whose mark bit is set survives; clear
+   its mark bit so the next cycle starts from a clean slate.
+
+The collector is **stop the world**: a collection runs to completion
+before the mutator (the compiled program) resumes. There is no
+concurrent or incremental marking.
+
+The collector is **single threaded**. v2.0 compiled programs are single
+threaded, so the global collector state (the all-objects list, the byte
+counters, the shadow stack) is plain global state guarded by that
+assumption rather than a lock. Calling any runtime entry point from more
+than one thread is undefined in v2.0.
+
+### Mark bit
+
+The mark bit lives in `ObjectHeader.gc_bits`, the field reserved for
+exactly this purpose in `runtime.md`. Bit 0 (`GC_MARK_BIT = 0x1`) is the
+mark; the remaining bits stay zero, reserved for a future colour scheme.
+Using the existing header field keeps every object exactly the size the
+layout spec already pins; the collector adds no per-object words.
+
+## Shadow-stack root ABI
+
+Codegen cannot leave live GC pointers only in CPU registers or unmanaged
+stack slots, because the collector must find every root precisely. The
+agreed mechanism is a **shadow stack**: a separate, runtime-owned stack
+of pointers to the stack slots that currently hold live GC pointers.
+Codegen pushes a function's GC-managed locals onto the shadow stack on
+entry and pops them on every exit path.
+
+The shadow stack stores **slot addresses** (`*mut *mut u8`), not object
+pointers directly. Storing the address of the local lets the collector
+read the current value at collection time, which matters because a slot
+can be reassigned during the function body and a moving collector (a
+later optimisation) could rewrite it in place. Reading through the slot
+address always observes the live pointer.
+
+### Entry points
+
+The collector exposes a frame-based root API. Codegen builds a small
+array of slot addresses in the function prologue and registers the whole
+array in one call, then unregisters it on exit. A frame-based API is
+cheaper for codegen to emit than per-slot push and pop: one call in,
+one call out, regardless of how many locals the frame roots.
+
+```c
+// Register a frame's root array. `roots` points to `count` contiguous
+// slots, each of which is the address of a stack local that holds a GC
+// pointer (or null). The array must outlive the matching
+// raven_gc_leave_frame call (it normally lives in the caller's frame).
+void raven_gc_enter_frame(void **roots, size_t count);
+
+// Unregister the most recently registered frame. Frames nest in strict
+// last-in-first-out order, mirroring the call stack.
+void raven_gc_leave_frame(void);
+```
+
+Rust signatures:
+
+```rust
+pub extern "C" fn raven_gc_enter_frame(roots: *mut *mut u8, count: usize);
+pub extern "C" fn raven_gc_leave_frame();
+```
+
+A convenience per-slot API is also provided for hand-written tests and
+for code paths that root a single temporary:
+
+```rust
+pub extern "C" fn raven_gc_push_root(slot: *mut *mut u8);
+pub extern "C" fn raven_gc_pop_roots(n: usize);
+```
+
+`raven_gc_enter_frame` is exactly `count` successive pushes followed by
+recording the frame boundary; `raven_gc_leave_frame` pops back to the
+previous boundary. The two APIs share one underlying slot stack and may
+be mixed, though codegen uses only the frame API.
+
+### Calling convention codegen must follow
+
+1. For each GC-managed local in the frame (any local whose static type
+   is a heap kind: `String`, `List`, `Map`, `Set`, `Closure`, `Box`, or
+   a user struct that lowers to one of those), reserve a stack slot.
+2. In the prologue, build a contiguous array of the **addresses** of
+   those slots. Initialise every rooted slot to null before the first
+   call that can trigger a collection, so the collector never reads an
+   uninitialised slot.
+3. Call `raven_gc_enter_frame(roots, count)` once, after the slots are
+   null-initialised and before any allocation.
+4. On every path that leaves the function (normal return, early return,
+   and the panic-free tail), call `raven_gc_leave_frame()` before
+   returning.
+5. A leaf function that allocates nothing and holds no GC locals across
+   a call that can collect may skip the frame entirely.
+
+### Worked example
+
+A function with two GC locals (`a`, `b`) and one GC temporary (`mid`):
+
+```raven
+fn join(a: String, b: String) -> String {
+    let mid: String = ", ";
+    return concat(concat(a, mid), b);
+}
+```
+
+Codegen emits, in pseudo-assembly:
+
+```
+join:
+    slot_a = alloca ptr;  store a   -> slot_a
+    slot_b = alloca ptr;  store b   -> slot_b
+    slot_mid = alloca ptr; store null -> slot_mid   ; null before first collect
+    roots = alloca [3 x ptr]
+    roots[0] = &slot_a; roots[1] = &slot_b; roots[2] = &slot_mid
+    call raven_gc_enter_frame(roots, 3)
+
+    t0 = call raven_string_new(2)        ; may collect; a, b stay rooted
+    store t0 -> slot_mid                 ; mid now rooted
+    t1 = call raven_string_concat(load slot_a, load slot_mid)
+    t2 = call raven_string_concat(t1, load slot_b)
+
+    call raven_gc_leave_frame()
+    return t2
+```
+
+Temporaries `t1` and `t2` are not separately rooted here because no
+collection can happen between their creation and their consumption. When
+a temporary does straddle a collection point, codegen spills it into a
+rooted slot the same way `mid` is rooted.
+
+## Object bookkeeping
+
+The sweeper must visit every live object. The collector keeps a global
+**all-objects list**: a `Vec<*mut ObjectHeader>` recording the base
+pointer of every object handed out by `raven_gc_alloc`. The list is a
+side table, not an intrusive header field, so the 16-byte `ObjectHeader`
+keeps the exact shape pinned in `object-layout.md`; no object grows by a
+`next` word.
+
+Each allocation appends its base pointer. Sweep walks the vector,
+retaining survivors (and clearing their mark bit) and dropping freed
+entries; the retained order does not matter.
+
+Two global counters back the trigger and the tests: `bytes_allocated`
+tracks total live object bytes (bodies plus owned buffers) and drives
+the collection threshold, and `live_objects` counts live objects so
+tests can assert bounded liveness deterministically without measuring
+flaky OS memory.
+
+## Marking per layout
+
+Marking dispatches on `ObjectHeader.tag`. For each root slot, the
+collector reads the slot's current pointer; if non-null and not yet
+marked, it marks the object and traces its internal pointers, following
+the offsets pinned in `object-layout.md`. Tracing is iterative (an
+explicit work stack), not recursive, so a deep or cyclic graph cannot
+overflow the native stack.
+
+| Tag | Pointers followed | Detail |
+| --- | ----------------- | ------ |
+| `TAG_STRING` | none into GC objects | `bytes` is a plain owned buffer, not a GC object. It is freed with the string in sweep, never traced. |
+| `TAG_LIST` | `elements` at offset 24, when `elements_are_gc_ptrs != 0` | The buffer holds `len` pointer slots; each non-null slot is traced. When the flag is zero (scalar elements) the buffer is opaque bytes and is not traced. |
+| `TAG_MAP` | `buckets` at offset 24; for each non-empty bucket `key` at entry offset 8 and `value` at entry offset 16 | `keys_are_gc_ptrs` and `values_are_gc_ptrs` flags gate whether key and value slots are traced. A slot is non-empty when `key != null`. |
+| `TAG_SET` | `buckets` at offset 24; for each non-empty bucket `element` at entry offset 8 | `elements_are_gc_ptrs` gates tracing. A slot is non-empty when `element != null`. |
+| `TAG_CLOSURE` | `captures` at offset 24 | The capture record holds `capture_ptr_count` leading pointer slots that the closure-lowering pass places first. Each non-null leading slot is traced; the remaining capture bytes are scalars and are not traced. |
+| `TAG_BOX` | payload at offset 16, when `payload_is_gc_ptr != 0` | A box that wraps a heap value stores a single pointer at offset 16 and is traced; a box that wraps a scalar is opaque. |
+
+### Why the layouts carry pointer-kind flags
+
+The collector cannot guess whether an 8-byte slot is a pointer or an
+integer: tracing an integer as a pointer is memory-unsafe. The
+collection layouts therefore carry an explicit flag set at construction
+time, supplied by codegen from the static element or capture type:
+
+* `List` gains `elements_are_gc_ptrs: u8`.
+* `Map` repurposes its reserved `_pad` word into
+  `keys_are_gc_ptrs: u8` and `values_are_gc_ptrs: u8`.
+* `Set` repurposes its reserved `_pad` word into
+  `elements_are_gc_ptrs: u8`.
+* `Closure` gains `capture_ptr_count: u32`, the number of leading
+  pointer-sized capture slots that are GC pointers.
+* `Box` gains `payload_is_gc_ptr: u8`.
+
+These are the only layout changes the collector introduces. The exact
+offsets after the change are pinned in `object-layout.md` and asserted
+by the inline layout tests. Constructors gain the corresponding extra
+parameters; the defaults (all flags zero, count zero) reproduce the
+previous "no internal GC pointers" behaviour for callers that do not
+yet supply them.
+
+## Sweeping and buffer freeing
+
+Sweep walks the all-objects list once. For each object:
+
+* If the mark bit is clear, the object is dead. The sweeper frees the
+  object's **owned buffers** first, then the object body:
+  * `String`: free `bytes` (`cap` bytes, align 1).
+  * `List`: free `elements` (`cap * element_size` bytes,
+    `element_align`).
+  * `Map` / `Set`: free `buckets` (`bucket_count * entry_size` bytes,
+    entry alignment 8).
+  * `Closure`: free `captures` (`capture_size` bytes, `capture_align`).
+  * `Box`: no separate buffer; the payload is inline in the body.
+  Then free the object body itself. The body size and alignment are
+  derived from the tag (fixed per kind, except `Box`, whose body size is
+  `16 + header.len`). The collector decrements `bytes_allocated` and
+  `live_objects` for each freed object.
+* If the mark bit is set, the object survives. Clear the mark bit and
+  retain it in the list.
+
+Owned buffers are **plain allocations** owned by their object, not
+separate GC objects. They are never on the all-objects list, never
+traced, and never independently collected; they live and die with the
+object that owns them. This keeps tracing and bookkeeping simple: the
+collector reasons only about object bodies, and every buffer has exactly
+one owner.
+
+## Collection trigger and threshold policy
+
+Allocation goes through `raven_gc_alloc(size, align, tag)`:
+
+1. If `bytes_allocated + size` would cross the current threshold, run a
+   full collection first.
+2. Allocate the object body through the raw allocator, zero it, register
+   it in the all-objects list, bump the counters, and return it.
+
+The threshold starts at `1 MiB`. After a collection it is reset to
+`max(1 MiB, 2 * bytes_live_after_sweep)`, so a program with a large live
+set collects less often while a program with a small live set keeps a
+tight ceiling. This is the standard "allocation high-water mark"
+heuristic; it bounds heap growth to a constant factor of the live set.
+
+`raven_gc_collect()` forces a full collection regardless of the
+threshold. It exists for deterministic testing and for any future
+explicit-collection point; the compiled program never needs to call it
+because allocation collects automatically.
+
+```rust
+pub extern "C" fn raven_gc_alloc(size: usize, align: usize, tag: u32) -> *mut u8;
+pub extern "C" fn raven_gc_collect();
+```
+
+The constructors in `object/*.rs` route their object-body allocation
+through `raven_gc_alloc` (passing the kind's tag) and continue to
+allocate owned buffers through the raw `raven_alloc`. `raven_alloc`
+itself stays a raw passthrough so non-object scratch allocations do not
+register with the collector.
+
+## Out of scope
+
+* **Cranelift stack maps.** The shadow stack is the v2.0 root mechanism;
+  stack maps are a later throughput optimisation that would not change
+  the object layouts or the sweep logic.
+* **Generational collection.** No nursery, remembered set, or write
+  barrier. Every collection is a full heap trace.
+* **Incremental or concurrent collection.** Marking and sweeping run to
+  completion with the mutator stopped.
+* **Moving or compacting collection.** Objects keep their addresses for
+  their whole lifetime. The slot-address shadow stack is forward
+  compatible with a future moving collector, but v2.0 never relocates an
+  object.
+* **Multiple threads.** Global collector state assumes a single mutator.
+* **Codegen emission of root frames.** This document defines the ABI
+  codegen targets; the prologue and epilogue emission is issue #67. The
+  collector ships with a Rust-side test harness that plays codegen's
+  role.
+
+## Test coverage
+
+Inline unit tests in the `gc` module and a cross-crate integration test
+in `raven-runtime/tests/` cover:
+
+* **Reachability.** Rooted objects, and objects reachable only
+  transitively from a root, survive a forced collection; unrooted
+  objects are freed.
+* **Cycle reclamation.** Two objects that point at each other, neither
+  rooted, are both collected: the property reference counting lacks and
+  the reason for a tracing collector.
+* **Per-layout tracing.** A graph built from a `List` of GC pointers, a
+  `Map` with GC keys and values, a `Set` of GC elements, a `Closure`
+  with GC captures, and a `Box` wrapping a GC pointer marks every
+  reachable object.
+* **Bounded liveness stress.** Allocating many small objects while
+  rooting only a bounded working set keeps `live_objects` bounded and
+  the final rooted state intact. The counter is asserted rather than OS
+  memory, which is flaky in CI.
+* **Frame nesting.** Nested enter and leave calls register and
+  unregister roots in last-in-first-out order; a collection mid-nesting
+  sees the union of all active frames' roots.
+* **Threshold trigger.** Allocating past the threshold triggers an
+  automatic collection without an explicit `raven_gc_collect` call.

--- a/docs/v2/specs/gc.md
+++ b/docs/v2/specs/gc.md
@@ -168,10 +168,12 @@ retaining survivors (and clearing their mark bit) and dropping freed
 entries; the retained order does not matter.
 
 Two global counters back the trigger and the tests: `bytes_allocated`
-tracks total live object bytes (bodies plus owned buffers) and drives
-the collection threshold, and `live_objects` counts live objects so
-tests can assert bounded liveness deterministically without measuring
-flaky OS memory.
+tracks live object-body bytes (the bytes handed out by
+`raven_gc_alloc`) and drives the collection threshold, and
+`live_objects` counts live objects so tests can assert bounded liveness
+deterministically without measuring flaky OS memory. Owned buffers are
+freed with their object but are not separately metered; counting bodies
+is enough to bound the live object set and pace collection.
 
 ## Marking per layout
 
@@ -229,8 +231,9 @@ Sweep walks the all-objects list once. For each object:
   * `Box`: no separate buffer; the payload is inline in the body.
   Then free the object body itself. The body size and alignment are
   derived from the tag (fixed per kind, except `Box`, whose body size is
-  `16 + header.len`). The collector decrements `bytes_allocated` and
-  `live_objects` for each freed object.
+  `BOX_PAYLOAD_OFFSET + header.len`). The collector decrements
+  `bytes_allocated` by the body size and `live_objects` by one for each
+  freed object.
 * If the mark bit is set, the object survives. Clear the mark bit and
   retain it in the list.
 

--- a/docs/v2/specs/object-layout.md
+++ b/docs/v2/specs/object-layout.md
@@ -65,19 +65,23 @@ struct List {
     ObjectHeader header;     // tag = TAG_LIST
     u32          element_size;
     u32          element_align;
+    u32          elements_are_gc_ptrs; // nonzero when slots are GC pointers
+    u32          _pad;                 // reserved, zeroed
     u8          *elements;   // owned buffer of `cap * element_size` bytes
 };
 ```
 
 Field offsets on 64-bit:
 
-| offset | size | field         |
-| -----: | ---: | ------------- |
-| 0      | 16   | header        |
-| 16     | 4    | element_size  |
-| 20     | 4    | element_align |
-| 24     | 8    | elements      |
-| total  | 32   |               |
+| offset | size | field                |
+| -----: | ---: | -------------------- |
+| 0      | 16   | header               |
+| 16     | 4    | element_size         |
+| 20     | 4    | element_align        |
+| 24     | 4    | elements_are_gc_ptrs |
+| 28     | 4    | _pad                 |
+| 32     | 8    | elements             |
+| total  | 40   |                      |
 
 * Alignment: 8.
 * `header.tag = TAG_LIST`.
@@ -88,13 +92,12 @@ Field offsets on 64-bit:
   pointer to the inner object.
 * `element_align` is the alignment of one element, the same value the
   back-end would pass to `raven_alloc` for an element.
+* `elements_are_gc_ptrs` is nonzero when each element slot is a GC
+  pointer the collector traces, zero for scalar elements. Codegen sets
+  it from the static element type. The GC reads it instead of guessing
+  from `element_size`, because an 8-byte `Int` slot is not a pointer.
 * `elements` points to an owned buffer of `cap * element_size` bytes.
   When `cap == 0`, `elements` is null.
-
-The GC tracing rule keys on whether the element is a pointer type. The
-back-end records this in a per-list descriptor in a follow-up; for now
-the tracer treats `element_size == 8` and `element_align == 8` lists as
-potentially pointer-bearing.
 
 ## Map
 
@@ -102,7 +105,9 @@ potentially pointer-bearing.
 struct Map {
     ObjectHeader header;     // tag = TAG_MAP
     u32          bucket_count;
-    u32          _pad;       // reserved, zeroed
+    u8           keys_are_gc_ptrs;   // nonzero when keys are GC pointers
+    u8           values_are_gc_ptrs; // nonzero when values are GC pointers
+    u16          _pad;               // reserved, zeroed
     MapEntry    *buckets;
 };
 
@@ -115,13 +120,15 @@ struct MapEntry {
 
 Map field offsets on 64-bit:
 
-| offset | size | field         |
-| -----: | ---: | ------------- |
-| 0      | 16   | header        |
-| 16     | 4    | bucket_count  |
-| 20     | 4    | _pad          |
-| 24     | 8    | buckets       |
-| total  | 32   |               |
+| offset | size | field              |
+| -----: | ---: | ------------------ |
+| 0      | 16   | header             |
+| 16     | 4    | bucket_count       |
+| 20     | 1    | keys_are_gc_ptrs   |
+| 21     | 1    | values_are_gc_ptrs |
+| 22     | 2    | _pad               |
+| 24     | 8    | buckets            |
+| total  | 32   |                    |
 
 `MapEntry` offsets:
 
@@ -139,6 +146,10 @@ Map field offsets on 64-bit:
 * `bucket_count` is a power of two, or zero for the freshly-constructed
   empty map. The constructor accepts any non-negative request and rounds
   up to the next power of two.
+* `keys_are_gc_ptrs` and `values_are_gc_ptrs` are nonzero when bucket
+  keys or values are GC pointers the collector traces. Codegen sets them
+  from the static key and value types. They reuse the word that was
+  reserved padding before the collector landed.
 * `buckets` points to `bucket_count` contiguous `MapEntry` slots. An
   empty or tombstoned slot has `key == null`. Tombstones are distinguished
   from truly-empty slots by `hash == TOMBSTONE_HASH` (a reserved bit
@@ -162,7 +173,8 @@ an ABI change, because `hash` is internal to `MapEntry`.
 struct Set {
     ObjectHeader header;     // tag = TAG_SET
     u32          bucket_count;
-    u32          _pad;
+    u8           elements_are_gc_ptrs; // nonzero when elements are GC pointers
+    u8           _pad[3];              // reserved, zeroed
     SetEntry    *buckets;
 };
 
@@ -174,13 +186,14 @@ struct SetEntry {
 
 Set field offsets mirror Map:
 
-| offset | size | field         |
-| -----: | ---: | ------------- |
-| 0      | 16   | header        |
-| 16     | 4    | bucket_count  |
-| 20     | 4    | _pad          |
-| 24     | 8    | buckets       |
-| total  | 32   |               |
+| offset | size | field                |
+| -----: | ---: | -------------------- |
+| 0      | 16   | header               |
+| 16     | 4    | bucket_count         |
+| 20     | 1    | elements_are_gc_ptrs |
+| 21     | 3    | _pad                 |
+| 24     | 8    | buckets              |
+| total  | 32   |                      |
 
 `SetEntry` offsets:
 
@@ -192,7 +205,8 @@ Set field offsets mirror Map:
 
 Same rules as `Map`: `header.tag = TAG_SET`, `header.cap` mirrors
 `bucket_count`, empty or tombstoned slots have `element == null`,
-FNV-1a 64 is the hash function.
+FNV-1a 64 is the hash function. `elements_are_gc_ptrs` is nonzero when
+elements are GC pointers the collector traces.
 
 ## Closure
 
@@ -203,19 +217,23 @@ struct Closure {
     void        *captures;   // owned buffer of size `capture_size`
     u32          capture_size;
     u32          capture_align;
+    u32          capture_ptr_count; // leading GC-pointer capture slots
+    u32          _pad;              // reserved, zeroed
 };
 ```
 
 Field offsets on 64-bit:
 
-| offset | size | field         |
-| -----: | ---: | ------------- |
-| 0      | 16   | header        |
-| 16     | 8    | fn_ptr        |
-| 24     | 8    | captures      |
-| 32     | 4    | capture_size  |
-| 36     | 4    | capture_align |
-| total  | 40   |               |
+| offset | size | field             |
+| -----: | ---: | ----------------- |
+| 0      | 16   | header            |
+| 16     | 8    | fn_ptr            |
+| 24     | 8    | captures          |
+| 32     | 4    | capture_size      |
+| 36     | 4    | capture_align     |
+| 40     | 4    | capture_ptr_count |
+| 44     | 4    | _pad              |
+| total  | 48   |                   |
 
 * Alignment: 8.
 * `header.tag = TAG_CLOSURE`. `header.len` is the capture count (the
@@ -225,8 +243,12 @@ Field offsets on 64-bit:
   has the calling convention `(captures: *mut u8, args...) -> ret`.
 * `captures` is a pointer to an owned buffer of `capture_size` bytes.
   Layout inside the capture record is decided by the closure-lowering
-  pass and is opaque to the runtime. The GC walks it through a
-  descriptor produced by codegen in a follow-up.
+  pass and is opaque to the runtime apart from the convention below.
+* `capture_ptr_count` is the number of leading pointer-sized capture
+  slots that are GC pointers. The closure-lowering pass places the GC
+  pointer captures first in the record, so the collector traces the
+  first `capture_ptr_count` pointer-sized slots and leaves the rest. A
+  closure with no GC captures sets it to zero.
 * `captures` is null when `capture_size == 0`.
 
 The pointer-indirect form (rather than inline-after-header) keeps every
@@ -239,24 +261,32 @@ allocation per closure with non-empty captures.
 ```c
 struct Box {
     ObjectHeader header;     // tag = TAG_BOX, len = payload byte size
-    u8           payload[];  // sized payload follows the header
+    u32          payload_is_gc_ptr; // nonzero when payload is a GC pointer
+    u32          _pad;              // reserved, zeroed
+    u8           payload[];  // sized payload follows the flag word
 };
 ```
 
 Field offsets on 64-bit:
 
-| offset | size       | field   |
-| -----: | ---------: | ------- |
-| 0      | 16         | header  |
-| 16     | payload_sz | payload |
+| offset | size       | field             |
+| -----: | ---------: | ----------------- |
+| 0      | 16         | header            |
+| 16     | 4          | payload_is_gc_ptr |
+| 20     | 4          | _pad              |
+| 24     | payload_sz | payload           |
 
 * Alignment: `max(OBJECT_ALIGN, payload_align)`.
 * `header.tag = TAG_BOX`. `header.len` is the payload size in bytes.
 * `header.cap` is 1 (a `Box<T>` always holds exactly one `T`).
-* The payload lives inline at offset 16. For payload alignments greater
-  than 8 the constructor pads the request to the alignment, but at
-  current Raven scalar widths (8 bytes for `Int`, `Float`, pointers, less
-  for `Bool`) no padding is needed.
+* `payload_is_gc_ptr` is nonzero when the inline payload is a single GC
+  pointer the collector traces, zero for a scalar payload. Codegen sets
+  it from the static payload type.
+* The payload lives inline at offset 24 (`BOX_PAYLOAD_OFFSET`), after the
+  header and flag word, so it stays 8-byte aligned. For payload
+  alignments greater than 8 the constructor pads the request to the
+  alignment, but at current Raven scalar widths (8 bytes for `Int`,
+  `Float`, pointers, less for `Bool`) no padding is needed.
 
 `Box` exists so generic collections over primitives can be uniformly
 typed: a `List<Int>` may store `Int` inline (when codegen specialises it)
@@ -275,49 +305,51 @@ opaque and only ever passes back through accessors.
 | `raven_string_len` | `fn(s: *const String) -> u32` | Returns `header.len`. |
 | `raven_string_bytes` | `fn(s: *const String) -> *const u8` | Returns the `bytes` field. |
 | `raven_string_concat` | `fn(a: *const String, b: *const String) -> *mut String` | Returns a new heap string equal to `a` followed by `b`. |
-| `raven_list_new` | `fn(element_size: u32, element_align: u32, cap: u32) -> *mut List` | Allocates a `List` with the given per-element shape and slot capacity. `header.len = 0`. |
+| `raven_list_new` | `fn(element_size: u32, element_align: u32, cap: u32, elements_are_gc_ptrs: u32) -> *mut List` | Allocates a `List` with the given per-element shape, slot capacity, and GC-pointer flag. `header.len = 0`. |
 | `raven_list_len` | `fn(l: *const List) -> u32` | Returns `header.len`. |
 | `raven_list_elements` | `fn(l: *const List) -> *mut u8` | Returns the `elements` field. |
 | `raven_list_push` | `fn(l: *mut List, payload: *const u8)` | Copies `element_size` bytes from `payload` into the next slot, growing the buffer if needed. |
-| `raven_map_new` | `fn(bucket_count: u32) -> *mut Map` | Allocates a `Map` with the given initial bucket count, rounded up to a power of two. Bucket buffer is zero-filled. |
+| `raven_map_new` | `fn(bucket_count: u32, keys_are_gc_ptrs: u8, values_are_gc_ptrs: u8) -> *mut Map` | Allocates a `Map` with the given initial bucket count, rounded up to a power of two, and the key and value GC-pointer flags. Bucket buffer is zero-filled. |
 | `raven_map_buckets` | `fn(m: *const Map) -> *mut MapEntry` | Returns the `buckets` field. |
 | `raven_map_bucket_count` | `fn(m: *const Map) -> u32` | Returns the `bucket_count` field. |
-| `raven_set_new` | `fn(bucket_count: u32) -> *mut Set` | Set counterpart of `raven_map_new`. |
+| `raven_set_new` | `fn(bucket_count: u32, elements_are_gc_ptrs: u8) -> *mut Set` | Set counterpart of `raven_map_new`, with one element GC-pointer flag. |
 | `raven_set_buckets` | `fn(s: *const Set) -> *mut SetEntry` | Returns the `buckets` field. |
 | `raven_set_bucket_count` | `fn(s: *const Set) -> u32` | Returns the `bucket_count` field. |
-| `raven_closure_new` | `fn(fn_ptr: *const u8, capture_size: u32, capture_align: u32, capture_count: u32) -> *mut Closure` | Allocates a `Closure` with the given function pointer and capture record. Capture buffer is zero-filled and owned by the closure. |
+| `raven_closure_new` | `fn(fn_ptr: *const u8, capture_size: u32, capture_align: u32, capture_count: u32, capture_ptr_count: u32) -> *mut Closure` | Allocates a `Closure` with the given function pointer, capture record, and count of leading GC-pointer capture slots. Capture buffer is zero-filled and owned by the closure. |
 | `raven_closure_fn_ptr` | `fn(c: *const Closure) -> *const u8` | Returns the function pointer. |
 | `raven_closure_captures` | `fn(c: *const Closure) -> *mut u8` | Returns the captures buffer. |
-| `raven_box_new` | `fn(payload_size: u32, payload_align: u32) -> *mut Box` | Allocates a `Box` whose payload is `payload_size` bytes aligned to `payload_align`. Payload is zero-filled. |
-| `raven_box_payload` | `fn(b: *const Box) -> *mut u8` | Returns a pointer to the inline payload at offset 16. |
+| `raven_box_new` | `fn(payload_size: u32, payload_align: u32, payload_is_gc_ptr: u32) -> *mut Box` | Allocates a `Box` whose payload is `payload_size` bytes aligned to `payload_align`, with the payload GC-pointer flag. Payload is zero-filled. |
+| `raven_box_payload` | `fn(b: *const Box) -> *mut u8` | Returns a pointer to the inline payload at `BOX_PAYLOAD_OFFSET` (offset 24). |
 
-The deallocator counterpart for each kind is a follow-up issue; today the
-process leaks every heap object on exit, which is fine for the v2
-scaffold because no test program holds objects long enough to matter.
+Each constructor routes its object-body allocation through
+`raven_gc_alloc` so the collector tracks every object, and allocates its
+owned buffer (string bytes, list elements, map and set buckets, closure
+captures) through the raw `raven_alloc`. The collector frees both during
+sweep; see `docs/v2/specs/gc.md`.
 
 ## Tracing summary
 
-The GC (issue #64) will dispatch on `header.tag` and walk the layout's
-internal pointers. The pointers each layout owns are:
+The collector (issue #64) dispatches on `header.tag` and walks the
+layout's internal GC pointers, gated by the per-layout pointer-kind
+flags. The pointers each layout owns are:
 
 | Tag | Internal pointers | Notes |
 | --- | ----------------- | ----- |
-| `TAG_STRING` | `bytes` at offset 16 | Owned `u8` buffer of size `cap`. No further tracing needed. |
-| `TAG_LIST` | `elements` at offset 24 | The buffer holds `cap * element_size` bytes. If `element_size == 8` and `element_align == 8` it may hold heap pointers that the tracer recurses into. |
-| `TAG_MAP` | `buckets` at offset 24, then for each non-empty bucket `key` at entry offset 8 and `value` at entry offset 16 | Both `key` and `value` are heap pointers (or boxes for primitives). |
-| `TAG_SET` | `buckets` at offset 24, then for each non-empty bucket `element` at entry offset 8 | |
-| `TAG_CLOSURE` | `captures` at offset 24 | The capture record is opaque to the tracer; a per-closure descriptor produced by codegen will enumerate its pointers in a follow-up. |
-| `TAG_BOX` | none of its own; the payload at offset 16 is treated by the descriptor attached to the box's static type | |
+| `TAG_STRING` | none into GC objects | `bytes` at offset 16 is a plain owned buffer of size `cap`, freed with the string in sweep. Never traced. |
+| `TAG_LIST` | `elements` at offset 32 | When `elements_are_gc_ptrs != 0`, each of the first `len` pointer slots is traced; otherwise the buffer is opaque scalar bytes. |
+| `TAG_MAP` | `buckets` at offset 24, then for each non-empty bucket `key` at entry offset 8 and `value` at entry offset 16 | `keys_are_gc_ptrs` and `values_are_gc_ptrs` gate tracing of keys and values. A bucket is non-empty when `key != null`. |
+| `TAG_SET` | `buckets` at offset 24, then for each non-empty bucket `element` at entry offset 8 | `elements_are_gc_ptrs` gates tracing. A bucket is non-empty when `element != null`. |
+| `TAG_CLOSURE` | `captures` at offset 24 | The first `capture_ptr_count` pointer-sized capture slots are traced; the rest of the record is scalar. |
+| `TAG_BOX` | payload at offset 24 | When `payload_is_gc_ptr != 0` the single payload pointer is traced; otherwise the payload is a scalar. |
 
-The actual tracing implementation lands in issue #64. This document
-exists so that issue can be written against a fixed set of offsets.
+The marking, sweeping, and threshold logic live in `docs/v2/specs/gc.md`
+and `raven-runtime/src/gc.rs`.
 
 ## Out of scope
 
-* Real GC. `gc_bits` stays zero. Allocations leak at process exit. Issue
-  #64 lands the collector.
 * Codegen integration. Issue #67 wires field loads and stores through the
-  offsets pinned here.
+  offsets pinned here, and emits the shadow-stack root frames defined in
+  `docs/v2/specs/gc.md`.
 * Trait object fat pointers. The `BOX` tag is the storage shape; the
   vtable layout is issue #66.
 * Full stdlib over these layouts (string methods, list iteration, map

--- a/docs/v2/specs/runtime.md
+++ b/docs/v2/specs/runtime.md
@@ -89,8 +89,9 @@ Constraints:
 * `tag` is read by `raven_panic` (when a debug build wants to print the
   object kind) and by the GC once it lands. The current scaffold writes
   it once at allocation time and never inspects it.
-* `gc_bits` is reserved. The scaffold leaves it zero. Issue #64 defines
-  the bit layout.
+* `gc_bits` carries the collector's mark bit (`GC_MARK_BIT`, bit 0); the
+  remaining bits stay zero and are reserved for a future colour scheme.
+  See `docs/v2/specs/gc.md`.
 
 ## Tag constants
 

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -16,7 +16,13 @@
 //! simply keeps the global state sound under Rust's aliasing rules
 //! without a lock.
 
-use std::cell::RefCell;
+use crate::object::{
+    free_object_buffers, object_body_layout, Closure, List, Map, ObjectHeader, Set, TAG_BOX,
+    TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET,
+};
+use crate::object::{MapEntry, SetEntry, BOX_PAYLOAD_OFFSET};
+use crate::{raven_alloc, raven_dealloc};
+use std::cell::{Cell, RefCell};
 
 /// A registered root: the address of a stack slot that holds a GC
 /// pointer (or null). The collector reads the slot's current value at
@@ -33,7 +39,26 @@ thread_local! {
     /// at the moment a frame was entered; leaving a frame truncates
     /// `ROOTS` back to that length.
     static FRAMES: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+
+    /// The all-objects list: the base pointer of every object handed
+    /// out by `raven_gc_alloc`. The sweeper walks it once per cycle.
+    static HEAP: RefCell<Vec<*mut ObjectHeader>> = const { RefCell::new(Vec::new()) };
+
+    /// Live object-body bytes. Drives the collection threshold.
+    static BYTES_ALLOCATED: Cell<usize> = const { Cell::new(0) };
+
+    /// Live object count. Lets tests assert bounded liveness without
+    /// measuring flaky OS memory.
+    static LIVE_OBJECTS: Cell<usize> = const { Cell::new(0) };
+
+    /// Allocation high-water mark: a collection runs before serving an
+    /// allocation that would carry `bytes_allocated` past this. Reset
+    /// after each collection to a multiple of the surviving live bytes.
+    static THRESHOLD: Cell<usize> = const { Cell::new(INITIAL_THRESHOLD) };
 }
+
+/// Initial and floor collection threshold in bytes (1 MiB).
+const INITIAL_THRESHOLD: usize = 1024 * 1024;
 
 /// Register a single root slot on the shadow stack.
 ///
@@ -118,6 +143,324 @@ pub(crate) fn root_count() -> usize {
     ROOTS.with(|r| r.borrow().len())
 }
 
+/// Allocate a zeroed object body of `size` bytes aligned to `align`,
+/// register it with the collector, and return its base pointer.
+///
+/// `tag` is the kind's `TAG_*` constant; the constructor writes the
+/// full header into the returned memory. The body is zero-filled so an
+/// object that is registered before its fields are written never holds
+/// a stale pointer the collector might follow. Owned buffers (string
+/// bytes, list elements, and so on) are allocated separately through
+/// `raven_alloc` and are not registered.
+///
+/// Returns null on allocation failure or invalid layout.
+///
+/// # Safety
+///
+/// The caller (a constructor) must initialise the object header at the
+/// returned pointer before the next collection can observe it.
+#[no_mangle]
+pub extern "C" fn raven_gc_alloc(size: usize, align: usize, tag: u32) -> *mut u8 {
+    let _ = tag;
+    // Collect before serving an allocation that would cross the
+    // threshold, so the heap stays a bounded multiple of the live set.
+    let current = BYTES_ALLOCATED.with(|b| b.get());
+    let threshold = THRESHOLD.with(|t| t.get());
+    if current + size > threshold {
+        collect();
+    }
+    let ptr = raven_alloc(size, align);
+    if ptr.is_null() {
+        return std::ptr::null_mut();
+    }
+    // SAFETY: `raven_alloc` returned `size` writable bytes.
+    unsafe { std::ptr::write_bytes(ptr, 0, size) };
+    register(ptr as *mut ObjectHeader, size);
+    ptr
+}
+
+/// Record a freshly allocated object in the all-objects list and bump
+/// the live counters.
+fn register(header: *mut ObjectHeader, size: usize) {
+    HEAP.with(|h| h.borrow_mut().push(header));
+    BYTES_ALLOCATED.with(|b| b.set(b.get() + size));
+    LIVE_OBJECTS.with(|n| n.set(n.get() + 1));
+}
+
+/// Free a single object: its owned buffers, then its body. Decrements
+/// the live counters by the body size and one object.
+///
+/// # Safety
+///
+/// `header` must point to a live object registered with the collector
+/// and not yet freed.
+unsafe fn free_one(header: *mut ObjectHeader) {
+    // SAFETY: caller guarantees `header` is a live registered object.
+    let (size, align) = unsafe { object_body_layout(header) };
+    // SAFETY: same guarantee; release owned buffers before the body.
+    unsafe { free_object_buffers(header) };
+    raven_dealloc(header as *mut u8, size, align);
+    BYTES_ALLOCATED.with(|b| b.set(b.get().saturating_sub(size)));
+    LIVE_OBJECTS.with(|n| n.set(n.get().saturating_sub(1)));
+}
+
+/// Force a full mark-and-sweep collection regardless of the threshold.
+///
+/// Marks from every shadow-stack root, frees every unmarked object, and
+/// resets the threshold to a multiple of the surviving live bytes.
+/// Exposed for deterministic testing and for any future explicit
+/// collection point; the compiled program never needs to call it.
+#[no_mangle]
+pub extern "C" fn raven_gc_collect() {
+    collect();
+}
+
+/// Run one full mark-and-sweep cycle.
+fn collect() {
+    mark();
+    sweep();
+    // Reset the threshold to twice the surviving live bytes, never
+    // below the floor, so a large live set collects less often and a
+    // small one keeps a tight ceiling.
+    let live = BYTES_ALLOCATED.with(|b| b.get());
+    let next = INITIAL_THRESHOLD.max(live.saturating_mul(2));
+    THRESHOLD.with(|t| t.set(next));
+}
+
+/// Mark phase: starting from every root, set the mark bit on every
+/// reachable object. Tracing uses an explicit work stack so a deep or
+/// cyclic graph cannot overflow the native stack.
+fn mark() {
+    let mut work: Vec<*mut ObjectHeader> = Vec::new();
+    for_each_root(|object| {
+        if mark_object(object) {
+            work.push(object);
+        }
+    });
+    while let Some(object) = work.pop() {
+        // SAFETY: `object` was reached from a root or another live
+        // object, so it is a live registered header.
+        unsafe {
+            trace_object(object, &mut work);
+        }
+    }
+}
+
+/// Set the mark bit on `object` if it is non-null and not already
+/// marked. Returns true when this call marked it (so the caller should
+/// trace its children).
+fn mark_object(object: *mut ObjectHeader) -> bool {
+    if object.is_null() {
+        return false;
+    }
+    // SAFETY: a registered object pointer is a live header.
+    let header = unsafe { &mut *object };
+    if header.is_marked() {
+        return false;
+    }
+    header.set_mark();
+    true
+}
+
+/// Visit a slot that may hold a GC pointer: mark the pointee and, when
+/// newly marked, push it for tracing.
+fn visit_slot(slot: *const *mut u8, work: &mut Vec<*mut ObjectHeader>) {
+    // SAFETY: caller guarantees `slot` points to a readable pointer.
+    let child = unsafe { *slot } as *mut ObjectHeader;
+    if mark_object(child) {
+        work.push(child);
+    }
+}
+
+/// Trace one already-marked object: follow the GC pointers its layout
+/// owns, per `docs/v2/specs/object-layout.md`, pushing newly marked
+/// children onto `work`.
+///
+/// # Safety
+///
+/// `object` must be a live registered header.
+unsafe fn trace_object(object: *mut ObjectHeader, work: &mut Vec<*mut ObjectHeader>) {
+    // SAFETY: caller guarantees `object` is a live header.
+    let tag = unsafe { (*object).tag };
+    match tag {
+        TAG_LIST => {
+            let list = object as *const List;
+            // SAFETY: tag confirms the List layout.
+            let (flag, len, elements) = unsafe {
+                (
+                    (*list).elements_are_gc_ptrs,
+                    (*list).header.len,
+                    (*list).elements,
+                )
+            };
+            if flag != 0 && !elements.is_null() {
+                let slots = elements as *const *mut u8;
+                for i in 0..len as usize {
+                    // SAFETY: the first `len` slots are initialised.
+                    visit_slot(unsafe { slots.add(i) }, work);
+                }
+            }
+        }
+        TAG_MAP => {
+            let map = object as *const Map;
+            // SAFETY: tag confirms the Map layout.
+            let (keys_flag, values_flag, bucket_count, buckets) = unsafe {
+                (
+                    (*map).keys_are_gc_ptrs,
+                    (*map).values_are_gc_ptrs,
+                    (*map).bucket_count,
+                    (*map).buckets,
+                )
+            };
+            if !buckets.is_null() && (keys_flag != 0 || values_flag != 0) {
+                for i in 0..bucket_count as usize {
+                    // SAFETY: `buckets` holds `bucket_count` slots.
+                    let entry = unsafe { buckets.add(i) } as *const MapEntry;
+                    // SAFETY: each entry slot is initialised.
+                    let key = unsafe { (*entry).key };
+                    if key.is_null() {
+                        continue; // empty or tombstoned slot
+                    }
+                    if keys_flag != 0 {
+                        visit_slot(unsafe { std::ptr::addr_of!((*entry).key) }, work);
+                    }
+                    if values_flag != 0 {
+                        visit_slot(unsafe { std::ptr::addr_of!((*entry).value) }, work);
+                    }
+                }
+            }
+        }
+        TAG_SET => {
+            let set = object as *const Set;
+            // SAFETY: tag confirms the Set layout.
+            let (flag, bucket_count, buckets) = unsafe {
+                (
+                    (*set).elements_are_gc_ptrs,
+                    (*set).bucket_count,
+                    (*set).buckets,
+                )
+            };
+            if flag != 0 && !buckets.is_null() {
+                for i in 0..bucket_count as usize {
+                    // SAFETY: `buckets` holds `bucket_count` slots.
+                    let entry = unsafe { buckets.add(i) } as *const SetEntry;
+                    // SAFETY: each entry slot is initialised.
+                    let element = unsafe { (*entry).element };
+                    if element.is_null() {
+                        continue; // empty or tombstoned slot
+                    }
+                    visit_slot(unsafe { std::ptr::addr_of!((*entry).element) }, work);
+                }
+            }
+        }
+        TAG_CLOSURE => {
+            let closure = object as *const Closure;
+            // SAFETY: tag confirms the Closure layout.
+            let (ptr_count, captures) =
+                unsafe { ((*closure).capture_ptr_count, (*closure).captures) };
+            if ptr_count != 0 && !captures.is_null() {
+                let slots = captures as *const *mut u8;
+                for i in 0..ptr_count as usize {
+                    // SAFETY: the first `ptr_count` capture slots are
+                    // pointer-sized GC pointers placed by lowering.
+                    visit_slot(unsafe { slots.add(i) }, work);
+                }
+            }
+        }
+        TAG_BOX => {
+            // SAFETY: tag confirms the Box layout; the flag sits at the
+            // header's start and the payload at BOX_PAYLOAD_OFFSET.
+            let flag = unsafe { (*(object as *const crate::object::Box)).payload_is_gc_ptr };
+            if flag != 0 {
+                let payload = (object as *const u8).wrapping_add(BOX_PAYLOAD_OFFSET);
+                visit_slot(payload as *const *mut u8, work);
+            }
+        }
+        // TAG_STRING and unknown tags own no GC pointers.
+        _ => {}
+    }
+}
+
+/// Sweep phase: free every unmarked object and clear the mark bit on
+/// survivors so the next cycle starts clean.
+fn sweep() {
+    HEAP.with(|h| {
+        let mut heap = h.borrow_mut();
+        let mut write = 0usize;
+        for read in 0..heap.len() {
+            let object = heap[read];
+            // SAFETY: every heap entry is a live registered header.
+            let marked = unsafe { (*object).is_marked() };
+            if marked {
+                // SAFETY: live header; clear the mark for next cycle.
+                unsafe { (*object).clear_mark() };
+                heap[write] = object;
+                write += 1;
+            } else {
+                // SAFETY: unmarked and registered; free it.
+                unsafe { free_one(object) };
+            }
+        }
+        heap.truncate(write);
+    });
+}
+
+/// Visit the current object pointer held by every registered root slot.
+/// Null slots and slots whose stored pointer is null are skipped.
+fn for_each_root(mut visit: impl FnMut(*mut ObjectHeader)) {
+    ROOTS.with(|r| {
+        for &slot in r.borrow().iter() {
+            if slot.is_null() {
+                continue;
+            }
+            // SAFETY: a registered slot points to a live `*mut u8`.
+            let object = unsafe { *slot } as *mut ObjectHeader;
+            if !object.is_null() {
+                visit(object);
+            }
+        }
+    });
+}
+
+/// Live object-body bytes currently tracked by the collector. A
+/// diagnostic entry point used by tests; the compiled program does not
+/// call it.
+#[no_mangle]
+pub extern "C" fn raven_gc_bytes_allocated() -> usize {
+    BYTES_ALLOCATED.with(|b| b.get())
+}
+
+/// Number of live objects currently tracked by the collector. A
+/// diagnostic entry point that lets tests assert bounded liveness
+/// without measuring flaky OS memory.
+#[no_mangle]
+pub extern "C" fn raven_gc_live_objects() -> usize {
+    LIVE_OBJECTS.with(|n| n.get())
+}
+
+/// Unregister a single object from the all-objects list and free it.
+/// Used by the object modules' test deallocators so that manually freed
+/// objects do not stay in the heap list where a later collection in the
+/// same thread would visit a dangling pointer.
+///
+/// # Safety
+///
+/// `header` must point to a live object registered with the collector.
+#[cfg(test)]
+pub(crate) unsafe fn free_for_test(header: *mut ObjectHeader) {
+    if header.is_null() {
+        return;
+    }
+    HEAP.with(|h| {
+        let mut heap = h.borrow_mut();
+        if let Some(idx) = heap.iter().position(|&p| p == header) {
+            heap.swap_remove(idx);
+        }
+    });
+    // SAFETY: caller guarantees `header` is a live registered object.
+    unsafe { free_one(header) };
+}
+
 #[cfg(test)]
 mod shadow_stack_tests {
     use super::*;
@@ -173,6 +516,309 @@ mod shadow_stack_tests {
         isolated(|| {
             raven_gc_leave_frame();
             assert_eq!(root_count(), 0);
+        });
+    }
+}
+
+#[cfg(test)]
+mod collector_tests {
+    use super::*;
+    use crate::object::{
+        raven_box_new, raven_box_payload, raven_closure_captures, raven_closure_new,
+        raven_list_new, raven_map_buckets, raven_map_new, raven_set_buckets, raven_set_new,
+        raven_string_new,
+    };
+
+    /// Run each collector test on its own thread so the thread-local
+    /// heap, shadow stack, and counters start clean.
+    fn isolated(body: impl FnOnce() + Send + 'static) {
+        std::thread::spawn(body).join().unwrap();
+    }
+
+    /// A dummy closure body pointer.
+    extern "C" fn dummy_body() {}
+
+    #[test]
+    fn unrooted_object_is_collected() {
+        isolated(|| {
+            let s = raven_string_new(8);
+            assert!(!s.is_null());
+            assert_eq!(raven_gc_live_objects(), 1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn rooted_object_survives() {
+        isolated(|| {
+            let s = raven_string_new(8);
+            let mut slot: *mut u8 = s as *mut u8;
+            raven_gc_push_root(&mut slot as *mut *mut u8);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 1);
+            // The header is still valid and its mark bit was cleared.
+            // SAFETY: the rooted object survived the sweep.
+            unsafe {
+                assert_eq!((*(s)).header.tag, crate::object::TAG_STRING);
+                assert!(!(*(s)).header.is_marked());
+            }
+            raven_gc_pop_roots(1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn transitively_reachable_object_survives() {
+        isolated(|| {
+            // A list of one GC pointer that points at a string. Root the
+            // list; the string must survive transitively.
+            let inner = raven_string_new(4);
+            let list = raven_list_new(8, 8, 1, 1);
+            assert!(!inner.is_null() && !list.is_null());
+            // SAFETY: list has capacity 1 for one pointer slot.
+            unsafe {
+                let slots = (*list).elements as *mut *mut u8;
+                slots.write(inner as *mut u8);
+                (*list).header.len = 1;
+            }
+            let mut slot: *mut u8 = list as *mut u8;
+            raven_gc_push_root(&mut slot as *mut *mut u8);
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_pop_roots(1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn cycle_with_no_root_is_reclaimed() {
+        isolated(|| {
+            // Two single-slot lists of GC pointers that reference each
+            // other. Neither is rooted; mark-sweep reclaims both, which
+            // reference counting could not.
+            let a = raven_list_new(8, 8, 1, 1);
+            let b = raven_list_new(8, 8, 1, 1);
+            assert!(!a.is_null() && !b.is_null());
+            // SAFETY: each list has one pointer slot.
+            unsafe {
+                let a_slots = (*a).elements as *mut *mut u8;
+                a_slots.write(b as *mut u8);
+                (*a).header.len = 1;
+                let b_slots = (*b).elements as *mut *mut u8;
+                b_slots.write(a as *mut u8);
+                (*b).header.len = 1;
+            }
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn cycle_survives_while_one_node_is_rooted() {
+        isolated(|| {
+            let a = raven_list_new(8, 8, 1, 1);
+            let b = raven_list_new(8, 8, 1, 1);
+            // SAFETY: each list has one pointer slot.
+            unsafe {
+                ((*a).elements as *mut *mut u8).write(b as *mut u8);
+                (*a).header.len = 1;
+                ((*b).elements as *mut *mut u8).write(a as *mut u8);
+                (*b).header.len = 1;
+            }
+            let mut slot: *mut u8 = a as *mut u8;
+            raven_gc_push_root(&mut slot as *mut *mut u8);
+            raven_gc_collect();
+            // Rooting one node of the cycle keeps the whole cycle alive.
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_pop_roots(1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn map_traces_gc_keys_and_values() {
+        isolated(|| {
+            let key = raven_string_new(2);
+            let value = raven_string_new(2);
+            let map = raven_map_new(4, 1, 1);
+            assert!(!map.is_null());
+            // SAFETY: write one live entry into the first bucket.
+            unsafe {
+                let buckets = raven_map_buckets(map);
+                let e = &mut *buckets.add(0);
+                e.hash = 1;
+                e.key = key as *mut u8;
+                e.value = value as *mut u8;
+                (*map).header.len = 1;
+            }
+            let mut slot: *mut u8 = map as *mut u8;
+            raven_gc_push_root(&mut slot as *mut *mut u8);
+            // map + key + value all live.
+            assert_eq!(raven_gc_live_objects(), 3);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 3);
+            raven_gc_pop_roots(1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn set_traces_gc_elements() {
+        isolated(|| {
+            let element = raven_string_new(2);
+            let set = raven_set_new(4, 1);
+            assert!(!set.is_null());
+            // SAFETY: write one live entry into the first bucket.
+            unsafe {
+                let buckets = raven_set_buckets(set);
+                let e = &mut *buckets.add(0);
+                e.hash = 1;
+                e.element = element as *mut u8;
+                (*set).header.len = 1;
+            }
+            let mut slot: *mut u8 = set as *mut u8;
+            raven_gc_push_root(&mut slot as *mut *mut u8);
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_pop_roots(1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn closure_traces_gc_captures() {
+        isolated(|| {
+            let captured = raven_string_new(2);
+            // One pointer-sized capture slot holding a GC pointer.
+            let closure = raven_closure_new(dummy_body as *const u8, 8, 8, 1, 1);
+            assert!(!closure.is_null());
+            // SAFETY: the capture buffer has room for one pointer.
+            unsafe {
+                let caps = raven_closure_captures(closure) as *mut *mut u8;
+                caps.write(captured as *mut u8);
+            }
+            let mut slot: *mut u8 = closure as *mut u8;
+            raven_gc_push_root(&mut slot as *mut *mut u8);
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_pop_roots(1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn box_traces_gc_payload() {
+        isolated(|| {
+            let inner = raven_string_new(2);
+            let boxed = raven_box_new(8, 8, 1);
+            assert!(!boxed.is_null());
+            // SAFETY: the payload holds one pointer.
+            unsafe {
+                let payload = raven_box_payload(boxed) as *mut *mut u8;
+                payload.write(inner as *mut u8);
+            }
+            let mut slot: *mut u8 = boxed as *mut u8;
+            raven_gc_push_root(&mut slot as *mut *mut u8);
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 2);
+            raven_gc_pop_roots(1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn scalar_list_elements_are_not_traced() {
+        isolated(|| {
+            // A list of scalar Ints (flag 0). Its 8-byte slots hold
+            // integers that look like pointers but must not be traced.
+            let list = raven_list_new(8, 8, 4, 0);
+            // SAFETY: fill slots with arbitrary non-pointer bit patterns.
+            unsafe {
+                let slots = (*list).elements as *mut u64;
+                slots.add(0).write(0xDEAD_BEEF_DEAD_BEEF);
+                slots.add(1).write(0x1);
+                (*list).header.len = 2;
+            }
+            let mut slot: *mut u8 = list as *mut u8;
+            raven_gc_push_root(&mut slot as *mut *mut u8);
+            // Only the list is live; the integer "pointers" are ignored.
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 1);
+            raven_gc_pop_roots(1);
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn bounded_liveness_under_churn() {
+        isolated(|| {
+            // Keep a bounded working set of rooted lists while churning
+            // many short-lived strings. Liveness must stay bounded.
+            const WORKING_SET: usize = 4;
+            let mut roots: [*mut u8; WORKING_SET] = [std::ptr::null_mut(); WORKING_SET];
+            for r in roots.iter_mut() {
+                *r = raven_list_new(8, 8, 0, 1) as *mut u8;
+            }
+            raven_gc_enter_frame(roots.as_mut_ptr(), WORKING_SET);
+
+            let mut peak = 0usize;
+            for i in 0..5000usize {
+                // Allocate a throwaway string that nothing roots.
+                let _garbage = raven_string_new(8);
+                // Force frequent collection so the churn cannot pile up.
+                if i % 64 == 0 {
+                    raven_gc_collect();
+                    peak = peak.max(raven_gc_live_objects());
+                }
+            }
+            raven_gc_collect();
+            // After a final collection only the working set survives.
+            assert_eq!(raven_gc_live_objects(), WORKING_SET);
+            // Liveness never exceeded the working set plus a small
+            // constant of in-flight garbage between collections.
+            assert!(
+                peak <= WORKING_SET + 64,
+                "liveness peaked at {peak}, expected bounded"
+            );
+
+            raven_gc_leave_frame();
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn allocation_triggers_collection_at_threshold() {
+        isolated(|| {
+            // Each string body is 24 bytes, so 1 MiB of bodies is about
+            // 43.7k objects. Allocating well past that with unrooted
+            // strings must trigger at least one automatic collection,
+            // keeping liveness below the total allocated count.
+            const COUNT: usize = 120_000;
+            for _ in 0..COUNT {
+                let _garbage = raven_string_new(8);
+            }
+            assert!(
+                raven_gc_live_objects() < COUNT,
+                "expected automatic collection to bound liveness, got {}",
+                raven_gc_live_objects()
+            );
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
         });
     }
 }

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -1,0 +1,178 @@
+//! Stop-the-world, single-threaded, tracing mark-and-sweep garbage
+//! collector for compiled Raven v2 programs.
+//!
+//! The collector finds its roots through a shadow stack the code
+//! generator maintains: a runtime-owned stack of the addresses of the
+//! stack slots that currently hold live GC pointers. Codegen registers
+//! a frame's root array on entry and unregisters it on exit. See
+//! `docs/v2/specs/gc.md` for the full design and the ABI contract.
+//!
+//! # Single-threaded assumption
+//!
+//! v2.0 compiled programs are single threaded. The collector state
+//! lives in `thread_local!` cells, so each thread that ever touches the
+//! runtime gets its own independent heap and shadow stack. Sharing GC
+//! objects across threads is undefined in v2.0; the thread-local form
+//! simply keeps the global state sound under Rust's aliasing rules
+//! without a lock.
+
+use std::cell::RefCell;
+
+/// A registered root: the address of a stack slot that holds a GC
+/// pointer (or null). The collector reads the slot's current value at
+/// collection time, so a slot reassigned during the function body is
+/// always observed at its live value.
+type RootSlot = *mut *mut u8;
+
+thread_local! {
+    /// The shadow stack of root slot addresses, shared by the frame API
+    /// and the per-slot API.
+    static ROOTS: RefCell<Vec<RootSlot>> = const { RefCell::new(Vec::new()) };
+
+    /// Frame boundaries into `ROOTS`. Each entry is the `ROOTS` length
+    /// at the moment a frame was entered; leaving a frame truncates
+    /// `ROOTS` back to that length.
+    static FRAMES: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Register a single root slot on the shadow stack.
+///
+/// `slot` is the address of a stack local holding a GC pointer. It must
+/// stay valid (the local must outlive the matching pop) and must be
+/// paired with a later `raven_gc_pop_roots`.
+///
+/// # Safety
+///
+/// `slot` must point to a writable, properly aligned `*mut u8` that
+/// remains live until it is popped.
+#[no_mangle]
+pub extern "C" fn raven_gc_push_root(slot: *mut *mut u8) {
+    if slot.is_null() {
+        return;
+    }
+    ROOTS.with(|r| r.borrow_mut().push(slot));
+}
+
+/// Pop the last `n` root slots off the shadow stack.
+///
+/// Popping more slots than are registered clears the stack rather than
+/// underflowing.
+#[no_mangle]
+pub extern "C" fn raven_gc_pop_roots(n: usize) {
+    ROOTS.with(|r| {
+        let mut roots = r.borrow_mut();
+        let new_len = roots.len().saturating_sub(n);
+        roots.truncate(new_len);
+    });
+}
+
+/// Register a frame's root array on the shadow stack.
+///
+/// `roots` points to `count` contiguous slot addresses, each the
+/// address of a stack local that holds a GC pointer (or null). The
+/// array must outlive the matching `raven_gc_leave_frame` call (it
+/// normally lives in the caller's frame). Frames nest in strict
+/// last-in-first-out order.
+///
+/// # Safety
+///
+/// `roots` must point to `count` readable, properly aligned
+/// `*mut *mut u8` entries, each of which stays live until the matching
+/// `raven_gc_leave_frame`.
+#[no_mangle]
+pub extern "C" fn raven_gc_enter_frame(roots: *mut *mut u8, count: usize) {
+    ROOTS.with(|r| {
+        let mut stack = r.borrow_mut();
+        FRAMES.with(|f| f.borrow_mut().push(stack.len()));
+        if !roots.is_null() {
+            for i in 0..count {
+                // SAFETY: caller guarantees `roots` has `count` entries.
+                let slot = unsafe { roots.add(i) };
+                stack.push(slot);
+            }
+        }
+    });
+}
+
+/// Unregister the most recently registered frame, truncating the shadow
+/// stack back to the boundary recorded by the matching
+/// `raven_gc_enter_frame`.
+///
+/// A call with no open frame is a no-op.
+#[no_mangle]
+pub extern "C" fn raven_gc_leave_frame() {
+    let boundary = FRAMES.with(|f| f.borrow_mut().pop());
+    if let Some(boundary) = boundary {
+        ROOTS.with(|r| {
+            let mut roots = r.borrow_mut();
+            // Defensive: never grow past the current length.
+            let target = boundary.min(roots.len());
+            roots.truncate(target);
+        });
+    }
+}
+
+/// Number of root slots currently registered. Test and diagnostic aid.
+#[cfg(test)]
+pub(crate) fn root_count() -> usize {
+    ROOTS.with(|r| r.borrow().len())
+}
+
+#[cfg(test)]
+mod shadow_stack_tests {
+    use super::*;
+
+    /// Each test runs on its own thread so the thread-local shadow
+    /// stack starts empty and does not leak state into sibling tests.
+    fn isolated(body: impl FnOnce() + Send + 'static) {
+        std::thread::spawn(body).join().unwrap();
+    }
+
+    #[test]
+    fn push_and_pop_track_root_count() {
+        isolated(|| {
+            assert_eq!(root_count(), 0);
+            let mut a: *mut u8 = std::ptr::null_mut();
+            let mut b: *mut u8 = std::ptr::null_mut();
+            raven_gc_push_root(&mut a as *mut *mut u8);
+            raven_gc_push_root(&mut b as *mut *mut u8);
+            assert_eq!(root_count(), 2);
+            raven_gc_pop_roots(2);
+            assert_eq!(root_count(), 0);
+        });
+    }
+
+    #[test]
+    fn pop_more_than_present_clears_stack() {
+        isolated(|| {
+            let mut a: *mut u8 = std::ptr::null_mut();
+            raven_gc_push_root(&mut a as *mut *mut u8);
+            raven_gc_pop_roots(10);
+            assert_eq!(root_count(), 0);
+        });
+    }
+
+    #[test]
+    fn frames_nest_last_in_first_out() {
+        isolated(|| {
+            let mut outer: [*mut u8; 2] = [std::ptr::null_mut(); 2];
+            let mut inner: [*mut u8; 3] = [std::ptr::null_mut(); 3];
+            raven_gc_enter_frame(outer.as_mut_ptr(), 2);
+            assert_eq!(root_count(), 2);
+            raven_gc_enter_frame(inner.as_mut_ptr(), 3);
+            assert_eq!(root_count(), 5);
+            raven_gc_leave_frame();
+            assert_eq!(root_count(), 2);
+            raven_gc_leave_frame();
+            assert_eq!(root_count(), 0);
+        });
+    }
+
+    #[test]
+    fn leave_frame_without_open_frame_is_noop() {
+        isolated(|| {
+            raven_gc_leave_frame();
+            assert_eq!(root_count(), 0);
+        });
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -14,16 +14,18 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![allow(clippy::missing_safety_doc)]
 
+pub mod gc;
 pub mod object;
 
+pub use gc::{raven_gc_enter_frame, raven_gc_leave_frame, raven_gc_pop_roots, raven_gc_push_root};
 pub use object::{
     raven_box_new, raven_box_payload, raven_closure_captures, raven_closure_fn_ptr,
     raven_closure_new, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,
     raven_map_bucket_count, raven_map_buckets, raven_map_new, raven_set_bucket_count,
     raven_set_buckets, raven_set_new, raven_string_bytes, raven_string_concat, raven_string_len,
     raven_string_new, Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap,
-    MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, OBJECT_ALIGN,
-    TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING,
+    MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, GC_MARK_BIT,
+    OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING,
 };
 
 use std::alloc::{self, Layout};

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -17,7 +17,10 @@
 pub mod gc;
 pub mod object;
 
-pub use gc::{raven_gc_enter_frame, raven_gc_leave_frame, raven_gc_pop_roots, raven_gc_push_root};
+pub use gc::{
+    raven_gc_alloc, raven_gc_bytes_allocated, raven_gc_collect, raven_gc_enter_frame,
+    raven_gc_leave_frame, raven_gc_live_objects, raven_gc_pop_roots, raven_gc_push_root,
+};
 pub use object::{
     raven_box_new, raven_box_payload, raven_closure_captures, raven_closure_fn_ptr,
     raven_closure_new, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -115,3 +115,64 @@ impl ObjectHeader {
         self.gc_bits &= !GC_MARK_BIT;
     }
 }
+
+/// Return the allocation size and alignment of an object body given its
+/// header. The body is the fixed-size struct that begins with the
+/// header; owned buffers it points to are sized and freed separately.
+///
+/// For every kind except `Box` the body size is a constant; a `Box`
+/// carries its inline payload, so its body is
+/// `BOX_PAYLOAD_OFFSET + header.len` bytes.
+///
+/// # Safety
+///
+/// `header` must point to a live object produced by one of the
+/// constructors, so its `tag` and `len` are valid.
+pub(crate) unsafe fn object_body_layout(header: *const ObjectHeader) -> (usize, usize) {
+    // SAFETY: caller guarantees `header` is a live object header.
+    let tag = unsafe { (*header).tag };
+    match tag {
+        TAG_STRING => (string::size_of_string(), string::align_of_string()),
+        TAG_LIST => (list::size_of_list(), list::align_of_list()),
+        TAG_MAP => (map::size_of_map(), map::align_of_map()),
+        TAG_SET => (set::size_of_set(), set::align_of_set()),
+        TAG_CLOSURE => (closure::size_of_closure(), closure::align_of_closure()),
+        TAG_BOX => {
+            // SAFETY: a live Box header carries its payload size in `len`.
+            let payload_size = unsafe { (*header).len };
+            (
+                boxed::box_total_size(payload_size),
+                boxed::box_align(OBJECT_ALIGN as u32),
+            )
+        }
+        // An unknown tag should never reach the collector. Treat it as a
+        // bare header so freeing at least releases the body.
+        _ => (
+            std::mem::size_of::<ObjectHeader>(),
+            std::mem::align_of::<ObjectHeader>().max(OBJECT_ALIGN),
+        ),
+    }
+}
+
+/// Free the owned buffers a heap object points to (string bytes, list
+/// elements, map and set buckets, closure captures). The object body
+/// itself is freed by the collector after this call. `Box` and unknown
+/// tags own no separate buffer and are a no-op.
+///
+/// # Safety
+///
+/// `header` must point to a live object produced by one of the
+/// constructors.
+pub(crate) unsafe fn free_object_buffers(header: *mut ObjectHeader) {
+    // SAFETY: caller guarantees `header` is a live object header.
+    let tag = unsafe { (*header).tag };
+    match tag {
+        // SAFETY: tag matches the layout cast in each arm.
+        TAG_STRING => unsafe { string::free_buffers(header as *mut String) },
+        TAG_LIST => unsafe { list::free_buffers(header as *mut List) },
+        TAG_MAP => unsafe { map::free_buffers(header as *mut Map) },
+        TAG_SET => unsafe { set::free_buffers(header as *mut Set) },
+        TAG_CLOSURE => unsafe { closure::free_buffers(header as *mut Closure) },
+        _ => {}
+    }
+}

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -58,6 +58,12 @@ pub const TAG_CLOSURE: u32 = 0x05;
 /// Generic heap box. Reserved for trait-object payloads (issue #66).
 pub const TAG_BOX: u32 = 0x06;
 
+/// Bit 0 of `ObjectHeader.gc_bits`: the mark bit the tracing collector
+/// sets during the mark phase and clears during sweep. The remaining
+/// `gc_bits` stay zero and are reserved for a future colour scheme. See
+/// `docs/v2/specs/gc.md`.
+pub const GC_MARK_BIT: u32 = 0x1;
+
 /// Canonical 16-byte object header.
 ///
 /// Every heap allocation the GC traces starts with one of these,
@@ -89,5 +95,23 @@ impl ObjectHeader {
             len,
             cap,
         }
+    }
+
+    /// Return true when the mark bit is set.
+    #[inline]
+    pub const fn is_marked(&self) -> bool {
+        self.gc_bits & GC_MARK_BIT != 0
+    }
+
+    /// Set the mark bit.
+    #[inline]
+    pub fn set_mark(&mut self) {
+        self.gc_bits |= GC_MARK_BIT;
+    }
+
+    /// Clear the mark bit.
+    #[inline]
+    pub fn clear_mark(&mut self) {
+        self.gc_bits &= !GC_MARK_BIT;
     }
 }

--- a/raven-runtime/src/object/boxed.rs
+++ b/raven-runtime/src/object/boxed.rs
@@ -6,16 +6,19 @@
 //! `docs/v2/specs/object-layout.md` for the byte-exact layout.
 
 use super::{ObjectHeader, OBJECT_ALIGN, TAG_BOX};
-use crate::raven_alloc;
+use crate::gc::raven_gc_alloc;
 use std::ptr;
 
 /// Offset, in bytes, from the start of a `Box` to its inline payload.
-/// The payload begins immediately after the 16-byte header.
-pub const BOX_PAYLOAD_OFFSET: usize = std::mem::size_of::<ObjectHeader>();
+/// The payload begins after the 16-byte header and the 8-byte flag word
+/// (`payload_is_gc_ptr` plus reserved padding), at offset 24, so the
+/// payload stays 8-byte aligned.
+pub const BOX_PAYLOAD_OFFSET: usize = std::mem::size_of::<Box>();
 
-/// Boxed primitive object. The struct models only the fixed header;
-/// the sized payload follows inline at `BOX_PAYLOAD_OFFSET`. `header.len`
-/// is the payload byte size, `header.cap` is 1 (a box holds one value).
+/// Boxed primitive or pointer object. The struct models the fixed
+/// header and flag word; the sized payload follows inline at
+/// `BOX_PAYLOAD_OFFSET`. `header.len` is the payload byte size,
+/// `header.cap` is 1 (a box holds one value).
 ///
 /// The payload is reached through `raven_box_payload`, not a struct
 /// field, because its size is decided at allocation time.
@@ -24,33 +27,46 @@ pub struct Box {
     /// Standard 16-byte object header. `tag == TAG_BOX`,
     /// `len == payload size`, `cap == 1`.
     pub header: ObjectHeader,
+    /// Nonzero when the inline payload is a single GC pointer the
+    /// collector traces; zero for a scalar payload.
+    pub payload_is_gc_ptr: u32,
+    /// Reserved padding; keeps the inline payload 8-byte aligned.
+    /// Always zero.
+    pub _pad: u32,
 }
 
 /// Allocate a fresh `Box` whose inline payload is `payload_size` bytes
 /// aligned to `payload_align`. The payload is zero-filled.
 ///
-/// The whole object (header plus payload) is one allocation aligned to
+/// `payload_is_gc_ptr` is nonzero when the payload is a single GC
+/// pointer the collector traces. The whole object (header, flag word,
+/// and payload) is one allocation aligned to
 /// `max(OBJECT_ALIGN, payload_align)`. Returns null on allocation
 /// failure or invalid layout.
 #[no_mangle]
-pub extern "C" fn raven_box_new(payload_size: u32, payload_align: u32) -> *mut Box {
+pub extern "C" fn raven_box_new(
+    payload_size: u32,
+    payload_align: u32,
+    payload_is_gc_ptr: u32,
+) -> *mut Box {
     if payload_align != 0 && !payload_align.is_power_of_two() {
         return ptr::null_mut();
     }
     let align = box_align(payload_align);
     let total = box_total_size(payload_size);
-    let ptr = raven_alloc(total, align) as *mut Box;
+    let ptr = raven_gc_alloc(total, align, TAG_BOX) as *mut Box;
     if ptr.is_null() {
         return ptr::null_mut();
     }
-    // SAFETY: `ptr` points to `total` writable bytes; zero the whole
-    // object, then write the header.
+    // SAFETY: `ptr` points to `total` zeroed bytes from the collector;
+    // write the header and flag word, leaving the payload zeroed.
     unsafe {
-        ptr::write_bytes(ptr as *mut u8, 0, total);
         ptr::write(
             ptr,
             Box {
                 header: ObjectHeader::new(TAG_BOX, payload_size, 1),
+                payload_is_gc_ptr,
+                _pad: 0,
             },
         );
     }
@@ -89,26 +105,28 @@ pub(crate) const fn box_align(payload_align: u32) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::raven_dealloc;
     use std::mem::{offset_of, size_of};
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn box_header_size_and_payload_offset_match_spec() {
-        assert_eq!(size_of::<Box>(), 16);
+        assert_eq!(size_of::<Box>(), 24);
         assert_eq!(offset_of!(Box, header), 0);
-        assert_eq!(BOX_PAYLOAD_OFFSET, 16);
+        assert_eq!(offset_of!(Box, payload_is_gc_ptr), 16);
+        assert_eq!(BOX_PAYLOAD_OFFSET, 24);
     }
 
     #[test]
     fn new_sets_header_and_zero_fills_payload() {
-        let b = raven_box_new(8, 8);
+        let b = raven_box_new(8, 8, 0);
         assert!(!b.is_null());
         // SAFETY: b came from the constructor with an 8-byte payload.
         unsafe {
             assert_eq!((*b).header.tag, TAG_BOX);
             assert_eq!((*b).header.len, 8);
             assert_eq!((*b).header.cap, 1);
+            assert_eq!((*b).payload_is_gc_ptr, 0);
+            assert_eq!((*b)._pad, 0);
         }
         let payload = raven_box_payload(b);
         assert!(!payload.is_null());
@@ -122,8 +140,19 @@ mod tests {
     }
 
     #[test]
+    fn new_records_gc_ptr_flag() {
+        let b = raven_box_new(8, 8, 1);
+        assert!(!b.is_null());
+        // SAFETY: b came from the constructor.
+        unsafe {
+            assert_eq!((*b).payload_is_gc_ptr, 1);
+        }
+        unsafe { drop_box_for_test(b) };
+    }
+
+    #[test]
     fn payload_roundtrips_a_value() {
-        let b = raven_box_new(8, 8);
+        let b = raven_box_new(8, 8, 0);
         let payload = raven_box_payload(b);
         // SAFETY: payload points to 8 writable, aligned bytes.
         unsafe {
@@ -135,14 +164,14 @@ mod tests {
 
     #[test]
     fn zero_sized_payload_is_valid() {
-        let b = raven_box_new(0, 0);
+        let b = raven_box_new(0, 0, 0);
         assert!(!b.is_null());
         // SAFETY: b came from the constructor.
         unsafe {
             assert_eq!((*b).header.len, 0);
             assert_eq!((*b).header.cap, 1);
         }
-        // Payload pointer is one-past-the-header; valid but not
+        // Payload pointer is one-past-the-body; valid but not
         // dereferenceable for reads.
         assert!(!raven_box_payload(b).is_null());
         unsafe { drop_box_for_test(b) };
@@ -150,7 +179,7 @@ mod tests {
 
     #[test]
     fn invalid_align_returns_null() {
-        assert!(raven_box_new(8, 3).is_null());
+        assert!(raven_box_new(8, 3, 0).is_null());
     }
 
     #[test]
@@ -158,21 +187,14 @@ mod tests {
         assert!(raven_box_payload(std::ptr::null()).is_null());
     }
 
-    /// Test-only deallocator.
+    /// Test-only deallocator: unregister the object from the collector
+    /// and free its body. A box owns no separate buffer.
     ///
     /// # Safety
     ///
     /// `b` must come from `raven_box_new` and not be freed yet.
     unsafe fn drop_box_for_test(b: *mut Box) {
-        if b.is_null() {
-            return;
-        }
         // SAFETY: matches construction layout.
-        let payload_size = unsafe { (*b).header.len };
-        raven_dealloc(
-            b as *mut u8,
-            box_total_size(payload_size),
-            box_align(OBJECT_ALIGN as u32),
-        );
+        unsafe { crate::gc::free_for_test(b as *mut ObjectHeader) };
     }
 }

--- a/raven-runtime/src/object/closure.rs
+++ b/raven-runtime/src/object/closure.rs
@@ -6,6 +6,7 @@
 //! object is the same fixed size regardless of capture count.
 
 use super::{ObjectHeader, OBJECT_ALIGN, TAG_CLOSURE};
+use crate::gc::raven_gc_alloc;
 use crate::{raven_alloc, raven_dealloc};
 use std::mem::align_of;
 use std::ptr;
@@ -27,28 +28,36 @@ pub struct Closure {
     pub capture_size: u32,
     /// Alignment in bytes of the capture record.
     pub capture_align: u32,
+    /// Number of leading pointer-sized capture slots that are GC
+    /// pointers the collector traces. The closure-lowering pass places
+    /// the GC pointer captures first in the record; the remaining bytes
+    /// are scalars. Zero when the closure captures no GC pointers.
+    pub capture_ptr_count: u32,
+    /// Reserved padding; always zero.
+    pub _pad: u32,
 }
 
 /// Allocate a fresh `Closure` with the given function pointer and
 /// capture record shape. The capture buffer is zero-filled.
 ///
 /// `capture_count` is recorded in `header.len`; `capture_size` and
-/// `capture_align` describe the owned capture buffer. Returns null on
-/// allocation failure or invalid layout.
+/// `capture_align` describe the owned capture buffer. `capture_ptr_count`
+/// is the number of leading pointer-sized capture slots that are GC
+/// pointers the collector traces. Returns null on allocation failure or
+/// invalid layout.
 #[no_mangle]
 pub extern "C" fn raven_closure_new(
     fn_ptr: *const u8,
     capture_size: u32,
     capture_align: u32,
     capture_count: u32,
+    capture_ptr_count: u32,
 ) -> *mut Closure {
     if capture_align != 0 && !capture_align.is_power_of_two() {
         return ptr::null_mut();
     }
-    let closure_ptr = raven_alloc(size_of_closure(), align_of_closure()) as *mut Closure;
-    if closure_ptr.is_null() {
-        return ptr::null_mut();
-    }
+    // Allocate the owned capture buffer first so a body-allocation
+    // failure does not leave a half-registered object in the collector.
     let captures = if capture_size == 0 {
         ptr::null_mut()
     } else {
@@ -59,17 +68,18 @@ pub extern "C" fn raven_closure_new(
         };
         let p = raven_alloc(capture_size as usize, align);
         if p.is_null() {
-            raven_dealloc(
-                closure_ptr as *mut u8,
-                size_of_closure(),
-                align_of_closure(),
-            );
             return ptr::null_mut();
         }
         // SAFETY: the allocator just gave us `capture_size` bytes.
         unsafe { ptr::write_bytes(p, 0, capture_size as usize) };
         p
     };
+    let closure_ptr =
+        raven_gc_alloc(size_of_closure(), align_of_closure(), TAG_CLOSURE) as *mut Closure;
+    if closure_ptr.is_null() {
+        free_capture_buffer(captures, capture_size, capture_align);
+        return ptr::null_mut();
+    }
     // SAFETY: closure_ptr points to writable, correctly aligned storage.
     unsafe {
         ptr::write(
@@ -80,6 +90,8 @@ pub extern "C" fn raven_closure_new(
                 captures,
                 capture_size,
                 capture_align,
+                capture_ptr_count,
+                _pad: 0,
             },
         );
     }
@@ -125,6 +137,34 @@ pub(crate) const fn align_of_closure() -> usize {
     }
 }
 
+/// Free a `Closure`'s owned capture buffer. The collector frees the
+/// object body separately after this call.
+///
+/// # Safety
+///
+/// `c` must point to a live `Closure` produced by `raven_closure_new`.
+pub(crate) unsafe fn free_buffers(c: *mut Closure) {
+    // SAFETY: caller guarantees `c` is a live Closure.
+    let capture_size = unsafe { (*c).capture_size };
+    let capture_align = unsafe { (*c).capture_align };
+    let captures = unsafe { (*c).captures };
+    free_capture_buffer(captures, capture_size, capture_align);
+}
+
+/// Release a capture buffer allocated by the constructor. Used to
+/// unwind a partly-built closure when the body allocation fails.
+fn free_capture_buffer(captures: *mut u8, capture_size: u32, capture_align: u32) {
+    if captures.is_null() || capture_size == 0 {
+        return;
+    }
+    let align = if capture_align == 0 {
+        1
+    } else {
+        capture_align as usize
+    };
+    raven_dealloc(captures, capture_size as usize, align);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -135,25 +175,28 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn closure_size_and_offsets_match_spec() {
-        assert_eq!(size_of::<Closure>(), 40);
+        assert_eq!(size_of::<Closure>(), 48);
         assert_eq!(offset_of!(Closure, header), 0);
         assert_eq!(offset_of!(Closure, fn_ptr), 16);
         assert_eq!(offset_of!(Closure, captures), 24);
         assert_eq!(offset_of!(Closure, capture_size), 32);
         assert_eq!(offset_of!(Closure, capture_align), 36);
+        assert_eq!(offset_of!(Closure, capture_ptr_count), 40);
         assert!(align_of::<Closure>() >= 8);
     }
 
     #[test]
     fn new_no_captures_leaves_buffer_null() {
         let fp = dummy_body as *const u8;
-        let c = raven_closure_new(fp, 0, 0, 0);
+        let c = raven_closure_new(fp, 0, 0, 0, 0);
         assert!(!c.is_null());
         // SAFETY: c came from the constructor.
         unsafe {
             assert_eq!((*c).header.tag, TAG_CLOSURE);
             assert_eq!((*c).header.len, 0);
             assert_eq!((*c).capture_size, 0);
+            assert_eq!((*c).capture_ptr_count, 0);
+            assert_eq!((*c)._pad, 0);
             assert!((*c).captures.is_null());
             assert_eq!((*c).fn_ptr, fp);
         }
@@ -163,13 +206,14 @@ mod tests {
     #[test]
     fn new_with_captures_zero_fills_buffer() {
         let fp = dummy_body as *const u8;
-        let c = raven_closure_new(fp, 24, 8, 3);
+        let c = raven_closure_new(fp, 24, 8, 3, 2);
         assert!(!c.is_null());
         // SAFETY: c has a 24-byte capture buffer and len 3.
         unsafe {
             assert_eq!((*c).header.len, 3);
             assert_eq!((*c).capture_size, 24);
             assert_eq!((*c).capture_align, 8);
+            assert_eq!((*c).capture_ptr_count, 2);
             let buf = (*c).captures;
             assert!(!buf.is_null());
             for i in 0..24 {
@@ -182,7 +226,7 @@ mod tests {
     #[test]
     fn accessors_match_fields() {
         let fp = dummy_body as *const u8;
-        let c = raven_closure_new(fp, 16, 8, 2);
+        let c = raven_closure_new(fp, 16, 8, 2, 0);
         assert_eq!(raven_closure_fn_ptr(c), fp);
         let captures = raven_closure_captures(c);
         assert!(!captures.is_null());
@@ -201,27 +245,14 @@ mod tests {
         assert!(raven_closure_captures(std::ptr::null()).is_null());
     }
 
-    /// Test-only deallocator.
+    /// Test-only deallocator: unregister the object from the collector
+    /// and free its buffer and body.
     ///
     /// # Safety
     ///
     /// `c` must come from `raven_closure_new` and not be freed yet.
     unsafe fn drop_closure_for_test(c: *mut Closure) {
-        if c.is_null() {
-            return;
-        }
         // SAFETY: matches construction layout.
-        let capture_size = unsafe { (*c).capture_size };
-        let capture_align = unsafe { (*c).capture_align };
-        let captures = unsafe { (*c).captures };
-        if !captures.is_null() && capture_size > 0 {
-            let align = if capture_align == 0 {
-                1
-            } else {
-                capture_align as usize
-            };
-            raven_dealloc(captures, capture_size as usize, align);
-        }
-        raven_dealloc(c as *mut u8, size_of_closure(), align_of_closure());
+        unsafe { crate::gc::free_for_test(c as *mut ObjectHeader) };
     }
 }

--- a/raven-runtime/src/object/list.rs
+++ b/raven-runtime/src/object/list.rs
@@ -4,6 +4,7 @@
 //! offsets the back-end relies on.
 
 use super::{ObjectHeader, OBJECT_ALIGN, TAG_LIST};
+use crate::gc::raven_gc_alloc;
 use crate::{raven_alloc, raven_dealloc};
 use std::mem::align_of;
 use std::ptr;
@@ -19,6 +20,12 @@ pub struct List {
     pub element_size: u32,
     /// Alignment in bytes of one element slot.
     pub element_align: u32,
+    /// Nonzero when each element slot is a GC pointer the collector must
+    /// trace. Zero for scalar elements (the buffer is opaque bytes).
+    /// Codegen sets it from the static element type.
+    pub elements_are_gc_ptrs: u32,
+    /// Reserved padding; keeps `elements` 8-byte aligned. Always zero.
+    pub _pad: u32,
     /// Owned buffer of `header.cap * element_size` bytes. Null when
     /// `header.cap == 0`.
     pub elements: *mut u8,
@@ -28,23 +35,31 @@ pub struct List {
 /// capacity. Header is `len = 0`, `cap = cap`. Elements buffer is
 /// zero-filled.
 ///
+/// `elements_are_gc_ptrs` is nonzero when each slot holds a GC pointer
+/// the collector traces; zero for scalar elements.
+///
 /// Returns null on allocation failure or invalid layout.
 #[no_mangle]
-pub extern "C" fn raven_list_new(element_size: u32, element_align: u32, cap: u32) -> *mut List {
+pub extern "C" fn raven_list_new(
+    element_size: u32,
+    element_align: u32,
+    cap: u32,
+    elements_are_gc_ptrs: u32,
+) -> *mut List {
     if element_align != 0 && !element_align.is_power_of_two() {
         return ptr::null_mut();
     }
-    let list_ptr = raven_alloc(size_of_list(), align_of_list()) as *mut List;
-    if list_ptr.is_null() {
-        return ptr::null_mut();
-    }
+    // Allocate the owned buffer first so a body-allocation failure does
+    // not leave a half-registered object in the collector.
     let buffer = match alloc_elements(element_size, element_align, cap) {
         Some(p) => p,
-        None => {
-            raven_dealloc(list_ptr as *mut u8, size_of_list(), align_of_list());
-            return ptr::null_mut();
-        }
+        None => return ptr::null_mut(),
     };
+    let list_ptr = raven_gc_alloc(size_of_list(), align_of_list(), TAG_LIST) as *mut List;
+    if list_ptr.is_null() {
+        free_element_buffer(buffer, element_size, element_align, cap);
+        return ptr::null_mut();
+    }
     // SAFETY: list_ptr points to writable, correctly aligned storage.
     unsafe {
         ptr::write(
@@ -53,6 +68,8 @@ pub extern "C" fn raven_list_new(element_size: u32, element_align: u32, cap: u32
                 header: ObjectHeader::new(TAG_LIST, 0, cap),
                 element_size,
                 element_align,
+                elements_are_gc_ptrs,
+                _pad: 0,
                 elements: buffer,
             },
         );
@@ -142,6 +159,29 @@ pub(crate) const fn align_of_list() -> usize {
     }
 }
 
+/// Free a `List`'s owned element buffer. The collector frees the object
+/// body separately after this call.
+///
+/// # Safety
+///
+/// `l` must point to a live `List` produced by `raven_list_new`.
+pub(crate) unsafe fn free_buffers(l: *mut List) {
+    // SAFETY: caller guarantees `l` is a live List.
+    let cap = unsafe { (*l).header.cap };
+    let elem_size = unsafe { (*l).element_size };
+    let elem_align = unsafe { (*l).element_align };
+    let buffer = unsafe { (*l).elements };
+    if !buffer.is_null() && cap > 0 && elem_size > 0 {
+        let bytes = (cap as usize) * (elem_size as usize);
+        let align = if elem_align == 0 {
+            1
+        } else {
+            elem_align as usize
+        };
+        raven_dealloc(buffer, bytes, align);
+    }
+}
+
 fn alloc_elements(element_size: u32, element_align: u32, cap: u32) -> Option<*mut u8> {
     if cap == 0 || element_size == 0 {
         return Some(ptr::null_mut());
@@ -159,6 +199,21 @@ fn alloc_elements(element_size: u32, element_align: u32, cap: u32) -> Option<*mu
     // SAFETY: the allocator just gave us `bytes` writable bytes.
     unsafe { ptr::write_bytes(p, 0, bytes) };
     Some(p)
+}
+
+/// Release an element buffer allocated by `alloc_elements`. Used to
+/// unwind a partly-built list when the body allocation fails.
+fn free_element_buffer(buffer: *mut u8, element_size: u32, element_align: u32, cap: u32) {
+    if buffer.is_null() || cap == 0 || element_size == 0 {
+        return;
+    }
+    let bytes = (element_size as usize) * (cap as usize);
+    let align = if element_align == 0 {
+        1
+    } else {
+        element_align as usize
+    };
+    raven_dealloc(buffer, bytes, align);
 }
 
 fn grow_buffer(l: *mut List, elem_size: u32, elem_align: u32, old_cap: u32, new_cap: u32) -> bool {
@@ -195,17 +250,18 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn list_size_and_offsets_match_spec() {
-        assert_eq!(size_of::<List>(), 32);
+        assert_eq!(size_of::<List>(), 40);
         assert_eq!(offset_of!(List, header), 0);
         assert_eq!(offset_of!(List, element_size), 16);
         assert_eq!(offset_of!(List, element_align), 20);
-        assert_eq!(offset_of!(List, elements), 24);
+        assert_eq!(offset_of!(List, elements_are_gc_ptrs), 24);
+        assert_eq!(offset_of!(List, elements), 32);
         assert!(align_of::<List>() >= 8);
     }
 
     #[test]
     fn new_zero_capacity_yields_empty_list() {
-        let l = raven_list_new(8, 8, 0);
+        let l = raven_list_new(8, 8, 0, 0);
         assert!(!l.is_null());
         // SAFETY: l came from the constructor.
         unsafe {
@@ -214,14 +270,27 @@ mod tests {
             assert_eq!((*l).header.cap, 0);
             assert_eq!((*l).element_size, 8);
             assert_eq!((*l).element_align, 8);
+            assert_eq!((*l).elements_are_gc_ptrs, 0);
+            assert_eq!((*l)._pad, 0);
             assert!((*l).elements.is_null());
         }
         unsafe { drop_list_for_test(l) };
     }
 
     #[test]
+    fn new_records_gc_ptr_flag() {
+        let l = raven_list_new(8, 8, 4, 1);
+        assert!(!l.is_null());
+        // SAFETY: l came from the constructor.
+        unsafe {
+            assert_eq!((*l).elements_are_gc_ptrs, 1);
+        }
+        unsafe { drop_list_for_test(l) };
+    }
+
+    #[test]
     fn new_with_capacity_zero_fills_buffer() {
-        let l = raven_list_new(4, 4, 6);
+        let l = raven_list_new(4, 4, 6, 0);
         assert!(!l.is_null());
         // SAFETY: l has a 24-byte buffer.
         unsafe {
@@ -236,7 +305,7 @@ mod tests {
     #[test]
     fn push_appends_and_grows() {
         // Start with cap 0 so we exercise the grow path.
-        let l = raven_list_new(8, 8, 0);
+        let l = raven_list_new(8, 8, 0, 0);
         let values: [u64; 10] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         for v in &values {
             // SAFETY: each push reads 8 bytes from a stack-local u64.
@@ -256,7 +325,7 @@ mod tests {
 
     #[test]
     fn push_preserves_earlier_elements_across_grow() {
-        let l = raven_list_new(8, 8, 2);
+        let l = raven_list_new(8, 8, 2, 0);
         let first = 0xDEADBEEFu64;
         let second = 0xCAFEBABEu64;
         raven_list_push(l, &first as *const u64 as *const u8);
@@ -283,30 +352,14 @@ mod tests {
         raven_list_push(std::ptr::null_mut(), std::ptr::null());
     }
 
-    /// Test-only deallocator. The real free path lands with the GC
-    /// (issue #64).
+    /// Test-only deallocator: unregister the object from the collector
+    /// and free its buffer and body.
     ///
     /// # Safety
     ///
     /// `l` must come from `raven_list_new` and not be freed yet.
     unsafe fn drop_list_for_test(l: *mut List) {
-        if l.is_null() {
-            return;
-        }
         // SAFETY: matches the construction layout.
-        let cap = unsafe { (*l).header.cap };
-        let elem_size = unsafe { (*l).element_size };
-        let elem_align = unsafe { (*l).element_align };
-        let buffer = unsafe { (*l).elements };
-        if !buffer.is_null() && cap > 0 && elem_size > 0 {
-            let bytes = (cap as usize) * (elem_size as usize);
-            let align = if elem_align == 0 {
-                1
-            } else {
-                elem_align as usize
-            };
-            raven_dealloc(buffer, bytes, align);
-        }
-        raven_dealloc(l as *mut u8, size_of_list(), align_of_list());
+        unsafe { crate::gc::free_for_test(l as *mut ObjectHeader) };
     }
 }

--- a/raven-runtime/src/object/map.rs
+++ b/raven-runtime/src/object/map.rs
@@ -5,6 +5,7 @@
 //! contiguously as `bucket_count` `MapEntry` slots.
 
 use super::{ObjectHeader, OBJECT_ALIGN, TAG_MAP};
+use crate::gc::raven_gc_alloc;
 use crate::{raven_alloc, raven_dealloc};
 use std::mem::align_of;
 use std::ptr;
@@ -18,8 +19,12 @@ pub struct Map {
     pub header: ObjectHeader,
     /// Power of two, or zero for the freshly-constructed empty map.
     pub bucket_count: u32,
+    /// Nonzero when bucket keys are GC pointers the collector traces.
+    pub keys_are_gc_ptrs: u8,
+    /// Nonzero when bucket values are GC pointers the collector traces.
+    pub values_are_gc_ptrs: u8,
     /// Reserved padding; always zero.
-    pub _pad: u32,
+    pub _pad: u16,
     /// Owned buffer of `bucket_count` `MapEntry` slots. Null when
     /// `bucket_count == 0`.
     pub buckets: *mut MapEntry,
@@ -46,14 +51,19 @@ pub struct MapEntry {
 /// "empty" state. `header.len = 0`, `header.cap = bucket_count` after
 /// rounding.
 ///
+/// `keys_are_gc_ptrs` and `values_are_gc_ptrs` are nonzero when bucket
+/// keys or values are GC pointers the collector traces.
+///
 /// Returns null on allocation failure.
 #[no_mangle]
-pub extern "C" fn raven_map_new(bucket_count: u32) -> *mut Map {
+pub extern "C" fn raven_map_new(
+    bucket_count: u32,
+    keys_are_gc_ptrs: u8,
+    values_are_gc_ptrs: u8,
+) -> *mut Map {
     let rounded = round_up_pow2(bucket_count);
-    let map_ptr = raven_alloc(size_of_map(), align_of_map()) as *mut Map;
-    if map_ptr.is_null() {
-        return ptr::null_mut();
-    }
+    // Allocate the owned bucket buffer first so a body-allocation
+    // failure does not leave a half-registered object in the collector.
     let buckets = if rounded == 0 {
         ptr::null_mut()
     } else {
@@ -61,18 +71,21 @@ pub extern "C" fn raven_map_new(bucket_count: u32) -> *mut Map {
             .checked_mul(std::mem::size_of::<MapEntry>())
             .unwrap_or(0);
         if bytes == 0 {
-            raven_dealloc(map_ptr as *mut u8, size_of_map(), align_of_map());
             return ptr::null_mut();
         }
         let p = raven_alloc(bytes, align_of::<MapEntry>());
         if p.is_null() {
-            raven_dealloc(map_ptr as *mut u8, size_of_map(), align_of_map());
             return ptr::null_mut();
         }
         // SAFETY: the allocator just gave us `bytes` writable bytes.
         unsafe { ptr::write_bytes(p, 0, bytes) };
         p as *mut MapEntry
     };
+    let map_ptr = raven_gc_alloc(size_of_map(), align_of_map(), TAG_MAP) as *mut Map;
+    if map_ptr.is_null() {
+        free_bucket_buffer(buckets as *mut u8, rounded);
+        return ptr::null_mut();
+    }
     // SAFETY: map_ptr points to writable, correctly aligned storage.
     unsafe {
         ptr::write(
@@ -80,6 +93,8 @@ pub extern "C" fn raven_map_new(bucket_count: u32) -> *mut Map {
             Map {
                 header: ObjectHeader::new(TAG_MAP, 0, rounded),
                 bucket_count: rounded,
+                keys_are_gc_ptrs,
+                values_are_gc_ptrs,
                 _pad: 0,
                 buckets,
             },
@@ -127,6 +142,29 @@ pub(crate) const fn align_of_map() -> usize {
     }
 }
 
+/// Free a `Map`'s owned bucket buffer. The collector frees the object
+/// body separately after this call.
+///
+/// # Safety
+///
+/// `m` must point to a live `Map` produced by `raven_map_new`.
+pub(crate) unsafe fn free_buffers(m: *mut Map) {
+    // SAFETY: caller guarantees `m` is a live Map.
+    let bucket_count = unsafe { (*m).bucket_count };
+    let buckets = unsafe { (*m).buckets };
+    free_bucket_buffer(buckets as *mut u8, bucket_count);
+}
+
+/// Release a bucket buffer allocated by the constructor. Used to unwind
+/// a partly-built map when the body allocation fails.
+fn free_bucket_buffer(buckets: *mut u8, bucket_count: u32) {
+    if buckets.is_null() || bucket_count == 0 {
+        return;
+    }
+    let bytes = (bucket_count as usize) * std::mem::size_of::<MapEntry>();
+    raven_dealloc(buckets, bytes, align_of::<MapEntry>());
+}
+
 fn round_up_pow2(n: u32) -> u32 {
     if n == 0 {
         0
@@ -148,7 +186,9 @@ mod tests {
         assert_eq!(size_of::<Map>(), 32);
         assert_eq!(offset_of!(Map, header), 0);
         assert_eq!(offset_of!(Map, bucket_count), 16);
-        assert_eq!(offset_of!(Map, _pad), 20);
+        assert_eq!(offset_of!(Map, keys_are_gc_ptrs), 20);
+        assert_eq!(offset_of!(Map, values_are_gc_ptrs), 21);
+        assert_eq!(offset_of!(Map, _pad), 22);
         assert_eq!(offset_of!(Map, buckets), 24);
         assert!(align_of::<Map>() >= 8);
     }
@@ -165,7 +205,7 @@ mod tests {
 
     #[test]
     fn new_zero_buckets_leaves_buffer_null() {
-        let m = raven_map_new(0);
+        let m = raven_map_new(0, 0, 0);
         assert!(!m.is_null());
         // SAFETY: m came from the constructor.
         unsafe {
@@ -173,6 +213,8 @@ mod tests {
             assert_eq!((*m).header.len, 0);
             assert_eq!((*m).header.cap, 0);
             assert_eq!((*m).bucket_count, 0);
+            assert_eq!((*m).keys_are_gc_ptrs, 0);
+            assert_eq!((*m).values_are_gc_ptrs, 0);
             assert_eq!((*m)._pad, 0);
             assert!((*m).buckets.is_null());
         }
@@ -180,8 +222,20 @@ mod tests {
     }
 
     #[test]
+    fn new_records_gc_ptr_flags() {
+        let m = raven_map_new(4, 1, 1);
+        assert!(!m.is_null());
+        // SAFETY: m came from the constructor.
+        unsafe {
+            assert_eq!((*m).keys_are_gc_ptrs, 1);
+            assert_eq!((*m).values_are_gc_ptrs, 1);
+        }
+        unsafe { drop_map_for_test(m) };
+    }
+
+    #[test]
     fn new_rounds_up_to_power_of_two() {
-        let m = raven_map_new(5);
+        let m = raven_map_new(5, 0, 0);
         assert!(!m.is_null());
         assert_eq!(raven_map_bucket_count(m), 8);
         // SAFETY: m came from the constructor.
@@ -193,7 +247,7 @@ mod tests {
 
     #[test]
     fn new_zero_fills_bucket_buffer() {
-        let m = raven_map_new(4);
+        let m = raven_map_new(4, 0, 0);
         assert!(!m.is_null());
         let buckets = raven_map_buckets(m);
         assert!(!buckets.is_null());
@@ -215,22 +269,14 @@ mod tests {
         assert_eq!(raven_map_bucket_count(std::ptr::null()), 0);
     }
 
-    /// Test-only deallocator.
+    /// Test-only deallocator: unregister the object from the collector
+    /// and free its buffer and body.
     ///
     /// # Safety
     ///
     /// `m` must come from `raven_map_new` and not be freed yet.
     unsafe fn drop_map_for_test(m: *mut Map) {
-        if m.is_null() {
-            return;
-        }
         // SAFETY: matches construction layout.
-        let bucket_count = unsafe { (*m).bucket_count };
-        let buckets = unsafe { (*m).buckets };
-        if !buckets.is_null() && bucket_count > 0 {
-            let bytes = (bucket_count as usize) * std::mem::size_of::<MapEntry>();
-            raven_dealloc(buckets as *mut u8, bytes, align_of::<MapEntry>());
-        }
-        raven_dealloc(m as *mut u8, size_of_map(), align_of_map());
+        unsafe { crate::gc::free_for_test(m as *mut ObjectHeader) };
     }
 }

--- a/raven-runtime/src/object/set.rs
+++ b/raven-runtime/src/object/set.rs
@@ -5,6 +5,7 @@
 //! contiguously as `bucket_count` `SetEntry` slots.
 
 use super::{ObjectHeader, OBJECT_ALIGN, TAG_SET};
+use crate::gc::raven_gc_alloc;
 use crate::{raven_alloc, raven_dealloc};
 use std::mem::align_of;
 use std::ptr;
@@ -18,8 +19,10 @@ pub struct Set {
     pub header: ObjectHeader,
     /// Power of two, or zero for the freshly-constructed empty set.
     pub bucket_count: u32,
+    /// Nonzero when bucket elements are GC pointers the collector traces.
+    pub elements_are_gc_ptrs: u8,
     /// Reserved padding; always zero.
-    pub _pad: u32,
+    pub _pad: [u8; 3],
     /// Owned buffer of `bucket_count` `SetEntry` slots. Null when
     /// `bucket_count == 0`.
     pub buckets: *mut SetEntry,
@@ -42,14 +45,15 @@ pub struct SetEntry {
 /// zero). The bucket buffer is zero-filled. `header.len = 0`,
 /// `header.cap = bucket_count` after rounding.
 ///
+/// `elements_are_gc_ptrs` is nonzero when bucket elements are GC
+/// pointers the collector traces.
+///
 /// Returns null on allocation failure.
 #[no_mangle]
-pub extern "C" fn raven_set_new(bucket_count: u32) -> *mut Set {
+pub extern "C" fn raven_set_new(bucket_count: u32, elements_are_gc_ptrs: u8) -> *mut Set {
     let rounded = round_up_pow2(bucket_count);
-    let set_ptr = raven_alloc(size_of_set(), align_of_set()) as *mut Set;
-    if set_ptr.is_null() {
-        return ptr::null_mut();
-    }
+    // Allocate the owned bucket buffer first so a body-allocation
+    // failure does not leave a half-registered object in the collector.
     let buckets = if rounded == 0 {
         ptr::null_mut()
     } else {
@@ -57,18 +61,21 @@ pub extern "C" fn raven_set_new(bucket_count: u32) -> *mut Set {
             .checked_mul(std::mem::size_of::<SetEntry>())
             .unwrap_or(0);
         if bytes == 0 {
-            raven_dealloc(set_ptr as *mut u8, size_of_set(), align_of_set());
             return ptr::null_mut();
         }
         let p = raven_alloc(bytes, align_of::<SetEntry>());
         if p.is_null() {
-            raven_dealloc(set_ptr as *mut u8, size_of_set(), align_of_set());
             return ptr::null_mut();
         }
         // SAFETY: the allocator just gave us `bytes` writable bytes.
         unsafe { ptr::write_bytes(p, 0, bytes) };
         p as *mut SetEntry
     };
+    let set_ptr = raven_gc_alloc(size_of_set(), align_of_set(), TAG_SET) as *mut Set;
+    if set_ptr.is_null() {
+        free_bucket_buffer(buckets as *mut u8, rounded);
+        return ptr::null_mut();
+    }
     // SAFETY: set_ptr points to writable, correctly aligned storage.
     unsafe {
         ptr::write(
@@ -76,7 +83,8 @@ pub extern "C" fn raven_set_new(bucket_count: u32) -> *mut Set {
             Set {
                 header: ObjectHeader::new(TAG_SET, 0, rounded),
                 bucket_count: rounded,
-                _pad: 0,
+                elements_are_gc_ptrs,
+                _pad: [0; 3],
                 buckets,
             },
         );
@@ -123,6 +131,29 @@ pub(crate) const fn align_of_set() -> usize {
     }
 }
 
+/// Free a `Set`'s owned bucket buffer. The collector frees the object
+/// body separately after this call.
+///
+/// # Safety
+///
+/// `s` must point to a live `Set` produced by `raven_set_new`.
+pub(crate) unsafe fn free_buffers(s: *mut Set) {
+    // SAFETY: caller guarantees `s` is a live Set.
+    let bucket_count = unsafe { (*s).bucket_count };
+    let buckets = unsafe { (*s).buckets };
+    free_bucket_buffer(buckets as *mut u8, bucket_count);
+}
+
+/// Release a bucket buffer allocated by the constructor. Used to unwind
+/// a partly-built set when the body allocation fails.
+fn free_bucket_buffer(buckets: *mut u8, bucket_count: u32) {
+    if buckets.is_null() || bucket_count == 0 {
+        return;
+    }
+    let bytes = (bucket_count as usize) * std::mem::size_of::<SetEntry>();
+    raven_dealloc(buckets, bytes, align_of::<SetEntry>());
+}
+
 fn round_up_pow2(n: u32) -> u32 {
     if n == 0 {
         0
@@ -144,7 +175,8 @@ mod tests {
         assert_eq!(size_of::<Set>(), 32);
         assert_eq!(offset_of!(Set, header), 0);
         assert_eq!(offset_of!(Set, bucket_count), 16);
-        assert_eq!(offset_of!(Set, _pad), 20);
+        assert_eq!(offset_of!(Set, elements_are_gc_ptrs), 20);
+        assert_eq!(offset_of!(Set, _pad), 21);
         assert_eq!(offset_of!(Set, buckets), 24);
         assert!(align_of::<Set>() >= 8);
     }
@@ -160,7 +192,7 @@ mod tests {
 
     #[test]
     fn new_zero_buckets_leaves_buffer_null() {
-        let s = raven_set_new(0);
+        let s = raven_set_new(0, 0);
         assert!(!s.is_null());
         // SAFETY: s came from the constructor.
         unsafe {
@@ -168,14 +200,27 @@ mod tests {
             assert_eq!((*s).header.len, 0);
             assert_eq!((*s).header.cap, 0);
             assert_eq!((*s).bucket_count, 0);
+            assert_eq!((*s).elements_are_gc_ptrs, 0);
+            assert_eq!((*s)._pad, [0; 3]);
             assert!((*s).buckets.is_null());
         }
         unsafe { drop_set_for_test(s) };
     }
 
     #[test]
+    fn new_records_gc_ptr_flag() {
+        let s = raven_set_new(4, 1);
+        assert!(!s.is_null());
+        // SAFETY: s came from the constructor.
+        unsafe {
+            assert_eq!((*s).elements_are_gc_ptrs, 1);
+        }
+        unsafe { drop_set_for_test(s) };
+    }
+
+    #[test]
     fn new_rounds_up_to_power_of_two() {
-        let s = raven_set_new(9);
+        let s = raven_set_new(9, 0);
         assert!(!s.is_null());
         assert_eq!(raven_set_bucket_count(s), 16);
         unsafe { drop_set_for_test(s) };
@@ -183,7 +228,7 @@ mod tests {
 
     #[test]
     fn new_zero_fills_bucket_buffer() {
-        let s = raven_set_new(4);
+        let s = raven_set_new(4, 0);
         assert!(!s.is_null());
         let buckets = raven_set_buckets(s);
         assert!(!buckets.is_null());
@@ -204,22 +249,14 @@ mod tests {
         assert_eq!(raven_set_bucket_count(std::ptr::null()), 0);
     }
 
-    /// Test-only deallocator.
+    /// Test-only deallocator: unregister the object from the collector
+    /// and free its buffer and body.
     ///
     /// # Safety
     ///
     /// `s` must come from `raven_set_new` and not be freed yet.
     unsafe fn drop_set_for_test(s: *mut Set) {
-        if s.is_null() {
-            return;
-        }
         // SAFETY: matches construction layout.
-        let bucket_count = unsafe { (*s).bucket_count };
-        let buckets = unsafe { (*s).buckets };
-        if !buckets.is_null() && bucket_count > 0 {
-            let bytes = (bucket_count as usize) * std::mem::size_of::<SetEntry>();
-            raven_dealloc(buckets as *mut u8, bytes, align_of::<SetEntry>());
-        }
-        raven_dealloc(s as *mut u8, size_of_set(), align_of_set());
+        unsafe { crate::gc::free_for_test(s as *mut ObjectHeader) };
     }
 }

--- a/raven-runtime/src/object/string.rs
+++ b/raven-runtime/src/object/string.rs
@@ -4,6 +4,7 @@
 //! offsets the back-end relies on.
 
 use super::{ObjectHeader, OBJECT_ALIGN, TAG_STRING};
+use crate::gc::raven_gc_alloc;
 use crate::{raven_alloc, raven_dealloc};
 use std::mem::align_of;
 use std::ptr;
@@ -28,22 +29,26 @@ pub struct String {
 /// Returns null when the allocation fails.
 #[no_mangle]
 pub extern "C" fn raven_string_new(cap: u32) -> *mut String {
-    let header_ptr = raven_alloc(size_of_string(), align_of_string()) as *mut String;
-    if header_ptr.is_null() {
-        return ptr::null_mut();
-    }
+    // Allocate the owned byte buffer first so a body-allocation failure
+    // does not leave a half-registered object in the collector.
     let bytes_ptr = if cap == 0 {
         ptr::null_mut()
     } else {
         let p = raven_alloc(cap as usize, 1);
         if p.is_null() {
-            raven_dealloc(header_ptr as *mut u8, size_of_string(), align_of_string());
             return ptr::null_mut();
         }
         // SAFETY: the allocator just gave us `cap` writable bytes.
         unsafe { ptr::write_bytes(p, 0, cap as usize) };
         p
     };
+    let header_ptr = raven_gc_alloc(size_of_string(), align_of_string(), TAG_STRING) as *mut String;
+    if header_ptr.is_null() {
+        if !bytes_ptr.is_null() {
+            raven_dealloc(bytes_ptr, cap as usize, 1);
+        }
+        return ptr::null_mut();
+    }
     // SAFETY: header_ptr points to writable, correctly aligned storage.
     unsafe {
         ptr::write(
@@ -117,8 +122,7 @@ pub extern "C" fn raven_string_concat(a: *const String, b: *const String) -> *mu
 }
 
 /// Size, in bytes, of the in-memory `String` object on the host
-/// target. Used by constructors and by the GC's free routine in a
-/// follow-up.
+/// target. Used by constructors and by the collector's free routine.
 pub(crate) const fn size_of_string() -> usize {
     std::mem::size_of::<String>()
 }
@@ -130,6 +134,22 @@ pub(crate) const fn align_of_string() -> usize {
         a
     } else {
         OBJECT_ALIGN
+    }
+}
+
+/// Free a `String`'s owned byte buffer. The object body is freed by the
+/// collector after this call; this routine only releases the separate
+/// `bytes` allocation.
+///
+/// # Safety
+///
+/// `s` must point to a live `String` produced by `raven_string_new`.
+pub(crate) unsafe fn free_buffers(s: *mut String) {
+    // SAFETY: caller guarantees `s` is a live String.
+    let cap = unsafe { (*s).header.cap };
+    let bytes = unsafe { (*s).bytes };
+    if !bytes.is_null() && cap > 0 {
+        raven_dealloc(bytes, cap as usize, 1);
     }
 }
 
@@ -256,11 +276,7 @@ mod tests {
             return;
         }
         // SAFETY: matches the construction layout.
-        let cap = unsafe { (*s).header.cap };
-        let bytes = unsafe { (*s).bytes };
-        if !bytes.is_null() && cap > 0 {
-            raven_dealloc(bytes, cap as usize, 1);
-        }
+        unsafe { free_buffers(s) };
         raven_dealloc(s as *mut u8, size_of_string(), align_of_string());
     }
 }

--- a/raven-runtime/tests/gc.rs
+++ b/raven-runtime/tests/gc.rs
@@ -1,0 +1,155 @@
+//! Cross-crate integration tests for the tracing collector.
+//!
+//! These play the role the v2 code generator (issue #67) will play:
+//! they register roots on the shadow stack, allocate objects through the
+//! collector's constructors, force collections, and assert that
+//! reachable objects survive while unreachable ones (including cycles)
+//! are reclaimed. They run through the public C ABI surface only, so a
+//! failure here means an exported symbol regressed or the collector's
+//! observable behaviour changed.
+//!
+//! Every test runs on its own thread because the collector state is
+//! thread local: a fresh thread gives each test a clean heap, shadow
+//! stack, and counters.
+
+use raven_runtime::{
+    raven_box_new, raven_box_payload, raven_closure_captures, raven_closure_new, raven_gc_collect,
+    raven_gc_enter_frame, raven_gc_leave_frame, raven_gc_live_objects, raven_gc_pop_roots,
+    raven_gc_push_root, raven_list_new, raven_map_buckets, raven_map_new, raven_string_new,
+};
+
+/// Run a test body on a dedicated thread so the thread-local collector
+/// state starts empty.
+fn isolated(body: impl FnOnce() + Send + 'static) {
+    std::thread::spawn(body).join().unwrap();
+}
+
+extern "C" fn dummy_body() {}
+
+#[test]
+fn rooted_survives_unrooted_collected_cross_crate() {
+    isolated(|| {
+        let kept = raven_string_new(8);
+        let dropped = raven_string_new(8);
+        assert!(!kept.is_null() && !dropped.is_null());
+        assert_eq!(raven_gc_live_objects(), 2);
+
+        let mut slot: *mut u8 = kept as *mut u8;
+        raven_gc_push_root(&mut slot as *mut *mut u8);
+        let _ = dropped; // intentionally unrooted
+
+        raven_gc_collect();
+        // Only the rooted string survives.
+        assert_eq!(raven_gc_live_objects(), 1);
+
+        raven_gc_pop_roots(1);
+        raven_gc_collect();
+        assert_eq!(raven_gc_live_objects(), 0);
+    });
+}
+
+#[test]
+fn cycle_is_reclaimed_cross_crate() {
+    isolated(|| {
+        // Two single-slot pointer lists referencing each other, unrooted.
+        let a = raven_list_new(8, 8, 1, 1);
+        let b = raven_list_new(8, 8, 1, 1);
+        assert!(!a.is_null() && !b.is_null());
+        // SAFETY: each list has one pointer slot.
+        unsafe {
+            let a_slots = raven_runtime::raven_list_elements(a) as *mut *mut u8;
+            a_slots.write(b as *mut u8);
+            (*a).header.len = 1;
+            let b_slots = raven_runtime::raven_list_elements(b) as *mut *mut u8;
+            b_slots.write(a as *mut u8);
+            (*b).header.len = 1;
+        }
+        assert_eq!(raven_gc_live_objects(), 2);
+        // Mark-sweep reclaims the cycle that refcounting would leak.
+        raven_gc_collect();
+        assert_eq!(raven_gc_live_objects(), 0);
+    });
+}
+
+#[test]
+fn frame_api_roots_a_graph_cross_crate() {
+    isolated(|| {
+        // Build a graph: a map with one GC key and value, a closure with
+        // one GC capture, and a box wrapping a GC pointer, plus their
+        // leaf strings. Root the three containers through one frame and
+        // confirm the whole graph survives.
+        let map_key = raven_string_new(2);
+        let map_value = raven_string_new(2);
+        let map = raven_map_new(4, 1, 1);
+        // SAFETY: write one live entry into the first bucket.
+        unsafe {
+            let buckets = raven_map_buckets(map);
+            let e = &mut *buckets.add(0);
+            e.hash = 1;
+            e.key = map_key as *mut u8;
+            e.value = map_value as *mut u8;
+            (*map).header.len = 1;
+        }
+
+        let captured = raven_string_new(2);
+        let closure = raven_closure_new(dummy_body as *const u8, 8, 8, 1, 1);
+        // SAFETY: the capture buffer holds one pointer.
+        unsafe {
+            let caps = raven_closure_captures(closure) as *mut *mut u8;
+            caps.write(captured as *mut u8);
+        }
+
+        let boxed_inner = raven_string_new(2);
+        let boxed = raven_box_new(8, 8, 1);
+        // SAFETY: the payload holds one pointer.
+        unsafe {
+            let payload = raven_box_payload(boxed) as *mut *mut u8;
+            payload.write(boxed_inner as *mut u8);
+        }
+
+        // map, map_key, map_value, closure, captured, boxed, boxed_inner.
+        assert_eq!(raven_gc_live_objects(), 7);
+
+        let mut roots: [*mut u8; 3] = [map as *mut u8, closure as *mut u8, boxed as *mut u8];
+        raven_gc_enter_frame(roots.as_mut_ptr(), roots.len());
+        raven_gc_collect();
+        assert_eq!(raven_gc_live_objects(), 7);
+
+        raven_gc_leave_frame();
+        raven_gc_collect();
+        assert_eq!(raven_gc_live_objects(), 0);
+    });
+}
+
+#[test]
+fn bounded_liveness_stress_cross_crate() {
+    isolated(|| {
+        // Root a small working set, then churn many unrooted strings.
+        // Liveness must stay bounded and the working set must survive.
+        const WORKING_SET: usize = 8;
+        let mut roots: [*mut u8; WORKING_SET] = [std::ptr::null_mut(); WORKING_SET];
+        for r in roots.iter_mut() {
+            *r = raven_string_new(8) as *mut u8;
+        }
+        raven_gc_enter_frame(roots.as_mut_ptr(), WORKING_SET);
+
+        let mut peak = 0usize;
+        for i in 0..20_000usize {
+            let _garbage = raven_string_new(8);
+            if i % 128 == 0 {
+                raven_gc_collect();
+                peak = peak.max(raven_gc_live_objects());
+            }
+        }
+        raven_gc_collect();
+        assert_eq!(raven_gc_live_objects(), WORKING_SET);
+        assert!(
+            peak <= WORKING_SET + 128,
+            "liveness peaked at {peak}, expected bounded"
+        );
+
+        raven_gc_leave_frame();
+        raven_gc_collect();
+        assert_eq!(raven_gc_live_objects(), 0);
+    });
+}

--- a/raven-runtime/tests/object_layouts.rs
+++ b/raven-runtime/tests/object_layouts.rs
@@ -38,7 +38,7 @@ fn string_constructor_and_concat_cross_crate() {
 
 #[test]
 fn list_push_grows_cross_crate() {
-    let l = raven_list_new(8, 8, 0);
+    let l = raven_list_new(8, 8, 0, 0);
     assert!(!l.is_null());
     // SAFETY: l is a fresh List.
     unsafe {
@@ -59,7 +59,7 @@ fn list_push_grows_cross_crate() {
 
 #[test]
 fn map_constructor_cross_crate() {
-    let m = raven_map_new(10);
+    let m = raven_map_new(10, 0, 0);
     assert!(!m.is_null());
     // 10 rounds up to 16.
     assert_eq!(raven_map_bucket_count(m), 16);
@@ -83,7 +83,7 @@ fn map_constructor_cross_crate() {
 
 #[test]
 fn set_constructor_cross_crate() {
-    let s = raven_set_new(3);
+    let s = raven_set_new(3, 0);
     assert!(!s.is_null());
     // 3 rounds up to 4.
     assert_eq!(raven_set_bucket_count(s), 4);
@@ -109,7 +109,7 @@ extern "C" fn closure_body() {}
 #[test]
 fn closure_constructor_cross_crate() {
     let fp = closure_body as *const u8;
-    let c = raven_closure_new(fp, 16, 8, 2);
+    let c = raven_closure_new(fp, 16, 8, 2, 0);
     assert!(!c.is_null());
     // SAFETY: c is a fresh Closure with 16 capture bytes.
     unsafe {
@@ -131,7 +131,7 @@ fn closure_constructor_cross_crate() {
 
 #[test]
 fn box_constructor_cross_crate() {
-    let b = raven_box_new(8, 8);
+    let b = raven_box_new(8, 8, 0);
     assert!(!b.is_null());
     // SAFETY: b is a fresh Box with an 8-byte payload.
     unsafe {


### PR DESCRIPTION
## Summary

Add a stop-the-world, single-threaded, tracing mark-and-sweep garbage collector to `raven-runtime`, plus the precise shadow-stack root-tracking ABI that the code generator (#67) will target.

Closes #64.

## Design

See `docs/v2/specs/gc.md` for the full design. Highlights:

- **Shadow-stack roots.** Codegen registers a frame's array of stack-slot addresses with `raven_gc_enter_frame(roots, count)` and unregisters it with `raven_gc_leave_frame()`, in strict last-in-first-out order. A per-slot `raven_gc_push_root(slot)` / `raven_gc_pop_roots(n)` pair shares the same stack for hand-written code and single temporaries. Slots hold the address of the local (`*mut *mut u8`), so the collector reads the live pointer at collection time.
- **Bookkeeping.** A side-table all-objects list (`Vec<*mut ObjectHeader>`) keeps the 16-byte header unchanged (no intrusive `next` word). The mark bit lives in the reserved `gc_bits` field (`GC_MARK_BIT`, bit 0).
- **Allocation.** Object bodies go through `raven_gc_alloc(size, align, tag)`, which collects before crossing an adaptive threshold (1 MiB floor, reset to twice the surviving live bytes after each cycle), then registers and meters the object. Owned buffers (string bytes, list elements, map and set buckets, closure captures) stay plain `raven_alloc` allocations freed with their object during sweep, never separately collected.
- **Marking.** Iterative tracing (explicit work stack) from every root, dispatching on `tag` and following the offsets pinned in `docs/v2/specs/object-layout.md`. Cycles are reclaimed.
- **Sweeping.** Unmarked objects are freed (buffers first, then body, derived from the tag); survivors have their mark bit cleared for the next cycle.
- **State assumption.** The collector state is `thread_local`, matching the single-threaded v2.0 runtime; sharing GC objects across threads is undefined.

## Shadow-stack root ABI (what #67 targets)

```rust
pub extern "C" fn raven_gc_enter_frame(roots: *mut *mut u8, count: usize);
pub extern "C" fn raven_gc_leave_frame();
pub extern "C" fn raven_gc_push_root(slot: *mut *mut u8);
pub extern "C" fn raven_gc_pop_roots(n: usize);
pub extern "C" fn raven_gc_alloc(size: usize, align: usize, tag: u32) -> *mut u8;
pub extern "C" fn raven_gc_collect();
pub extern "C" fn raven_gc_live_objects() -> usize;
pub extern "C" fn raven_gc_bytes_allocated() -> usize;
```

## Layout changes for precise tracing

The collector cannot tell a pointer from an integer in an 8-byte slot, so the collection layouts carry codegen-set pointer-kind flags (documented and offset-tested in `docs/v2/specs/object-layout.md`):

- `List.elements_are_gc_ptrs` (List grows to 40 bytes).
- `Map.keys_are_gc_ptrs` and `Map.values_are_gc_ptrs` (reuse reserved padding; stays 32 bytes).
- `Set.elements_are_gc_ptrs` (reuses reserved padding; stays 32 bytes).
- `Closure.capture_ptr_count`, the number of leading GC-pointer capture slots (Closure grows to 48 bytes).
- `Box.payload_is_gc_ptr` (inline payload moves to offset 24).

Constructors gain the corresponding parameters.

## Tested

- Reachability: rooted and transitively-reachable objects survive; unrooted objects are freed.
- Cycle reclamation: mutually-referencing unrooted objects are both collected.
- Per-layout tracing: a `List` of GC pointers, a `Map` with GC keys and values, a `Set` of GC elements, a `Closure` with a GC capture, and a `Box` wrapping a GC pointer all mark every reachable object; scalar list elements are not traced.
- Bounded liveness: churning many unrooted objects against a bounded rooted working set keeps `live_objects` bounded (counter asserted, not flaky OS memory).
- Threshold trigger: allocating past the threshold collects automatically.
- Frame nesting: enter and leave register and unregister roots last-in-first-out.

Inline unit tests in `raven-runtime/src/gc.rs` and a cross-crate integration test in `raven-runtime/tests/gc.rs`.

## Deferred

- Codegen emission of root frames (#67). This PR defines and documents the ABI and ships a Rust-side harness that plays codegen's role.
- Cranelift stack maps, generational and incremental collection, moving or compacting collection, multi-threaded collection.

## Test plan

- [ ] `cargo build`
- [ ] `cargo test` (247 raven lib + runtime + golden suites)
- [ ] `cargo test -p raven-runtime` (67 lib + 3 abi + 4 gc + 6 object_layouts)
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets`
