### PR TITLE
feat(codegen): dyn Trait objects with vtable dispatch

### DIFF
--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -375,9 +375,11 @@ that only consult MIR lowering do not depend on a linker.
 
 ## Out of scope (tracked by follow up issues)
 
-* Trait object (`dyn Trait`) dispatch through vtables (issue #66). Static
-  trait method calls are already monomorphized by MIR into direct calls
-  and work today.
+* ~~Trait object (`dyn Trait`) dispatch through vtables (issue #66).~~
+  Implemented: a trait object is a boxed fat pointer, vtables are emitted
+  as read-only data, and a `dyn` method call dispatches through the
+  vtable. See `docs/v2/specs/dyn-trait.md`. Static trait method calls are
+  monomorphized by MIR into direct calls.
 * Calling closure values and capturing closures (lambda body lifting and
   capture analysis); non-capturing closure allocation is supported.
 * `defer` ordering and runtime hooks (issue #68).

--- a/docs/v2/specs/dyn-trait.md
+++ b/docs/v2/specs/dyn-trait.md
@@ -1,0 +1,189 @@
+# dyn Trait Spec
+
+## Goal
+
+Specify `dyn Trait` trait objects with vtable-based dynamic dispatch.
+A trait object lets a value of any concrete type that implements a trait
+be used through a single uniform handle, with the method called resolved
+at run time from a per-type method table (the vtable). This is the
+dynamic counterpart to the static, monomorphized trait method calls that
+the compiler already lowers to direct calls.
+
+The covered surface is: the `dyn Trait` type, unsizing coercions at
+assignment, argument passing, and return, vtable emission, virtual
+dispatch, an object-safety check, and the garbage collector interaction.
+See the out-of-scope section for what is deferred.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> Resolver -> Tycheck -> HIR -> MIR -> Codegen
+```
+
+* The parser already accepts `dyn TraitPath` as a type (`TypeKind::Dyn`).
+* The type checker resolves it to `Ty::Dyn`, records coercions, and
+  validates object safety.
+* HIR materializes each recorded coercion as a `DynCoerce` node.
+* MIR lowers coercions and virtual calls to dedicated rvalues.
+* Codegen emits vtables and the fat pointer construction and dispatch.
+
+## Type representation
+
+`Ty::Dyn { name, methods }` is a first-class type. `name` is the trait's
+short name; `methods` is the trait's method names in declaration order.
+Carrying the method order in the type fixes the vtable slot order once,
+so every later pass picks the same slot for a method without re-reading
+the trait declaration. `MirType::Dyn` mirrors the same shape.
+
+A trait declaration is treated as a `Self`-bearing context by the
+resolver, so trait methods may take a `self` receiver and reference
+`Self` exactly like an `impl` block.
+
+## Fat pointer representation
+
+A `dyn Trait` value is a fat pointer with two pointer-width words: the
+data word (the erased concrete value) and the vtable word (a pointer to
+the static method table). Rather than pass these as two registers or two
+stack slots, the back end boxes them as a small heap object: a two-slot
+struct value `{ data, vtable }`.
+
+```
+slot 0  data    the erased concrete value (a GC pointer)
+slot 1  vtable  address of the (concrete_type, trait) vtable (static)
+```
+
+The box reuses the standard struct value layout (a 16-byte object header
+followed by 8-byte slots), so the trait object value is a single GC
+pointer. This choice keeps every other part of the back end unchanged:
+the value flows through one-word locals, one-word function parameters and
+returns, and one-word collection elements without any special handling.
+The cost is one extra allocation and one extra indirection per coercion,
+which is acceptable for the first implementation. A future revision may
+pass the two words unboxed once the calling convention and stack slot
+machinery grow two-word value support.
+
+## Vtable layout and emission
+
+For each `(concrete_type, trait)` pair that is coerced to `dyn Trait`,
+the back end emits one vtable as a read-only data object in the object
+file. The vtable is an array of pointer-width slots, one per trait
+method, in the trait's declaration order. Slot `i` holds the address of
+the concrete type's implementation of the trait's `i`-th method.
+
+```
+vtable for (Dog, Speak):
+  slot 0  &Dog$sound
+  ...
+```
+
+Each slot is filled with a function-address relocation against the
+method's symbol, so the linker patches the final address. Vtables are
+interned by the key `<concrete_type_mangle>$<trait>`, so one pair shares
+a single vtable across every coercion site. No size, align, or drop slot
+is included: the collector owns memory reclamation, so a destructor slot
+is unnecessary for now.
+
+Method symbols are per-type. An impl method `sound` on `Dog` has the
+symbol `Dog$sound`. This per-type mangling is what lets several types
+implement a method of the same name without colliding at the object
+level, and it is the same symbol a static call site computes from its
+receiver type.
+
+## Coercion sites and where they are inserted
+
+A `dyn Trait` value is created by an unsizing coercion: a concrete value
+whose type implements the trait is used where `dyn Trait` is expected.
+The supported sites are:
+
+* assignment with an annotation: `let d: dyn Speak = some_dog`
+* argument passing: `describe(some_dog)` where the parameter is
+  `dyn Speak`
+* return: a function with return type `dyn Speak` returning a concrete
+  value
+
+The type checker drives coercion insertion. Every one of these sites
+funnels through a single `unify(expected, actual, span)` call. Before
+reporting a mismatch, `unify` checks whether `expected` is a `Ty::Dyn`
+and `actual` is a concrete struct or enum that implements the trait. When
+it is, the checker records a `DynCoercion { trait_name, methods,
+concrete_ty }` keyed by the coerced expression's span and reports
+success. A concrete type that does not implement the trait still reports
+a mismatch.
+
+HIR lowering reads the recorded coercion at each expression's span and
+wraps the lowered value in a `DynCoerce` node whose type is the trait
+object type. MIR lowers that node to a `DynCoerce` rvalue, and codegen
+materializes the box. Keeping the decision in the type checker (which
+already has both the expected type and the trait impl environment) and
+the materialization in the back end keeps each pass focused.
+
+## Dispatch lowering
+
+A method call on a `dyn Trait` receiver is virtual dispatch. The type
+checker resolves the call against the trait's method signatures (the
+method must belong to the trait) and yields the method's return type. MIR
+lowers it to a `VirtualCall` rvalue carrying the receiver, the method's
+vtable slot index (its position in the trait method order), the
+non-receiver argument operands, and the call signature shape.
+
+Codegen lowers a `VirtualCall` by:
+
+1. loading the data word (slot 0) and vtable word (slot 1) from the
+   receiver box,
+2. loading the method pointer from the vtable at the method's slot,
+3. building the indirect call signature: the data pointer as the
+   receiver, followed by the declared parameters, returning the method's
+   return type,
+4. emitting an indirect call to the loaded method pointer with the data
+   word as the first argument.
+
+A static method call on a concrete receiver stays a direct call, now to
+the per-type symbol `<RecvType>$<method>` so multiple impls of a
+same-named method resolve to distinct functions.
+
+## Object safety
+
+`dyn Trait` is allowed only for an object-safe trait. A trait is
+object-safe in this subset when:
+
+* no method is generic (has its own type parameters), and
+* no method takes `Self` by value in a non-receiver parameter position.
+
+The receiver `self` is always allowed. A `dyn` of a non-object-safe trait
+is a type error with a hint to use a generic bound (`<T: Trait>`) instead.
+This is a good-faith subset: associated types, `Self` return positions
+beyond the receiver, and richer rules are not modeled yet.
+
+## GC interaction
+
+The data word is the only GC-managed word in the fat pointer. The box's
+descriptor marks slot 0 (data) as a GC pointer and leaves slot 1 (vtable)
+unmarked, because the vtable is a static read-only address, not a heap
+object. The descriptor is keyed by the trait object's mangled name
+(`dyn_<trait>`), so every coercion to the same `dyn Trait` shares it.
+
+Because the trait object value is a single GC pointer to the box, the
+existing root frame logic covers it with no special case: a `dyn Trait`
+local is classified as a GC pointer, rooted in the shadow stack like any
+heap value, and a collection traces the box, which in turn traces the
+data word. The data word is therefore reachable as a transitive root for
+as long as the trait object local is live. See `docs/v2/specs/gc.md` and
+the GC root frame section of `docs/v2/specs/codegen.md`.
+
+## Out of scope
+
+* Trait upcasting (`dyn Sub` to `dyn Super`).
+* `dyn` with generic methods: such methods are not object-safe and are
+  rejected with a clear error.
+* Associated types in trait objects.
+* Auto-trait bounds (`dyn Trait + Send`).
+* Heterogeneous `List<dyn Trait>` as a runnable showcase. The fat pointer
+  is a single GC pointer, so it fits the existing one-word collection
+  storage, but two pieces are missing: the type checker does not yet push
+  an expected `dyn` element type down to each array element to coerce it,
+  and the `List` element access methods (`get`, `push`) are themselves
+  deferred to the stdlib collection issues. A trait object stored in a
+  list would box correctly today; building and reading such a list end to
+  end lands with those issues.
+```
+

--- a/examples/v2/dyn_dispatch.rv
+++ b/examples/v2/dyn_dispatch.rv
@@ -1,0 +1,26 @@
+// Dynamic dispatch through `dyn Trait`. Each concrete type implements
+// the trait; passing it where `dyn Speak` is expected boxes it as a fat
+// pointer, and the call dispatches through the vtable. Prints 1 then 2.
+trait Speak {
+    fun sound(self) -> Int
+}
+
+struct Dog {}
+struct Cat {}
+
+impl Speak for Dog {
+    fun sound(self) -> Int = 1
+}
+
+impl Speak for Cat {
+    fun sound(self) -> Int = 2
+}
+
+fun describe(s: dyn Speak) -> Int = s.sound()
+
+fun main() {
+    let d = Dog {}
+    let c = Cat {}
+    print_int(describe(d))
+    print_int(describe(c))
+}

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -56,6 +56,13 @@ pub struct ModuleCx {
     descriptors: HashMap<String, StructDescriptor>,
     /// Counter handing out the next struct descriptor id.
     next_type_id: u32,
+    /// Emitted vtables keyed by `<concrete_type>$<trait>`. Each value is
+    /// the read-only data symbol holding the method pointer slots in the
+    /// trait's declaration order. Interned so one `(type, trait)` pair
+    /// shares a single vtable across every coercion site.
+    vtables: HashMap<String, DataId>,
+    /// Counter handing out unique vtable data symbol names.
+    vtable_counter: u32,
 }
 
 /// The exported `main` shim plus the Raven `main` it dispatches to.
@@ -85,7 +92,55 @@ impl ModuleCx {
             main_entry: None,
             descriptors: HashMap::new(),
             next_type_id: 0,
+            vtables: HashMap::new(),
+            vtable_counter: 0,
         }
+    }
+
+    /// Intern and emit the vtable for a `(concrete_type, trait)` pair.
+    ///
+    /// `key` is the stable identity `<concrete_type_mangle>$<trait>`.
+    /// `method_symbols` is the list of method symbols (the concrete
+    /// type's implementations) in the trait's declaration order, which is
+    /// the vtable's slot order. The first call emits a read-only data
+    /// object with one pointer-sized slot per method, each carrying a
+    /// relocation to the method symbol; later calls return the same id.
+    ///
+    /// Method symbols must already be declared as functions (they are,
+    /// because every reachable impl method is in the function table).
+    pub fn intern_vtable(
+        &mut self,
+        key: &str,
+        method_symbols: &[String],
+    ) -> Result<DataId, CodegenError> {
+        if let Some(id) = self.vtables.get(key) {
+            return Ok(*id);
+        }
+        let ptr_bytes = self.pointer_type().bytes() as usize;
+        let name = format!("__raven_vtable_{}", self.vtable_counter);
+        self.vtable_counter += 1;
+        let data_id = self
+            .module
+            .declare_data(&name, Linkage::Local, false, false)?;
+
+        let mut desc = DataDescription::new();
+        // A zeroed buffer of N pointer slots; each slot's bits are filled
+        // by a function-address relocation written below.
+        let total = ptr_bytes * method_symbols.len().max(1);
+        desc.define(vec![0u8; total].into_boxed_slice());
+        for (i, sym) in method_symbols.iter().enumerate() {
+            let func_id = self.function_id(sym).ok_or_else(|| {
+                CodegenError::Unsupported(format!(
+                    "vtable slot {} references undefined method symbol `{}`",
+                    i, sym
+                ))
+            })?;
+            let func_ref = self.module.declare_func_in_data(func_id, &mut desc);
+            desc.write_function_addr((i * ptr_bytes) as u32, func_ref);
+        }
+        self.module.define_data(data_id, &desc)?;
+        self.vtables.insert(key.to_string(), data_id);
+        Ok(data_id)
     }
 
     /// Return the descriptor id for an aggregate type, assigning a fresh

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -44,7 +44,10 @@ pub fn cranelift_ty(ty: &MirType, ptr: CType) -> Option<CType> {
         | MirType::Option(_)
         | MirType::Result(_, _)
         | MirType::List(_)
-        | MirType::Function { .. } => Some(ptr),
+        | MirType::Function { .. }
+        // A `dyn Trait` value is a single GC pointer to a boxed fat
+        // pointer `{ data, vtable }`; see the heap layout note below.
+        | MirType::Dyn { .. } => Some(ptr),
     }
 }
 

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -324,6 +324,19 @@ fn lower_rvalue(
         MirRvalue::ClosureCreate { fn_name, captures } => {
             lower_closure_create(cx, builder, fn_name, captures, slots)
         }
+        MirRvalue::DynCoerce {
+            value,
+            concrete_ty,
+            trait_name,
+            methods,
+        } => lower_dyn_coerce(cx, builder, value, concrete_ty, trait_name, methods, slots),
+        MirRvalue::VirtualCall {
+            receiver,
+            slot,
+            args,
+            param_tys,
+            ret_ty,
+        } => lower_virtual_call(cx, builder, receiver, *slot, args, param_tys, ret_ty, slots),
         MirRvalue::IndexAccess { .. } | MirRvalue::ArrayLit { .. } => {
             Err(CodegenError::Unsupported(format!(
                 "rvalue not supported in MVP backend: {:?}",
@@ -346,6 +359,8 @@ fn rvalue_kind(r: &MirRvalue) -> &'static str {
         MirRvalue::ArrayLit { .. } => "ArrayLit",
         MirRvalue::Cast { .. } => "Cast",
         MirRvalue::ClosureCreate { .. } => "ClosureCreate",
+        MirRvalue::DynCoerce { .. } => "DynCoerce",
+        MirRvalue::VirtualCall { .. } => "VirtualCall",
     }
 }
 
@@ -724,6 +739,124 @@ fn lower_closure_create(
     let inst = builder
         .ins()
         .call(new_ref, &[fn_ptr, zero32, zero32, zero32, zero32]);
+    Ok(builder.inst_results(inst).first().copied())
+}
+
+/// Lower a `dyn Trait` unsizing coercion.
+///
+/// A trait object is a single GC pointer to a boxed two-slot fat pointer
+/// `{ data, vtable }`. This allocates the box through the struct value
+/// constructor (so the GC traces it like any aggregate), stores the
+/// concrete value in slot 0 (a traced pointer), and the address of the
+/// `(concrete_type, trait)` vtable in slot 1 (a static pointer). The
+/// box's descriptor marks only slot 0 as a GC pointer, so the collector
+/// follows the data word and leaves the static vtable word alone.
+#[allow(clippy::too_many_arguments)]
+fn lower_dyn_coerce(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    value: &MirOperand,
+    concrete_ty: &MirType,
+    trait_name: &str,
+    methods: &[String],
+    slots: &[LocalSlot],
+) -> Result<RValue, CodegenError> {
+    let ptr = cx.pointer_type();
+
+    // Evaluate the concrete data value first; it is a GC pointer (every
+    // struct or enum the front end coerces is a heap value).
+    let data = require_value(
+        lower_operand(cx, builder, value, slots)?,
+        "dyn coerce value",
+    )?;
+    let data = widen_to_slot(builder, Some(data), ptr);
+
+    // Build the vtable for this (concrete_type, trait) pair. The method
+    // symbols are the concrete type's implementations, in trait order.
+    let vtable_key = format!("{}${}", concrete_ty.mangle(), trait_name);
+    let method_symbols: Vec<String> = methods
+        .iter()
+        .map(|m| concrete_ty.method_symbol(m))
+        .collect();
+    let vtable_id = cx.intern_vtable(&vtable_key, &method_symbols)?;
+    let vtable_ref = cx.module().declare_data_in_func(vtable_id, builder.func);
+    let vtable_ptr = builder.ins().symbol_value(ptr, vtable_ref);
+
+    // The box is a two-slot struct value: slot 0 = data (GC pointer),
+    // slot 1 = vtable (static). The descriptor marks only slot 0, keyed
+    // by the trait object's mangled name so every coercion to the same
+    // `dyn Trait` shares the descriptor.
+    let box_key = format!("dyn_{}", trait_name);
+    let type_id = cx.intern_descriptor(&box_key, 0b01);
+    let obj = call_struct_new(cx, builder, 2, type_id, ptr);
+    let base = call_struct_fields(cx, builder, obj, ptr);
+    builder
+        .ins()
+        .store(MemFlags::new(), data, base, layout::slot_offset(0));
+    builder
+        .ins()
+        .store(MemFlags::new(), vtable_ptr, base, layout::slot_offset(1));
+    Ok(Some(obj))
+}
+
+/// Lower a virtual call through a `dyn Trait` receiver.
+///
+/// Loads the data and vtable words from the receiver's fat pointer box,
+/// loads the method pointer at `slot` from the vtable, and emits an
+/// indirect call with the data word as the receiver plus the arguments.
+#[allow(clippy::too_many_arguments)]
+fn lower_virtual_call(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    receiver: &MirOperand,
+    slot: usize,
+    args: &[MirOperand],
+    param_tys: &[MirType],
+    ret_ty: &MirType,
+    slots: &[LocalSlot],
+) -> Result<RValue, CodegenError> {
+    let ptr = cx.pointer_type();
+    let box_ptr = require_value(
+        lower_operand(cx, builder, receiver, slots)?,
+        "virtual call receiver",
+    )?;
+    let base = call_struct_fields(cx, builder, box_ptr, ptr);
+    // Slot 0: the data pointer (the erased receiver). Slot 1: the vtable.
+    let data = builder
+        .ins()
+        .load(ptr, MemFlags::new(), base, layout::slot_offset(0));
+    let vtable = builder
+        .ins()
+        .load(ptr, MemFlags::new(), base, layout::slot_offset(1));
+    // Load the method pointer from the vtable's slot.
+    let method_ptr = builder.ins().load(
+        ptr,
+        MemFlags::new(),
+        vtable,
+        (slot as i32) * (ptr.bytes() as i32),
+    );
+
+    // Build the indirect call signature: the receiver (a pointer) plus
+    // each non-receiver parameter, returning the method's return type.
+    let mut sig = Signature::new(cx.module().target_config().default_call_conv);
+    sig.params.push(cranelift_codegen::ir::AbiParam::new(ptr));
+    for pt in param_tys {
+        if let Some(t) = cranelift_ty(pt, ptr) {
+            sig.params.push(cranelift_codegen::ir::AbiParam::new(t));
+        }
+    }
+    if let Some(t) = cranelift_ty(ret_ty, ptr) {
+        sig.returns.push(cranelift_codegen::ir::AbiParam::new(t));
+    }
+    let sig_ref = builder.import_signature(sig);
+
+    let mut call_args = vec![data];
+    for a in args {
+        if let Some(v) = lower_operand(cx, builder, a, slots)? {
+            call_args.push(v);
+        }
+    }
+    let inst = builder.ins().call_indirect(sig_ref, method_ptr, &call_args);
     Ok(builder.inst_results(inst).first().copied())
 }
 

--- a/src/codegen/layout.rs
+++ b/src/codegen/layout.rs
@@ -50,6 +50,10 @@ pub fn is_gc_pointer(ty: &MirType) -> bool {
             | MirType::Result(_, _)
             | MirType::List(_)
             | MirType::Function { .. }
+            // A `dyn Trait` value is a single GC pointer to its boxed fat
+            // pointer; the collector traces the box, which in turn traces
+            // the data word it holds.
+            | MirType::Dyn { .. }
     )
 }
 

--- a/src/hir/decl.rs
+++ b/src/hir/decl.rs
@@ -6,6 +6,7 @@
 //! stay tied to the resolver output and pass through as a passive list.
 
 use crate::span::Span;
+use crate::tycheck::Ty;
 
 use super::expr::{HirBlock, HirExpr};
 use super::ty::HirTy;
@@ -93,6 +94,9 @@ pub struct HirTrait {
 pub struct HirImpl {
     /// The implementing type's source-level name (for diagnostics).
     pub self_name: String,
+    /// The resolved implementing type. The MIR pass mangles it to build
+    /// each method's symbol so per-type methods get unique names.
+    pub self_ty: Ty,
     /// `Some(trait_name)` for a trait impl, `None` for an inherent impl.
     pub trait_name: Option<String>,
     pub methods: Vec<HirFn>,

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -208,4 +208,18 @@ pub enum HirExprKind {
         ret: HirTy,
         body: HirBlock,
     },
+
+    /// Unsize a concrete value to a `dyn Trait` value. Synthesized by HIR
+    /// lowering at each coercion site the type checker recorded. The
+    /// inner expression's type is the concrete type; this node's type is
+    /// the `dyn Trait` target.
+    DynCoerce {
+        value: Box<HirExpr>,
+        /// The target trait's short name.
+        trait_name: String,
+        /// The trait's method names in declaration order (vtable slots).
+        methods: Vec<String>,
+        /// The concrete source type being coerced.
+        concrete_ty: HirTy,
+    },
 }

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -291,7 +291,28 @@ pub(crate) fn lower_expr(
             }
         }
     };
-    Ok(HirExpr { kind, ty, span })
+    let inner = HirExpr { kind, ty, span };
+    // If the type checker recorded a `dyn Trait` coercion at this site,
+    // wrap the concrete value in a `DynCoerce` node so MIR materializes
+    // the fat pointer. The wrapper's type is the trait object type.
+    if let Some(c) = cx.typed.types.lookup_coercion(&inner.span) {
+        let dyn_ty = Ty::Dyn {
+            name: c.trait_name.clone(),
+            methods: c.methods.clone(),
+        };
+        let coerce_span = inner.span.clone();
+        return Ok(HirExpr {
+            kind: HirExprKind::DynCoerce {
+                trait_name: c.trait_name.clone(),
+                methods: c.methods.clone(),
+                concrete_ty: c.concrete_ty.clone(),
+                value: Box::new(inner),
+            },
+            ty: dyn_ty,
+            span: coerce_span,
+        });
+    }
+    Ok(inner)
 }
 
 fn lower_unop(op: UnaryOp) -> HirUnaryOp {

--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -149,9 +149,14 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
             }))
         }
         DeclKind::Trait(t) => {
+            // A trait method's `Self` is abstract. The trait's HIR body is
+            // never lowered to MIR (only concrete impl methods are), so a
+            // placeholder `Self` type lets `self` receivers and any `Self`
+            // annotations resolve without a concrete implementing type.
+            let abstract_self = Ty::Error;
             let mut methods = Vec::with_capacity(t.members.len());
             for m in &t.members {
-                methods.push(lower_function(m, None, &t.generics, cx)?);
+                methods.push(lower_function(m, Some(&abstract_self), &t.generics, cx)?);
             }
             Ok(Some(HirItem {
                 span: decl.span.clone(),
@@ -177,6 +182,7 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
                 span: decl.span.clone(),
                 kind: HirItemKind::Impl(HirImpl {
                     self_name,
+                    self_ty,
                     trait_name,
                     methods,
                     span: i.span.clone(),

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -449,6 +449,22 @@ fn pretty_expr(buf: &mut String, expr: &HirExpr, depth: usize) {
             indent(buf, depth);
             buf.push_str(")\n");
         }
+        HirExprKind::DynCoerce {
+            trait_name,
+            value,
+            concrete_ty,
+            ..
+        } => {
+            writeln!(
+                buf,
+                "(dyn-coerce trait={} from={} ty={}",
+                trait_name, concrete_ty, expr.ty
+            )
+            .unwrap();
+            pretty_expr(buf, value, depth + 1);
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
     }
 }
 

--- a/src/mir/ir.rs
+++ b/src/mir/ir.rs
@@ -125,6 +125,35 @@ pub enum MirRvalue {
         fn_name: String,
         captures: Vec<MirOperand>,
     },
+    /// Unsize a concrete value to a `dyn Trait` value. The back end
+    /// allocates a two-slot fat pointer `{ data, vtable }`: slot 0 holds
+    /// the concrete value (`value`), slot 1 holds the address of the
+    /// `(concrete_type, trait)` vtable. The result is a single GC pointer.
+    DynCoerce {
+        value: MirOperand,
+        /// The concrete source type, used to pick and emit the vtable.
+        concrete_ty: MirType,
+        /// The target trait's short name.
+        trait_name: String,
+        /// The trait's method names in declaration order (vtable slots).
+        methods: Vec<String>,
+    },
+    /// Dynamic dispatch through a `dyn Trait` value. The back end loads
+    /// the data and vtable words from the receiver's fat pointer box,
+    /// loads the method pointer at `slot` from the vtable, and indirect
+    /// calls it with the data word as the receiver plus `args`.
+    VirtualCall {
+        receiver: MirOperand,
+        /// The dispatched method's vtable slot index (trait method order).
+        slot: usize,
+        /// The remaining (non-receiver) arguments.
+        args: Vec<MirOperand>,
+        /// Cranelift signature shape: the non-receiver parameter types
+        /// and the return type, so the back end can build the indirect
+        /// call signature.
+        param_tys: Vec<MirType>,
+        ret_ty: MirType,
+    },
 }
 
 /// One statement inside a basic block.

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -85,22 +85,24 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             receiver,
             name,
             args,
+        } => lower_method_call(cx, receiver, name, args, ty),
+        HirExprKind::DynCoerce {
+            value,
+            trait_name,
+            methods,
+            concrete_ty,
         } => {
-            let recv = lower_expr(cx, receiver);
-            let mut arg_ops = vec![recv];
-            for a in args {
-                arg_ops.push(lower_expr(cx, a));
-            }
-            let dst = cx.builder.fresh_temp("mcall", ty);
+            let v = lower_expr(cx, value);
+            let concrete = mir_ty(concrete_ty, cx.subst);
+            let dst = cx.builder.fresh_temp("dyn", ty);
             cx.builder.assign(
                 cx.current,
                 dst,
-                MirRvalue::Call {
-                    callee: MirFnRef {
-                        mangled: name.clone(),
-                        origin: None,
-                    },
-                    args: arg_ops,
+                MirRvalue::DynCoerce {
+                    value: v,
+                    concrete_ty: concrete,
+                    trait_name: trait_name.clone(),
+                    methods: methods.clone(),
                 },
             );
             MirOperand::Copy(dst)
@@ -144,6 +146,7 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             // so subsequent statements still have a target.
             let dead = cx.builder.new_block();
             cx.current = dead;
+            cx.diverged = true;
             MirOperand::Const(MirConstant::Unit)
         }
         HirExprKind::Break(value) => {
@@ -163,6 +166,7 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             }
             let dead = cx.builder.new_block();
             cx.current = dead;
+            cx.diverged = true;
             MirOperand::Const(MirConstant::Unit)
         }
         HirExprKind::Continue => {
@@ -177,6 +181,7 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             }
             let dead = cx.builder.new_block();
             cx.current = dead;
+            cx.diverged = true;
             MirOperand::Const(MirConstant::Unit)
         }
         HirExprKind::Interpolate(parts) => lower_interpolate(cx, parts, ty),
@@ -330,6 +335,8 @@ fn lower_if(
     }
 
     cx.current = cont_bb;
+    // The merge block is reachable even if one branch diverged.
+    cx.diverged = false;
     MirOperand::Copy(result)
 }
 
@@ -361,6 +368,7 @@ fn lower_loop(cx: &mut LowerCx<'_>, body: &HirBlock, ty: MirType) -> MirOperand 
     cx.loops.pop();
 
     cx.current = cont;
+    cx.diverged = false;
     MirOperand::Copy(result)
 }
 
@@ -399,6 +407,7 @@ fn lower_while(cx: &mut LowerCx<'_>, cond: &HirExpr, body: &HirBlock, _ty: MirTy
     cx.loops.pop();
 
     cx.current = cont;
+    cx.diverged = false;
     MirOperand::Const(MirConstant::Unit)
 }
 
@@ -527,6 +536,66 @@ fn call_ref_from_callee(_cx: &mut LowerCx<'_>, callee: &HirExpr) -> MirFnRef {
             origin: None,
         },
     }
