### PR TITLE
feat: defer statement with LIFO function-scoped execution

### DIFF
--- a/docs/v2/specs/defer.md
+++ b/docs/v2/specs/defer.md
@@ -1,0 +1,164 @@
+# defer Spec
+
+## Goal
+
+Specify the `defer` statement: `defer expr` schedules `expr` to run when
+the enclosing function returns. Deferred work runs in reverse declaration
+order (LIFO), runs on every normal return path the deferred statement was
+reached through, and runs before the function hands control back to its
+caller. This is the v2.0 counterpart to Go's `defer`, scoped to fit a
+control-flow-graph back end that does not unwind.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> Resolver -> Tycheck -> HIR -> MIR -> Codegen
+```
+
+* The parser already accepts `defer expr` as `StmtKind::Defer(Expr)`.
+* The type checker checks the deferred expression like any expression and
+  discards its type (the result is evaluated for side effects only).
+* HIR keeps the statement as `HirStmtKind::Defer(HirExpr)`.
+* MIR lowering performs the expansion: it records each deferred expression
+  and re-emits the pending set, in reverse order, at every block exit and
+  at every `return`.
+* Codegen needs no defer-specific logic. The deferred calls are ordinary
+  MIR statements that land in the block before its `Return` terminator,
+  so they are emitted before the GC leave-frame epilogue automatically.
+
+## Semantics
+
+* **LIFO.** Within a return path, deferred expressions run in the reverse
+  of the order they were declared. `defer A; defer B; return` runs `B`
+  then `A`.
+* **Reached-only.** A `defer` schedules its expression only if control
+  actually reached the `defer` statement at run time. A `defer` placed
+  after an early `return` that was taken never runs, because that line was
+  never executed.
+* **Return value first.** On `return e`, the return value `e` is evaluated
+  first, then the deferred expressions run, then the function returns.
+  This matches Go: defers observe the already-computed result, not a
+  partially evaluated one.
+* **Block-scoped, function-scoped in practice.** A defer runs when the
+  block that registered it exits, by normal fall-through or by a `return`
+  escaping through it. A defer written at the function-body level (the
+  common case, and where Go programs put defers) therefore runs at every
+  function return, indistinguishable from Go's function scope. A defer
+  nested inside an inner block runs at that inner block's exit. See
+  Scope below for the precise rule and the rationale.
+* **No run on panic.** Raven `panic` aborts the process in v2.0; there is
+  no stack unwinding. Deferred expressions do not run on a panic, exactly
+  as a process that calls `abort()` runs no cleanup. This is intentional
+  and documented, not a gap to be patched with unwinding.
+* **Loops.** A `defer` inside a loop body runs when the body block exits
+  (each iteration), not at loop teardown, because the body is its
+  enclosing block. A `break` or `continue` is a control-flow edge out of
+  the body block and triggers the body's pending defers the same way a
+  fall-through does. Defers do not accumulate across iterations.
+
+## Lowering strategy
+
+The chosen strategy is **compile-time expansion at MIR lowering** with a
+per-function pending-defer stack. No runtime defer stack, no heap thunks,
+no closures-as-defer-bodies. The alternative, a runtime per-frame stack of
+`(fn_ptr, env)` thunks, was rejected for v2.0: it needs runtime support
+and closure capture (issue #62), and the compile-time expansion already
+covers every required control-flow case correctly.
+
+### The pending stack
+
+`mir::lower::LowerCx` carries `defers: Vec<HirExpr>`, the deferred
+expressions registered so far in declaration order.
+
+* Lowering `HirStmtKind::Defer(e)` pushes a clone of `e` onto `defers`.
+  Nothing is emitted at the `defer` site.
+* Lowering a block records `mark = defers.len()` on entry. On the block's
+  normal exit (after its tail expression, when control has not diverged)
+  it emits `defers[mark..]` in reverse order as ordinary side-effecting
+  expressions, then truncates `defers` back to `mark` so an enclosing
+  block does not re-run them.
+* Lowering `HirExprKind::Return(value)` lowers `value` first, then emits
+  the entire pending `defers` stack in reverse order (a `return` escapes
+  all enclosing blocks at once), then closes the block with the `Return`
+  terminator. The stack is cloned, not consumed, so a return that escapes
+  several blocks emits each pending defer exactly once on its own path.
+* When a block has already diverged (a `return`, `break`, or `continue`
+  closed it and rolled a fresh dead block), the normal-exit flush is
+  skipped: the escaping statement already emitted what it needed, and the
+  dead block must stay empty.
+
+### Worked example
+
+```
+fun f(early: Bool) -> Int {
+    defer print_int(9)      // push 9         -> defers = [9]
+    if early {
+        return 1            // emit [9] reversed -> print 9; return 1
+    }
+    defer print_int(8)      // push 8         -> defers = [9, 8]
+    return 2                // emit [9, 8] reversed -> print 8, print 9; return 2
+}
+```
+
+The MIR has two return-bearing blocks. The early-return block contains
+`print_int(9); return 1`. The fall-through block contains
+`print_int(8); print_int(9); return 2`. So `f(true)` prints `9` and
+`f(false)` prints `8` then `9`. The corresponding executable confirms
+this on a real run.
+
+For the classic ordering case:
+
+```
+fun demo() -> Int {
+    defer print_int(1)      // defers = [1]
+    defer print_int(2)      // defers = [1, 2]
+    return 0                // emit reversed: print 2, print 1; return 0
+}
+```
+
+The single return block is `print_int(2); print_int(1); return 0`, so the
+program prints `2` then `1`.
+
+## Interaction with `?`
+
+The `?` operator is already desugared in HIR to a `match` whose error arm
+is `return Err(__e)` (or `return None` for `Option`). That synthesized
+`return` is an ordinary `HirExprKind::Return`, so it flushes the pending
+defers exactly like a written `return`. A defer declared before a `?` runs
+when the `?` takes its early-return arm; a defer declared after it does
+not, because the `?` return was reached first. No `?`-specific code is
+needed.
+
+## Interaction with the GC leave-frame
+
+Codegen maintains a GC root frame for any function with GC pointer locals
+and emits `raven_gc_leave_frame` inside the `Return` terminator, after
+evaluating the return operand. Deferred expressions are lowered as MIR
+statements that precede the `Return` terminator, so codegen emits them
+before `raven_gc_leave_frame`. Deferred code may therefore read and write
+GC-managed locals safely: the locals are still rooted when the deferred
+calls run. This ordering is verified by an example whose deferred call
+reads a heap-allocated struct local and prints its field.
+
+## Scope rationale
+
+True Go function-scope with reached-only semantics for defers nested in
+conditional sub-blocks needs runtime state, because a compile-time pass
+cannot know at the merge point whether a conditional branch executed. The
+block-scoped rule sidesteps this: every defer has a statically known exit
+point (the end of its block, plus any `return` escaping it), so reached-
+only is exact without runtime bookkeeping. For function-body-level defers,
+the enclosing block is the function body, so the rule coincides with Go's
+function scope. This keeps the required cases correct and the
+implementation runtime-free.
+
+## Out of scope
+
+* Running defers on panic or any form of unwinding. v2.0 panic aborts.
+* A runtime defer stack and deferred closures with captured environments.
+* Deferring a `return` value rewrite (Go's named-return mutation from a
+  defer). Deferred expressions are evaluated for side effects only.
+* Defer inside generic functions interacts with monomorphization only
+  through ordinary expression lowering; no defer-specific specialization
+  is needed.
+```

