### PR TITLE
feat: C FFI with extern blocks and c-string literals

### DIFF
--- a/docs/v2/specs/ffi.md
+++ b/docs/v2/specs/ffi.md
@@ -1,0 +1,157 @@
+# C FFI Spec
+
+## Goal
+
+Specify calling C functions from Raven. A program declares foreign
+signatures in an `extern "C"` block, then calls them like ordinary
+functions. The minimum to be useful is a small set of C ABI primitive
+types, a C string literal `c"..."`, type checking of the foreign
+signatures, and codegen that emits direct C-ABI calls to imported
+symbols. `strlen(c"hello")` returns `5`.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> Resolver -> Tycheck -> HIR -> MIR -> Codegen -> Linker
+```
+
+* The lexer produces `CStringLit` for `c"..."` and `Extern` for the
+  keyword.
+* The parser produces an `Extern` declaration holding `ExternFn`
+  signatures. This is already part of the grammar (`docs/v2/specs/parser.md`).
+* The resolver records each foreign function as `Binding::Extern` and
+  treats the FFI type names as built-in.
+* The type checker assigns each FFI type name a distinct `Ty::Ffi(...)`
+  and checks calls against the foreign signature.
+* HIR carries the resolved extern signatures through as a passive item.
+* MIR records the foreign functions in `MirProgram.externs` and lowers a
+  call to a foreign name as a direct `Call`.
+* Codegen declares each foreign function as an imported symbol and lowers
+  the call to a direct C-ABI call. The linker satisfies the symbol.
+
+## Syntax
+
+```raven
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+    fun abs(x: CInt) -> CInt
+    fun puts(s: CStr) -> CInt
+}
+```
+
+* `extern` is followed by an ABI string literal. Only `"C"` is meaningful
+  in v2.0; other ABI strings parse but are treated as C.
+* The block holds zero or more `fun name(params) -> Ret` signatures with
+  no bodies. A signature with no `-> Ret` returns the C `void`
+  equivalent (`Unit`).
+* Foreign functions are not generic.
+
+A call uses the foreign name directly:
+
+```raven
+fun main() {
+    let n = strlen(c"hello")
+    print_int(n)
+}
+```
+
+## FFI primitive types
+
+These names are recognized by the type checker as C ABI primitives.
+They are kept distinct from the native Raven types so a native value is
+not silently passed where the C ABI expects a foreign one.
+
+| Raven type | C type           | Cranelift ABI type     |
+|------------|------------------|------------------------|
+| `CInt`     | `int`            | `i32`                  |
+| `CLong`    | `long`           | `i64`                  |
+| `CSize`    | `size_t`         | pointer width (`i64`)  |
+| `CStr`     | `const char *`   | pointer width (`i64`)  |
+| `CPtr<T>`  | `T *` (opaque)   | pointer width (`i64`)  |
+
+`CInt` is fixed at 32-bit, which matches the C `int` on every ABI Raven
+targets. `CLong` and `CSize` are 64-bit on the 64-bit targets Raven
+supports. `CStr`, `CSize`, and `CPtr<T>` are all pointer width.
+
+`CPtr<T>` is a typed but opaque pointer in v2.0: the pointee type is kept
+for documentation and future conversions, but the back end treats the
+value as a raw pointer-width integer. There is no dereference operator
+for it yet.
+
+`CString` is accepted as an alias for `CStr` so that older `extern`
+signatures keep checking.
+
+The full `std/ffi` module with conversion helpers is issue #80; this
+spec provides only what is needed to call C.
+
+## C string literals and `CStr`
+
+A `c"..."` literal types as `CStr`. In codegen it lowers to the address
+of a static, read-only, null-terminated byte buffer: the literal's bytes
+followed by a single `\0`. No heap allocation and no runtime call occur,
+so the pointer is handed straight to the C function as a `const char *`.
+Identical literals share one symbol.
+
+Passing a native Raven `String` where a `CStr` is expected is rejected.
+A heap `String` (see `docs/v2/specs/object-layout.md` and
+`raven-runtime/src/object/string.rs`) is length-prefixed and not
+guaranteed to be null-terminated, so it is not a valid `const char *`.
+String-to-CStr conversion (a null-terminated copy through a helper such
+as `raven_string_as_cstr`) is deferred to issue #80. In this release,
+only `c"..."` literals produce a `CStr`.
+
+An integer C parameter (`CInt`, `CLong`, `CSize`) accepts a native `Int`
+argument, so a literal such as `abs(-7)` checks. The back end converts
+the i64 `Int` to the parameter's machine width at the call (a reduce to
+i32 for `CInt`, a pass-through for the i64-width types). This keeps a C
+function with integer parameters callable without a cast.
+
+## Type checking extern declarations
+
+Each `extern "C"` function becomes a known signature (`Binding::Extern`)
+with FFI parameter and return types. A call:
+
+* checks arity against the signature,
+* checks each argument against the parameter's FFI type, with the two
+  coercions above (`c"..."` -> `CStr`, native `Int` -> integer FFI type),
+* otherwise requires the argument type to unify with the parameter type.
+
+A mismatch (for example a `c"..."` where a `CInt` is expected, or a
+`String` where a `CStr` is expected) is a normal `TypeError` reported at
+the argument's span.
+
+The return type flows out as the call's type. An integer FFI return
+(`CInt`, `CLong`, `CSize`) may be handed to `print_int`, which observes
+it directly; a narrower one is sign-extended to i64 first.
+
+## Codegen
+
+Each foreign function in `MirProgram.externs` is declared as a Cranelift
+external symbol with `Linkage::Import`, under the module's default
+calling convention (the platform C ABI), using the ABI type of each
+parameter and the return. The raw C name is the link-time symbol and the
+key a call site resolves against. A call to a foreign name lowers to a
+direct call to that imported symbol, the same mechanism the back end
+already uses for runtime symbols such as `raven_println_str`.
+
+## Linking boundary
+
+On `x86_64-pc-windows-msvc` the link step already puts the C runtime on
+the link line (`/defaultlib:msvcrt`), so CRT-provided symbols such as
+`strlen`, `abs`, and `printf` resolve without any extra flags. The CRT is
+the only library guaranteed to link in this release.
+
+Symbols from any other library are out of scope here. Per-project link
+flags (an `[ffi]` section in `rv.toml` passing `-l<lib>` or `.lib`
+entries) arrive with `rvpm build`, tracked by issue #81. Until then a
+non-CRT symbol surfaces as an unresolved-symbol error at link time.
+
+## Out of scope
+
+* Passing or returning structs by value across the C ABI.
+* Variadic C functions (for example `printf` with format arguments).
+* Callbacks from C back into Raven (passing a Raven function as a C
+  function pointer).
+* String-to-CStr conversion of a heap `String` (issue #80).
+* Non-CRT libraries and their link flags (issue #81).
+* Dereferencing or arithmetic on `CPtr<T>`.

--- a/examples/v2/ffi_abs.rv
+++ b/examples/v2/ffi_abs.rv
@@ -1,0 +1,11 @@
+// C FFI with a non-pointer foreign type. libc `abs(int) -> int` takes
+// and returns a C `int` (CInt, 32-bit). A negative literal is passed and
+// its absolute value is printed: abs(-7) is 7.
+extern "C" {
+    fun abs(x: CInt) -> CInt
+}
+
+fun main() {
+    let n = abs(-7)
+    print_int(n)
+}

--- a/examples/v2/ffi_strlen.rv
+++ b/examples/v2/ffi_strlen.rv
@@ -1,0 +1,12 @@
+// C FFI: declare libc `strlen` and call it on a C string literal.
+// `c"hello"` lowers to a pointer to a static null-terminated buffer, so
+// strlen counts 5 bytes. CSize is size_t, which is pointer width (i64 on
+// x86_64), and print_int observes it directly. Prints 5.
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+}
+
+fun main() {
+    let n = strlen(c"hello")
+    print_int(n)
+}

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -40,6 +40,10 @@ pub struct ModuleCx {
     functions: HashMap<String, FuncId>,
     /// Runtime intrinsic function ids keyed by their C symbol name.
     runtime: HashMap<&'static str, FuncId>,
+    /// Parameter types of each declared extern C function, keyed by its
+    /// raw C symbol name. A call site uses these to coerce each argument
+    /// to the C ABI machine width before the direct call.
+    extern_params: HashMap<String, Vec<MirType>>,
     /// Interned string literal data ids keyed by the literal's bytes.
     strings: BTreeMap<Vec<u8>, DataId>,
     /// Counter for unique data symbol names.
@@ -87,6 +91,7 @@ impl ModuleCx {
             module,
             functions: HashMap::new(),
             runtime: HashMap::new(),
+            extern_params: HashMap::new(),
             strings: BTreeMap::new(),
             string_counter: 0,
             main_entry: None,
@@ -231,6 +236,33 @@ impl ModuleCx {
         Ok(id)
     }
 
+    /// Intern a C string literal as a static, read-only,
+    /// null-terminated byte buffer and return its data id.
+    ///
+    /// The literal's bytes are stored verbatim with a trailing `\0`
+    /// appended, matching the `*const c_char` a C function expects.
+    /// Identical literals (after null termination) share one symbol.
+    /// The interning table is keyed by the null-terminated bytes, which
+    /// never collides with a plain string literal of the same text
+    /// because that literal interns its bytes without the terminator.
+    pub fn intern_cstring(&mut self, text: &[u8]) -> Result<DataId, CodegenError> {
+        let mut bytes = text.to_vec();
+        bytes.push(0);
+        if let Some(id) = self.strings.get(&bytes) {
+            return Ok(*id);
+        }
+        let name = format!("__raven_cstr_{}", self.string_counter);
+        self.string_counter += 1;
+        let id = self
+            .module
+            .declare_data(&name, Linkage::Local, false, false)?;
+        let mut desc = DataDescription::new();
+        desc.define(bytes.clone().into_boxed_slice());
+        self.module.define_data(id, &desc)?;
+        self.strings.insert(bytes, id);
+        Ok(id)
+    }
+
     /// Declare the runtime C ABI symbols the backend can call into.
     ///
     /// The heap-value lowering needs the string and integer print
@@ -349,6 +381,51 @@ impl ModuleCx {
         let id = self.module.declare_function(symbol, Linkage::Import, sig)?;
         self.runtime.insert(symbol, id);
         Ok(())
+    }
+
+    /// Declare every foreign function from the program's `extern`
+    /// blocks as an imported C-ABI symbol.
+    ///
+    /// The signature uses each parameter's and the return's C ABI
+    /// machine type (`CInt` -> i32, pointers -> pointer width) under the
+    /// module's default calling convention, which is the platform C ABI.
+    /// The symbol is recorded in the function table under its raw C name
+    /// so a `Call` to that name resolves to the import; the linker
+    /// satisfies it from the CRT (for `strlen`, `abs`, ...) or a library
+    /// supplied on the link line. See `docs/v2/specs/ffi.md`.
+    pub fn declare_externs(&mut self, program: &MirProgram) -> Result<(), CodegenError> {
+        let ptr = self.pointer_type();
+        for ext in &program.externs {
+            // A foreign function may be declared but never called; only
+            // the symbols a call site references need to resolve at link
+            // time, but declaring all of them is harmless and keeps the
+            // table complete for diagnostics.
+            if self.functions.contains_key(&ext.name) {
+                continue;
+            }
+            let mut sig = self.module.make_signature();
+            for p in &ext.params {
+                if let Some(t) = super::function::cranelift_ty(p, ptr) {
+                    sig.params.push(AbiParam::new(t));
+                }
+            }
+            if let Some(t) = super::function::cranelift_ty(&ext.ret, ptr) {
+                sig.returns.push(AbiParam::new(t));
+            }
+            let id = self
+                .module
+                .declare_function(&ext.name, Linkage::Import, &sig)?;
+            self.functions.insert(ext.name.clone(), id);
+            self.extern_params
+                .insert(ext.name.clone(), ext.params.clone());
+        }
+        Ok(())
+    }
+
+    /// Parameter types of a declared extern C function, if `name` names
+    /// one. Used by a call site to coerce arguments to the C ABI width.
+    pub fn extern_params(&self, name: &str) -> Option<&[MirType]> {
+        self.extern_params.get(name).map(|v| v.as_slice())
     }
 
     /// Declare every MIR function ahead of body emission so that calls

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -16,8 +16,8 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::Module;
 
 use crate::mir::{
-    MirBinOp, MirBlock, MirBlockId, MirConstant, MirFnRef, MirFunction, MirLocal, MirOperand,
-    MirRvalue, MirStatement, MirTerminator, MirType, MirUnOp,
+    MirBinOp, MirBlock, MirBlockId, MirConstant, MirFfiTy, MirFnRef, MirFunction, MirLocal,
+    MirOperand, MirRvalue, MirStatement, MirTerminator, MirType, MirUnOp,
 };
 
 use super::context::ModuleCx;
@@ -48,6 +48,15 @@ pub fn cranelift_ty(ty: &MirType, ptr: CType) -> Option<CType> {
         // A `dyn Trait` value is a single GC pointer to a boxed fat
         // pointer `{ data, vtable }`; see the heap layout note below.
         | MirType::Dyn { .. } => Some(ptr),
+        // C FFI primitives map to their C ABI machine types. `CInt` is a
+        // 32-bit C `int`; `CLong`, `CSize`, `CStr`, and `CPtr<T>` are all
+        // pointer-width on the 64-bit targets Raven supports. See
+        // `docs/v2/specs/ffi.md`.
+        MirType::Ffi(ffi) => Some(match ffi {
+            MirFfiTy::CInt => types::I32,
+            MirFfiTy::CLong => types::I64,
+            MirFfiTy::CSize | MirFfiTy::CStr | MirFfiTy::CPtr(_) => ptr,
+        }),
     }
 }
 
@@ -411,6 +420,16 @@ fn lower_constant(
             let fref = cx.module().declare_func_in_func(func_id, builder.func);
             let inst = builder.ins().call(fref, &[bytes_ptr, len_val]);
             Ok(Some(builder.inst_results(inst)[0]))
+        }
+        MirConstant::CStr(s) => {
+            // A C string literal lowers to the address of a static,
+            // read-only, null-terminated byte buffer: a `*const c_char`.
+            // No heap allocation and no runtime call; the pointer is
+            // handed straight to the C function.
+            let id = cx.intern_cstring(s.as_bytes())?;
+            let local_id = cx.module().declare_data_in_func(id, builder.func);
+            let ptr = cx.pointer_type();
+            Ok(Some(builder.ins().symbol_value(ptr, local_id)))
         }
     }
 }
@@ -937,16 +956,53 @@ fn lower_call(
     let func_id = cx.function_id(&callee.mangled).ok_or_else(|| {
         CodegenError::Unsupported(format!("unresolved callee: {}", callee.mangled))
     })?;
+    // When the callee is a foreign C function, coerce each argument to
+    // its declared C ABI machine width. A native `Int` passed to a `CInt`
+    // parameter is an i64 value that must be reduced to i32 to match the
+    // imported signature; an `Int` to a `CLong`/`CSize` is already i64.
+    let extern_param_tys: Option<Vec<MirType>> =
+        cx.extern_params(&callee.mangled).map(|s| s.to_vec());
     let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
     let mut arg_vals = Vec::with_capacity(args.len());
-    for a in args {
+    for (i, a) in args.iter().enumerate() {
         if let Some(v) = lower_operand(cx, builder, a, slots)? {
+            let v = match &extern_param_tys {
+                Some(tys) => match tys.get(i) {
+                    Some(pt) => coerce_to_param(builder, v, pt, cx.pointer_type()),
+                    None => v,
+                },
+                None => v,
+            };
             arg_vals.push(v);
         }
     }
     let inst = builder.ins().call(local_ref, &arg_vals);
     let results = builder.inst_results(inst);
     Ok(results.first().copied())
+}
+
+/// Reconcile an argument value's machine type with the type the callee's
+/// parameter expects. Used for foreign C calls, where a native `Int`
+/// (i64) may need reducing to a narrower C integer (`CInt` is i32) or a
+/// scalar may need widening to pointer width. Equal widths pass through.
+fn coerce_to_param(
+    builder: &mut FunctionBuilder<'_>,
+    v: Value,
+    param: &MirType,
+    ptr: CType,
+) -> Value {
+    let Some(want) = cranelift_ty(param, ptr) else {
+        return v;
+    };
+    let got = builder.func.dfg.value_type(v);
+    if got == want || !got.is_int() || !want.is_int() {
+        return v;
+    }
+    if want.bytes() < got.bytes() {
+        builder.ins().ireduce(want, v)
+    } else {
+        builder.ins().sextend(want, v)
+    }
 }
 
 fn lower_intrinsic(
@@ -983,6 +1039,20 @@ fn lower_intrinsic(
                 lower_operand(cx, builder, &args[0], slots)?,
                 "print_int argument",
             )?;
+            // `raven_println_int` takes an i64. A native `Int` is already
+            // i64; a C FFI integer may be narrower (`CInt` is i32) or the
+            // same width (`CLong`/`CSize`). Sign-extend a narrower value
+            // so a negative C `int` prints correctly.
+            let v = {
+                let got = builder.func.dfg.value_type(v);
+                if got == types::I64 {
+                    v
+                } else if got.is_int() && got.bytes() < types::I64.bytes() {
+                    builder.ins().sextend(types::I64, v)
+                } else {
+                    v
+                }
+            };
             let func_id = cx
                 .runtime_id(intrinsics::RUNTIME_PRINTLN_INT)
                 .expect("runtime imports declared at module init");

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -118,6 +118,7 @@ pub fn compile_to_object(
 
     let mut cx = ModuleCx::new(module);
     cx.declare_runtime_imports()?;
+    cx.declare_externs(program)?;
     cx.declare_functions(program)?;
     cx.define_functions(program)?;
 

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -115,6 +115,72 @@ fn compiles_print_intrinsic_call() {
 }
 
 #[test]
+fn compiles_extern_c_call_with_cstring_literal() {
+    let src = r#"
+        extern "C" {
+            fun strlen(s: CStr) -> CSize
+        }
+        fun main() {
+            let n = strlen(c"hello")
+            print_int(n)
+        }
+    "#;
+    let prog = compile(src);
+    // The program records the foreign function in its extern table.
+    assert!(
+        prog.externs.iter().any(|e| e.name == "strlen"),
+        "MIR program should declare the extern strlen"
+    );
+    // The call site lowers to a direct call to the raw C symbol name.
+    let main = prog
+        .functions
+        .iter()
+        .find(|f| f.origin == "main")
+        .expect("main function");
+    let calls_strlen = main
+        .blocks
+        .iter()
+        .flat_map(|b| b.statements.iter())
+        .any(|s| {
+            matches!(
+                s,
+                MirStatement::Assign {
+                    rvalue: MirRvalue::Call { callee, .. },
+                    ..
+                } if callee.mangled == "strlen"
+            )
+        });
+    assert!(calls_strlen, "MIR should contain a call to strlen");
+
+    let object = compile_program(&prog).expect("codegen extern call");
+    assert!(object.len() > 64);
+    // The c-string literal lands in the data section, null-terminated.
+    assert!(
+        contains_bytes(&object, b"hello\0"),
+        "object should contain the null-terminated c-string bytes"
+    );
+}
+
+#[test]
+fn compiles_extern_c_call_with_int_literal() {
+    // A non-pointer FFI type: abs(CInt) -> CInt called on a negative
+    // literal. Exercises the i64-to-i32 argument coercion at the call.
+    let src = r#"
+        extern "C" {
+            fun abs(x: CInt) -> CInt
+        }
+        fun main() {
+            let n = abs(-7)
+            print_int(n)
+        }
+    "#;
+    let prog = compile(src);
+    assert!(prog.externs.iter().any(|e| e.name == "abs"));
+    let object = compile_program(&prog).expect("codegen extern abs");
+    assert!(object.len() > 64);
+}
+
+#[test]
 fn compiles_float_arithmetic() {
     let prog = compile("fun mix(x: Float, y: Float) -> Float { return x * y + 1.0 }");
     let object = compile_program(&prog).expect("codegen float");

--- a/src/hir/decl.rs
+++ b/src/hir/decl.rs
@@ -38,9 +38,32 @@ pub enum HirItemKind {
         ty: HirTy,
         init: Option<HirExpr>,
     },
-    /// Import or extern blocks pass through opaquely. Lowering does not
-    /// touch them.
+    /// An `extern "ABI" { ... }` block with its resolved foreign
+    /// function signatures. The codegen back end declares each as an
+    /// imported C-ABI symbol.
+    Extern(HirExtern),
+    /// Import blocks pass through opaquely. Lowering does not touch them.
     Opaque(String),
+}
+
+/// An extern block in HIR, carrying resolved signatures.
+#[derive(Debug, Clone)]
+pub struct HirExtern {
+    /// The ABI string, for example `"C"`.
+    pub abi: String,
+    pub items: Vec<HirExternFn>,
+    pub span: Span,
+}
+
+/// One foreign function signature in an extern block. The symbol is the
+/// raw C name; the parameter and return types are resolved FFI types the
+/// back end maps to C ABI machine types.
+#[derive(Debug, Clone)]
+pub struct HirExternFn {
+    pub name: String,
+    pub params: Vec<HirTy>,
+    pub ret: HirTy,
+    pub span: Span,
 }
 
 /// A function (or method) declaration in HIR.

--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -23,7 +23,10 @@ use crate::tycheck::{
     Ty, TypeEnv, TypedFile,
 };
 
-use super::decl::{HirEnum, HirFn, HirImpl, HirItem, HirItemKind, HirStruct, HirTrait, HirVariant};
+use super::decl::{
+    HirEnum, HirExtern, HirExternFn, HirFn, HirImpl, HirItem, HirItemKind, HirStruct, HirTrait,
+    HirVariant,
+};
 use super::HirProgram;
 
 /// Lower a type-checked file into a `HirProgram`.
@@ -229,10 +232,38 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
             span: decl.span.clone(),
             kind: HirItemKind::Opaque("import".into()),
         })),
-        DeclKind::Extern(_) => Ok(Some(HirItem {
-            span: decl.span.clone(),
-            kind: HirItemKind::Opaque("extern".into()),
-        })),
+        DeclKind::Extern(ext) => {
+            // Resolve each foreign signature's parameter and return types
+            // so codegen can declare the symbol with its C ABI shape.
+            // Extern functions never have generic parameters, so an empty
+            // scope is correct.
+            let scope = scope_from_params(&[]);
+            let mut items = Vec::with_capacity(ext.items.len());
+            for item in &ext.items {
+                let mut params = Vec::with_capacity(item.params.len());
+                for p in &item.params {
+                    params.push(resolve_ty_for_decl(&p.ty, cx, &scope)?);
+                }
+                let ret = match &item.ret {
+                    Some(t) => resolve_ty_for_decl(t, cx, &scope)?,
+                    None => Ty::Unit,
+                };
+                items.push(HirExternFn {
+                    name: item.name.clone(),
+                    params,
+                    ret,
+                    span: item.span.clone(),
+                });
+            }
+            Ok(Some(HirItem {
+                span: decl.span.clone(),
+                kind: HirItemKind::Extern(HirExtern {
+                    abi: ext.abi.clone(),
+                    items,
+                    span: ext.span.clone(),
+                }),
+            }))
+        }
     }
 }
 

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -19,7 +19,10 @@ pub mod ty;
 #[cfg(test)]
 mod tests;
 
-pub use decl::{HirEnum, HirFn, HirImpl, HirItem, HirItemKind, HirStruct, HirTrait, HirVariant};
+pub use decl::{
+    HirEnum, HirExtern, HirExternFn, HirFn, HirImpl, HirItem, HirItemKind, HirStruct, HirTrait,
+    HirVariant,
+};
 pub use expr::{HirArm, HirBinaryOp, HirBlock, HirExpr, HirExprKind, HirUnaryOp, InterpolPart};
 pub use lower::lower_file;
 pub use pattern::{HirFieldPat, HirLiteralPat, HirPattern, HirPatternKind};

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -71,6 +71,22 @@ fn pretty_item(buf: &mut String, item: &HirItem, depth: usize) {
             indent(buf, depth);
             buf.push_str(")\n");
         }
+        HirItemKind::Extern(e) => {
+            writeln!(buf, "(extern {}", quote(&e.abi)).unwrap();
+            for item in &e.items {
+                indent(buf, depth + 1);
+                write!(buf, "(extern-fn {} params=(", quote(&item.name)).unwrap();
+                for (i, p) in item.params.iter().enumerate() {
+                    if i > 0 {
+                        buf.push(' ');
+                    }
+                    write!(buf, "{}", p).unwrap();
+                }
+                writeln!(buf, ") ret={})", item.ret).unwrap();
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
         HirItemKind::Opaque(s) => {
             writeln!(buf, "(opaque {})", quote(s)).unwrap();
         }

--- a/src/mir/ir.rs
+++ b/src/mir/ir.rs
@@ -59,6 +59,11 @@ pub enum MirConstant {
     Float(f64),
     Str(String),
     Char(char),
+    /// A C string literal `c"..."`. Lowered by the back end to a pointer
+    /// to a static, read-only, null-terminated byte buffer rather than a
+    /// heap `String`. The stored text excludes the trailing `\0`, which
+    /// codegen appends.
+    CStr(String),
 }
 
 /// One operand: either a copy of a local or a constant.
@@ -228,16 +233,34 @@ impl MirFunction {
     }
 }
 
-/// One full MIR program: a flat list of monomorphic functions.
+/// A foreign function declared in an `extern "C"` block. The back end
+/// declares each as an imported C-ABI symbol; a call site referencing
+/// `name` resolves to it. Foreign functions have no Raven body.
+#[derive(Debug, Clone)]
+pub struct MirExternFn {
+    /// The raw C symbol name, used verbatim as the link-time symbol.
+    pub name: String,
+    /// Parameter types in declaration order.
+    pub params: Vec<MirType>,
+    /// Return type, or `MirType::Unit` for a `void` return.
+    pub ret: MirType,
+}
+
+/// One full MIR program: a flat list of monomorphic functions plus the
+/// foreign functions declared in `extern` blocks.
 #[derive(Debug, Clone)]
 pub struct MirProgram {
     pub functions: Vec<MirFunction>,
+    /// Foreign functions declared in `extern "C"` blocks. Declared as
+    /// imported symbols by the back end and resolved at link time.
+    pub externs: Vec<MirExternFn>,
 }
 
 impl MirProgram {
     pub fn new() -> Self {
         Self {
             functions: Vec::new(),
+            externs: Vec::new(),
         }
     }
 }

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -26,7 +26,7 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
         HirExprKind::Bool(b) => MirOperand::Const(MirConstant::Bool(*b)),
         HirExprKind::Str(s) => MirOperand::Const(MirConstant::Str(s.clone())),
         HirExprKind::Char(c) => MirOperand::Const(MirConstant::Char(*c)),
-        HirExprKind::CStr(s) => MirOperand::Const(MirConstant::Str(s.clone())),
+        HirExprKind::CStr(s) => MirOperand::Const(MirConstant::CStr(s.clone())),
         HirExprKind::Unit => MirOperand::Const(MirConstant::Unit),
         HirExprKind::Ident(name) => match cx.lookup(name) {
             Some(local) => MirOperand::Copy(local),

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -20,11 +20,11 @@ pub mod ty;
 mod tests;
 
 pub use ir::{
-    MirBinOp, MirBlock, MirBlockId, MirConstant, MirFnRef, MirFunction, MirLocal, MirLocalDecl,
-    MirOperand, MirProgram, MirRvalue, MirStatement, MirTerminator, MirUnOp,
+    MirBinOp, MirBlock, MirBlockId, MirConstant, MirExternFn, MirFnRef, MirFunction, MirLocal,
+    MirLocalDecl, MirOperand, MirProgram, MirRvalue, MirStatement, MirTerminator, MirUnOp,
 };
 pub use pretty::pretty_program;
-pub use ty::MirType;
+pub use ty::{MirFfiTy, MirType};
 
 use crate::error::RavenError;
 use crate::hir::HirProgram;

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -41,6 +41,7 @@ type SymbolIndex = HashMap<DeclId, String>;
 /// Run the full monomorphization pass.
 pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
     let mut program = MirProgram::new();
+    program.externs = collect_externs(hir);
     let (index, roots, symbols) = collect_roots(hir);
     let decls = collect_decls(hir);
 
@@ -70,6 +71,26 @@ pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
     }
 
     Ok(program)
+}
+
+/// Collect every foreign function from the HIR's extern blocks, lowering
+/// each resolved signature to ground MIR types. The back end declares
+/// these as imported C-ABI symbols.
+fn collect_externs(hir: &HirProgram) -> Vec<super::ir::MirExternFn> {
+    use super::ty::MirType;
+    let mut out = Vec::new();
+    for item in &hir.items {
+        if let HirItemKind::Extern(ext) = &item.kind {
+            for f in &ext.items {
+                out.push(super::ir::MirExternFn {
+                    name: f.name.clone(),
+                    params: f.params.iter().map(MirType::from_ty).collect(),
+                    ret: MirType::from_ty(&f.ret),
+                });
+            }
+        }
+    }
+    out
 }
 
 /// Index every struct and enum declaration by its source name so the

--- a/src/mir/pretty.rs
+++ b/src/mir/pretty.rs
@@ -237,6 +237,7 @@ fn pretty_operand(buf: &mut String, op: &MirOperand) {
             MirConstant::Float(v) => write!(buf, "{}", v).unwrap(),
             MirConstant::Str(s) => buf.push_str(&quote(s)),
             MirConstant::Char(c) => buf.push_str(&quote(&c.to_string())),
+            MirConstant::CStr(s) => write!(buf, "c{}", quote(s)).unwrap(),
         },
     }
 }

--- a/src/mir/ty.rs
+++ b/src/mir/ty.rs
@@ -6,8 +6,26 @@
 //! substitute before any MIR is built, so MIR types are always ground.
 
 use crate::resolve::DeclId;
-use crate::tycheck::Ty;
+use crate::tycheck::{FfiTy, Ty};
 use std::fmt;
+
+/// Ground C FFI primitive type carried through MIR. Mirrors
+/// [`FfiTy`](crate::tycheck::FfiTy) without the inference-only cases;
+/// the codegen back end maps each to a concrete Cranelift ABI type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MirFfiTy {
+    /// C `int`. Codegen maps it to `i32`.
+    CInt,
+    /// C `long`. Codegen maps it to `i64`.
+    CLong,
+    /// C `size_t`. Codegen maps it to a pointer-width int.
+    CSize,
+    /// `*const c_char`. Codegen maps it to a pointer-width int.
+    CStr,
+    /// `CPtr<T>`, an opaque pointer. Codegen maps it to a pointer-width
+    /// int. The pointee mangle is kept for symbol uniqueness only.
+    CPtr(Box<MirType>),
+}
 
 /// Ground type used inside MIR.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -43,6 +61,10 @@ pub enum MirType {
         name: String,
         methods: Vec<String>,
     },
+    /// A C FFI primitive type. Carried so the back end can pick the
+    /// matching Cranelift ABI type for an `extern "C"` parameter,
+    /// return, or `c"..."` literal.
+    Ffi(MirFfiTy),
 }
 
 impl MirType {
@@ -84,6 +106,7 @@ impl MirType {
                 methods: methods.clone(),
             },
             Ty::SelfTy(inner) => MirType::from_ty(inner),
+            Ty::Ffi(ffi) => MirType::Ffi(MirFfiTy::from_ffi(ffi)),
             Ty::Error => MirType::Unit,
             Ty::Param(_) | Ty::Var(_) => MirType::Unit,
         }
@@ -116,6 +139,7 @@ impl MirType {
                 format!("Fn_{}", parts.join("_"))
             }
             MirType::Dyn { name, .. } => format!("dyn_{}", name),
+            MirType::Ffi(ffi) => ffi.mangle(),
         }
     }
 
@@ -172,6 +196,43 @@ impl fmt::Display for MirType {
                 write!(f, ") -> {}", ret)
             }
             MirType::Dyn { name, .. } => write!(f, "dyn {}", name),
+            MirType::Ffi(ffi) => write!(f, "{}", ffi),
+        }
+    }
+}
+
+impl MirFfiTy {
+    /// Build a ground MIR FFI type from a checker FFI type.
+    pub fn from_ffi(ffi: &FfiTy) -> Self {
+        match ffi {
+            FfiTy::CInt => MirFfiTy::CInt,
+            FfiTy::CLong => MirFfiTy::CLong,
+            FfiTy::CSize => MirFfiTy::CSize,
+            FfiTy::CStr => MirFfiTy::CStr,
+            FfiTy::CPtr(inner) => MirFfiTy::CPtr(Box::new(MirType::from_ty(inner))),
+        }
+    }
+
+    /// Identifier-safe mangling for use inside symbol names.
+    pub fn mangle(&self) -> String {
+        match self {
+            MirFfiTy::CInt => "CInt".into(),
+            MirFfiTy::CLong => "CLong".into(),
+            MirFfiTy::CSize => "CSize".into(),
+            MirFfiTy::CStr => "CStr".into(),
+            MirFfiTy::CPtr(inner) => format!("CPtr_{}", inner.mangle()),
+        }
+    }
+}
+
+impl fmt::Display for MirFfiTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MirFfiTy::CInt => f.write_str("CInt"),
+            MirFfiTy::CLong => f.write_str("CLong"),
+            MirFfiTy::CSize => f.write_str("CSize"),
+            MirFfiTy::CStr => f.write_str("CStr"),
+            MirFfiTy::CPtr(inner) => write!(f, "CPtr<{}>", inner),
         }
     }
 }

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -624,6 +624,11 @@ fn is_builtin_type_name(name: &str) -> bool {
             | "Vec"
             | "List"
             | "CString"
+            | "CStr"
+            | "CInt"
+            | "CLong"
+            | "CSize"
+            | "CPtr"
             | "Any"
     )
 }

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -19,7 +19,7 @@ use super::env::{
     EnumSig, FieldSig, FnSig, GenericParamSig, ImplSig, StructSig, TraitSig, TypeEnv,
     VariantPayloadSig, VariantSig,
 };
-use super::ty::{ParamId, Ty};
+use super::ty::{FfiTy, ParamId, Ty};
 
 /// A small lexical scope of generic parameters introduced by an
 /// enclosing declaration. Layered as a stack of frames so methods
@@ -560,6 +560,17 @@ fn resolve_type_path(
         "List" | "Array" | "Vec" => {
             let inner = expect_one_generic(head, resolved, env, self_ty, scope)?;
             return Ok(Ty::List(Box::new(inner)));
+        }
+        "CInt" => return ok_zero_generics(head, Ty::Ffi(FfiTy::CInt)),
+        "CLong" => return ok_zero_generics(head, Ty::Ffi(FfiTy::CLong)),
+        "CSize" => return ok_zero_generics(head, Ty::Ffi(FfiTy::CSize)),
+        // `CStr` is the spec name; `CString` is accepted as an alias so
+        // older `extern` signatures keep checking. Both denote a pointer
+        // to a null-terminated byte buffer.
+        "CStr" | "CString" => return ok_zero_generics(head, Ty::Ffi(FfiTy::CStr)),
+        "CPtr" => {
+            let inner = expect_one_generic(head, resolved, env, self_ty, scope)?;
+            return Ok(Ty::Ffi(FfiTy::CPtr(Box::new(inner))));
         }
         "Self" => {
             return self_ty

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -24,7 +24,7 @@ use super::collect::{resolve_ty, scope_from_params, GenericScope};
 use super::env::{FnSig, GenericParamSig, TypeEnv};
 use super::infer::{substitute, InferCtx};
 use super::pattern;
-use super::ty::{ParamId, Ty};
+use super::ty::{FfiTy, ParamId, Ty};
 use super::unify::assignable;
 use super::TypeMap;
 
@@ -547,7 +547,11 @@ impl<'a, 'b> Checker<'a, 'b> {
             ExprKind::Int(_) => Ok(Ty::Int),
             ExprKind::Float(_) => Ok(Ty::Float),
             ExprKind::Bool(_) => Ok(Ty::Bool),
-            ExprKind::Str(_) | ExprKind::BlockStr(_) | ExprKind::CStr(_) => Ok(Ty::Str),
+            ExprKind::Str(_) | ExprKind::BlockStr(_) => Ok(Ty::Str),
+            // A `c"..."` literal is a C string: a pointer to a static
+            // null-terminated byte buffer. It types as the FFI `CStr`
+            // type so it can be passed where a C function expects one.
+            ExprKind::CStr(_) => Ok(Ty::Ffi(FfiTy::CStr)),
             ExprKind::InterpolatedString(fragments) => self.check_interpolated_string(fragments),
             ExprKind::Char(_) => Ok(Ty::Char),
             ExprKind::SelfLower => Ok(self
@@ -947,6 +951,20 @@ impl<'a, 'b> Checker<'a, 'b> {
         }
         for (param_ty, arg) in params.iter().zip(args.iter()) {
             let a = self.check_expr(arg)?;
+            // An integer C FFI parameter (`CInt`, `CLong`, `CSize`)
+            // accepts a native `Int`, so an integer literal or expression
+            // can be passed to a C function (for example `abs(-7)`). The
+            // back end converts the i64 to the parameter's machine width
+            // at the call. A `c"..."` literal is already typed `CStr`, so
+            // it unifies directly with a `CStr` parameter. Any other
+            // mismatch falls through to the normal unify diagnostic.
+            let resolved_param = self.infer.resolve(param_ty);
+            let resolved_arg = self.infer.resolve(&a);
+            if is_int_ffi(resolved_param.strip_self())
+                && matches!(resolved_arg.strip_self(), Ty::Int)
+            {
+                continue;
+            }
             self.unify(param_ty, &a, &arg.span)?;
         }
         Ok(ret)
@@ -1023,7 +1041,11 @@ impl<'a, 'b> Checker<'a, 'b> {
                 // Built in `print_int(n: Int)` intrinsic. The codegen
                 // backend recognizes the mangled name and emits a call
                 // to the runtime's `raven_println_int` ABI symbol so a
-                // program can observe a computed integer.
+                // program can observe a computed integer. The integer C
+                // FFI types (`CInt`, `CLong`, `CSize`) are also accepted
+                // so the result of a C call (for example `strlen`) can be
+                // printed directly; the back end widens narrower ones to
+                // the i64 the runtime expects.
                 if args.len() != 1 {
                     return Err(RavenError::ty(
                         TypeError::WrongArity {
@@ -1035,7 +1057,14 @@ impl<'a, 'b> Checker<'a, 'b> {
                     ));
                 }
                 let arg_ty = self.check_expr(&args[0])?;
-                self.unify(&Ty::Int, &arg_ty, &args[0].span)?;
+                let resolved = self.infer.resolve(&arg_ty);
+                let is_int_ffi = matches!(
+                    resolved.strip_self(),
+                    Ty::Ffi(FfiTy::CInt) | Ty::Ffi(FfiTy::CLong) | Ty::Ffi(FfiTy::CSize)
+                );
+                if !is_int_ffi {
+                    self.unify(&Ty::Int, &arg_ty, &args[0].span)?;
+                }
                 Ok(Ty::Unit)
             }
             other => Err(RavenError::ty(
@@ -1692,6 +1721,15 @@ fn describe_callee(expr: &Expr) -> String {
         ExprKind::Ident { name, .. } => name.clone(),
         _ => "<expression>".to_string(),
     }
+}
+
+/// True for the integer C FFI types (`CInt`, `CLong`, `CSize`). A native
+/// `Int` may be passed where one of these is expected at a C call.
+fn is_int_ffi(ty: &Ty) -> bool {
+    matches!(
+        ty,
+        Ty::Ffi(FfiTy::CInt) | Ty::Ffi(FfiTy::CLong) | Ty::Ffi(FfiTy::CSize)
+    )
 }
 
 fn ty_custom(msg: &str, span: &Span) -> RavenError {

--- a/src/tycheck/infer.rs
+++ b/src/tycheck/infer.rs
@@ -330,6 +330,13 @@ fn unify_inner(cx: &mut InferCtx, a: &Ty, b: &Ty, span: &Span) -> Result<(), Rav
                 Err(mismatch(a, b, span))
             }
         }
+        // Two opaque typed pointers unify when their pointee types do.
+        // The other FFI primitives are handled by the `a == b`
+        // short-circuit at the top; a CStr against a CInt, or any FFI
+        // type against a native type, falls through to the mismatch.
+        (Ty::Ffi(super::ty::FfiTy::CPtr(x)), Ty::Ffi(super::ty::FfiTy::CPtr(y))) => {
+            unify_inner(cx, x, y, span)
+        }
         _ => Err(mismatch(a, b, span)),
     }
 }

--- a/src/tycheck/mod.rs
+++ b/src/tycheck/mod.rs
@@ -44,7 +44,7 @@ pub use env::{
     EnumSig, FieldSig, FnSig, GenericParamSig, ImplSig, StructSig, TraitSig, TypeEnv,
     VariantPayloadSig, VariantSig,
 };
-pub use ty::Ty;
+pub use ty::{FfiTy, Ty};
 
 /// One recorded `dyn Trait` unsizing coercion.
 ///

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -420,3 +420,53 @@ fn ty_display_does_not_panic() {
     let t = Ty::List(Box::new(Ty::Option(Box::new(Ty::Int))));
     assert_eq!(format!("{}", t), "List<Option<Int>>");
 }
+
+#[test]
+fn extern_decl_and_cstr_literal_call_checks() {
+    // An extern signature with FFI types, called on a `c"..."` literal.
+    check(
+        "extern \"C\" {\n    fun strlen(s: CStr) -> CSize\n}\nfun main() {\n    let n = strlen(c\"hello\")\n    print_int(n)\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn extern_int_param_accepts_int_literal() {
+    // A native Int literal is accepted where an integer FFI type (CInt)
+    // is expected, so `abs(-7)` checks.
+    check(
+        "extern \"C\" {\n    fun abs(x: CInt) -> CInt\n}\nfun main() {\n    let n = abs(-7)\n    print_int(n)\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn cstring_alias_resolves_to_cstr() {
+    // `CString` is accepted as an alias for `CStr` so older signatures
+    // keep checking.
+    check(
+        "extern \"C\" {\n    fun puts(s: CString) -> CInt\n}\nfun main() {\n    let _ = puts(c\"hi\")\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn passing_native_string_to_cstr_is_rejected() {
+    // A heap `String` is not a `CStr`: String-to-CStr conversion is
+    // deferred (issue #80), so this is a clear type error.
+    let err = check(
+        "extern \"C\" {\n    fun strlen(s: CStr) -> CSize\n}\nfun main() {\n    let s = \"hi\"\n    let _ = strlen(s)\n}\n",
+    )
+    .unwrap_err();
+    assert!(matches!(err, RavenError::Type(_, _, _)));
+}
+
+#[test]
+fn ffi_type_mismatch_is_rejected() {
+    // A `c"..."` (CStr) where a CInt is expected is rejected.
+    let err = check(
+        "extern \"C\" {\n    fun abs(x: CInt) -> CInt\n}\nfun main() {\n    let _ = abs(c\"oops\")\n}\n",
+    )
+    .unwrap_err();
+    assert!(matches!(err, RavenError::Type(_, _, _)));
+}

--- a/src/tycheck/ty.rs
+++ b/src/tycheck/ty.rs
@@ -74,6 +74,43 @@ impl std::hash::Hash for ParamId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct InferVarId(pub u32);
 
+/// A C FFI primitive type.
+///
+/// These are the foreign-function interface types recognized by the
+/// type checker for use in `extern "C"` blocks. They are deliberately
+/// kept distinct from the native Raven types (`Int`, `String`) so a
+/// program cannot accidentally pass a native value where the C ABI
+/// expects a foreign one. The codegen back end maps each to a concrete
+/// Cranelift ABI type. See `docs/v2/specs/ffi.md`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FfiTy {
+    /// C `int`, 32-bit on the ABIs Raven targets. Maps to `i32`.
+    CInt,
+    /// C `long`, 64-bit on the ABIs Raven targets. Maps to `i64`.
+    CLong,
+    /// C `size_t`, pointer-width unsigned. Maps to a pointer-width int.
+    CSize,
+    /// `*const c_char`: a pointer to a null-terminated byte buffer.
+    /// Maps to a pointer-width int.
+    CStr,
+    /// An opaque typed pointer `CPtr<T>`. Maps to a pointer-width int.
+    /// The pointee type is carried for documentation and future
+    /// conversions; the v2.0 back end treats it as an opaque pointer.
+    CPtr(Box<Ty>),
+}
+
+impl fmt::Display for FfiTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FfiTy::CInt => f.write_str("CInt"),
+            FfiTy::CLong => f.write_str("CLong"),
+            FfiTy::CSize => f.write_str("CSize"),
+            FfiTy::CStr => f.write_str("CStr"),
+            FfiTy::CPtr(inner) => write!(f, "CPtr<{}>", inner),
+        }
+    }
+}
+
 /// A resolved internal type.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Ty {
@@ -116,6 +153,9 @@ pub enum Ty {
     /// `Self` inside an `impl` block, bound to the implementing type.
     /// The contained type is the implementing type for convenience.
     SelfTy(Box<Ty>),
+    /// A C FFI primitive type (`CInt`, `CStr`, `CPtr<T>`, ...). Used in
+    /// `extern "C"` signatures and `c"..."` literals.
+    Ffi(FfiTy),
     /// A declared generic parameter.
     Param(ParamId),
     /// An inference variable.
@@ -149,6 +189,7 @@ impl Ty {
             Ty::Result(a, b) => a.has_var() || b.has_var(),
             Ty::Struct { args, .. } | Ty::Enum { args, .. } => args.iter().any(|t| t.has_var()),
             Ty::Function { params, ret } => params.iter().any(|t| t.has_var()) || ret.has_var(),
+            Ty::Ffi(FfiTy::CPtr(inner)) => inner.has_var(),
             Ty::Dyn { .. } => false,
             _ => false,
         }
@@ -193,6 +234,7 @@ impl fmt::Display for Ty {
             }
             Ty::Dyn { name, .. } => write!(f, "dyn {}", name),
             Ty::SelfTy(inner) => write!(f, "Self/* = {} */", inner),
+            Ty::Ffi(ffi) => write!(f, "{}", ffi),
             Ty::Param(p) => f.write_str(&p.name),
             Ty::Var(v) => write!(f, "?{}", v.0),
             Ty::Error => f.write_str("<error>"),

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -103,6 +103,29 @@ fn defer_early_return_program_compiles_and_runs() {
     compile_link_run_and_check("defer_early_return.rv", "9\n8\n9\n", &runtime);
 }
 
+#[test]
+fn ffi_strlen_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // C FFI end to end: `extern "C" { fun strlen(s: CStr) -> CSize }` is
+    // declared as an imported symbol, resolved against the CRT at link
+    // time, and called on the C string literal `c"hello"` (a static
+    // null-terminated buffer). strlen counts 5 bytes; prints 5.
+    compile_link_run_and_check("ffi_strlen.rv", "5\n", &runtime);
+}
+
+#[test]
+fn ffi_abs_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A non-pointer FFI type: `abs(x: CInt) -> CInt` takes and returns a
+    // 32-bit C int. The negative literal -7 is reduced to i32 at the
+    // call; abs(-7) is 7.
+    compile_link_run_and_check("ffi_abs.rv", "7\n", &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Calling C functions from Raven via `extern "C"` blocks, end to end from the type checker through codegen to a linked, running binary.

Closes #70. Design and boundaries are documented in `docs/v2/specs/ffi.md`.

## Observed output

`examples/v2/ffi_strlen.rv` declares `fun strlen(s: CStr) -> CSize`, calls it on `c"hello"`, and prints the result. Built and run on x86_64-pc-windows-msvc:

```
5
```

`examples/v2/ffi_abs.rv` calls `abs(x: CInt) -> CInt` on `-7` and prints `7`.

## What is supported

* `extern "C" { fun ... }` blocks with foreign signatures.
* FFI primitive types and their C ABI mapping:

  | Raven | C | Cranelift |
  |-------|---|-----------|
  | `CInt` | `int` | i32 |
  | `CLong` | `long` | i64 |
  | `CSize` | `size_t` | pointer width |
  | `CStr` | `const char *` | pointer width |
  | `CPtr<T>` | `T *` (opaque) | pointer width |

  `CString` is accepted as an alias for `CStr`.
* `c"..."` literals lower to a static, read-only, null-terminated byte buffer (no heap allocation).
* A native `Int` may be passed to an integer FFI parameter (so `abs(-7)` checks); the back end converts to the parameter width at the call.
* Type checking of extern calls: arity and FFI parameter and return types, with clear errors on mismatch.
* Codegen declares each foreign function as a `Linkage::Import` C-ABI symbol and lowers calls as direct calls, the same mechanism used for runtime symbols.

## Linking boundary

On windows-msvc the CRT is already on the link line (`/defaultlib:msvcrt`), so `strlen`, `abs`, `printf`, and other CRT symbols resolve with no extra flags. The CRT is the only library guaranteed to link in this PR.

## Deferred

* String-to-CStr conversion of a heap `String` (issue #80).
* Non-CRT libraries and their link flags via `rv.toml` `[ffi]` (issue #81).
* Variadic C functions, callbacks from C into Raven, and struct-by-value across the ABI.
* Dereferencing or arithmetic on `CPtr<T>`.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (266 lib tests, 10 codegen smoke tests including FFI strlen and abs)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` clean
- [x] Built and ran `examples/v2/ffi_strlen.rv`, observed `5`
- [x] Built and ran `examples/v2/ffi_abs.rv`, observed `7`