+}
+
+/// Lower a method call. A concrete receiver dispatches statically to the
+/// per-type method symbol `<RecvType>$<method>`. A `dyn Trait` receiver
+/// dispatches virtually through the receiver's vtable.
+fn lower_method_call(
+    cx: &mut LowerCx<'_>,
+    receiver: &HirExpr,
+    name: &str,
+    args: &[HirExpr],
+    ty: MirType,
+) -> MirOperand {
+    let recv_ty = mir_ty(&receiver.ty, cx.subst);
+    if let MirType::Dyn { methods, .. } = &recv_ty {
+        // Virtual dispatch: the slot index is the method's position in the
+        // trait's declaration order, which the dyn type carries.
+        let slot = methods.iter().position(|m| m == name).unwrap_or(0);
+        let recv = lower_expr(cx, receiver);
+        let mut arg_ops = Vec::with_capacity(args.len());
+        let mut param_tys = Vec::with_capacity(args.len());
+        for a in args {
+            param_tys.push(mir_ty(&a.ty, cx.subst));
+            arg_ops.push(lower_expr(cx, a));
+        }
+        let dst = cx.builder.fresh_temp("vcall", ty.clone());
+        cx.builder.assign(
+            cx.current,
+            dst,
+            MirRvalue::VirtualCall {
+                receiver: recv,
+                slot,
+                args: arg_ops,
+                param_tys,
+                ret_ty: ty,
+            },
+        );
+        return MirOperand::Copy(dst);
+    }
+
+    // Static dispatch: build the per-type method symbol from the receiver
+    // type so it matches the impl method's definition symbol.
+    let symbol = recv_ty.method_symbol(name);
+    let recv = lower_expr(cx, receiver);
+    let mut arg_ops = vec![recv];
+    for a in args {
+        arg_ops.push(lower_expr(cx, a));
+    }
+    let dst = cx.builder.fresh_temp("mcall", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::Call {
+            callee: MirFnRef {
+                mangled: symbol,
+                origin: None,
+            },
+            args: arg_ops,
+        },
+    );
+    MirOperand::Copy(dst)
 }
 
 /// Resolve a field's slot index from the receiver's struct type and the