--- a/docs/v2/specs/hir.md
+++ b/docs/v2/specs/hir.md
@@ -210,7 +210,6 @@ the result type; the surface form does not appear at HIR level.
 * User-defined `Iterator` trait protocol. Built-in iteration over
   `List<T>` and ranges only.
 * Closure capture analysis (defer to MIR).
-* `defer` lowering: tracked in a follow-up issue.
 * C FFI lowering.
 * `dyn Trait` virtual dispatch.
 * Or-patterns and nested or-pattern lowering.

--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -161,8 +161,16 @@ statements at the start of the arm block that pull payload fields out
 of the discriminant via `EnumCreate` projections (or struct field
 projections), one per pattern binding name.
 
+`defer e` does not emit at its own site. The lowering records `e` on a
+per-function pending stack and re-emits the pending set, in reverse
+(LIFO) order, at each block's normal exit and before every `return`. A
+`return` escapes all enclosing blocks and flushes the whole stack; a
+block's normal exit flushes only the defers registered inside it. See
+`docs/v2/specs/defer.md` for the full algorithm and worked examples.
+
 `?` propagation is already desugared to a match in HIR, so MIR has no
-special rule for it.
+special rule for it. Because the desugaring produces an ordinary
+`return`, defers flush on the `?` early-return path with no extra work.
 
 ## Monomorphization
 
