### PR TITLE
feat: string interpolation with runtime concat and value-to-string

### DIFF
--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -134,26 +134,45 @@ other code runs so subsequent reads can use the uniform slot path.
 ## Print intrinsic
 
 The MIR call site `Call { callee: MirFnRef { mangled: "print", .. } }`
-is recognized as an intrinsic. The codegen:
+is recognized as an intrinsic. It produces a `(pointer, length)` pair
+for its single argument and calls `raven_println_str(ptr, len)`, which
+prints the slice and writes a trailing newline. The pointer width is
+whatever `module.target_config().pointer_type()` reports (i64 on every
+supported host).
 
-1. Pulls the single argument operand. If it is `Const(Str s)`, the bytes
-   are interned into the per module string table, producing a pair of
-   constants: the address of the bytes and the length in bytes.
-2. Declares `raven_println_str` with signature `fn(ptr: i64, len: i64)`.
-   The pointer width is whatever `module.target_config().pointer_type()`
-   reports; the description here uses i64 because every supported host
-   is 64 bit.
-3. Emits a `call` with the two constants as arguments. The runtime
-   prints the slice and writes a trailing newline.
+The argument can be a string in one of two shapes:
+
+1. A bare string literal (`Const(Str s)`). The bytes are interned into
+   the per module string table and the call receives the address of the
+   bytes plus the compile-time byte length. This is the allocation-free
+   fast path so `print("literal")` never touches the heap.
+2. Any other `Str` value (a `let`-bound string, a returned string, an
+   interpolation result). It is a heap `String` pointer, so the codegen
+   calls `raven_string_bytes` and `raven_string_len` on it to read the
+   byte buffer pointer and length (the `u32` length is widened to
+   pointer width for the ABI), then calls `raven_println_str`.
 
 The string table is a `BTreeMap<Vec<u8>, DataId>` keyed by the bytes, so
 identical literals share a single allocation in the object file. Each
 data symbol is named `__raven_str_<n>` for stable diagnostic output.
 
-When the print argument is a non literal `Str` value, the codegen emits
-an `Unreachable` and the driver reports a `print: non literal string
-not supported` diagnostic. Literal printing is enough to get hello
-world running; the full string type lands with issue #65.
+## String values
+
+A string constant used as a *value* (assigned to a local, passed to a
+function, concatenated, interpolated) is promoted to a heap `String`:
+the codegen interns the bytes, then calls `raven_string_from_bytes(ptr,
+len)` to allocate a GC-managed `String` object. Every `Str`-typed local
+therefore holds a real GC pointer, so the GC root frame traces it and
+the runtime string functions can consume it directly. Only the bare
+`print("literal")` argument keeps the static fast path.
+
+String interpolation lowers (in MIR) to a chain of runtime calls that
+the back-end recognizes by mangled name and routes to the runtime:
+`__raven_str_concat` to `raven_string_concat`, and the per-type
+conversions `__raven_int_to_string`, `__raven_bool_to_string`,
+`__raven_float_to_string`, and `__raven_char_to_string` to their
+matching `raven_*_to_string` symbols. Each returns a heap `String`
+pointer that flows like any other string value.
 
 ### `print_int` intrinsic
 

--- a/docs/v2/specs/hir.md
+++ b/docs/v2/specs/hir.md
@@ -45,7 +45,7 @@ translation pass that buys nothing for the desugarings in scope.
 |-----------------------------------|---------------------------------------------------------|
 | `ExprKind::For { pat, iter, body }` | Lowered to `Loop` containing a `Match` on iterator `next` |
 | `ExprKind::Try(inner)`            | Lowered to `Match` on `Ok/Err` (or `Some/None`)         |
-| `ExprKind::Str(s)` with `${...}`  | `Interpolate { parts: Vec<InterpolPart> }`              |
+| `ExprKind::InterpolatedString(fragments)` | `Interpolate { parts: Vec<InterpolPart> }`      |
 | `ExprKind::Range { ... }`         | `RangeNew { start, end, inclusive }`                    |
 | `StmtKind::Assign { op != = }`    | Lowered to `Assign` with a synthesized RHS              |
 | `ExprKind::If`/`Match` in value position | Same node; trailing expression is the value         |
@@ -104,15 +104,20 @@ the type of `expr` from the `TypeMap` and selects the right enum.
 
 ### String interpolation
 
-The lexer keeps `${...}` verbatim inside a `StringLit`. HIR lowering
-splits the raw string into a `Vec<InterpolPart>` where each part is
-either a `Text(String)` chunk or an `Expr(HirExpr)` placeholder. The
-embedded expressions are re-lexed and re-parsed by the lowering pass
-so the resulting HIR expression mirrors what the user wrote.
+The parser splits a `"...${expr}..."` literal into an
+`ExprKind::InterpolatedString(Vec<StrFragment>)` where each fragment is
+either literal `Text` or a fully parsed embedded `Expr`. HIR lowering
+walks those fragments and produces a `Interpolate { parts:
+Vec<InterpolPart> }` node: literal fragments become `Text(String)`
+chunks and embedded fragments become `Expr(HirExpr)` (lowered like any
+other expression, carrying their static type).
 
-Concatenation is left to MIR/codegen so HIR retains the structured
-form. When no `${...}` segment is present, the literal stays as a
-plain `HirExpr::Str(s)`.
+Concatenation is left to MIR so HIR retains the structured form. MIR
+folds the parts into a chain of runtime string-concat calls, inserting
+a per-type to-string conversion for each non-String part. A literal
+with no real `${...}` (or only an escaped `\$`) stays a plain
+`HirExpr::Str(s)`. See `docs/v2/specs/interpolation.md` for the full
+pipeline.
 
 ### Range expressions
 