--- a/src/mir/lower/mod.rs
+++ b/src/mir/lower/mod.rs
@@ -61,6 +61,12 @@ pub struct LowerCx<'a> {
     pub pending_calls: Vec<(DeclId, Vec<Ty>)>,
     /// Struct and enum declaration tables for field and variant lookup.
     pub decls: &'a DeclTables<'a>,
+    /// Set when control flow diverged (a `return`, `break`, or `continue`
+    /// closed the current block and rolled a fresh dead block). The
+    /// function finalizer uses this to mark a trailing empty block as
+    /// `Unreachable` rather than falsely treating a real empty-bodied
+    /// function (for example `fun f() -> Int = 1`) as dead.
+    pub diverged: bool,
 }
 
 impl LowerCx<'_> {
@@ -154,6 +160,7 @@ pub fn lower_function(
         loops: Vec::new(),
         pending_calls: Vec::new(),
         decls,
+        diverged: false,
     };
 
     let body = hir
@@ -166,10 +173,12 @@ pub fn lower_function(
     let result = stmt::lower_block(&mut cx, body);
 
     if !cx.builder.is_closed(cx.current) {
-        if cx.builder.is_empty_open(cx.current) {
-            // The body's final action was a `return` which closed its
-            // own block and rolled a fresh dead one. Leave the dead
-            // block as `Unreachable` to keep the dump tidy.
+        if cx.diverged && cx.builder.is_empty_open(cx.current) {
+            // The body's final action was a `return` (or `break` /
+            // `continue`) which closed its own block and rolled a fresh
+            // dead one. Mark the dead block `Unreachable` to keep the dump
+            // tidy. A non-diverged empty block carries a real tail value
+            // (for example `fun f() -> Int = 1`) and must return it.
             cx.builder
                 .close_block(cx.current, super::ir::MirTerminator::Unreachable);
         } else {

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -45,6 +45,7 @@ pub fn lower_match(
     }
 
     cx.current = cont;
+    cx.diverged = false;
     MirOperand::Copy(result_local)
 }
 

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -32,10 +32,16 @@ type Item = (DeclId, Vec<Ty>);
 /// worklist to retrieve bodies.
 type HirIndex<'a> = HashMap<DeclId, &'a HirFn>;
 
+/// Map from a function declaration to the base symbol the back end uses.
+/// Free functions keep their source name; impl methods get a per-type
+/// symbol (`<TypeMangle>$<method>`) so several types implementing a
+/// method of the same name do not collide.
+type SymbolIndex = HashMap<DeclId, String>;
+
 /// Run the full monomorphization pass.
 pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
     let mut program = MirProgram::new();
-    let (index, roots) = collect_roots(hir);
+    let (index, roots, symbols) = collect_roots(hir);
     let decls = collect_decls(hir);
 
     let mut seen: HashSet<(DeclId, Vec<MangleKey>)> = HashSet::new();
@@ -50,8 +56,12 @@ pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
             Some(f) => *f,
             None => continue,
         };
+        let base = symbols
+            .get(&decl)
+            .cloned()
+            .unwrap_or_else(|| hir_fn.name.clone());
         let subst = build_subst(hir_fn, &args);
-        let mangled = mangle_name(&hir_fn.name, &args);
+        let mangled = mangle_name(&base, &args);
         let (mir_fn, pending) = lower_function(mangled, hir_fn, &subst, &decls);
         program.functions.push(mir_fn);
         for next in pending {
@@ -81,10 +91,12 @@ fn collect_decls(hir: &HirProgram) -> DeclTables<'_> {
 }
 
 /// Collect every top-level function plus impl methods. Returns the
-/// HIR lookup table and the initial worklist of non-generic roots.
-fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>) {
+/// HIR lookup table, the initial worklist of non-generic roots, and the
+/// per-declaration base symbol used by the back end.
+fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>, SymbolIndex) {
     let mut index: HirIndex<'a> = HashMap::new();
     let mut roots: Vec<Item> = Vec::new();
+    let mut symbols: SymbolIndex = HashMap::new();
     let mut next_id: usize = 0;
 
     for item in &hir.items {
@@ -98,10 +110,16 @@ fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>) {
                 }
             }
             HirItemKind::Impl(imp) => {
+                // Each method gets a per-type symbol so several types
+                // implementing a method of the same name do not collide
+                // at the object level. The symbol matches what a call
+                // site recomputes from the receiver type.
+                let type_mangle = super::ty::MirType::from_ty(&imp.self_ty).mangle();
                 for m in &imp.methods {
                     let id = DeclId(next_id);
                     next_id += 1;
                     index.insert(id, m);
+                    symbols.insert(id, super::ty::method_symbol(&type_mangle, &m.name));
                     if !is_generic(m) && m.body.is_some() {
                         roots.push((id, Vec::new()));
                     }
@@ -120,7 +138,7 @@ fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>) {
             _ => {}
         }
     }
-    (index, roots)
+    (index, roots, symbols)
 }
 
 /// Best-effort generic test. A function counts as generic if any of