@@ -231,8 +239,6 @@ visible in diffs.
   empty capture list. Full capture rewriting is tracked by issue #62.
 * `dyn Trait` virtual dispatch. Trait method calls are resolved to
   concrete functions during type checking; `dyn` lowering is issue #66.
-* `defer` execution: HIR retains a `Defer` statement variant; MIR
-  passes it through as a `Nop` for now and reserves a follow-up issue.
 * Async, generators, drop tracking, borrow analysis.
 * Cross-file monomorphization: the v2 pipeline still operates per file.
 

--- a/examples/v2/defer_early_return.rv
+++ b/examples/v2/defer_early_return.rv
@@ -1,0 +1,20 @@
+// Only defers that have been reached at runtime run. The first defer is
+// registered before the conditional, so it fires on every return path.
+// The second defer is registered after the early return, so a run that
+// takes the early path never schedules it.
+//
+// f(true)  reaches only `defer print_int(9)`  -> prints 9
+// f(false) reaches both, LIFO at the return    -> prints 8 then 9
+fun f(early: Bool) -> Int {
+    defer print_int(9)
+    if early {
+        return 1
+    }
+    defer print_int(8)
+    return 2
+}
+
+fun main() {
+    let _ = f(true)
+    let _ = f(false)
+}

--- a/examples/v2/defer_order.rv
+++ b/examples/v2/defer_order.rv
@@ -1,0 +1,13 @@
+// Deferred expressions run in reverse declaration order (LIFO) when the
+// enclosing function returns. The return value is computed first, then
+// the deferred calls fire, so this program prints 2 then 1 before main
+// observes the result.
+fun demo() -> Int {
+    defer print_int(1)
+    defer print_int(2)
+    return 0
+}
+
+fun main() {
+    let _ = demo()
+}

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -138,6 +138,14 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
                 Some(v) => lower_expr(cx, v),
                 None => MirOperand::Const(MirConstant::Unit),
             };