--- a/docs/v2/specs/interpolation.md
+++ b/docs/v2/specs/interpolation.md
@@ -1,0 +1,182 @@
+# String Interpolation Spec
+
+## Goal
+
+Specify string interpolation: a `"..."` literal may embed expressions
+with `${expr}`, and the result is a `String` built by converting each
+embedded value to text and concatenating the pieces. `print("sum is
+${a + b}")` prints `sum is 7` when `a + b` is `7`. This carries
+interpolation end to end, from the lexer through the runtime, for the
+value types that have a known text rendering.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> Resolver -> Tycheck -> HIR -> MIR -> Codegen -> Runtime
+```
+
+* The lexer decodes escapes inside the literal and marks an escaped `\$`
+  so the splitter can tell it apart from a real `${`.
+* The parser splits the decoded literal into fragments, re-parsing each
+  `${expr}` as a real expression.
+* The resolver and type checker treat each embedded expression normally.
+* HIR keeps the structured `Interpolate` node carrying typed fragments.
+* MIR desugars the node into a concat chain with per-type conversions.
+* Codegen lowers those to runtime calls returning a heap `String`.
+
+## Syntax
+
+```
+"text ${expr} more text"
+```
+
+* `${` opens an interpolation; the matching `}` closes it. Braces nest,
+  so `${ f({ a: 1 }) }` finds the correct closing brace by depth.
+* The text between `${` and `}` is parsed as an ordinary Raven
+  expression. Exactly one expression is allowed per `${...}`.
+* A literal with no `${...}` is an ordinary string and keeps the plain
+  `Str` representation.
+
+### Escaping
+
+* `\$` is a literal dollar sign. `"\${x}"` is the five-character text
+  `${x}`, not an interpolation.
+* All other string escapes (`\n`, `\t`, `\"`, `\\`, `\0`, `\'`) decode as
+  usual before splitting.
+* **Block strings are never interpolated.** A triple-quoted `"""..."""`
+  literal is raw text; a `${...}` inside it is literal characters.
+
+## AST
+
+The parser produces:
+
+```rust
+enum ExprKind {
+    // ...
+    InterpolatedString(Vec<StrFragment>),
+}
+
+enum StrFragment {
+    Literal(String),    // a run of literal text, escapes already decoded
+    Expr(Box<Expr>),    // one embedded expression, fully parsed
+}
+```
+
+A literal that turns out to have no real `${...}` (for example only an
+escaped `\$`) collapses back to a plain `ExprKind::Str`, so
+`InterpolatedString` always carries at least one embedded expression.
+
+## Lexer and parser split
+
+The lexer decodes the literal into a single `StringLit` token. An
+escaped `\$` is decoded to a private-use sentinel (`U+E000`) followed by
+`$`, so the parser can distinguish an escaped dollar from a real `${`
+even though both look like `$` after decoding.
+
+The parser walks the decoded text:
+
+* A sentinel-plus-`$` becomes a literal `$` in the current text run (the
+  sentinel is dropped).
+* A real `${` starts a fragment. The parser scans to the depth-matched
+  `}`, takes the inner snippet, and re-lexes and re-parses it as a
+  standalone expression. The snippet is parsed against a synthetic
+  per-fragment source path so that the resolver, type checker, and
+  lowering passes (all keyed on file plus byte range) give each
+  fragment's spans a private keyspace that never collides with the
+  surrounding source or with another fragment.
+* Anything else accumulates into the current literal text run.
+
+An unterminated `${` or an empty `${}` is a parse error.
+
+## Type rules
+
+An interpolated string has type `String`. Each embedded expression must
+have a type with a known text rendering. The supported set is:
+
+| Embedded type | Conversion |
+|---------------|------------|
+| `String`      | identity (used as-is) |
+| `Int`         | base-ten, with a leading `-` for negatives |
+| `Bool`        | `true` or `false` |
+| `Float`       | default `{}` rendering (so `7.0` renders `7`) |
+| `Char`        | the single Unicode scalar value |
+
+Any other embedded type is a type error with a hint that points the user
+at converting to a `String` first, for example a struct value cannot be
+interpolated until it has a string conversion. The type checker records
+each fragment expression's resolved type so the lowering pass can pick
+the right conversion.
+
+## HIR desugaring
+
+HIR lowering walks the AST fragments and produces a structured
+`Interpolate { parts: Vec<InterpolPart> }` node. A `Literal` fragment
+becomes `Text(String)`; an `Expr` fragment is lowered like any other
+expression into `Expr(HirExpr)`, carrying its static type. HIR keeps the
+structured form so the concat strategy stays a lowering concern.
+
+MIR lowering performs the desugaring. It turns each part into a heap
+`String` operand and folds them left to right:
+
+```
+["sum is ", a + b, "!"]
+  becomes
+concat(concat("sum is ", int_to_string(a + b)), "!")
+```
+
+A `String` part needs no conversion. An `Int`, `Bool`, `Float`, or
+`Char` part is routed through its per-type to-string intrinsic. Literal
+text parts are string constants the back-end promotes to heap Strings.
+An empty interpolation yields an empty `String`; a single part binds
+straight to a result temporary.
+
+The intrinsic mangled names are `__raven_str_concat`,
+`__raven_int_to_string`, `__raven_bool_to_string`,
+`__raven_float_to_string`, and `__raven_char_to_string`. They live in
+`mir::intrinsics` so the lowering and the back-end share one source of
+truth.
+
+## Runtime
+
+The runtime exposes C-ABI functions that allocate GC-managed `String`
+objects through the existing `raven_string_new` constructor (tag
+`TAG_STRING`), so every result is a real heap value the collector
+traces:
+
+* `raven_string_from_bytes(ptr, len) -> *mut String`: copy a byte slice
+  into a fresh `String`. Used to promote a literal into a heap value.
+* `raven_string_concat(a, b) -> *mut String`: allocate a `String` whose
+  bytes are `a` then `b`. Either input may be null (treated as empty).
+* `raven_int_to_string(i64)`, `raven_bool_to_string(i8)`,
+  `raven_float_to_string(f64)`, `raven_char_to_string(u32)`: render a
+  scalar into a fresh `String`.
+
+## Codegen and generalized print
+
+A string constant used as a value (assigned, passed, concatenated,
+interpolated) is promoted to a heap `String` via
+`raven_string_from_bytes`, so every `Str`-typed local is a GC pointer
+the root frame traces. The interpolation intrinsics are recognized by
+mangled name and routed to their runtime symbols.
+
+The `print` intrinsic accepts both shapes of string. A bare string
+literal keeps the allocation-free static fast path: it passes the
+interned bytes and the compile-time length straight to
+`raven_println_str`. Any other `String` value (a `let`-bound string, a
+returned string, an interpolation result) is a heap `String` pointer, so
+the codegen reads the byte buffer pointer and length through
+`raven_string_bytes` and `raven_string_len` before calling
+`raven_println_str`. Both `print("literal")` and `print("x is ${x}")`
+work.
+
+## Out of scope
+
+* Interpolating struct, enum, list, map, or function values. These need
+  a user-facing string conversion (a future `Display`-style trait) and
+  raise a type error today.
+* Format specifiers or alignment (`${x:04}` style). The `${...}` body is
+  a plain expression with no formatting mini-language.
+* Reusing one parsed snippet across passes by source byte offset. The
+  synthetic per-fragment span keyspace is internal and is not surfaced
+  in diagnostics; errors inside a snippet are re-anchored to the
+  enclosing string literal.

--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -150,7 +150,7 @@ Calling `emit_statement` appends to the current block; calling
 | `Return(v)`   | Lower `v`, then close the current block with `Return(local)` |
 | `Break(v)`    | Optional value written to the enclosing loop's result local, then `Goto continuation` |
 | `Continue`    | `Goto header` of the enclosing loop |
-| `Interpolate` | Concatenation through a synthetic `__concat_string` runtime call |
+| `Interpolate` | Left-folded chain of `__raven_str_concat` calls; each non-String part is first converted with its per-type to-string intrinsic (`__raven_int_to_string`, `__raven_bool_to_string`, `__raven_float_to_string`, `__raven_char_to_string`). Literal-text parts are string constants the back-end promotes to heap Strings. An empty interpolation yields an empty String. |
 | `RangeNew`    | `StructCreate` of the built-in `Range` struct (or a runtime call when codegen needs it) |
 | `IterNew`     | `Call { callee: __iter_new, args: [source] }` |
 | `IterNext`    | `Call { callee: __iter_next, args: [iter] }` |

--- a/docs/v2/specs/runtime.md
+++ b/docs/v2/specs/runtime.md
@@ -59,11 +59,20 @@ intentionally short. New symbols are added as later issues need them.
 | `raven_panic` | `fn(msg_ptr: *const u8, msg_len: usize) -> !` | Writes the UTF-8 slice `msg_ptr[..msg_len]` to standard error with a `raven panic: ` prefix and a trailing newline, then exits the process with status 101 (Rust panic code). Does not return. |
 | `raven_print_str` | `fn(ptr: *const u8, len: usize)` | Writes the UTF-8 slice to standard output without a trailing newline. |
 | `raven_println_str` | `fn(ptr: *const u8, len: usize)` | Writes the UTF-8 slice to standard output followed by a single `\n`. |
+| `raven_string_from_bytes` | `fn(ptr: *const u8, len: usize) -> *mut String` | Allocates a GC-managed `String` and copies `len` UTF-8 bytes into it. A zero `len` or null `ptr` yields an empty string. The back-end promotes static string literals into heap String values with this. |
+| `raven_string_concat` | `fn(a: *const String, b: *const String) -> *mut String` | Allocates a fresh GC `String` whose bytes are the concatenation of `a` then `b`. Either input may be null (treated as empty). The interpolation concat chain folds through this. |
+| `raven_int_to_string` | `fn(value: i64) -> *mut String` | Allocates a GC `String` with the base-ten rendering of `value`; negatives carry a leading `-`, zero renders `0`. |
+| `raven_bool_to_string` | `fn(value: i8) -> *mut String` | Allocates a GC `String` of `true` or `false`; any nonzero `value` is `true`. |
+| `raven_float_to_string` | `fn(value: f64) -> *mut String` | Allocates a GC `String` with the default `{}` rendering of `value` (so `7.0` renders `7`). |
+| `raven_char_to_string` | `fn(value: u32) -> *mut String` | Allocates a GC `String` holding the single Unicode scalar `value`; an invalid code point renders the replacement character `U+FFFD`. |
 
 All string-shaped entries take a raw pointer plus length so the codegen
 back-end does not need to know any Rust slice layout. The bytes are
 assumed valid UTF-8; the runtime does not re-validate them, mirroring
-the type-checker invariant.
+the type-checker invariant. The `raven_*_to_string` and
+`raven_string_concat` constructors return GC pointers to `String`
+objects (tag `TAG_STRING`) allocated through `raven_gc_alloc`, so the
+collector traces and frees them like any other heap value.
 
 ## Object header layout
 

--- a/examples/v2/interpolation.rv
+++ b/examples/v2/interpolation.rv
@@ -1,0 +1,7 @@
+fun main() {
+    let name = "Raven"
+    let a = 3
+    let b = 4
+    print("Hello, ${name}!")
+    print("sum is ${a + b}")
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -23,14 +23,15 @@ pub use gc::{
     raven_struct_register,
 };
 pub use object::{
-    raven_box_new, raven_box_payload, raven_closure_captures, raven_closure_fn_ptr,
-    raven_closure_new, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,
+    raven_bool_to_string, raven_box_new, raven_box_payload, raven_char_to_string,
+    raven_closure_captures, raven_closure_fn_ptr, raven_closure_new, raven_float_to_string,
+    raven_int_to_string, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,
     raven_map_bucket_count, raven_map_buckets, raven_map_new, raven_set_bucket_count,
-    raven_set_buckets, raven_set_new, raven_string_bytes, raven_string_concat, raven_string_len,
-    raven_string_new, raven_struct_fields, raven_struct_new, Box as RavenBox,
-    Closure as RavenClosure, List as RavenList, Map as RavenMap, MapEntry, ObjectHeader,
-    Set as RavenSet, SetEntry, String as RavenString, GC_MARK_BIT, OBJECT_ALIGN, TAG_BOX,
-    TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING, TAG_STRUCT,
+    raven_set_buckets, raven_set_new, raven_string_bytes, raven_string_concat,
+    raven_string_from_bytes, raven_string_len, raven_string_new, raven_struct_fields,
+    raven_struct_new, Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap,
+    MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, GC_MARK_BIT,
+    OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING, TAG_STRUCT,
 };
 
 use std::alloc::{self, Layout};

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -26,7 +26,9 @@ pub use list::{raven_list_elements, raven_list_len, raven_list_new, raven_list_p
 pub use map::{raven_map_bucket_count, raven_map_buckets, raven_map_new, Map, MapEntry};
 pub use set::{raven_set_bucket_count, raven_set_buckets, raven_set_new, Set, SetEntry};
 pub use string::{
-    raven_string_bytes, raven_string_concat, raven_string_len, raven_string_new, String,
+    raven_bool_to_string, raven_char_to_string, raven_float_to_string, raven_int_to_string,
+    raven_string_bytes, raven_string_concat, raven_string_from_bytes, raven_string_len,
+    raven_string_new, String,
 };
 pub use structval::{
     raven_struct_fields, raven_struct_new, STRUCT_FIELDS_OFFSET, STRUCT_FIELD_SLOT,

--- a/raven-runtime/src/object/string.rs
+++ b/raven-runtime/src/object/string.rs
@@ -121,6 +121,102 @@ pub extern "C" fn raven_string_concat(a: *const String, b: *const String) -> *mu
     out
 }
 
+/// Build a GC-managed `String` from a borrowed UTF-8 byte slice.
+///
+/// Allocates a fresh `String` with capacity equal to `len`, copies the
+/// `len` bytes from `ptr`, and sets the length. A zero `len` (or null
+/// `ptr`) yields an empty string. Returns null on allocation failure.
+///
+/// The back-end calls this to promote a static string literal into a
+/// heap String value so every `String`-typed local is a real GC object
+/// the collector can trace and the concat path can consume.
+///
+/// # Safety
+///
+/// `ptr` must point to `len` initialized UTF-8 bytes, or `len` must be
+/// zero.
+#[no_mangle]
+pub extern "C" fn raven_string_from_bytes(ptr: *const u8, len: usize) -> *mut String {
+    let len_u32 = match u32::try_from(len) {
+        Ok(v) => v,
+        Err(_) => return ptr::null_mut(),
+    };
+    let out = raven_string_new(len_u32);
+    if out.is_null() {
+        return ptr::null_mut();
+    }
+    if len_u32 > 0 && !ptr.is_null() {
+        // SAFETY: out has `len` bytes of capacity, and the caller
+        // guarantees `ptr` points to `len` initialized bytes.
+        unsafe {
+            ptr::copy_nonoverlapping(ptr, (*out).bytes, len);
+            (*out).header.len = len_u32;
+        }
+    }
+    out
+}
+
+/// Allocate a GC `String` whose bytes are the decimal rendering of a
+/// signed 64-bit integer. Negatives carry a leading `-`; zero renders
+/// as `0`.
+#[no_mangle]
+pub extern "C" fn raven_int_to_string(value: i64) -> *mut String {
+    let mut buf = [0u8; 20];
+    let s = format_i64_into(value, &mut buf);
+    raven_string_from_bytes(s.as_ptr(), s.len())
+}
+
+/// Allocate a GC `String` rendering of a boolean. The C ABI passes the
+/// value as an `i8`; any nonzero value is `true`.
+#[no_mangle]
+pub extern "C" fn raven_bool_to_string(value: i8) -> *mut String {
+    let s: &[u8] = if value != 0 { b"true" } else { b"false" };
+    raven_string_from_bytes(s.as_ptr(), s.len())
+}
+
+/// Allocate a GC `String` rendering of an `f64`, matching Rust's
+/// default `{}` float formatting (so `7.0` renders as `7`).
+#[no_mangle]
+pub extern "C" fn raven_float_to_string(value: f64) -> *mut String {
+    let rendered = format!("{}", value);
+    raven_string_from_bytes(rendered.as_ptr(), rendered.len())
+}
+
+/// Allocate a GC `String` holding a single Unicode scalar value. The C
+/// ABI passes the `Char` as a `u32` code point; an invalid code point
+/// renders as the Unicode replacement character.
+#[no_mangle]
+pub extern "C" fn raven_char_to_string(value: u32) -> *mut String {
+    let ch = char::from_u32(value).unwrap_or('\u{FFFD}');
+    let mut buf = [0u8; 4];
+    let s = ch.encode_utf8(&mut buf);
+    raven_string_from_bytes(s.as_ptr(), s.len())
+}
+
+/// Format `value` into `buf` as base-ten ASCII and return the written
+/// slice. Twenty bytes hold the widest `i64` (`-9223372036854775808`).
+/// Mirrors the `format_i64` helper in the crate root; kept local so the
+/// string conversions do not reach across modules.
+fn format_i64_into(value: i64, buf: &mut [u8; 20]) -> &str {
+    let negative = value < 0;
+    let mut magnitude = value.unsigned_abs();
+    let mut pos = buf.len();
+    loop {
+        pos -= 1;
+        buf[pos] = b'0' + (magnitude % 10) as u8;
+        magnitude /= 10;
+        if magnitude == 0 {
+            break;
+        }
+    }
+    if negative {
+        pos -= 1;
+        buf[pos] = b'-';
+    }
+    // SAFETY: every written byte is an ASCII digit or '-'.
+    unsafe { std::str::from_utf8_unchecked(&buf[pos..]) }
+}
+
 /// Size, in bytes, of the in-memory `String` object on the host
 /// target. Used by constructors and by the collector's free routine.
 pub(crate) const fn size_of_string() -> usize {
@@ -263,6 +359,111 @@ mod tests {
     fn null_accessors_are_safe() {
         assert_eq!(raven_string_len(std::ptr::null()), 0);
         assert!(raven_string_bytes(std::ptr::null()).is_null());
+    }
+
+    /// Read a String object's bytes into a Rust `String` for assertions.
+    fn read(s: *const String) -> std::string::String {
+        let len = raven_string_len(s) as usize;
+        if len == 0 {
+            return std::string::String::new();
+        }
+        // SAFETY: s is a live String with `len` valid UTF-8 bytes.
+        let slice = unsafe { std::slice::from_raw_parts(raven_string_bytes(s), len) };
+        std::str::from_utf8(slice).unwrap().to_string()
+    }
+
+    #[test]
+    fn from_bytes_copies_payload() {
+        let src = b"hello";
+        let s = raven_string_from_bytes(src.as_ptr(), src.len());
+        assert!(!s.is_null());
+        assert_eq!(read(s), "hello");
+        unsafe { drop_string_for_test(s) };
+    }
+
+    #[test]
+    fn from_bytes_empty_is_empty_string() {
+        let s = raven_string_from_bytes(std::ptr::null(), 0);
+        assert!(!s.is_null());
+        assert_eq!(raven_string_len(s), 0);
+        assert_eq!(read(s), "");
+        unsafe { drop_string_for_test(s) };
+    }
+
+    #[test]
+    fn int_to_string_handles_zero_and_negatives() {
+        for (value, want) in [
+            (0i64, "0"),
+            (7, "7"),
+            (-7, "-7"),
+            (i64::MAX, "9223372036854775807"),
+            (i64::MIN, "-9223372036854775808"),
+        ] {
+            let s = raven_int_to_string(value);
+            assert!(!s.is_null());
+            assert_eq!(read(s), want, "int_to_string({value})");
+            unsafe { drop_string_for_test(s) };
+        }
+    }
+
+    #[test]
+    fn bool_to_string_renders_true_and_false() {
+        let t = raven_bool_to_string(1);
+        let f = raven_bool_to_string(0);
+        // Any nonzero byte is true.
+        let other = raven_bool_to_string(-1);
+        assert_eq!(read(t), "true");
+        assert_eq!(read(f), "false");
+        assert_eq!(read(other), "true");
+        unsafe {
+            drop_string_for_test(t);
+            drop_string_for_test(f);
+            drop_string_for_test(other);
+        }
+    }
+
+    #[test]
+    fn float_to_string_matches_default_formatting() {
+        let whole = raven_float_to_string(7.0);
+        let frac = raven_float_to_string(3.5);
+        let neg = raven_float_to_string(-0.25);
+        assert_eq!(read(whole), "7");
+        assert_eq!(read(frac), "3.5");
+        assert_eq!(read(neg), "-0.25");
+        unsafe {
+            drop_string_for_test(whole);
+            drop_string_for_test(frac);
+            drop_string_for_test(neg);
+        }
+    }
+
+    #[test]
+    fn char_to_string_encodes_ascii_and_multibyte() {
+        let a = raven_char_to_string('A' as u32);
+        let euro = raven_char_to_string('€' as u32);
+        let invalid = raven_char_to_string(0xD800); // lone surrogate
+        assert_eq!(read(a), "A");
+        assert_eq!(read(euro), "€");
+        assert_eq!(read(invalid), "\u{FFFD}");
+        unsafe {
+            drop_string_for_test(a);
+            drop_string_for_test(euro);
+            drop_string_for_test(invalid);
+        }
+    }
+
+    #[test]
+    fn concat_result_is_gc_managed_and_correct() {
+        let a = raven_string_from_bytes(b"foo".as_ptr(), 3);
+        let b = raven_string_from_bytes(b"bar".as_ptr(), 3);
+        let joined = raven_string_concat(a, b);
+        assert!(!joined.is_null());
+        assert_eq!(read(joined), "foobar");
+        unsafe {
+            drop_string_for_test(joined);
+            drop_string_for_test(a);
+            drop_string_for_test(b);
+        }
     }
 
     /// Test-only deallocator. The real free path lands with the GC

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -28,10 +28,16 @@ pub enum ExprKind {
     Float(f64),
     /// Boolean literal.
     Bool(bool),
-    /// Regular `"..."` string literal. Interpolation segments are kept
-    /// verbatim; splitting is tracked in a later issue.
+    /// Regular `"..."` string literal with no `${...}` interpolation.
     Str(String),
-    /// Triple quoted block string literal.
+    /// A string literal containing one or more `${...}` interpolation
+    /// segments, split into an ordered run of literal-text and embedded
+    /// expression fragments. The parser produces this only when at least
+    /// one real (non-escaped) `${...}` is present; otherwise the literal
+    /// stays a plain `Str`. See `docs/v2/specs/interpolation.md`.
+    InterpolatedString(Vec<StrFragment>),
+    /// Triple quoted block string literal. Block strings are raw and are
+    /// never interpolated.
     BlockStr(String),
     /// Character literal.
     Char(char),
@@ -135,6 +141,19 @@ pub enum ExprKind {
         body: LambdaBody,
         params_inferred: bool,
     },
+}
+
+/// One fragment of an interpolated string literal. An interpolated
+/// string is an ordered sequence of these: literal text chunks and
+/// embedded expressions, in source order.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StrFragment {
+    /// A run of literal characters between embedded expressions. Already
+    /// escape-decoded by the lexer (and with any `\$` un-escaped).
+    Literal(String),
+    /// An embedded `${expr}` expression, parsed as a normal Raven
+    /// expression.
+    Expr(Box<Expr>),
 }
 
 /// Unary prefix operators.

--- a/src/ast/pretty.rs
+++ b/src/ast/pretty.rs
@@ -11,8 +11,8 @@ use std::fmt::Write;
 
 use super::{
     AssignOp, BinaryOp, Block, Decl, DeclKind, ElseBranch, Expr, ExprKind, File, FunctionBody,
-    ImportSource, LambdaBody, LiteralPattern, Pattern, PatternKind, Stmt, StmtKind, Type, TypeKind,
-    TypePath, UnaryOp, VariantPayload,
+    ImportSource, LambdaBody, LiteralPattern, Pattern, PatternKind, Stmt, StmtKind, StrFragment,
+    Type, TypeKind, TypePath, UnaryOp, VariantPayload,
 };
 
 /// Render a [`File`] as a multi line S expression string.
@@ -318,6 +318,23 @@ fn pretty_expr(buf: &mut String, expr: &Expr, depth: usize) {
         ExprKind::Float(v) => writeln!(buf, "(float {})", v).unwrap(),
         ExprKind::Bool(b) => writeln!(buf, "(bool {})", b).unwrap(),
         ExprKind::Str(s) => writeln!(buf, "(str {})", quote(s)).unwrap(),
+        ExprKind::InterpolatedString(fragments) => {
+            buf.push_str("(interpolated\n");
+            for frag in fragments {
+                indent(buf, depth + 1);
+                match frag {
+                    StrFragment::Literal(s) => writeln!(buf, "(lit {})", quote(s)).unwrap(),
+                    StrFragment::Expr(e) => {
+                        buf.push_str("(frag\n");
+                        pretty_expr(buf, e, depth + 2);
+                        indent(buf, depth + 1);
+                        buf.push_str(")\n");
+                    }
+                }
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
         ExprKind::BlockStr(s) => writeln!(buf, "(blockstr {})", quote(s)).unwrap(),
         ExprKind::Char(c) => writeln!(buf, "(char {:?})", c).unwrap(),
         ExprKind::CStr(s) => writeln!(buf, "(cstr {})", quote(s)).unwrap(),

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -284,6 +284,42 @@ impl ModuleCx {
         sig = self.make_sig(&[ptr], &[ptr]);
         self.declare_runtime(intrinsics::RUNTIME_CLOSURE_CAPTURES, &sig)?;
 
+        // String value support for interpolation and the generalized
+        // print path.
+        let f64t = types::F64;
+
+        // raven_string_from_bytes(ptr, len) -> String ptr
+        sig = self.make_sig(&[ptr, ptr], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_FROM_BYTES, &sig)?;
+
+        // raven_string_bytes(String ptr) -> byte ptr
+        sig = self.make_sig(&[ptr], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_BYTES, &sig)?;
+
+        // raven_string_len(String ptr) -> u32
+        sig = self.make_sig(&[ptr], &[i32t]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_LEN, &sig)?;
+
+        // raven_string_concat(String ptr, String ptr) -> String ptr
+        sig = self.make_sig(&[ptr, ptr], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_CONCAT, &sig)?;
+
+        // raven_int_to_string(i64) -> String ptr
+        sig = self.make_sig(&[i64t], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_INT_TO_STRING, &sig)?;
+
+        // raven_bool_to_string(i8) -> String ptr
+        sig = self.make_sig(&[types::I8], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_BOOL_TO_STRING, &sig)?;
+
+        // raven_float_to_string(f64) -> String ptr
+        sig = self.make_sig(&[f64t], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_FLOAT_TO_STRING, &sig)?;
+
+        // raven_char_to_string(u32) -> String ptr
+        sig = self.make_sig(&[i32t], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_CHAR_TO_STRING, &sig)?;
+
         Ok(())
     }
 

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -391,14 +391,26 @@ fn lower_constant(
         MirConstant::Float(f) => Ok(Some(builder.ins().f64const(*f))),
         MirConstant::Char(c) => Ok(Some(builder.ins().iconst(types::I32, *c as i64))),
         MirConstant::Str(s) => {
-            // String constants in the MVP only flow into the print
-            // intrinsic. We materialize the pointer to the interned
-            // bytes here so the caller can read the address and the
-            // length companion separately.
-            let id = cx.intern_string(s.as_bytes())?;
+            // A string constant used as a value (assigned to a local,
+            // passed to concat, interpolated, ...) is promoted to a heap
+            // `String` so every `Str`-typed value is a real GC object the
+            // collector can trace and the runtime string functions can
+            // consume. The direct `print("literal")` fast path bypasses
+            // this by pattern matching the const operand before it
+            // reaches here, so a bare literal print stays allocation
+            // free.
+            let bytes = s.as_bytes();
+            let id = cx.intern_string(bytes)?;
             let local_id = cx.module().declare_data_in_func(id, builder.func);
             let ptr = cx.pointer_type();
-            Ok(Some(builder.ins().symbol_value(ptr, local_id)))
+            let bytes_ptr = builder.ins().symbol_value(ptr, local_id);
+            let len_val = builder.ins().iconst(ptr, bytes.len() as i64);
+            let func_id = cx
+                .runtime_id(intrinsics::RUNTIME_STRING_FROM_BYTES)
+                .expect("string-from-bytes runtime symbol declared at module init");
+            let fref = cx.module().declare_func_in_func(func_id, builder.func);
+            let inst = builder.ins().call(fref, &[bytes_ptr, len_val]);
+            Ok(Some(builder.inst_results(inst)[0]))
         }
     }
 }
@@ -904,6 +916,24 @@ fn lower_call(
     if intrinsics::is_intrinsic(&callee.mangled) {
         return lower_intrinsic(cx, builder, &callee.mangled, args, slots);
     }
+    // Interpolation desugaring emits calls to the string concat and
+    // per-type to-string intrinsics. Route each to its runtime symbol;
+    // every argument lowers as an ordinary operand (a String pointer or
+    // a scalar) and the call returns a heap String pointer.
+    if let Some(symbol) = intrinsics::interpolation_runtime_symbol(&callee.mangled) {
+        let mut arg_vals = Vec::with_capacity(args.len());
+        for a in args {
+            if let Some(v) = lower_operand(cx, builder, a, slots)? {
+                arg_vals.push(v);
+            }
+        }
+        let func_id = cx
+            .runtime_id(symbol)
+            .expect("interpolation runtime symbol declared at module init");
+        let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+        let inst = builder.ins().call(local_ref, &arg_vals);
+        return Ok(builder.inst_results(inst).first().copied());
+    }
     let func_id = cx.function_id(&callee.mangled).ok_or_else(|| {
         CodegenError::Unsupported(format!("unresolved callee: {}", callee.mangled))
     })?;
@@ -934,7 +964,7 @@ fn lower_intrinsic(
                     args.len()
                 )));
             }
-            let (ptr_val, len_val) = lower_string_arg(cx, builder, &args[0])?;
+            let (ptr_val, len_val) = lower_string_arg(cx, builder, &args[0], slots)?;
             let func_id = cx
                 .runtime_id(intrinsics::RUNTIME_PRINTLN_STR)
                 .expect("runtime imports declared at module init");
@@ -968,28 +998,56 @@ fn lower_intrinsic(
 }
 
 /// Produce a `(pointer, length)` pair for a string argument that
-/// reaches an intrinsic.
+/// reaches the `print` intrinsic.
 ///
-/// Only literal strings are supported in the MVP. Non literal string
-/// values would need the full object layout from issue #65.
+/// A bare string literal takes the static fast path: the interned bytes
+/// and their compile-time length are passed straight to the runtime, so
+/// `print("literal")` performs no allocation. Any other string value is
+/// a heap `String` pointer (an interpolation result, a `let`-bound
+/// string, a returned string, ...); the bytes pointer and byte length
+/// are read from the String object through the runtime accessors so
+/// `print(someStringValue)` works uniformly.
 fn lower_string_arg(
     cx: &mut ModuleCx,
     builder: &mut FunctionBuilder<'_>,
     op: &MirOperand,
+    slots: &[LocalSlot],
 ) -> Result<(Value, Value), CodegenError> {
+    let ptr = cx.pointer_type();
     match op {
         MirOperand::Const(MirConstant::Str(s)) => {
             let bytes = s.as_bytes();
             let id = cx.intern_string(bytes)?;
             let local_id = cx.module().declare_data_in_func(id, builder.func);
-            let ptr = cx.pointer_type();
             let ptr_val = builder.ins().symbol_value(ptr, local_id);
             let len_val = builder.ins().iconst(ptr, bytes.len() as i64);
             Ok((ptr_val, len_val))
         }
-        _ => Err(CodegenError::Unsupported(
-            "print currently only accepts a string literal argument".into(),
-        )),
+        _ => {
+            // A heap String value. Load its byte buffer pointer and byte
+            // length from the object through the runtime accessors.
+            let string_ptr = require_value(
+                lower_operand(cx, builder, op, slots)?,
+                "print string argument",
+            )?;
+            let bytes_id = cx
+                .runtime_id(intrinsics::RUNTIME_STRING_BYTES)
+                .expect("string-bytes runtime symbol declared at module init");
+            let bytes_ref = cx.module().declare_func_in_func(bytes_id, builder.func);
+            let bytes_inst = builder.ins().call(bytes_ref, &[string_ptr]);
+            let ptr_val = builder.inst_results(bytes_inst)[0];
+
+            let len_id = cx
+                .runtime_id(intrinsics::RUNTIME_STRING_LEN)
+                .expect("string-len runtime symbol declared at module init");
+            let len_ref = cx.module().declare_func_in_func(len_id, builder.func);
+            let len_inst = builder.ins().call(len_ref, &[string_ptr]);
+            // raven_string_len returns a u32; widen it to pointer width
+            // for the `raven_println_str(ptr, len)` ABI.
+            let len_u32 = builder.inst_results(len_inst)[0];
+            let len_val = builder.ins().uextend(ptr, len_u32);
+            Ok((ptr_val, len_val))
+        }
     }
 }
 

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -17,6 +17,39 @@ pub const RUNTIME_PRINTLN_STR: &str = "raven_println_str";
 /// Runtime C symbol the `print_int` intrinsic dispatches to.
 pub const RUNTIME_PRINTLN_INT: &str = "raven_println_int";
 
+/// Runtime C symbol building a heap `String` from a byte slice. Used to
+/// promote a string literal into a heap `String` value.
+pub const RUNTIME_STRING_FROM_BYTES: &str = "raven_string_from_bytes";
+
+/// Runtime C symbol returning a heap `String`'s byte buffer pointer.
+pub const RUNTIME_STRING_BYTES: &str = "raven_string_bytes";
+
+/// Runtime C symbol returning a heap `String`'s byte length.
+pub const RUNTIME_STRING_LEN: &str = "raven_string_len";
+
+/// Runtime C symbols backing the interpolation desugaring intrinsics.
+/// Each MIR mangled name on the left dispatches to the runtime symbol on
+/// the right; see [`crate::mir::intrinsics`].
+pub const RUNTIME_STRING_CONCAT: &str = "raven_string_concat";
+pub const RUNTIME_INT_TO_STRING: &str = "raven_int_to_string";
+pub const RUNTIME_BOOL_TO_STRING: &str = "raven_bool_to_string";
+pub const RUNTIME_FLOAT_TO_STRING: &str = "raven_float_to_string";
+pub const RUNTIME_CHAR_TO_STRING: &str = "raven_char_to_string";
+
+/// Map a MIR interpolation intrinsic mangled name to the runtime C
+/// symbol it lowers to, or `None` when `mangled` is not one of them.
+pub fn interpolation_runtime_symbol(mangled: &str) -> Option<&'static str> {
+    use crate::mir::intrinsics as mir_intr;
+    Some(match mangled {
+        mir_intr::STR_CONCAT => RUNTIME_STRING_CONCAT,
+        mir_intr::INT_TO_STRING => RUNTIME_INT_TO_STRING,
+        mir_intr::BOOL_TO_STRING => RUNTIME_BOOL_TO_STRING,
+        mir_intr::FLOAT_TO_STRING => RUNTIME_FLOAT_TO_STRING,
+        mir_intr::CHAR_TO_STRING => RUNTIME_CHAR_TO_STRING,
+        _ => return None,
+    })
+}
+
 /// Runtime C symbol allocating a struct or enum value body.
 pub const RUNTIME_STRUCT_NEW: &str = "raven_struct_new";
 

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -67,7 +67,25 @@ pub(crate) fn lower_expr(
         ExprKind::Int(i) => HirExprKind::Int(*i),
         ExprKind::Float(f) => HirExprKind::Float(*f),
         ExprKind::Bool(b) => HirExprKind::Bool(*b),
-        ExprKind::Str(s) | ExprKind::BlockStr(s) => lower_string_literal(s, &span),
+        ExprKind::Str(s) | ExprKind::BlockStr(s) => HirExprKind::Str(s.clone()),
+        ExprKind::InterpolatedString(fragments) => {
+            let mut parts = Vec::with_capacity(fragments.len());
+            for frag in fragments {
+                match frag {
+                    crate::ast::StrFragment::Literal(text) => {
+                        parts.push(InterpolPart::Text(text.clone()))
+                    }
+                    crate::ast::StrFragment::Expr(e) => {
+                        // Each fragment was parsed as a real expression and
+                        // type-checked under its own span, so it lowers like
+                        // any other value. Lowering to MIR turns each part
+                        // into a per-type to-string conversion and a concat.
+                        parts.push(InterpolPart::Expr(lower_expr(e, &Ty::Str, cx)?));
+                    }
+                }
+            }
+            HirExprKind::Interpolate(parts)
+        }
         ExprKind::CStr(s) => HirExprKind::CStr(s.clone()),
         ExprKind::Char(c) => HirExprKind::Char(*c),
         ExprKind::SelfLower => HirExprKind::SelfValue,
@@ -343,93 +361,6 @@ fn lower_binop(op: BinaryOp) -> HirBinaryOp {
         BinaryOp::BitXor => HirBinaryOp::BitXor,
         BinaryOp::Shl => HirBinaryOp::Shl,
         BinaryOp::Shr => HirBinaryOp::Shr,
-    }
-}
-
-/// Inspect a raw string literal: if it contains `${...}` it is an
-/// interpolation; otherwise it is a plain string.
-fn lower_string_literal(s: &str, span: &Span) -> HirExprKind {
-    if !s.contains("${") {
-        return HirExprKind::Str(s.to_string());
-    }
-    let parts = split_interpolation(s, span);
-    if parts.iter().all(|p| matches!(p, InterpolPart::Text(_))) {
-        // No actual `${...}` once we look closely (e.g. `\$`).
-        let mut buf = String::new();
-        for p in &parts {
-            if let InterpolPart::Text(t) = p {
-                buf.push_str(t);
-            }
-        }
-        HirExprKind::Str(buf)
-    } else {
-        HirExprKind::Interpolate(parts)
-    }
-}
-
-/// Split the raw contents of a `StringLit` into text and expression
-/// fragments. Embedded expressions are stored as their textual source
-/// inside an `Expr` placeholder; the lowering pass cannot re-parse
-/// them in isolation without re-running the full pipeline, so this
-/// release ships them as raw `Ident` placeholders when the embedded
-/// snippet parses as a bare identifier and as text otherwise. The
-/// embedded form is documented in `docs/v2/specs/hir.md`.
-fn split_interpolation(s: &str, span: &Span) -> Vec<InterpolPart> {
-    let mut parts = Vec::new();
-    let mut text = String::new();
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
-            // Find matching `}`.
-            let start = i + 2;
-            let mut depth = 1;
-            let mut j = start;
-            while j < bytes.len() && depth > 0 {
-                match bytes[j] {
-                    b'{' => depth += 1,
-                    b'}' => depth -= 1,
-                    _ => {}
-                }
-                if depth == 0 {
-                    break;
-                }
-                j += 1;
-            }
-            if depth == 0 && j < bytes.len() {
-                if !text.is_empty() {
-                    parts.push(InterpolPart::Text(std::mem::take(&mut text)));
-                }
-                let snippet = &s[start..j];
-                parts.push(InterpolPart::Expr(make_snippet_expr(snippet, span)));
-                i = j + 1;
-                continue;
-            }
-            // Unterminated; fall through and treat as text.
-            text.push(s[i..].chars().next().unwrap_or('$'));
-            i += 1;
-        } else {
-            let c = s[i..].chars().next().unwrap_or(' ');
-            text.push(c);
-            i += c.len_utf8();
-        }
-    }
-    if !text.is_empty() {
-        parts.push(InterpolPart::Text(text));
-    }
-    parts
-}
-
-/// Wrap a literal snippet as an HIR `Ident` placeholder. The MIR pass
-/// is responsible for performing the real string-conversion call; for
-/// now we expose the snippet verbatim so snapshot tests can show what
-/// fragments the splitter produced. The span of the surrounding string
-/// is reused because the lexer keeps the literal as one token.
-fn make_snippet_expr(snippet: &str, span: &Span) -> HirExpr {
-    HirExpr {
-        kind: HirExprKind::Ident(snippet.trim().to_string()),
-        ty: Ty::Str,
-        span: span.clone(),
     }
 }
 

--- a/src/hir/tests.rs
+++ b/src/hir/tests.rs
@@ -143,83 +143,41 @@ fun caller() -> Result<Int, String> {
 
 #[test]
 fn string_with_interpolation_lowers_to_parts() {
-    let src = "fun s() -> String { return \"hi ${name}!\" }";
-    // The string has no resolved `name`, so we cannot run the full
-    // pipeline. Build the literal in isolation through the lowering
-    // helper by re-running just the lexer and parser.
-    let tokens = crate::lexer::Lexer::new(src.to_string(), PathBuf::from("t.rv"))
-        .tokenize()
-        .expect("lex");
-    let file = crate::parser::parse(&tokens).expect("parse");
-    // We do not run resolve/tycheck (the placeholder name is unbound).
-    // Walk the AST to find the string literal directly.
-    let mut found_interpolate = false;
-    for item in &file.items {
-        if let crate::ast::DeclKind::Function(f) = &item.kind {
-            if let crate::ast::FunctionBody::Block(b) = &f.body {
-                for s in &b.stmts {
-                    if let crate::ast::StmtKind::Return(Some(expr)) = &s.kind {
-                        if let crate::ast::ExprKind::Str(raw) = &expr.kind {
-                            // Use the splitter via the lowering's
-                            // public-ish helper: re-run the split.
-                            let parts = split_for_test(raw, &expr.span);
-                            found_interpolate =
-                                parts.iter().any(|p| matches!(p, InterpolPart::Expr(_)));
-                        }
-                    }
-                }
-            }
-        }
-    }
-    assert!(found_interpolate, "expected an interpolation part");
-}
-
-// A tiny re-implementation of the splitter for the unit test only. The
-// real splitter is private to `lower::expr`; we test the externally
-// visible HIR form through the golden corpus instead.
-fn split_for_test(s: &str, span: &crate::span::Span) -> Vec<InterpolPart> {
-    use crate::hir::expr::HirExpr;
-    let mut parts: Vec<InterpolPart> = Vec::new();
-    let mut text = String::new();
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
-            let start = i + 2;
-            let mut depth = 1;
-            let mut j = start;
-            while j < bytes.len() && depth > 0 {
-                match bytes[j] {
-                    b'{' => depth += 1,
-                    b'}' => depth -= 1,
-                    _ => {}
-                }
-                if depth == 0 {
-                    break;
-                }
-                j += 1;
-            }
-            if depth == 0 && j < bytes.len() {
-                if !text.is_empty() {
-                    parts.push(InterpolPart::Text(std::mem::take(&mut text)));
-                }
-                parts.push(InterpolPart::Expr(HirExpr {
-                    kind: HirExprKind::Ident(s[start..j].trim().to_string()),
-                    ty: crate::tycheck::Ty::Str,
-                    span: span.clone(),
-                }));
-                i = j + 1;
-                continue;
-            }
-        }
-        let c = s[i..].chars().next().unwrap_or(' ');
-        text.push(c);
-        i += c.len_utf8();
-    }
-    if !text.is_empty() {
-        parts.push(InterpolPart::Text(text));
-    }
-    parts
+    // An interpolated string with an `Int` fragment runs the full
+    // pipeline and lowers to a structured `Interpolate` HIR node whose
+    // parts alternate literal text and the embedded expression.
+    let src = "fun s() -> String { let n = 7; return \"hi ${n}!\" }";
+    let p = lower(src);
+    let f = only_fn(&p, "s");
+    let body = f.body.as_ref().expect("function body");
+    // `return e` lowers to a bare-expression statement whose expression
+    // is a `Return(Some(..))` HIR node carrying the value.
+    let returned = body
+        .stmts
+        .iter()
+        .find_map(|stmt| match &stmt.kind {
+            HirStmtKind::Expr(e) => match &e.kind {
+                HirExprKind::Return(Some(inner)) => Some(inner.as_ref()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .expect("return with a value");
+    let HirExprKind::Interpolate(parts) = &returned.kind else {
+        panic!("expected an Interpolate node, got {:?}", returned.kind);
+    };
+    assert!(
+        matches!(parts.first(), Some(InterpolPart::Text(t)) if t == "hi "),
+        "first part should be the literal text `hi `"
+    );
+    assert!(
+        parts.iter().any(|p| matches!(p, InterpolPart::Expr(_))),
+        "expected an embedded expression part"
+    );
+    assert!(
+        matches!(parts.last(), Some(InterpolPart::Text(t)) if t == "!"),
+        "last part should be the literal text `!`"
+    );
 }
 
 #[test]

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -15,6 +15,16 @@ use std::sync::Arc;
 use crate::error::{LexError, RavenError};
 use crate::span::Span;
 
+/// Private-use sentinel the lexer emits in front of an escaped dollar
+/// sign (`\$`). String interpolation splitting runs on the lexer's
+/// decoded literal text, where an escaped `\$` and a real `$` would
+/// otherwise be indistinguishable. The sentinel marks the dollar as
+/// escaped; the interpolation splitter strips it and treats the dollar
+/// as ordinary text. `U+E000` is in the Unicode private-use area and is
+/// reserved for this internal purpose. See
+/// `docs/v2/specs/interpolation.md`.
+pub const ESCAPED_DOLLAR_SENTINEL: char = '\u{E000}';
+
 /// Kinds of tokens produced by the lexer.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenKind {
@@ -697,6 +707,18 @@ impl Lexer {
             '\'' => {
                 self.bump();
                 Ok("'".to_string())
+            }
+            '$' => {
+                // `\$` escapes a dollar sign so that `\${...}` is a literal
+                // `${...}` and not an interpolation. The decoded text keeps
+                // a private-use sentinel (`U+E000`) in front of the dollar
+                // so the interpolation splitter, which runs later on the
+                // decoded literal, can tell an escaped `$` apart from a real
+                // `${` interpolation start. The sentinel is dropped when the
+                // splitter emits the literal text. See
+                // `docs/v2/specs/interpolation.md`.
+                self.bump();
+                Ok(format!("{}$", ESCAPED_DOLLAR_SENTINEL))
             }
             '0' => {
                 self.bump();

--- a/src/mir/intrinsics.rs
+++ b/src/mir/intrinsics.rs
@@ -1,0 +1,27 @@
+//! Mangled names for MIR-level runtime intrinsics.
+//!
+//! Some sugar (string interpolation today) desugars during HIR-to-MIR
+//! lowering into ordinary `Call` rvalues whose callee mangled name is
+//! one of the constants below. The code generator recognizes these
+//! names and rewrites each call into a direct call to the matching
+//! `raven-runtime` C-ABI symbol. Keeping the names in one module lets
+//! the lowering and the back-end agree without a circular dependency.
+
+/// Concatenate two heap `String` values into a new heap `String`.
+/// Lowers to `raven_string_concat`.
+pub const STR_CONCAT: &str = "__raven_str_concat";
+
+/// Render an `Int` as a heap `String`. Lowers to `raven_int_to_string`.
+pub const INT_TO_STRING: &str = "__raven_int_to_string";
+
+/// Render a `Bool` as a heap `String`. Lowers to
+/// `raven_bool_to_string`.
+pub const BOOL_TO_STRING: &str = "__raven_bool_to_string";
+
+/// Render a `Float` as a heap `String`. Lowers to
+/// `raven_float_to_string`.
+pub const FLOAT_TO_STRING: &str = "__raven_float_to_string";
+
+/// Render a `Char` as a heap `String`. Lowers to
+/// `raven_char_to_string`.
+pub const CHAR_TO_STRING: &str = "__raven_char_to_string";

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -435,24 +435,94 @@ fn lower_while(cx: &mut LowerCx<'_>, cond: &HirExpr, body: &HirBlock, _ty: MirTy
     MirOperand::Const(MirConstant::Unit)
 }
 
+/// Desugar an interpolated string into a left-folded chain of runtime
+/// string concatenations. Each part is first turned into a heap `String`
+/// operand: a literal-text part is a string constant (codegen promotes
+/// it to a heap String), and an embedded-expression part is converted
+/// with the per-type `to_string` intrinsic selected from its static
+/// type (a `String` part needs no conversion). The parts are then folded
+/// with `__raven_str_concat` so
+/// `["a", x, "b"]` becomes `concat(concat("a", to_string(x)), "b")`.
+///
+/// An empty interpolation, or one with no parts, still yields a valid
+/// (empty) `String`.
 fn lower_interpolate(cx: &mut LowerCx<'_>, parts: &[InterpolPart], ty: MirType) -> MirOperand {
-    let mut args: Vec<MirOperand> = Vec::with_capacity(parts.len());
+    // Build the per-part String operands first.
+    let mut operands: Vec<MirOperand> = Vec::with_capacity(parts.len());
     for p in parts {
         match p {
-            InterpolPart::Text(s) => args.push(MirOperand::Const(MirConstant::Str(s.clone()))),
-            InterpolPart::Expr(e) => args.push(lower_expr(cx, e)),
+            InterpolPart::Text(s) => operands.push(MirOperand::Const(MirConstant::Str(s.clone()))),
+            InterpolPart::Expr(e) => operands.push(stringify_part(cx, e)),
         }
     }
-    let dst = cx.builder.fresh_temp("interp", ty);
+
+    // No parts: produce an empty heap String.
+    let Some(first) = operands.first().cloned() else {
+        let dst = cx.builder.fresh_temp("interp", ty);
+        cx.builder.assign(
+            cx.current,
+            dst,
+            MirRvalue::Use(MirOperand::Const(MirConstant::Str(String::new()))),
+        );
+        return MirOperand::Copy(dst);
+    };
+
+    // A single part is already a String; bind it to a temp so the result
+    // is uniformly a local holding a heap String.
+    if operands.len() == 1 {
+        let dst = cx.builder.fresh_temp("interp", ty);
+        cx.builder
+            .assign(cx.current, dst, MirRvalue::Use(first));
+        return MirOperand::Copy(dst);
+    }
+
+    // Left-fold: acc = concat(acc, next).
+    let mut acc = first;
+    for next in operands.into_iter().skip(1) {
+        let dst = cx.builder.fresh_temp("concat", MirType::Str);
+        cx.builder.assign(
+            cx.current,
+            dst,
+            MirRvalue::Call {
+                callee: MirFnRef {
+                    mangled: super::super::intrinsics::STR_CONCAT.into(),
+                    origin: None,
+                },
+                args: vec![acc, next],
+            },
+        );
+        acc = MirOperand::Copy(dst);
+    }
+    acc
+}
+
+/// Lower an embedded interpolation expression and convert it to a heap
+/// `String`. A `String`-typed expression is used as-is; the other
+/// interpolatable scalars (`Int`, `Bool`, `Float`, `Char`) are routed
+/// through their `to_string` runtime intrinsic. The type checker has
+/// already rejected any other type, so an unexpected type here is a
+/// lowering bug; we fall back to using the value directly.
+fn stringify_part(cx: &mut LowerCx<'_>, e: &HirExpr) -> MirOperand {
+    let value = lower_expr(cx, e);
+    let part_ty = mir_ty(&e.ty, cx.subst);
+    let intrinsic = match part_ty {
+        MirType::Str => return value,
+        MirType::Int => super::super::intrinsics::INT_TO_STRING,
+        MirType::Bool => super::super::intrinsics::BOOL_TO_STRING,
+        MirType::Float => super::super::intrinsics::FLOAT_TO_STRING,
+        MirType::Char => super::super::intrinsics::CHAR_TO_STRING,
+        _ => return value,
+    };
+    let dst = cx.builder.fresh_temp("tostr", MirType::Str);
     cx.builder.assign(
         cx.current,
         dst,
         MirRvalue::Call {
             callee: MirFnRef {
-                mangled: "__concat_string".into(),
+                mangled: intrinsic.into(),
                 origin: None,
             },
-            args,
+            args: vec![value],
         },
     );
     MirOperand::Copy(dst)

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -471,8 +471,7 @@ fn lower_interpolate(cx: &mut LowerCx<'_>, parts: &[InterpolPart], ty: MirType) 
     // is uniformly a local holding a heap String.
     if operands.len() == 1 {
         let dst = cx.builder.fresh_temp("interp", ty);
-        cx.builder
-            .assign(cx.current, dst, MirRvalue::Use(first));
+        cx.builder.assign(cx.current, dst, MirRvalue::Use(first));
         return MirOperand::Copy(dst);
     }
 

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -9,6 +9,7 @@
 //! See `docs/v2/specs/mir.md` for the full design.
 
 pub mod builder;
+pub mod intrinsics;
 pub mod ir;
 pub mod lower;
 pub mod mono;

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -5,10 +5,10 @@
 
 use crate::ast::{
     BinaryOp, Block, ElseBranch, Expr, ExprKind, FieldInit, LambdaBody, LambdaParam, MatchArm,
-    Type, UnaryOp,
+    StrFragment, Type, UnaryOp,
 };
 use crate::error::{ParseError, RavenError};
-use crate::lexer::TokenKind;
+use crate::lexer::{Lexer, TokenKind, ESCAPED_DOLLAR_SENTINEL};
 use crate::span::Span;
 
 use super::{merge_spans, ParseResult, Parser};
@@ -379,10 +379,7 @@ impl Parser {
             }
             TokenKind::StringLit(s) => {
                 self.advance();
-                Ok(Expr {
-                    kind: ExprKind::Str(s),
-                    span: tok.span,
-                })
+                self.string_literal_expr(s, tok.span)
             }
             TokenKind::BlockStringLit(s) => {
                 self.advance();
@@ -431,6 +428,34 @@ impl Parser {
             TokenKind::Identifier(_) => self.parse_ident_primary(),
             _ => Err(self.unexpected("expression")),
         }
+    }
+
+    /// Build the expression for a `"..."` string literal token. The
+    /// lexer has already decoded escapes and kept any real `${...}`
+    /// interpolation verbatim, marking each escaped `\$` with the
+    /// `ESCAPED_DOLLAR_SENTINEL`. This splits the decoded text into
+    /// fragments. A literal with no real `${...}` becomes a plain
+    /// `ExprKind::Str` (with any escaped dollars un-escaped). One or more
+    /// real interpolations produce an `ExprKind::InterpolatedString`.
+    fn string_literal_expr(&self, decoded: String, span: Span) -> ParseResult<Expr> {
+        let fragments = split_interpolation(&decoded, &span)?;
+        // Collapse to a plain string when no embedded expression survived.
+        if fragments.iter().all(|f| matches!(f, StrFragment::Literal(_))) {
+            let mut buf = String::new();
+            for f in &fragments {
+                if let StrFragment::Literal(s) = f {
+                    buf.push_str(s);
+                }
+            }
+            return Ok(Expr {
+                kind: ExprKind::Str(buf),
+                span,
+            });
+        }
+        Ok(Expr {
+            kind: ExprKind::InterpolatedString(fragments),
+            span,
+        })
     }
 
     fn parse_paren_or_tuple(&mut self) -> ParseResult<Expr> {
@@ -1021,5 +1046,169 @@ impl Parser {
                 | TokenKind::LParen
                 | TokenKind::LBracket
         )
+    }
+}
+
+/// Split the decoded text of a `"..."` literal into interpolation
+/// fragments. The lexer has already decoded escapes; a real `${...}`
+/// appears verbatim as the bytes `$ { ... }`, while an escaped `\$`
+/// appears as [`ESCAPED_DOLLAR_SENTINEL`] immediately followed by `$`.
+///
+/// Each real `${...}` snippet is re-lexed and re-parsed as a standalone
+/// Raven expression. The embedded expression's spans are anchored to a
+/// synthetic per-fragment source path so that the resolver, type
+/// checker, and lowering passes (all of which key on file plus byte
+/// range) never collide a fragment's spans with the surrounding source
+/// or with another fragment.
+///
+/// A literal with no real `${...}` yields a single
+/// [`StrFragment::Literal`] (with the sentinel stripped). The caller
+/// collapses an all-literal result back to a plain `ExprKind::Str`.
+fn split_interpolation(decoded: &str, span: &Span) -> ParseResult<Vec<StrFragment>> {
+    let mut fragments: Vec<StrFragment> = Vec::new();
+    let mut text = String::new();
+    let mut frag_index = 0usize;
+    let bytes = decoded.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        // An escaped dollar is the sentinel followed by `$`; emit a
+        // literal `$` and skip the sentinel so `\${x}` is literal text.
+        if decoded[i..].starts_with(ESCAPED_DOLLAR_SENTINEL) {
+            let sentinel_len = ESCAPED_DOLLAR_SENTINEL.len_utf8();
+            text.push('$');
+            // Skip the sentinel and the `$` byte that follows it.
+            i += sentinel_len;
+            if i < bytes.len() && bytes[i] == b'$' {
+                i += 1;
+            }
+            continue;
+        }
+        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
+            // Find the matching `}` with brace-depth tracking so a
+            // nested `{ }` inside the expression does not close early.
+            let start = i + 2;
+            let mut depth = 1usize;
+            let mut j = start;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+                j += 1;
+            }
+            if depth != 0 {
+                return Err(RavenError::parse(
+                    ParseError::Custom(
+                        "unterminated `${` interpolation in string literal".into(),
+                    ),
+                    span.clone(),
+                ));
+            }
+            // Flush the pending literal text.
+            if !text.is_empty() {
+                fragments.push(StrFragment::Literal(std::mem::take(&mut text)));
+            }
+            let snippet = &decoded[start..j];
+            if snippet.trim().is_empty() {
+                return Err(RavenError::parse(
+                    ParseError::Custom(
+                        "empty `${}` interpolation in string literal".into(),
+                    ),
+                    span.clone(),
+                ));
+            }
+            let expr = parse_interpolation_snippet(snippet, span, frag_index)?;
+            fragments.push(StrFragment::Expr(Box::new(expr)));
+            frag_index += 1;
+            i = j + 1;
+            continue;
+        }
+        let c = decoded[i..].chars().next().unwrap_or(' ');
+        text.push(c);
+        i += c.len_utf8();
+    }
+    if !text.is_empty() {
+        fragments.push(StrFragment::Literal(text));
+    }
+    Ok(fragments)
+}
+
+/// Re-lex and re-parse a single `${...}` snippet into an [`Expr`].
+///
+/// The snippet is parsed against a synthetic source file whose path is
+/// derived from the enclosing literal's span and the fragment index, so
+/// every fragment's spans occupy a private `(file, byte-range)` keyspace
+/// that cannot collide with real source spans. Parse errors are
+/// re-anchored to the literal's span so the diagnostic points the reader
+/// at the offending string.
+fn parse_interpolation_snippet(
+    snippet: &str,
+    span: &Span,
+    frag_index: usize,
+) -> ParseResult<Expr> {
+    let synthetic = std::path::PathBuf::from(format!(
+        "{}<interp:{}:{}>",
+        span.file.display(),
+        span.start,
+        frag_index
+    ));
+    let tokens = Lexer::new(snippet.to_string(), synthetic)
+        .tokenize()
+        .map_err(|e| reanchor(e, span))?;
+    let mut parser = Parser::new(&tokens);
+    parser.skip_newlines();
+    let expr = parser.parse_expr().map_err(|e| reanchor(e, span))?;
+    parser.skip_newlines();
+    if !parser.is_at_end() {
+        return Err(RavenError::parse(
+            ParseError::Custom(format!(
+                "`${{{}}}` interpolation must contain a single expression",
+                snippet.trim()
+            )),
+            span.clone(),
+        ));
+    }
+    Ok(expr)
+}
+
+/// Re-anchor an error raised while parsing an interpolation snippet onto
+/// the enclosing string literal's span, preserving the error kind and
+/// hint. The snippet's synthetic span is not useful to a reader.
+fn reanchor(err: RavenError, span: &Span) -> RavenError {
+    match err {
+        RavenError::Lex(k, _, h) => {
+            let mut e = RavenError::Lex(k, span.clone(), None);
+            if let Some(h) = h {
+                e = e.with_hint(h);
+            }
+            e
+        }
+        RavenError::Parse(k, _, h) => {
+            let mut e = RavenError::Parse(k, span.clone(), None);
+            if let Some(h) = h {
+                e = e.with_hint(h);
+            }
+            e
+        }
+        RavenError::Resolve(k, _, h) => {
+            let mut e = RavenError::Resolve(k, span.clone(), None);
+            if let Some(h) = h {
+                e = e.with_hint(h);
+            }
+            e
+        }
+        RavenError::Type(k, _, h) => {
+            let mut e = RavenError::Type(k, span.clone(), None);
+            if let Some(h) = h {
+                e = e.with_hint(h);
+            }
+            e
+        }
     }
 }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -440,7 +440,10 @@ impl Parser {
     fn string_literal_expr(&self, decoded: String, span: Span) -> ParseResult<Expr> {
         let fragments = split_interpolation(&decoded, &span)?;
         // Collapse to a plain string when no embedded expression survived.
-        if fragments.iter().all(|f| matches!(f, StrFragment::Literal(_))) {
+        if fragments
+            .iter()
+            .all(|f| matches!(f, StrFragment::Literal(_)))
+        {
             let mut buf = String::new();
             for f in &fragments {
                 if let StrFragment::Literal(s) = f {
@@ -1104,9 +1107,7 @@ fn split_interpolation(decoded: &str, span: &Span) -> ParseResult<Vec<StrFragmen
             }
             if depth != 0 {
                 return Err(RavenError::parse(
-                    ParseError::Custom(
-                        "unterminated `${` interpolation in string literal".into(),
-                    ),
+                    ParseError::Custom("unterminated `${` interpolation in string literal".into()),
                     span.clone(),
                 ));
             }
@@ -1117,9 +1118,7 @@ fn split_interpolation(decoded: &str, span: &Span) -> ParseResult<Vec<StrFragmen
             let snippet = &decoded[start..j];
             if snippet.trim().is_empty() {
                 return Err(RavenError::parse(
-                    ParseError::Custom(
-                        "empty `${}` interpolation in string literal".into(),
-                    ),
+                    ParseError::Custom("empty `${}` interpolation in string literal".into()),
                     span.clone(),
                 ));
             }
@@ -1147,11 +1146,7 @@ fn split_interpolation(decoded: &str, span: &Span) -> ParseResult<Vec<StrFragmen
 /// that cannot collide with real source spans. Parse errors are
 /// re-anchored to the literal's span so the diagnostic points the reader
 /// at the offending string.
-fn parse_interpolation_snippet(
-    snippet: &str,
-    span: &Span,
-    frag_index: usize,
-) -> ParseResult<Expr> {
+fn parse_interpolation_snippet(snippet: &str, span: &Span, frag_index: usize) -> ParseResult<Expr> {
     let synthetic = std::path::PathBuf::from(format!(
         "{}<interp:{}:{}>",
         span.file.display(),

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -361,6 +361,17 @@ fn walk_expr(
                 walk_expr(&f.value, scope, map)?;
             }
         }
+        ExprKind::InterpolatedString(fragments) => {
+            // Each embedded `${expr}` is a normal expression that may
+            // reference names in scope at the literal's location. The
+            // parser parsed each fragment against a synthetic source
+            // path, so their use sites are bound under disjoint keys.
+            for frag in fragments {
+                if let crate::ast::StrFragment::Expr(e) = frag {
+                    walk_expr(e, scope, map)?;
+                }
+            }
+        }
         ExprKind::Array(items) | ExprKind::Tuple(items) => {
             for e in items {
                 walk_expr(e, scope, map)?;

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use crate::ast::{
     AssignOp, BinaryOp, Block, Decl, DeclKind, ElseBranch, Expr, ExprKind, FieldInit, Function,
-    FunctionBody, LambdaBody, Stmt, StmtKind, UnaryOp,
+    FunctionBody, LambdaBody, Stmt, StmtKind, StrFragment, UnaryOp,
 };
 use crate::error::{RavenError, TypeError};
 use crate::resolve::{Binding, ResolvedFile, UseKey};
@@ -548,6 +548,9 @@ impl<'a, 'b> Checker<'a, 'b> {
             ExprKind::Float(_) => Ok(Ty::Float),
             ExprKind::Bool(_) => Ok(Ty::Bool),
             ExprKind::Str(_) | ExprKind::BlockStr(_) | ExprKind::CStr(_) => Ok(Ty::Str),
+            ExprKind::InterpolatedString(fragments) => {
+                self.check_interpolated_string(fragments)
+            }
             ExprKind::Char(_) => Ok(Ty::Char),
             ExprKind::SelfLower => Ok(self
                 .self_ty
@@ -1556,6 +1559,51 @@ impl<'a, 'b> Checker<'a, 'b> {
     fn record(&mut self, span: &Span, ty: Ty) {
         self.types.types.insert(UseKey::from_span(span), ty);
     }
+
+    /// Type an interpolated string literal. The whole literal has type
+    /// `String`. Every embedded `${expr}` must resolve to a type that
+    /// can be converted to a string: `String` (identity), `Int`, `Bool`,
+    /// `Float`, or `Char`. Any other type is rejected with a hint that
+    /// points the user at converting to a `String` first.
+    ///
+    /// Each embedded expression is checked through `check_expr`, which
+    /// records its resolved type under its (synthetic, per-fragment)
+    /// span so HIR lowering can pick the right conversion.
+    fn check_interpolated_string(&mut self, fragments: &[StrFragment]) -> Result<Ty, RavenError> {
+        for frag in fragments {
+            let StrFragment::Expr(e) = frag else {
+                continue;
+            };
+            let ty = self.check_expr(e)?;
+            let resolved = self.infer.resolve(&ty);
+            let stripped = resolved.strip_self();
+            if matches!(stripped, Ty::Error) {
+                // Eat the cascade; an earlier error was already reported.
+                continue;
+            }
+            if !is_interpolatable(stripped) {
+                return Err(RavenError::ty(
+                    TypeError::Custom(format!(
+                        "values of type `{}` cannot be interpolated into a string",
+                        resolved
+                    )),
+                    e.span.clone(),
+                )
+                .with_hint(format!(
+                    "only `String`, `Int`, `Bool`, `Float`, and `Char` interpolate today; convert the `{}` value to a `String` first",
+                    resolved
+                )));
+            }
+        }
+        Ok(Ty::Str)
+    }
+}
+
+/// True when a value of type `ty` can be interpolated into a string via
+/// a known per-type conversion. The set is kept in sync with the runtime
+/// `raven_*_to_string` conversions wired up in codegen.
+fn is_interpolatable(ty: &Ty) -> bool {
+    matches!(ty, Ty::Str | Ty::Int | Ty::Bool | Ty::Float | Ty::Char)
 }
 
 /// Type rules for binary operators. Exposed so the assignment helper

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -548,9 +548,7 @@ impl<'a, 'b> Checker<'a, 'b> {
             ExprKind::Float(_) => Ok(Ty::Float),
             ExprKind::Bool(_) => Ok(Ty::Bool),
             ExprKind::Str(_) | ExprKind::BlockStr(_) | ExprKind::CStr(_) => Ok(Ty::Str),
-            ExprKind::InterpolatedString(fragments) => {
-                self.check_interpolated_string(fragments)
-            }
+            ExprKind::InterpolatedString(fragments) => self.check_interpolated_string(fragments),
             ExprKind::Char(_) => Ok(Ty::Char),
             ExprKind::SelfLower => Ok(self
                 .self_ty

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -71,6 +71,17 @@ fn dyn_dispatch_program_compiles_and_runs() {
 }
 
 #[test]
+fn interpolation_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // String interpolation end to end: a String fragment (`name`) and an
+    // arithmetic Int fragment (`a + b`) are converted, concatenated, and
+    // printed. Prints `Hello, Raven!` then `sum is 7`.
+    compile_link_run_and_check("interpolation.rv", "Hello, Raven!\nsum is 7\n", &runtime);
+}
+
+#[test]
 fn defer_order_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Carry string interpolation end to end so a `"...${expr}..."` literal compiles and runs, building a `String` from converted-and-concatenated fragments.

Closes #69. See `docs/v2/specs/interpolation.md` for the full design.

## What it does

The parser splits a `"...${expr}..."` literal into `ExprKind::InterpolatedString(Vec<StrFragment>)`, re-parsing each `${expr}` as a real expression. The type checker types the literal as `String` and verifies every embedded expression is convertible. HIR keeps a structured `Interpolate` node; MIR desugars it into a left-folded chain of runtime concat calls with a per-type to-string conversion for each non-String part. The runtime gains GC-managed string concat and value-to-string functions, and codegen promotes string values to heap `String` objects and generalizes `print` to accept them.

## Observed output

Building and running `examples/v2/interpolation.rv` on windows-msvc:

```
Hello, Raven!
sum is 7
```

(raw bytes: `Hello, Raven!\nsum is 7\n`)

## Supported interpolated types

`String` (identity), `Int`, `Bool`, `Float`, `Char`. Any other embedded type is a type error with a hint to convert to a `String` first.

## Deferred

* Interpolating struct, enum, list, map, or function values (needs a future `Display`-style trait).
* Format specifiers and alignment (`${x:04}`). The `${...}` body is a plain expression.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` all green (lib, runtime, golden corpora, codegen smoke)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] New runtime unit tests for concat, from-bytes, and int/bool/float/char rendering (zero, negatives, i64 extremes, multibyte, invalid char)
- [x] New `tests/codegen_smoke.rs` case compiles, links, runs `interpolation.rv`, asserts stdout is exactly `Hello, Raven!\nsum is 7\n`
- [x] Existing smoke programs (hello, point, option, closure, dyn, defer) still link and run