--- a/src/mir/pretty.rs
+++ b/src/mir/pretty.rs
@@ -200,6 +200,30 @@ fn pretty_rvalue(buf: &mut String, r: &MirRvalue) {
             }
             buf.push(')');
         }
+        MirRvalue::DynCoerce {
+            value,
+            concrete_ty,
+            trait_name,
+            ..
+        } => {
+            write!(buf, "(dyn-coerce {} from={} ", trait_name, concrete_ty).unwrap();
+            pretty_operand(buf, value);
+            buf.push(')');
+        }
+        MirRvalue::VirtualCall {
+            receiver,
+            slot,
+            args,
+            ..
+        } => {
+            write!(buf, "(vcall slot={} ", slot).unwrap();
+            pretty_operand(buf, receiver);
+            for a in args {
+                buf.push(' ');
+                pretty_operand(buf, a);
+            }
+            buf.push(')');
+        }
     }
 }
 

--- a/src/mir/ty.rs
+++ b/src/mir/ty.rs
@@ -118,6 +118,21 @@ impl MirType {
             MirType::Dyn { name, .. } => format!("dyn_{}", name),
         }
     }
+
+    /// The mangled symbol for a method `method` implemented for this type.
+    /// Both the impl method definition and a static or virtual call site
+    /// agree on this name, so a per-type method has a unique symbol even
+    /// when several types implement a method of the same name.
+    pub fn method_symbol(&self, method: &str) -> String {
+        method_symbol(&self.mangle(), method)
+    }
+}
+
+/// Build the mangled symbol for `method` on a type whose mangled name is
+/// `type_mangle`. Used by HIR (defining impl method symbols) and MIR
+/// (resolving a call site), which must agree on the name.
+pub fn method_symbol(type_mangle: &str, method: &str) -> String {
+    format!("{}${}", type_mangle, method)
 }
 
 impl fmt::Display for MirType {

--- a/src/mir/ty.rs
+++ b/src/mir/ty.rs
@@ -35,6 +35,14 @@ pub enum MirType {
         params: Vec<MirType>,
         ret: Box<MirType>,
     },
+    /// A `dyn Trait` trait object. Lowered as a single GC pointer to a
+    /// boxed two-slot fat pointer `{ data, vtable }`. `name` is the
+    /// trait's short name and `methods` is the trait's method order, used
+    /// by the back end to lay out vtables and pick a dispatch slot.
+    Dyn {
+        name: String,
+        methods: Vec<String>,
+    },
 }
 
 impl MirType {
@@ -71,6 +79,10 @@ impl MirType {
                 params: params.iter().map(MirType::from_ty).collect(),
                 ret: Box::new(MirType::from_ty(ret)),
             },
+            Ty::Dyn { name, methods } => MirType::Dyn {
+                name: name.clone(),
+                methods: methods.clone(),
+            },
             Ty::SelfTy(inner) => MirType::from_ty(inner),
             Ty::Error => MirType::Unit,
             Ty::Param(_) | Ty::Var(_) => MirType::Unit,
@@ -103,6 +115,7 @@ impl MirType {
                 parts.push(ret.mangle());
                 format!("Fn_{}", parts.join("_"))
             }
+            MirType::Dyn { name, .. } => format!("dyn_{}", name),
         }
     }
 }
