### PR TITLE
feat(stdlib): bundled-module loading and the std/io module

### DIFF
--- a/docs/v2/specs/stdlib.md
+++ b/docs/v2/specs/stdlib.md
@@ -1,0 +1,193 @@
+# Standard Library Spec
+
+## Goal
+
+Define how Raven ships a standard library and implement its first module,
+`std/io`. The standard library is written in Raven (`.rv` source) bundled
+with the compiler. Bundled modules call a small set of compiler
+intrinsics for the operations that cannot be expressed in safe Raven
+(writing bytes to stdout, reading a line from stdin). Every later stdlib
+module (issues #72 to #80) plugs into the same mechanism this PR builds.
+
+## Pipeline position
+
+```
+Source -> Lexer -> Parser -> [stdlib expansion] -> Resolver -> Tycheck -> HIR -> MIR -> Codegen -> Linker
+```
+
+Stdlib expansion is a new step between parsing and resolution. It rewrites
+the parsed program into a combined file that contains the bundled modules
+the program imports plus the user's own items. From that point on the
+existing single file pipeline compiles and links everything together with
+no per stage special casing.
+
+## Bundled source model
+
+Stdlib modules live under `stdlib/std/` in the repository, one `.rv` file
+per module (for example `stdlib/std/io.rv`). Each module is embedded into
+the compiler binary with `include_str!`, so the compiler carries its own
+standard library and does not depend on a runtime file path or an
+installed copy on disk.
+
+The embedding lives in `src/resolve/stdlib.rs`:
+
+```rust
+pub const BUNDLED_MODULES: &[(&str, &str)] =
+    &[("io", include_str!("../../stdlib/std/io.rv"))];
+```
+
+The key is the module path under `std/`. A `std/io` import maps to the
+`"io"` entry. Adding a later module is one new row here plus the new
+`.rv` file. An import of a module name that has no bundled source is
+reported by the resolver as `UnresolvedImport`, the same as today.
+
+## Import to source mapping
+
+When the program imports a bundled module, the compiler:
+
+1. Looks up the embedded source for the module path.
+2. Lexes and parses that source into a module file. The virtual source
+   path is `<bundled>/std/<module>.rv`, used only for diagnostics.
+3. Namespaces every top level function in the module (see below).
+4. Merges the namespaced declarations into the program ahead of the
+   user's own items.
+
+A module is loaded once. Duplicate imports of the same `std/<module>` (in
+the same program, or selecting different names) merge a single copy.
+
+## Multi module compilation and namespacing
+
+The driver builds one combined `ast::File` whose `items` are the bundled
+stdlib declarations followed by the user's declarations. The combined file
+is owned by the driver and flows through the whole pipeline, so the
+resolver, type checker, HIR, MIR, and codegen all see the stdlib functions
+as ordinary top level functions defined alongside the user program. The
+monomorphizer already roots every non generic top level function, so each
+stdlib function is compiled into the object and linked with no extra
+reachability analysis.
+
+Namespacing avoids collisions between a stdlib function and a user
+function of the same name. A function `f` in module `io` is renamed at the
+AST level to `std.io.f`. The separator is a literal `.`, which a user
+cannot type in an identifier, so a namespaced name never clashes with a
+user declaration. The back end keys every call on the compiled function's
+name, so a call site must use the namespaced name rather than the source
+spelling; HIR lowering resolves a callee identifier to its declared
+function name through the resolution map, which yields `std.io.println`
+for a `println(...)` call that bound to the bundled function.
+
+## Import forms
+
+The working import form for a bundled module is the selective import:
+
+```raven
+import std/io { println, println_int }
+```
+
+The resolver binds each selector (`println`, `println_int`) directly to
+the namespaced function (`std.io.println`, `std.io.println_int`). The call
+site `println("hi")` is then an ordinary call to a known function, which
+the type checker, HIR, MIR, and codegen handle with no member access
+machinery. An explicit selector binding wins over a builtin of the same
+name, so `import std/io { print }` shadows the builtin `print` and gives
+the no newline behavior the module documents.
+
+The aliased form `import std/io as io` with member access `io.println(...)`
+is not supported in this release: member resolution through an import
+alias is type checker work that is out of scope here. Programs use the
+selective import form.
+
+## Intrinsic boundary
+
+Bundled Raven needs three operations below safe Raven: write bytes to
+stdout with no newline, write bytes followed by a newline, and read a line
+from stdin. These are exposed as a minimal set of compiler intrinsics that
+the bundled source calls. The leading `__io_` marks them internal; users
+do not write them directly.
+
+| Intrinsic                     | Lowers to runtime symbol | Meaning                          |
+|-------------------------------|--------------------------|----------------------------------|
+| `__io_print_str(s: String)`   | `raven_print_str`        | write `s` bytes, no newline      |
+| `__io_println_str(s: String)` | `raven_println_str`      | write `s` bytes plus a newline   |
+| `__io_read_line() -> String`  | `raven_read_line`        | read one line, newline stripped  |
+
+The intrinsics are recognized at three points, mirroring the existing
+`print` builtin:
+
+* The resolver bypasses scope lookup for the `__io_*` names so the bundled
+  source can call them without importing them.
+* The type checker assigns each intrinsic its signature (a `String`
+  argument returning `Unit`, or no argument returning `String`).
+* The codegen back end pattern matches the mangled name and emits a direct
+  call to the matching `raven-runtime` C ABI symbol. The String argument
+  is lowered through the same path as the `print` builtin: a string
+  literal passes its interned bytes and compile time length, and any other
+  `String` value reads its byte pointer and length from the object through
+  `raven_string_bytes` and `raven_string_len`.
+
+The runtime gains one new symbol, `raven_read_line() -> *mut String`. It
+reads one line from stdin, strips a trailing `\n` (and a preceding `\r`
+for Windows line endings), and returns a heap `String`. At end of input it
+returns an empty `String`, so a caller always receives a valid pointer.
+`raven_print_str` and `raven_println_str` already existed.
+
+This boundary dogfoods the existing string runtime and keeps the intrinsic
+surface to three internal names. A future module that needs a new
+primitive adds one intrinsic and one runtime symbol the same way.
+
+## The std/io surface
+
+`stdlib/std/io.rv` exports:
+
+* `print(s: String)`: write `s` with no trailing newline.
+* `println(s: String)`: write `s` followed by a newline.
+* `print_int(n: Int)`: write the base ten rendering of `n`, no newline.
+* `println_int(n: Int)`: write the base ten rendering of `n`, plus a newline.
+* `int_to_string(n: Int) -> String`: render an `Int` as a `String`.
+* `bool_to_string(b: Bool) -> String`: render a `Bool` as `"true"` / `"false"`.
+* `input(prompt: String) -> String`: print `prompt` (no newline), read one
+  line from stdin, and return it without the trailing newline.
+* `read_line() -> String`: read one line from stdin, newline stripped.
+
+The integer and conversion functions are built on string interpolation
+(`"${n}"`), which the compiler already lowers to the runtime integer to
+string and bool to string conversions. The module thus needs no separate
+integer intrinsics.
+
+## Relationship to the print builtins
+
+The compiler keeps `print` and `print_int` as global builtins for
+convenience (used by examples and quick programs without an import). For
+historical reasons those builtins append a newline. `std/io` is the
+blessed user facing surface: its `print` writes with no newline and its
+`println` adds one, which is the conventional split. Because an explicit
+import binds over a builtin, a program that imports `std/io`'s `print`
+gets the module's no newline behavior; a program that does not import it
+keeps the builtin.
+
+## How later modules plug in
+
+A new module (for example `std/collections`, `std/math`, `std/fs`):
+
+1. Adds `stdlib/std/<module>.rv` with its functions and types.
+2. Adds one `include_str!` row to `BUNDLED_MODULES`.
+3. If it needs an operation below safe Raven, adds an internal intrinsic
+   and its runtime symbol following the `__io_*` pattern above.
+
+No driver, resolver, type checker, or codegen change is needed for a
+module that only adds functions and types built on existing primitives.
+The packaging note in `CLAUDE.md` about shipping `lib/*.rv` does not apply
+to bundled modules: they are compiled into the binary, so nothing extra
+ships.
+
+## Out of scope
+
+* The aliased import form `import std/io as io` with `io.member(...)`
+  access. Selective imports are the working form here.
+* Variadic `format(template, args...)`. String interpolation already
+  covers formatted output, so a variadic `format` is deferred.
+* Buffered or unbuffered output control, flushing, and standard error
+  helpers (`eprint` / `eprintln`).
+* Async I/O and file I/O (`std/fs`, a later module).
+* Structs and traits in a bundled module. The `std/io` surface is free
+  functions only; later modules that need types exercise that path.

--- a/examples/v2/use_io.rv
+++ b/examples/v2/use_io.rv
@@ -1,0 +1,10 @@
+// golden:skip
+// Import the bundled std/io module and use its functions. The selective
+// import binds `println` and `println_int` to the namespaced stdlib
+// functions the compiler merges into the program. Prints two lines.
+import std/io { println, println_int }
+
+fun main() {
+    println("Hello from std/io!")
+    println_int(40 + 2)
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -35,7 +35,7 @@ pub use object::{
 };
 
 use std::alloc::{self, Layout};
-use std::io::{self, Write};
+use std::io::{self, BufRead, Write};
 use std::process;
 use std::slice;
 
@@ -150,6 +150,32 @@ pub extern "C" fn raven_println_str(ptr: *const u8, len: usize) {
         let _ = handle.write_all(bytes);
     }
     let _ = handle.write_all(b"\n");
+}
+
+/// Read one line from standard input and return it as a heap `String`.
+///
+/// The trailing line terminator is stripped: a final `\n` is dropped,
+/// and a preceding `\r` (Windows `\r\n`) is dropped with it. At end of
+/// input (no bytes read) an empty `String` is returned, so a caller can
+/// always treat the result as a valid `String` pointer.
+///
+/// Returns null only when the underlying `String` allocation fails.
+#[no_mangle]
+pub extern "C" fn raven_read_line() -> *mut object::String {
+    let mut line = std::string::String::new();
+    let stdin = io::stdin();
+    // A read error or clean EOF both leave `line` as the bytes gathered
+    // so far (empty at a clean EOF); either way we hand back a String.
+    let _ = stdin.lock().read_line(&mut line);
+    // Strip the trailing newline and an optional preceding carriage
+    // return so callers see the line content without the terminator.
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+    object::raven_string_from_bytes(line.as_ptr(), line.len())
 }
 
 /// Write a signed 64-bit integer to standard output in base ten,

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -279,6 +279,14 @@ impl ModuleCx {
         let mut sig = self.make_sig(&[ptr, ptr], &[]);
         self.declare_runtime(intrinsics::RUNTIME_PRINTLN_STR, &sig)?;
 
+        // raven_print_str(ptr, len)
+        sig = self.make_sig(&[ptr, ptr], &[]);
+        self.declare_runtime(intrinsics::RUNTIME_PRINT_STR, &sig)?;
+
+        // raven_read_line() -> String ptr
+        sig = self.make_sig(&[], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_READ_LINE, &sig)?;
+
         // raven_println_int(i64)
         sig = self.make_sig(&[i64t], &[]);
         self.declare_runtime(intrinsics::RUNTIME_PRINTLN_INT, &sig)?;

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -1028,6 +1028,41 @@ fn lower_intrinsic(
             builder.ins().call(local_ref, &[ptr_val, len_val]);
             Ok(None)
         }
+        intrinsics::IO_PRINT_STR | intrinsics::IO_PRINTLN_STR => {
+            if args.len() != 1 {
+                return Err(CodegenError::Unsupported(format!(
+                    "{} intrinsic expects 1 arg, got {}",
+                    mangled,
+                    args.len()
+                )));
+            }
+            let (ptr_val, len_val) = lower_string_arg(cx, builder, &args[0], slots)?;
+            let symbol = if mangled == intrinsics::IO_PRINTLN_STR {
+                intrinsics::RUNTIME_PRINTLN_STR
+            } else {
+                intrinsics::RUNTIME_PRINT_STR
+            };
+            let func_id = cx
+                .runtime_id(symbol)
+                .expect("runtime imports declared at module init");
+            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+            builder.ins().call(local_ref, &[ptr_val, len_val]);
+            Ok(None)
+        }
+        intrinsics::IO_READ_LINE => {
+            if !args.is_empty() {
+                return Err(CodegenError::Unsupported(format!(
+                    "__io_read_line intrinsic expects 0 args, got {}",
+                    args.len()
+                )));
+            }
+            let func_id = cx
+                .runtime_id(intrinsics::RUNTIME_READ_LINE)
+                .expect("runtime imports declared at module init");
+            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+            let inst = builder.ins().call(local_ref, &[]);
+            Ok(builder.inst_results(inst).first().copied())
+        }
         intrinsics::PRINT_INT => {
             if args.len() != 1 {
                 return Err(CodegenError::Unsupported(format!(

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -11,8 +11,26 @@ pub const PRINT: &str = "print";
 /// MIR mangled name produced by the front end for a `print_int(n)` call.
 pub const PRINT_INT: &str = "print_int";
 
+/// Internal stdlib I/O intrinsics. The bundled `std/io` source calls
+/// these to reach the runtime's byte-level I/O symbols; the leading
+/// `__io_` marks them internal (a user uses `std/io`'s exported
+/// functions instead). See `docs/v2/specs/stdlib.md`.
+///
+/// `__io_print_str(s: String)` writes the bytes of `s` with no newline.
+pub const IO_PRINT_STR: &str = "__io_print_str";
+/// `__io_println_str(s: String)` writes the bytes of `s` plus a newline.
+pub const IO_PRINTLN_STR: &str = "__io_println_str";
+/// `__io_read_line() -> String` reads one line from stdin (no newline).
+pub const IO_READ_LINE: &str = "__io_read_line";
+
 /// Runtime C symbol the `print` intrinsic dispatches to.
 pub const RUNTIME_PRINTLN_STR: &str = "raven_println_str";
+
+/// Runtime C symbol writing bytes to stdout with no trailing newline.
+pub const RUNTIME_PRINT_STR: &str = "raven_print_str";
+
+/// Runtime C symbol reading one line from stdin into a heap `String`.
+pub const RUNTIME_READ_LINE: &str = "raven_read_line";
 
 /// Runtime C symbol the `print_int` intrinsic dispatches to.
 pub const RUNTIME_PRINTLN_INT: &str = "raven_println_int";
@@ -78,5 +96,8 @@ pub const RUNTIME_CLOSURE_CAPTURES: &str = "raven_closure_captures";
 
 /// True when `mangled` is one of the recognized intrinsics.
 pub fn is_intrinsic(mangled: &str) -> bool {
-    matches!(mangled, PRINT | PRINT_INT)
+    matches!(
+        mangled,
+        PRINT | PRINT_INT | IO_PRINT_STR | IO_PRINTLN_STR | IO_READ_LINE
+    )
 }

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -91,7 +91,15 @@ pub(crate) fn lower_expr(
         ExprKind::SelfLower => HirExprKind::SelfValue,
         ExprKind::SelfUpper => HirExprKind::Ident("Self".into()),
         ExprKind::Ident { name, .. } if name == "None" => HirExprKind::NoneCtor,
-        ExprKind::Ident { name, .. } => HirExprKind::Ident(name.clone()),
+        ExprKind::Ident { name, .. } => {
+            // A use that binds to a top level function carries that
+            // function's declared name, which may differ from the source
+            // spelling when the function was namespaced (a bundled stdlib
+            // function such as `std.io.println`). Any other identifier
+            // keeps its source spelling.
+            let resolved_name = cx.fn_name_at(&expr.span).unwrap_or_else(|| name.clone());
+            HirExprKind::Ident(resolved_name)
+        }
         ExprKind::Array(items) => {
             let elem_hint = match &ty {
                 Ty::List(t) => (**t).clone(),

--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -84,6 +84,33 @@ impl<'a> LowerCtx<'a> {
     pub(crate) fn ty_at(&self, span: &Span) -> Ty {
         self.typed.types.lookup(span).cloned().unwrap_or(Ty::Error)
     }
+
+    /// Resolve an identifier use site to the declared name of the
+    /// top level function it binds to, if any.
+    ///
+    /// A bare call like `println(...)` carries the source spelling
+    /// `println` at its callee span, but the binding may point at a
+    /// function declared under a different name (for example a bundled
+    /// stdlib function namespaced as `std.io.println`). The back end keys
+    /// every call on the compiled function's name, so the call site must
+    /// use that declared name rather than the source spelling. Returns
+    /// `None` when the span does not resolve to a function (a local, a
+    /// parameter, a builtin like `print`, ...), in which case the caller
+    /// keeps the source spelling.
+    pub(crate) fn fn_name_at(&self, span: &Span) -> Option<String> {
+        use crate::resolve::Binding;
+        match self.resolved.map.lookup(span)? {
+            Binding::Function(decl_id) => {
+                let decl = self.resolved.file.items.get(decl_id.0)?;
+                if let crate::ast::DeclKind::Function(f) = &decl.kind {
+                    Some(f.name.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
 }
 
 fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use raven::hir::lower_file;
 use raven::lexer::Lexer;
 use raven::mir::lower_program;
 use raven::parser::parse;
-use raven::resolve::{resolve_file, FsLoader};
+use raven::resolve::{expand_with_stdlib, resolve_file, FsLoader};
 use raven::tycheck::check_file;
 
 fn main() -> ExitCode {
@@ -58,6 +58,12 @@ fn run_build(rest: &[String]) -> Result<(), DriverError> {
         .tokenize()
         .map_err(|e| DriverError::Frontend(format!("lex: {}", e)))?;
     let file = parse(&tokens).map_err(|e| DriverError::Frontend(format!("parse: {}", e)))?;
+    // Merge any imported bundled stdlib modules (for example `std/io`)
+    // into the program before resolving. The combined file owns the
+    // stdlib functions plus the user's items, so the single-file pipeline
+    // compiles and links them all together. See `docs/v2/specs/stdlib.md`.
+    let file =
+        expand_with_stdlib(&file).map_err(|e| DriverError::Frontend(format!("stdlib: {}", e)))?;
     let mut loader = FsLoader;
     let resolved = resolve_file(&file, &mut loader)
         .map_err(|e| DriverError::Frontend(format!("resolve: {}", e)))?;

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -284,8 +284,32 @@ fn bind_import(
     id: ImportId,
     scope: &mut ScopeStack,
 ) -> Result<(), RavenError> {
+    // The module name a `std/<module>` import resolves to, used to find
+    // the bundled functions the resolver merged ahead of this pass. When
+    // present, a selector binds directly to the namespaced function so
+    // the rest of the pipeline sees `println` as an ordinary call to a
+    // known function rather than a deferred import member.
+    let std_module: Option<&str> = match &resolved.target {
+        ImportTarget::StdlibModule { segments } => segments.first().map(|s| s.as_str()),
+        _ => None,
+    };
+
     if !import.selectors.is_empty() {
         for name in &import.selectors {
+            // For a bundled stdlib module, bind the selector to the
+            // namespaced function the resolver merged into the module
+            // scope. Fall back to the deferred `ImportedItem` binding when
+            // the function is not present (an unknown selector, or a
+            // resolver run that did not merge the bundle, as in unit
+            // tests that call `resolve_imports` directly).
+            if let Some(module) = std_module {
+                let mangled = super::stdlib::mangle_stdlib_fn(module, name);
+                if let Some(entry) = scope.lookup(&mangled) {
+                    let binding = entry.binding.clone();
+                    scope.insert(name, binding, import.span.clone())?;
+                    continue;
+                }
+            }
             scope.insert(
                 name,
                 Binding::ImportedItem {

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -11,6 +11,7 @@ pub mod bindings;
 pub mod imports;
 pub mod items;
 pub mod scope;
+pub mod stdlib;
 pub mod walk;
 
 #[cfg(test)]
@@ -26,6 +27,7 @@ pub use bindings::{
 };
 pub use imports::{FsLoader, LoadedSource, SourceLoader, STDLIB_MODULES};
 pub use scope::{Scope, ScopeKind, ScopeStack};
+pub use stdlib::{expand_with_stdlib, mangle_stdlib_fn};
 
 /// The resolver output for a single file.
 ///

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -1,0 +1,184 @@
+//! Bundled standard library loading.
+//!
+//! Standard library modules are written in Raven (`.rv` source) and
+//! bundled into the compiler with `include_str!`. When a program writes
+//! `import std/io { ... }`, the compiler parses the embedded source for
+//! that module, namespaces its top level functions, and merges them into
+//! the program so the rest of the pipeline (type checker, lowering,
+//! codegen) sees them as ordinary functions defined alongside the user
+//! code.
+//!
+//! Namespacing: a stdlib function `f` in module `io` is renamed to
+//! `std.io.f`. The `.` makes the name unwritable by a user, so a stdlib
+//! function never collides with a user declaration. A selective import
+//! `import std/io { println }` then binds the bare name `println` to the
+//! `std.io.println` function (see `imports.rs`).
+//!
+//! See `docs/v2/specs/stdlib.md` for the full mechanism.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::ast::{DeclKind, File, ImportSource};
+use crate::error::{RavenError, ResolveError};
+use crate::lexer::Lexer;
+use crate::parser::parse;
+
+/// The embedded source of one bundled stdlib module, keyed by its module
+/// path under `std/`. A `std/io` import maps to the `"io"` entry. The
+/// list grows as later modules (issues #72 to #80) land; each adds one
+/// `include_str!` row here.
+pub const BUNDLED_MODULES: &[(&str, &str)] = &[("io", include_str!("../../stdlib/std/io.rv"))];
+
+/// The separator used when namespacing a bundled function name. The
+/// resulting name (for example `std.io.println`) is unwritable by a user
+/// because Raven identifiers cannot contain `.`.
+pub const NAMESPACE_SEP: char = '.';
+
+/// Build the mangled name of a stdlib function: `std.<module>.<name>`.
+pub fn mangle_stdlib_fn(module: &str, name: &str) -> String {
+    format!("std{sep}{module}{sep}{name}", sep = NAMESPACE_SEP)
+}
+
+/// Look up the embedded source for a bundled module by its `std/` path.
+pub fn bundled_source(module_path: &str) -> Option<&'static str> {
+    BUNDLED_MODULES
+        .iter()
+        .find(|(name, _)| *name == module_path)
+        .map(|(_, src)| *src)
+}
+
+/// Expand `user` into a combined [`File`] that contains every bundled
+/// stdlib module the program imports, followed by the user's own items.
+///
+/// Each imported `std/<module>` is loaded once (duplicate imports are
+/// deduplicated), parsed, and its top level functions are renamed to
+/// `std.<module>.<name>`. The returned file is owned by the caller and
+/// must outlive the resolution that borrows it.
+///
+/// An unknown `std/<module>` (one with no bundled source) is left for
+/// the import pass to report as `UnresolvedImport`; this function only
+/// merges the modules it can load.
+pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
+    let mut wanted: BTreeSet<String> = BTreeSet::new();
+    for decl in &user.items {
+        if let DeclKind::Import(import) = &decl.kind {
+            if let ImportSource::Std(segments) = &import.source {
+                if let Some(head) = segments.first() {
+                    if bundled_source(head).is_some() {
+                        wanted.insert(head.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let mut combined_items = Vec::new();
+    for module in &wanted {
+        let source = bundled_source(module).expect("module presence checked above");
+        let virtual_path = PathBuf::from(format!("<bundled>/std/{module}.rv"));
+        let tokens = Lexer::new(source.to_string(), virtual_path.clone())
+            .tokenize()
+            .map_err(|e| bundled_error(module, format!("lex: {e}")))?;
+        let module_file =
+            parse(&tokens).map_err(|e| bundled_error(module, format!("parse: {e}")))?;
+        for mut decl in module_file.items {
+            if let DeclKind::Function(f) = &mut decl.kind {
+                f.name = mangle_stdlib_fn(module, &f.name);
+            }
+            combined_items.push(decl);
+        }
+    }
+
+    // The user's items follow the stdlib items so user DeclIds shift by a
+    // fixed, known amount but otherwise keep their relative order. The
+    // combined file's span borrows the user's file path for diagnostics
+    // that key off the top level file.
+    combined_items.extend(user.items.iter().cloned());
+
+    Ok(File {
+        items: combined_items,
+        span: user.span.clone(),
+    })
+}
+
+/// Build a resolve error for a bundled module that failed to load. A
+/// failure here is a compiler bug (the bundled source is shipped with
+/// the compiler), not a user error, but it is surfaced through the
+/// normal error channel anchored at a synthetic span.
+fn bundled_error(module: &str, detail: String) -> RavenError {
+    let span = crate::span::Span::point(
+        Arc::new(PathBuf::from(format!("<bundled>/std/{module}.rv"))),
+        0,
+        1,
+        1,
+    );
+    RavenError::resolve(
+        ResolveError::UnresolvedImport(format!("std/{module}")),
+        span,
+    )
+    .with_hint(format!("bundled stdlib module failed to load: {detail}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Lexer;
+    use crate::parser::parse;
+
+    fn parse_src(src: &str) -> File {
+        let tokens = Lexer::new(src.to_string(), PathBuf::from("main.rv"))
+            .tokenize()
+            .expect("lex");
+        parse(&tokens).expect("parse")
+    }
+
+    #[test]
+    fn io_module_is_bundled() {
+        assert!(bundled_source("io").is_some());
+        assert!(bundled_source("nope").is_none());
+    }
+
+    #[test]
+    fn mangling_uses_dotted_namespace() {
+        assert_eq!(mangle_stdlib_fn("io", "println"), "std.io.println");
+    }
+
+    #[test]
+    fn expand_prepends_namespaced_io_functions() {
+        let user = parse_src("import std/io { println }\nfun main() {}\n");
+        let combined = expand_with_stdlib(&user).expect("expand");
+        let names: Vec<String> = combined
+            .items
+            .iter()
+            .filter_map(|d| match &d.kind {
+                DeclKind::Function(f) => Some(f.name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(names.contains(&"std.io.println".to_string()));
+        assert!(names.contains(&"main".to_string()));
+        // The user `main` keeps its bare name; only stdlib names mangle.
+        assert!(!names.contains(&"std.io.main".to_string()));
+    }
+
+    #[test]
+    fn no_std_import_leaves_file_unchanged() {
+        let user = parse_src("fun main() {}\n");
+        let combined = expand_with_stdlib(&user).expect("expand");
+        assert_eq!(combined.items.len(), user.items.len());
+    }
+
+    #[test]
+    fn duplicate_imports_load_module_once() {
+        let user = parse_src("import std/io { println }\nimport std/io { print }\nfun main() {}\n");
+        let combined = expand_with_stdlib(&user).expect("expand");
+        let println_count = combined
+            .items
+            .iter()
+            .filter(|d| matches!(&d.kind, DeclKind::Function(f) if f.name == "std.io.println"))
+            .count();
+        assert_eq!(println_count, 1);
+    }
+}

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -313,26 +313,30 @@ fn walk_expr(
             map.bind_use(&expr.span, Binding::SelfType);
         }
         ExprKind::Ident { name, generics } => {
-            // Built in constructor identifiers (`None`, `Some`, `Ok`,
-            // `Err`) bypass scope lookup. The type checker recognizes
-            // them and assigns the correct `Option<T>` or
-            // `Result<T, E>` type at the call site.
-            if is_builtin_ctor_name(name) {
-                for g in generics {
-                    walk_type(g, scope, map)?;
-                }
-            } else {
-                let entry = scope.lookup(name).ok_or_else(|| {
-                    RavenError::resolve(
-                        ResolveError::UnresolvedName(name.clone()),
-                        expr.span.clone(),
-                    )
-                })?;
+            // An explicit binding in scope always wins. This lets a user
+            // shadow a builtin name by importing it: `import std/io { print }`
+            // binds `print` to the stdlib function, which then takes
+            // precedence over the built in `print` free function.
+            if let Some(entry) = scope.lookup(name) {
                 let binding = entry.binding.clone();
                 map.bind_use(&expr.span, binding);
                 for g in generics {
                     walk_type(g, scope, map)?;
                 }
+            } else if is_builtin_ctor_name(name) {
+                // Built in constructor identifiers (`None`, `Some`, `Ok`,
+                // `Err`), the `print`/`print_int` free functions, and the
+                // internal `__io_*` intrinsics bypass scope lookup. The
+                // type checker recognizes them and assigns the correct
+                // type at the call site.
+                for g in generics {
+                    walk_type(g, scope, map)?;
+                }
+            } else {
+                return Err(RavenError::resolve(
+                    ResolveError::UnresolvedName(name.clone()),
+                    expr.span.clone(),
+                ));
             }
         }
         ExprKind::StructLit {
@@ -639,6 +643,23 @@ fn is_builtin_type_name(name: &str) -> bool {
 /// can be used without an explicit import. `print` and `print_int` are
 /// treated the same way: they are built in free function intrinsics
 /// whose call sites are wired to the runtime by the codegen back end.
+///
+/// The `__io_*` names are internal stdlib intrinsics: the bundled
+/// `std/io` source calls them to reach the runtime's byte-level I/O
+/// symbols. The leading `__` marks them internal; users do not write
+/// them directly (they use `std/io`'s exported functions). They bypass
+/// scope lookup the same way the print builtins do.
 fn is_builtin_ctor_name(name: &str) -> bool {
-    matches!(name, "None" | "Some" | "Ok" | "Err" | "print" | "print_int")
+    matches!(
+        name,
+        "None"
+            | "Some"
+            | "Ok"
+            | "Err"
+            | "print"
+            | "print_int"
+            | "__io_print_str"
+            | "__io_println_str"
+            | "__io_read_line"
+    )
 }

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1067,6 +1067,39 @@ impl<'a, 'b> Checker<'a, 'b> {
                 }
                 Ok(Ty::Unit)
             }
+            // Internal stdlib I/O intrinsics. The bundled `std/io` source
+            // calls these to reach the runtime's byte-level output and
+            // input symbols; the codegen back end recognizes the mangled
+            // names and emits the matching runtime calls. They are not a
+            // user-facing surface (the leading `__` marks them internal).
+            "__io_print_str" | "__io_println_str" => {
+                if args.len() != 1 {
+                    return Err(RavenError::ty(
+                        TypeError::WrongArity {
+                            func: name.to_string(),
+                            expected: 1,
+                            actual: args.len(),
+                        },
+                        span.clone(),
+                    ));
+                }
+                let arg_ty = self.check_expr(&args[0])?;
+                self.unify(&Ty::Str, &arg_ty, &args[0].span)?;
+                Ok(Ty::Unit)
+            }
+            "__io_read_line" => {
+                if !args.is_empty() {
+                    return Err(RavenError::ty(
+                        TypeError::WrongArity {
+                            func: name.to_string(),
+                            expected: 0,
+                            actual: args.len(),
+                        },
+                        span.clone(),
+                    ));
+                }
+                Ok(Ty::Str)
+            }
             other => Err(RavenError::ty(
                 TypeError::Custom(format!("identifier `{}` has no type binding", other)),
                 span.clone(),

--- a/stdlib/std/io.rv
+++ b/stdlib/std/io.rv
@@ -1,0 +1,56 @@
+// std/io: the standard input and output module.
+//
+// This is bundled Raven source compiled into the program when a user
+// writes `import std/io { ... }`. The functions are ordinary Raven, with
+// the operations that cannot be written in safe Raven (writing bytes to
+// stdout, reading a line from stdin) expressed through a small set of
+// compiler intrinsics whose names begin with `__io_`. Those intrinsics
+// are recognized by the compiler and lowered to the matching
+// `raven-runtime` C ABI symbols. See `docs/v2/specs/stdlib.md`.
+
+// Write `s` to standard output with no trailing newline.
+fun print(s: String) {
+    __io_print_str(s)
+}
+
+// Write `s` to standard output followed by a single newline.
+fun println(s: String) {
+    __io_println_str(s)
+}
+
+// Write the base-ten rendering of `n` to standard output with no
+// trailing newline. Built on string interpolation, which the compiler
+// lowers to the runtime integer-to-string conversion.
+fun print_int(n: Int) {
+    __io_print_str("${n}")
+}
+
+// Write the base-ten rendering of `n` followed by a single newline.
+fun println_int(n: Int) {
+    __io_println_str("${n}")
+}
+
+// Render an `Int` as a `String`. A thin wrapper over interpolation so
+// callers have a named conversion without writing `"${n}"` by hand.
+fun int_to_string(n: Int) -> String {
+    "${n}"
+}
+
+// Render a `Bool` as a `String` ("true" or "false").
+fun bool_to_string(b: Bool) -> String {
+    "${b}"
+}
+
+// Print `prompt` (no trailing newline), then read one line from standard
+// input and return it without the trailing newline. At end of input the
+// returned `String` is empty.
+fun input(prompt: String) -> String {
+    __io_print_str(prompt)
+    __io_read_line()
+}
+
+// Read one line from standard input and return it without the trailing
+// newline. At end of input the returned `String` is empty.
+fun read_line() -> String {
+    __io_read_line()
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -19,7 +19,7 @@ use raven::hir::lower_file;
 use raven::lexer::Lexer;
 use raven::mir::lower_program;
 use raven::parser::parse;
-use raven::resolve::{resolve_file, FsLoader};
+use raven::resolve::{expand_with_stdlib, resolve_file, FsLoader};
 use raven::tycheck::check_file;
 
 #[test]
@@ -126,6 +126,19 @@ fn ffi_abs_program_compiles_and_runs() {
     compile_link_run_and_check("ffi_abs.rv", "7\n", &runtime);
 }
 
+#[test]
+fn std_io_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // The first stdlib module end to end: `import std/io { println,
+    // println_int }` merges the bundled `std/io` source into the program,
+    // namespaced as `std.io.*`. The selectors bind to those functions,
+    // which call the internal `__io_*` intrinsics wired to the runtime.
+    // Prints the greeting then 42.
+    compile_link_run_and_check("use_io.rv", "Hello from std/io!\n42\n", &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.
@@ -206,6 +219,9 @@ fn build_object(source: &str, path: &Path) -> Result<Vec<u8>, String> {
         .tokenize()
         .map_err(|e| format!("lex: {}", e))?;
     let file = parse(&tokens).map_err(|e| format!("parse: {}", e))?;
+    // Mirror the driver: merge any imported bundled stdlib modules before
+    // resolving. A program with no `std/` imports is unchanged.
+    let file = expand_with_stdlib(&file).map_err(|e| format!("stdlib: {}", e))?;
     let mut loader = FsLoader;
     let resolved = resolve_file(&file, &mut loader).map_err(|e| format!("resolve: {}", e))?;
     let typed = check_file(&resolved).map_err(|e| format!("tycheck: {}", e))?;


### PR DESCRIPTION
This PR adds the first standard library module, `std/io`, and the bundled-module loading mechanism every later stdlib module will use.

Closes #71. See `docs/v2/specs/stdlib.md` for the full design.

## Literal output of the use_io program

```
Hello from std/io!
42
```

(`examples/v2/use_io.rv`, built with `cargo run --bin raven -- build examples/v2/use_io.rv -o io_test.exe` and run on x86_64-pc-windows-msvc.)

## The stdlib mechanism

Stdlib modules are written in Raven and bundled into the compiler with `include_str!` (`stdlib/std/io.rv`, registered in `src/resolve/stdlib.rs`). A new expansion step runs between parsing and resolution: when a program imports `std/io`, the compiler parses the embedded source, namespaces each top level function as `std.io.<name>` (the `.` is unwritable by a user, so no collisions), and merges the declarations into one combined file ahead of the user's items. That combined file flows through the existing single file pipeline, so the type checker, lowering, and codegen compile and link the stdlib functions alongside the user program with no per stage special casing. The monomorphizer already roots every non generic top level function, so each stdlib function is compiled. HIR lowering resolves a callee identifier to its declared function name so `println(...)` reaches the `std.io.println` symbol the back end compiled. Modules are deduplicated, so repeated imports load one copy.

Working import form (selective import):

```raven
import std/io { println, println_int }
```

Each selector binds directly to the namespaced function, so the call site is an ordinary call. An explicit import binding wins over a builtin of the same name. The aliased `io.println(...)` member form is deferred (member resolution through an import alias is type checker work out of scope here).

A later module plugs in by adding one `.rv` file, one `include_str!` row, and (if needed) one intrinsic plus runtime symbol.

## Intrinsic boundary

Bundled Raven reaches three operations below safe Raven through internal `__io_*` intrinsics (leading `__` marks them internal):

| Intrinsic | Runtime symbol |
|-----------|----------------|
| `__io_print_str(s: String)` | `raven_print_str` |
| `__io_println_str(s: String)` | `raven_println_str` |
| `__io_read_line() -> String` | `raven_read_line` (new) |

Each is recognized by the resolver (scope bypass), the type checker (signature), and codegen (direct runtime call). The String argument lowers through the same path as the existing `print` builtin.

## std/io surface

`print`, `println`, `print_int`, `println_int`, `int_to_string(Int) -> String`, `bool_to_string(Bool) -> String`, `input(prompt: String) -> String`, `read_line() -> String`. Integer and conversion functions are built on string interpolation, so no separate integer intrinsics are needed. `std/io` is the blessed surface: its `print` writes with no newline (the global builtin `print` appends one and stays for convenience).

## Deferrals

- Aliased import `import std/io as io` with `io.member(...)` access.
- Variadic `format(template, args...)` (interpolation already covers formatted output).
- Buffered I/O, flush control, and standard error helpers.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (271 lib + 11 codegen smoke + goldens, all green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] End to end: `examples/v2/use_io.rv` builds, links, and prints the output above; added as a codegen smoke case
- [x] Verified `print` (no newline), `input` (stdin), and `int_to_string` work end to end
- [x] All prior example programs still build and run