+            // A return escapes every enclosing block, so run all pending
+            // deferred expressions in reverse order. The return value was
+            // already evaluated above, matching Go: the result is computed
+            // first, then defers run, then the function returns. Emitting
+            // them here (before the Return terminator) also places them
+            // before codegen's GC leave-frame epilogue, so deferred code
+            // can still touch rooted GC locals.
+            cx.emit_all_defers();
             if !cx.builder.is_closed(cx.current) {
                 cx.builder
                     .close_block(cx.current, MirTerminator::Return(op));
@@ -282,6 +290,11 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
 /// side effects; the trailing expression (or unit) becomes the result.
 pub fn lower_block(cx: &mut LowerCx<'_>, block: &HirBlock) -> MirOperand {
     cx.push_scope();
+    // Defers are function-scoped at the body level: a `defer` registered
+    // in a nested block runs when that block exits, and the mark records
+    // where this block's own defers begin so its normal-exit flush does
+    // not disturb defers owned by an enclosing block.
+    let defer_mark = cx.defer_mark();
     for s in &block.stmts {
         stmt::lower_stmt(cx, s);
     }
@@ -289,6 +302,17 @@ pub fn lower_block(cx: &mut LowerCx<'_>, block: &HirBlock) -> MirOperand {
         Some(tail) => lower_expr(cx, tail),
         None => MirOperand::Const(MirConstant::Unit),
     };
+    // Run the defers this block registered, in reverse order, on the
+    // normal fall-through exit. When control already diverged (a `return`,
+    // `break`, or `continue` closed the block and rolled a fresh dead
+    // block), the normal exit is unreachable: the escaping statement
+    // already emitted the defers it needed, so skip the flush rather than
+    // populate the dead block. Then drop them so an enclosing block does
+    // not re-run them on its own exit.
+    if !cx.diverged {
+        cx.emit_defers_from(defer_mark);
+    }
+    cx.defers.truncate(defer_mark);
     cx.pop_scope();
     result
 }

--- a/src/mir/lower/mod.rs
+++ b/src/mir/lower/mod.rs
@@ -67,6 +67,11 @@ pub struct LowerCx<'a> {
     /// `Unreachable` rather than falsely treating a real empty-bodied
     /// function (for example `fun f() -> Int = 1`) as dead.
     pub diverged: bool,
+    /// Pending deferred expressions, in declaration order. A `defer e`
+    /// statement pushes a clone of `e` here; the deferred work runs in
+    /// reverse (LIFO) order at each block exit and at every `return`.
+    /// See `src/hir` defer lowering and `docs/v2/specs/defer.md`.
+    pub defers: Vec<crate::hir::expr::HirExpr>,
 }
 
 impl LowerCx<'_> {
@@ -92,6 +97,39 @@ impl LowerCx<'_> {
 
     pub fn pop_scope(&mut self) {
         self.scopes.pop();
+    }
+
+    /// Number of deferred expressions registered so far. A block records
+    /// this on entry so it can flush only the defers added inside it.
+    pub fn defer_mark(&self) -> usize {
+        self.defers.len()
+    }
+
+    /// Emit the deferred expressions in `self.defers[from..]` into the
+    /// current block in reverse (LIFO) declaration order, lowered for
+    /// their side effects only. Does nothing when the current block has
+    /// already been closed (for example after a `return`), since a dead
+    /// block must stay empty. The defers are cloned, not consumed, so a
+    /// `return` that escapes several blocks can re-emit the same defers.
+    pub fn emit_defers_from(&mut self, from: usize) {
+        if from >= self.defers.len() {
+            return;
+        }
+        if self.builder.is_closed(self.current) {
+            return;
+        }
+        // Clone the slice first: lowering each expression borrows `self`
+        // mutably, so the pending list cannot be borrowed across the loop.
+        let pending: Vec<crate::hir::expr::HirExpr> = self.defers[from..].to_vec();
+        for e in pending.iter().rev() {
+            let _ = expr::lower_expr(self, e);
+        }
+    }
+
+    /// Emit every pending deferred expression in reverse order. Used at a
+    /// `return`, which escapes all enclosing blocks at once.
+    pub fn emit_all_defers(&mut self) {
+        self.emit_defers_from(0);
     }
 }
 
@@ -161,6 +199,7 @@ pub fn lower_function(
         pending_calls: Vec::new(),
         decls,
         diverged: false,
+        defers: Vec::new(),
     };
 
     let body = hir

--- a/src/mir/lower/stmt.rs
+++ b/src/mir/lower/stmt.rs
@@ -3,7 +3,7 @@
 use crate::hir::expr::HirBlock;
 use crate::hir::stmt::{HirAssignTarget, HirStmt, HirStmtKind};
 
-use super::super::ir::{MirOperand, MirRvalue, MirStatement};
+use super::super::ir::{MirOperand, MirRvalue};
 use super::{mir_ty, LowerCx};
 
 /// Lower one HIR statement into the current block.
@@ -67,11 +67,12 @@ pub fn lower_stmt(cx: &mut LowerCx<'_>, stmt: &HirStmt) {
                 );
             }
         },