@@ -143,6 +156,7 @@ impl fmt::Display for MirType {
                 }
                 write!(f, ") -> {}", ret)
             }
+            MirType::Dyn { name, .. } => write!(f, "dyn {}", name),
         }
     }
 }

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -105,14 +105,24 @@ fn walk_trait(
     scope: &mut ScopeStack,
     map: &mut ResolutionMap,
 ) -> Result<(), RavenError> {
-    scope.push(ScopeKind::Function);
+    // A trait body is an implicit `Self`-bearing context: methods may
+    // take `self`, annotate parameters as `Self`, and reference `Self`
+    // in their signatures, exactly like an `impl` block. Push an `Impl`
+    // frame and bind `Self` so those uses resolve rather than reporting
+    // `SelfOutsideImpl`.
+    scope.push(ScopeKind::Impl);
+    let _ = scope.insert("Self", Binding::SelfType, t.span.clone());
     push_generics(scope, &t.generics, &t.span)?;
     for member in &t.members {
-        scope.push(ScopeKind::Function);
+        scope.push(ScopeKind::Impl);
         push_generics(scope, &member.generics, &member.span)?;
         for p in &member.params {
-            scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
-            walk_type(&p.ty, scope, map)?;
+            if p.name == "self" {
+                scope.insert_shadowing("self", Binding::SelfValue, p.span.clone());
+            } else {
+                scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+                walk_type(&p.ty, scope, map)?;
+            }
         }
         if let Some(r) = &member.ret {
             walk_type(r, scope, map)?;

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -104,6 +104,7 @@ pub fn collect_declarations(
                         name: t.name.clone(),
                         generics,
                         methods: HashMap::new(),
+                        method_order: Vec::new(),
                         span: t.span.clone(),
                     },
                 );
@@ -307,17 +308,65 @@ fn fill_trait(
     push_generics_into_scope(&mut scope, &trait_generics);
 
     let mut methods = HashMap::new();
+    let mut method_order = Vec::with_capacity(t.members.len());
     for member in &t.members {
         scope.push();
         let m_generics = collect_generic_params(&member.generics, &member.span);
         push_generics_into_scope(&mut scope, &m_generics);
         let sig = collect_fn_sig(member, resolved, env, None, &scope, m_generics)?;
         scope.pop();
+        method_order.push(member.name.clone());
         methods.insert(member.name.clone(), sig);
     }
     let entry = env.traits.get_mut(&id).expect("trait sig pre populated");
     entry.methods = methods;
+    entry.method_order = method_order;
     Ok(())
+}
+
+/// Report whether a trait is object-safe and, if not, why. A trait is
+/// object-safe in this subset when none of its methods are generic and
+/// none take `Self` by value in a non-receiver parameter position. The
+/// returned `Err` string is a user-facing reason for the diagnostic.
+pub fn object_safety_violation(sig: &TraitSig) -> Option<String> {
+    for name in &sig.method_order {
+        let Some(m) = sig.methods.get(name) else {
+            continue;
+        };
+        if !m.generics.is_empty() {
+            return Some(format!(
+                "method `{}` is generic; methods with type parameters are not object-safe",
+                name
+            ));
+        }
+        // The receiver `self` is `Ty::SelfTy(..)` and is allowed. Any
+        // other parameter that mentions `Self` by value is not object
+        // safe in this subset.
+        for (i, p) in m.params.iter().enumerate() {
+            let is_receiver = i == 0 && matches!(p, Ty::SelfTy(_));
+            if !is_receiver && ty_mentions_self(p) {
+                return Some(format!(
+                    "method `{}` takes `Self` by value in a non-receiver position, which is not object-safe",
+                    name
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// Whether a resolved type mentions the `Self` type anywhere.
+fn ty_mentions_self(ty: &Ty) -> bool {
+    match ty {
+        Ty::SelfTy(_) => true,
+        Ty::Option(t) | Ty::List(t) => ty_mentions_self(t),
+        Ty::Result(a, b) => ty_mentions_self(a) || ty_mentions_self(b),
+        Ty::Struct { args, .. } | Ty::Enum { args, .. } => args.iter().any(ty_mentions_self),
+        Ty::Function { params, ret } => {
+            params.iter().any(ty_mentions_self) || ty_mentions_self(ret)
+        }
+        _ => false,
+    }
 }
 
 fn fill_impl(i: &Impl, resolved: &ResolvedFile<'_>, env: &mut TypeEnv) -> Result<(), RavenError> {
@@ -407,19 +456,7 @@ pub fn resolve_ty(
             Ok(Ty::Option(Box::new(t)))
         }
         TypeKind::Path(p) => resolve_type_path(p, resolved, env, self_ty, scope),
-        TypeKind::Dyn(p) => {
-            // `dyn Trait` is parsed but not yet supported by the type
-            // checker. The resolver has already bound the trait name;
-            // we surface a clear error here so users see a hint rather
-            // than a panic. The receiving issue #66 will replace this.
-            Err(RavenError::ty(
-                TypeError::Custom(format!(
-                    "`dyn {}` trait objects are not yet supported by the type checker",
-                    type_path_name(p)
-                )),
-                p.span.clone(),
-            ))
-        }
+        TypeKind::Dyn(p) => resolve_dyn(p, resolved, env),
         TypeKind::Function { params, ret } => {
             let mut ps = Vec::with_capacity(params.len());
             for p in params {
@@ -432,6 +469,52 @@ pub fn resolve_ty(
             })
         }
     }
+}
+
+/// Resolve a `dyn Trait` type expression. The head segment must bind to
+/// a trait declaration; the trait must be object-safe. The produced
+/// [`Ty::Dyn`] carries the trait's method order so later passes lay out
+/// the vtable in a stable slot order.
+fn resolve_dyn(
+    path: &TypePath,
+    resolved: &ResolvedFile<'_>,
+    env: &TypeEnv,
+) -> Result<Ty, RavenError> {
+    let head = &path.segments[0];
+    let name = &head.name;
+    let binding = resolved
+        .map
+        .lookup(&head.span)
+        .ok_or_else(|| RavenError::ty(TypeError::UnknownType(name.clone()), head.span.clone()))?;
+    let trait_id = match binding {
+        Binding::Trait(id) => *id,
+        _ => {
+            return Err(RavenError::ty(
+                TypeError::Custom(format!(
+                    "`dyn {}` requires a trait; `{}` is not a trait",
+                    name, name
+                )),
+                head.span.clone(),
+            ));
+        }
+    };
+    let sig = env
+        .traits
+        .get(&trait_id)
+        .ok_or_else(|| RavenError::ty(TypeError::UnknownType(name.clone()), head.span.clone()))?;
+    if let Some(reason) = object_safety_violation(sig) {
+        return Err(RavenError::ty(
+            TypeError::Custom(format!(
+                "`dyn {}` is not allowed: {}. Consider a generic bound `<T: {}>` instead",
+                name, reason, name
+            )),
+            head.span.clone(),
+        ));
+    }
+    Ok(Ty::Dyn {
+        name: sig.name.clone(),
+        methods: sig.method_order.clone(),
+    })
 }
 
 fn resolve_type_path(

--- a/src/tycheck/env.rs
+++ b/src/tycheck/env.rs
@@ -108,6 +108,10 @@ pub struct TraitSig {
     pub name: String,
     pub generics: Vec<GenericParamSig>,
     pub methods: HashMap<String, FnSig>,
+    /// Method names in declaration order. The vtable slot order for
+    /// `dyn Trait` dispatch follows this list, so the slot index of a
+    /// method is its position here.
+    pub method_order: Vec<String>,
     pub span: Span,
 }
 

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -283,7 +283,31 @@ impl<'a, 'b> Checker<'a, 'b> {
 
     /// Unify two types under the inference context. On failure, raise a
     /// TypeMismatch at `span` with a suggestion hint when possible.
+    ///
+    /// Before reporting a mismatch this checks for a `dyn Trait` unsizing
+    /// coercion: a concrete struct or enum used where `dyn Trait` is
+    /// expected, where that type implements the trait. When it applies,
+    /// the coercion is recorded at `span` (the coerced expression's span)
+    /// and unification succeeds.
     fn unify(&mut self, expected: &Ty, actual: &Ty, span: &Span) -> Result<(), RavenError> {
+        let exp_resolved = self.infer.resolve(expected);
+        if let Ty::Dyn { name, methods } = exp_resolved.strip_self() {
+            let act_resolved = self.infer.resolve(actual);
+            let concrete = act_resolved.strip_self().clone();
+            if self.implements_trait(&concrete, name) {
+                self.types.record_coercion(
+                    span,
+                    crate::tycheck::DynCoercion {
+                        trait_name: name.clone(),
+                        methods: methods.clone(),
+                        concrete_ty: concrete,
+                    },
+                );
+                return Ok(());
+            }
+            // A `dyn Trait` target with a concrete actual that does not
+            // implement the trait: fall through to the mismatch report.
+        }
         match self.infer.unify(expected, actual, span) {
             Ok(()) => Ok(()),
             Err(e) => {
@@ -327,6 +351,20 @@ impl<'a, 'b> Checker<'a, 'b> {
                 Err(err)
             }
         }
+    }
+
+    /// Whether `concrete` has a trait impl for the trait named `trait_name`.
+    /// Used to validate a `dyn Trait` unsizing coercion. The match is by
+    /// the implementing type's identity (ignoring `Self` wrappers) and the
+    /// impl's recorded trait name.
+    fn implements_trait(&self, concrete: &Ty, trait_name: &str) -> bool {
+        if concrete.is_error() {
+            return true;
+        }
+        self.env.impls.iter().any(|imp| {
+            imp.trait_name.as_deref() == Some(trait_name)
+                && super::env::tys_equal(&imp.self_ty, concrete)
+        })
     }
 
     /// After body checking, walk every recorded type and resolve any
@@ -1024,6 +1062,17 @@ impl<'a, 'b> Checker<'a, 'b> {
             return Ok(Ty::Error);
         }
 
+        // A `dyn Trait` receiver dispatches dynamically. The method must
+        // be one of the trait's own methods; its signature comes from the
+        // trait declaration with `Self` standing for the erased concrete
+        // type. The return type is the trait method's return type.
+        if let Ty::Dyn {
+            name: trait_name, ..
+        } = &recv_stripped
+        {
+            return self.check_dyn_method_call(trait_name, name, args, span);
+        }
+
         // Built in methods first (Option/Result/List/String). These are
         // matched directly against the resolved receiver shape; their
         // signatures already substitute the element type.
@@ -1159,6 +1208,58 @@ impl<'a, 'b> Checker<'a, 'b> {
             self.unify(pt, &a, &arg.span)?;
         }
         Ok(substitute(&sig.ret, &full))
+    }
+
+    /// Check a method call whose receiver is a `dyn Trait` value. The
+    /// method must belong to the trait. Argument types are checked against
+    /// the trait method's declared parameter types (with `Self` left
+    /// abstract, which is sound because object-safe methods never use
+    /// `Self` outside the receiver). The result is the method's return
+    /// type, with any `Self` return collapsed to the trait object type so
+    /// the value stays usable.
+    fn check_dyn_method_call(
+        &mut self,
+        trait_name: &str,
+        method: &str,
+        args: &[Expr],
+        span: &Span,
+    ) -> Result<Ty, RavenError> {
+        let sig = self
+            .env
+            .traits
+            .values()
+            .find(|t| t.name == trait_name)
+            .and_then(|t| t.methods.get(method).cloned());
+        let Some(sig) = sig else {
+            return Err(RavenError::ty(
+                TypeError::UndefinedMethod {
+                    receiver_ty: format!("dyn {}", trait_name),
+                    method: method.to_string(),
+                },
+                span.clone(),
+            ));
+        };
+        let user_params: Vec<Ty> = sig
+            .params
+            .iter()
+            .filter(|t| !matches!(t, Ty::SelfTy(_)))
+            .cloned()
+            .collect();
+        if user_params.len() != args.len() {
+            return Err(RavenError::ty(
+                TypeError::WrongArity {
+                    func: method.to_string(),
+                    expected: user_params.len(),
+                    actual: args.len(),
+                },
+                span.clone(),
+            ));
+        }
+        for (pt, arg) in user_params.iter().zip(args.iter()) {
+            let a = self.check_expr(arg)?;
+            self.unify(pt, &a, &arg.span)?;
+        }
+        Ok(sig.ret.clone())
     }
 
     fn check_field(&mut self, receiver: &Expr, name: &str, span: &Span) -> Result<Ty, RavenError> {

--- a/src/tycheck/mod.rs
+++ b/src/tycheck/mod.rs
@@ -46,6 +46,26 @@ pub use env::{
 };
 pub use ty::Ty;
 
+/// One recorded `dyn Trait` unsizing coercion.
+///
+/// The type checker inserts an entry whenever a concrete value is used
+/// where a `dyn Trait` is expected (a `let` with a `dyn` annotation, an
+/// argument to a `dyn` parameter, or a `return` of a `dyn` value). The
+/// HIR lowering reads the entry, keyed by the coerced expression's span,
+/// and materializes the fat pointer construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DynCoercion {
+    /// The target trait's short name.
+    pub trait_name: String,
+    /// The trait's method names in declaration order (the vtable slot
+    /// order). Carried so the back end can lay out and dispatch through
+    /// the vtable without re-reading the trait declaration.
+    pub methods: Vec<String>,
+    /// The source concrete type being coerced. Used by the back end to
+    /// select the `(concrete_type, trait)` vtable.
+    pub concrete_ty: Ty,
+}
+
 /// Per file type checking output.
 #[derive(Debug, Clone, Default)]
 pub struct TypeMap {
@@ -54,6 +74,8 @@ pub struct TypeMap {
     /// a binding store the binding's type under the introducing span as
     /// well so downstream passes can look it up.
     pub types: HashMap<UseKey, Ty>,
+    /// `dyn Trait` coercions keyed by the coerced expression's span.
+    pub coercions: HashMap<UseKey, DynCoercion>,
 }
 
 impl TypeMap {
@@ -70,6 +92,16 @@ impl TypeMap {
     /// Look up the type recorded at `span`, if any.
     pub fn lookup(&self, span: &Span) -> Option<&Ty> {
         self.types.get(&UseKey::from_span(span))
+    }
+
+    /// Record a `dyn Trait` coercion at `span` (the coerced expression).
+    pub fn record_coercion(&mut self, span: &Span, coercion: DynCoercion) {
+        self.coercions.insert(UseKey::from_span(span), coercion);
+    }
+
+    /// Look up a `dyn Trait` coercion recorded at `span`, if any.
+    pub fn lookup_coercion(&self, span: &Span) -> Option<&DynCoercion> {
+        self.coercions.get(&UseKey::from_span(span))
     }
 
     /// Iterator yielding `(key, ty)` pairs sorted by file and offset

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -83,6 +83,78 @@ fn unknown_field_is_error() {
     }
 }
 
+const DYN_SPEAK: &str = concat!(
+    "trait Speak { fun sound(self) -> Int }\n",
+    "struct Dog {}\n",
+    "struct Cat {}\n",
+    "impl Speak for Dog { fun sound(self) -> Int = 1 }\n",
+    "impl Speak for Cat { fun sound(self) -> Int = 2 }\n",
+);
+
+#[test]
+fn dyn_argument_coercion_and_dispatch_check() {
+    let src = format!(
+        "{DYN_SPEAK}\
+         fun describe(s: dyn Speak) -> Int = s.sound()\n\
+         fun main() {{\n    let d = Dog {{}}\n    print_int(describe(d))\n}}\n"
+    );
+    check(&src).unwrap();
+}
+
+#[test]
+fn dyn_let_coercion_checks() {
+    let src = format!(
+        "{DYN_SPEAK}\
+         fun main() {{\n    let s: dyn Speak = Cat {{}}\n    print_int(s.sound())\n}}\n"
+    );
+    check(&src).unwrap();
+}
+
+#[test]
+fn dyn_coercion_of_non_implementor_is_error() {
+    let src = format!(
+        "{DYN_SPEAK}\
+         struct Rock {{}}\n\
+         fun describe(s: dyn Speak) -> Int = s.sound()\n\
+         fun main() {{\n    print_int(describe(Rock {{}}))\n}}\n"
+    );
+    let err = check(&src).unwrap_err();
+    assert!(matches!(err, RavenError::Type(_, _, _)));
+}
+
+#[test]
+fn dyn_unknown_trait_method_is_error() {
+    let src = format!(
+        "{DYN_SPEAK}\
+         fun describe(s: dyn Speak) -> Int = s.bark()\n"
+    );
+    let err = check(&src).unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::UndefinedMethod { .. })),
+        other => panic!("expected UndefinedMethod, got {:?}", other),
+    }
+}
+
+#[test]
+fn dyn_of_non_object_safe_generic_method_is_error() {
+    // A generic method makes the trait non-object-safe.
+    let src = concat!(
+        "trait Maker { fun make<T>(self, x: T) -> Int }\n",
+        "fun describe(m: dyn Maker) -> Int = 0\n",
+    );
+    let err = check(src).unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => match *b {
+            TypeError::Custom(msg) => assert!(
+                msg.contains("not object-safe") || msg.contains("object-safe"),
+                "unexpected message: {msg}"
+            ),
+            other => panic!("expected Custom object-safety error, got {:?}", other),
+        },
+        other => panic!("expected TypeError, got {:?}", other),
+    }
+}
+
 #[test]
 fn array_literal_unifies_element_types() {
     check("fun f() -> Int {\n    let xs = [1, 2, 3]\n    return xs.len()\n}\n").unwrap();

--- a/src/tycheck/ty.rs
+++ b/src/tycheck/ty.rs
@@ -109,6 +109,10 @@ pub enum Ty {
     List(Box<Ty>),
     /// A function value type: `fun(A, B) -> C`.
     Function { params: Vec<Ty>, ret: Box<Ty> },
+    /// A `dyn Trait` trait object. `name` is the trait's short name and
+    /// `methods` is the trait's method names in declaration order, which
+    /// fixes the vtable slot order used by dynamic dispatch.
+    Dyn { name: String, methods: Vec<String> },
     /// `Self` inside an `impl` block, bound to the implementing type.
     /// The contained type is the implementing type for convenience.
     SelfTy(Box<Ty>),
@@ -145,6 +149,7 @@ impl Ty {
             Ty::Result(a, b) => a.has_var() || b.has_var(),
             Ty::Struct { args, .. } | Ty::Enum { args, .. } => args.iter().any(|t| t.has_var()),
             Ty::Function { params, ret } => params.iter().any(|t| t.has_var()) || ret.has_var(),
+            Ty::Dyn { .. } => false,
             _ => false,
         }
     }
@@ -186,6 +191,7 @@ impl fmt::Display for Ty {
                 }
                 write!(f, ") -> {}", ret)
             }
+            Ty::Dyn { name, .. } => write!(f, "dyn {}", name),
             Ty::SelfTy(inner) => write!(f, "Self/* = {} */", inner),
             Ty::Param(p) => f.write_str(&p.name),
             Ty::Var(v) => write!(f, "?{}", v.0),

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -59,6 +59,17 @@ fn closure_value_program_compiles_and_runs() {
     compile_link_run_and_check("closure_value.rv", "42\n", &runtime);
 }
 
+#[test]
+fn dyn_dispatch_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Two concrete types are coerced to `dyn Speak` and dispatched
+    // through their vtables: Dog.sound() is 1, Cat.sound() is 2, each on
+    // its own line.
+    compile_link_run_and_check("dyn_dispatch.rv", "1\n2\n", &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.

--- a/tests/mir_corpus/generic_call.rv.mir
+++ b/tests/mir_corpus/generic_call.rv.mir
@@ -26,7 +26,7 @@
     )
     (entry bb0)
     (bb0
-      (unreachable)
+      (return _0)
     )
   )
   (fn "id_int" origin="id_int" ret=Int
@@ -36,7 +36,7 @@
     )
     (entry bb0)
     (bb0
-      (unreachable)
+      (return _0)
     )
   )
 )

--- a/tests/mir_corpus/trait_method.rv.mir
+++ b/tests/mir_corpus/trait_method.rv.mir
@@ -10,14 +10,14 @@
     (bb0
       (assign _1 (struct-create Counter 41))
       (assign _0 (use _1))
-      (assign _2 (call "bump" _0))
+      (assign _2 (call "Counter$bump" _0))
       (return _2)
     )
     (bb1
       (unreachable)
     )
   )
-  (fn "bump" origin="bump" ret=Int
+  (fn "Counter$bump" origin="bump" ret=Int
     (params (_0: Counter "self"))
     (locals
       (_0 Counter "self" param=true)


### PR DESCRIPTION
## Summary

Implements `dyn Trait` trait objects with vtable-based dynamic dispatch across the type checker, MIR, and the Cranelift back end.

Closes #66. Design is documented in `docs/v2/specs/dyn-trait.md`.

## Verified output

Compiling and running `examples/v2/dyn_dispatch.rv` on windows-msvc (x86_64) with the MSVC linker prints, literally:

```
1
2
```

(exit 0). The same program is asserted end to end by `dyn_dispatch_program_compiles_and_runs` in `tests/codegen_smoke.rs`.

## Design

* **Fat pointer**: a `dyn Trait` value is a single GC pointer to a boxed two-slot fat pointer `{ data, vtable }` (slot 0 the erased value, slot 1 the vtable address). Boxing keeps the value one word, so it flows through existing one-word locals, parameters, returns, and GC root frames with no special case. The unboxed two-register form is left for a later revision.
* **Vtables**: one read-only data object per `(concrete_type, trait)` pair, one pointer slot per trait method in declaration order, each a relocation to that type's method symbol (`<Type>$<method>`). Interned so a pair shares one table.
* **Coercions**: inserted by the type checker at `unify` time (assignment, argument, return), recorded by span, then materialized by HIR as a `DynCoerce` node and lowered through MIR to codegen.
* **GC**: the box descriptor marks only slot 0 (data) as a pointer; the static vtable word is not traced. The data word is reachable as a transitive root while the trait object local is live.
* **Object safety**: enforced subset rejects generic methods and `Self` by value outside the receiver, with a hint to use a generic bound.

## Supported coercion sites

* `let d: dyn Trait = concrete`
* passing a concrete value to a `dyn Trait` parameter
* returning a concrete value as `dyn Trait`

## Deferrals

* Trait upcasting (`dyn Sub` to `dyn Super`).
* Generic methods in `dyn` (rejected by the object-safety check).
* Associated types and auto-trait bounds (`dyn Trait + Send`).
* Heterogeneous `List<dyn Trait>` as a runnable showcase: the fat pointer fits one-word list storage, but the type checker does not yet push an expected `dyn` element type down to each array element, and `List` element access methods are deferred to the stdlib issues. Documented in the spec.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (lib, runtime, golden suites, codegen smoke all green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` clean
- [x] New tycheck tests cover dyn coercion, dispatch, non-implementor rejection, unknown trait method, and object safety
- [x] New end-to-end smoke test compiles, links, and runs the dynamic dispatch program and asserts `1\n2\n`
- [x] Refreshed MIR golden baselines for the per-type method symbol and the dead-block return fix