-        HirStmtKind::Defer(_) => {
-            // Defer is preserved through HIR but its lowering is
-            // deferred to a follow-up pass; emit a Nop so the shape
-            // remains visible.
-            cx.builder.emit(cx.current, MirStatement::Nop);
+        HirStmtKind::Defer(e) => {
+            // Register the deferred expression. It is not emitted here:
+            // `lower_block` flushes it (in reverse order) when its
+            // enclosing block exits, and any `return` that escapes the
+            // block emits it first. See `docs/v2/specs/defer.md`.
+            cx.defers.push(e.clone());
         }
     }
 }

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -12,7 +12,7 @@ use crate::hir::lower_file;
 use crate::lexer::Lexer;
 use crate::mir::builder::FunctionBuilder;
 use crate::mir::ir::{
-    MirConstant, MirFunction, MirOperand, MirRvalue, MirStatement, MirTerminator,
+    MirBlock, MirConstant, MirFunction, MirOperand, MirRvalue, MirStatement, MirTerminator,
 };
 use crate::mir::ty::MirType;
 use crate::mir::{lower_program, MirProgram};
@@ -258,5 +258,93 @@ fn mir_type_mangling_is_stable() {
     assert_eq!(
         MirType::Result(Box::new(MirType::Int), Box::new(MirType::Str)).mangle(),
         "Result_Int_Str"
+    );
+}
+
+// ----- Defer lowering -----
+
+/// Collect the integer constant argument of each `print_int` call in the
+/// block, in statement order. Used to assert deferred call ordering.
+fn print_int_args_in_block(block: &MirBlock) -> Vec<i64> {
+    let mut out = Vec::new();
+    for s in &block.statements {
+        if let MirStatement::Assign {
+            rvalue: MirRvalue::Call { callee, args },
+            ..
+        } = s
+        {
+            if callee.mangled == "print_int" {
+                if let Some(MirOperand::Const(MirConstant::Int(n))) = args.first() {
+                    out.push(*n);
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn defer_runs_in_reverse_order_before_return() {
+    // Two defers at the function body level: print_int(1) then
+    // print_int(2). The block that ends in `return` must call them in
+    // reverse (LIFO) order: 2 then 1.
+    let prog = compile(
+        r#"
+        fun demo() -> Int {
+            defer print_int(1)
+            defer print_int(2)
+            return 0
+        }
+    "#,
+    );
+    let demo = find_fn(&prog, "demo");
+    let ret_block = demo
+        .blocks
+        .iter()
+        .find(|b| matches!(b.terminator, MirTerminator::Return(_)))
+        .expect("demo has a return block");
+    assert_eq!(
+        print_int_args_in_block(ret_block),
+        vec![2, 1],
+        "deferred calls must run LIFO before the return"
+    );
+}
+
+#[test]
+fn only_reached_defers_run_on_each_return_path() {
+    // The first defer precedes the early return, so it is scheduled on
+    // both paths. The second defer follows the early return, so the early
+    // path never schedules it. The early-path return block runs only [9];
+    // the fall-through return block runs [8, 9] (LIFO).
+    let prog = compile(
+        r#"
+        fun f(early: Bool) -> Int {
+            defer print_int(9)
+            if early {
+                return 1
+            }
+            defer print_int(8)
+            return 2
+        }
+    "#,
+    );
+    let f = find_fn(&prog, "f");
+
+    let return_blocks: Vec<Vec<i64>> = f
+        .blocks
+        .iter()
+        .filter(|b| matches!(b.terminator, MirTerminator::Return(_)))
+        .map(print_int_args_in_block)
+        .collect();
+
+    assert!(
+        return_blocks.contains(&vec![9]),
+        "the early-return path runs only the first defer, got {:?}",
+        return_blocks
+    );
+    assert!(
+        return_blocks.contains(&vec![8, 9]),
+        "the fall-through path runs both defers LIFO, got {:?}",
+        return_blocks
     );
 }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -70,6 +70,28 @@ fn dyn_dispatch_program_compiles_and_runs() {
     compile_link_run_and_check("dyn_dispatch.rv", "1\n2\n", &runtime);
 }
 
+#[test]
+fn defer_order_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Two defers run in reverse declaration order at the return: the
+    // function schedules print_int(1) then print_int(2), so the program
+    // prints 2 then 1.
+    compile_link_run_and_check("defer_order.rv", "2\n1\n", &runtime);
+}
+
+#[test]
+fn defer_early_return_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Only reached defers run. f(true) takes the early return after the
+    // first defer, printing 9. f(false) reaches both defers and runs
+    // them LIFO at its return, printing 8 then 9. Combined: 9, 8, 9.
+    compile_link_run_and_check("defer_early_return.rv", "9\n8\n9\n", &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Implement the `defer` statement end to end: `defer expr` schedules `expr` to run when the enclosing function returns, in reverse declaration order (LIFO), on every reached return path, before the function hands control back.

Closes #68

## What changed

- `feat(mir)`: defer is now expanded during HIR-to-MIR lowering with a per-function pending stack instead of passing through as a `Nop`. Each `defer` records its expression; the pending set is re-emitted in reverse order at every block's normal exit and before every `return`. A `return` flushes the whole stack (it escapes all enclosing blocks); a block's normal exit flushes only the defers it registered. The deferred calls land in the block before its `Return` terminator, so codegen emits them before the GC leave-frame epilogue and deferred code can still touch rooted locals.
- `test`: two v2 example programs plus link-and-run smoke cases, and two MIR unit tests pinning the reverse ordering and the reached-only behavior.
- `docs`: `docs/v2/specs/defer.md` plus updates to the HIR and MIR specs.

## Lowering strategy

Compile-time expansion at MIR lowering (no runtime defer stack, no heap thunks, no closures-as-defer-bodies). The runtime per-frame thunk approach was rejected for v2.0: it needs runtime support and closure capture (issue #62), and the compile-time expansion already covers every required control-flow case. All return paths are centralized at MIR: written `return`, fall-off-the-end (the function-body block's normal exit), and the synthesized `return` from `?`, so each gets the pending defers flushed with one mechanism. Full algorithm and worked examples in `docs/v2/specs/defer.md`.

## Semantics

- LIFO within a return path.
- Reached-only: a `defer` schedules its expression only if control reached the statement at run time.
- Return value evaluated first, then defers run, then the function returns (matches Go).
- Block-scoped, which coincides with Go's function scope for the common case of defers written at the function-body level.
- No run on panic: v2.0 `panic` aborts the process with no unwinding, so deferred expressions do not run on a panic. Documented, intentional.
- Deferred expressions are evaluated for side effects; the result is discarded.

## Verified outputs (built and run on windows-msvc, x86_64)

`examples/v2/defer_order.rv`:

```
2
1
```

`examples/v2/defer_early_return.rv` (`f(true)` then `f(false)`):

```
9
8
9
```

`f(true)` prints only `9` (the second defer was never reached); `f(false)` prints `8` then `9` (both defers, LIFO at the return). A GC-bearing check (a deferred call that reads a heap-allocated struct local) printed the field correctly, confirming defers run before the GC leave-frame.

## `?` and GC interaction

The `?` operator desugars in HIR to a `match` whose error arm is an ordinary `return`, so its early-exit path flushes defers with no `?`-specific code. Codegen needs no defer-specific logic: deferred calls are ordinary MIR statements emitted before the `Return` terminator, hence before `raven_gc_leave_frame`.

## Deferrals

- No run on panic (abort semantics, no unwinding).
- Block-scoped rather than a runtime function-scoped defer stack; equivalent to Go for function-body-level defers, which is where defers are written in practice.
- Named-return mutation from a defer (Go style) is out of scope; deferred expressions are side-effect only.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (259 lib tests, 7 codegen_smoke link-and-run cases including the two new defer programs, all golden suites)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Built and ran `examples/v2/defer_order.rv` -> prints 2 then 1
- [x] Built and ran `examples/v2/defer_early_return.rv` -> prints 9, 8, 9
- [x] Verified deferred code runs before the GC leave-frame with a heap-local example
