### PR TITLE
feat(stdlib): std/string utilities

### DIFF
--- a/docs/v2/specs/std-string.md
+++ b/docs/v2/specs/std-string.md
@@ -1,0 +1,149 @@
+# std/string Spec
+
+## Goal
+
+Provide a useful string-utility surface for Raven v2 programs: case
+mapping, length and access, search, transforms, and validation. The
+module is bundled Raven source compiled into the program the same way
+`std/io` is (see `stdlib.md`). It is written in pure Raven on top of a
+small set of byte-level compiler intrinsics, so most of the logic
+dogfoods the language itself.
+
+## Import
+
+`std/string` uses the selective-import form the resolver supports:
+
+```raven
+import std/string { to_upper, trim, contains, repeat }
+```
+
+Each selector binds the bare name to the namespaced function
+(`std.string.to_upper`, ...) the compiler merges into the program. The
+aliased `import std/string as s` form with `s.member(...)` access is not
+supported, the same limitation `std/io` documents.
+
+## Byte versus codepoint semantics
+
+Every function in this module is byte oriented. Indices, lengths, and
+slices count UTF-8 bytes, not Unicode code points or grapheme clusters.
+
+* `length(s)` returns the byte count. A string of multi-byte characters
+  reports a length larger than its visible character count: `length("é")`
+  is 2 because `é` is the two bytes `0xC3 0xA9` in UTF-8.
+* `char_at(s, i)` and `substring(s, start, end)` cut on byte boundaries.
+  Cutting through the middle of a multi-byte character yields a string
+  whose bytes are not valid UTF-8; that is the caller's responsibility.
+* `index_of`, `contains`, `starts_with`, `ends_with`, and `replace`
+  compare whole byte sequences, so they work correctly on multi-byte
+  text as long as the needle and haystack are themselves valid UTF-8
+  (the common case). `contains("café", "fé")` is true because the byte
+  sequence of `fé` occurs in `café`.
+* `to_upper` and `to_lower` map only ASCII letters (`A`..`Z` <->
+  `a`..`z`); every other byte, including the bytes of a multi-byte
+  character, passes through unchanged.
+* `trim` and `is_blank` treat the ASCII whitespace set (space, tab,
+  newline, carriage return, vertical tab, form feed) as whitespace.
+
+This byte model keeps v2.0 small and predictable. Code-point and
+grapheme-aware operations are deferred (see Out of scope).
+
+## The std/string surface
+
+`stdlib/std/string.rv` exports:
+
+* `length(s: String) -> Int`: byte length of `s`.
+* `is_empty(s: String) -> Bool`: true when `s` has zero bytes.
+* `char_at(s: String, i: Int) -> String`: the `i`-th byte as a one-byte
+  string; out of range yields the empty string.
+* `substring(s: String, start: Int, end: Int) -> String`: the half-open
+  byte range `[start, end)`, with bounds clamped to `0..length(s)` and a
+  `start` past `end` yielding the empty string.
+* `concat(a: String, b: String) -> String`: join two strings.
+* `to_upper(s: String) -> String`, `to_lower(s: String) -> String`:
+  ASCII case mapping.
+* `trim(s: String) -> String`: remove leading and trailing ASCII
+  whitespace; interior whitespace is kept.
+* `is_blank(s: String) -> Bool`: true when `s` is empty or all ASCII
+  whitespace.
+* `repeat(s: String, n: Int) -> String`: `s` repeated `n` times; a non
+  positive `n` yields the empty string.
+* `index_of(s: String, needle: String) -> Int`: byte index of the first
+  occurrence of `needle`, or `-1` when absent; an empty `needle` returns
+  `0`.
+* `contains(s: String, needle: String) -> Bool`: true when `needle`
+  occurs anywhere in `s`.
+* `starts_with(s: String, prefix: String) -> Bool`,
+  `ends_with(s: String, suffix: String) -> Bool`: prefix and suffix
+  tests; an empty prefix or suffix always matches.
+* `replace(s: String, from: String, to: String) -> String`: replace
+  every non-overlapping occurrence of `from` with `to`, scanning left to
+  right; an empty `from` returns `s` unchanged so the scan terminates.
+
+Two helpers, `is_space_byte` and `matches_at`, are also exported because
+the bundled module calls them internally; they are documented but not
+part of the intended public surface.
+
+## Intrinsic boundary
+
+The module needs byte-level operations below safe Raven. These are
+exposed as internal compiler intrinsics whose names begin with `__str_`.
+A user does not write them; they call the exported functions. The
+intrinsics are recognized at three points, mirroring the `__io_*`
+pattern (see `stdlib.md`):
+
+* The resolver bypasses scope lookup for the `__str_*` names.
+* The type checker assigns each intrinsic its signature.
+* The codegen back end pattern matches the mangled name and emits a
+  direct call to the matching `raven-runtime` C ABI symbol.
+
+| Intrinsic                                  | Runtime symbol            | Meaning                                                       |
+|--------------------------------------------|---------------------------|--------------------------------------------------------------|
+| `__str_len(s: String) -> Int`              | `raven_string_len`        | byte length of `s` (u32 zero-extended to `Int`)              |
+| `__str_byte_at(s: String, i: Int) -> Int`  | `raven_string_byte_at`    | byte at index `i` as `0..=255`, or `-1` when out of range    |
+| `__str_substring(s, start, end) -> String` | `raven_string_substring`  | clamped half-open byte range `[start, end)`                  |
+| `__str_from_byte(b: Int) -> String`        | `raven_string_from_byte`  | one-byte string from the low eight bits of `b`               |
+| `__str_concat(a, b) -> String`             | `raven_string_concat`     | concatenate two strings into a fresh string                  |
+
+`raven_string_len` and `raven_string_concat` already existed for the
+print path and interpolation. The runtime gains three new symbols:
+`raven_string_byte_at`, `raven_string_substring`, and
+`raven_string_from_byte`. Each has unit tests in
+`raven-runtime/src/object/string.rs`.
+
+## Building strings in Raven
+
+The transforms (`to_upper`, `to_lower`, `repeat`, `replace`) build their
+result by repeated `__str_concat`, growing a `String` one piece at a
+time. No mutable string builder was added to the runtime: the concat
+primitive already produces a fresh GC-managed `String`, the inputs here
+are small, and keeping the intrinsic surface minimal was preferred over
+a builder. The repeated-concat approach is `O(n^2)` in the result length
+for the character-by-character paths (`to_upper`, `to_lower`); for the
+typical short strings this module targets that is acceptable in v2.0. A
+builder (`raven_string_builder_*`) is a natural later optimization that
+would not change this surface.
+
+## Intra-module call resolution
+
+Unlike `std/io`, the `std/string` functions call one another (for
+example `trim` calls `is_space_byte`, and `index_of` calls
+`matches_at`). The stdlib expansion renames each declared function to
+`std.string.<name>` and, so a sibling call still resolves, rewrites any
+call-site identifier inside a bundled function body that names a sibling
+function to the same namespaced name. Local variables and parameters in
+the bundled sources never share a name with a sibling function, so the
+rewrite is unambiguous. This is implemented in `src/resolve/stdlib.rs`
+and is general: any later bundled module whose functions call each other
+benefits without extra work.
+
+## Out of scope
+
+* Unicode-aware case mapping (locale rules, `ß` to `SS`, Turkish dotless
+  `i`, ...). Case mapping is ASCII only.
+* Unicode normalization (NFC/NFD/NFKC/NFKD).
+* Grapheme-cluster and code-point indexing. All indices are byte
+  offsets.
+* Splitting, joining a list, and regular expressions. These wait on the
+  collection surface and a regex module.
+* A mutable string builder in the runtime. The transforms use repeated
+  concat instead; a builder is a later optimization.

--- a/docs/v2/specs/stdlib.md
+++ b/docs/v2/specs/stdlib.md
@@ -180,6 +180,15 @@ The packaging note in `CLAUDE.md` about shipping `lib/*.rv` does not apply
 to bundled modules: they are compiled into the binary, so nothing extra
 ships.
 
+## Modules
+
+* `std/io`: input and output. Documented above.
+* `std/string`: byte-oriented string utilities (case, search, trim,
+  substring, replace, ...). See `std-string.md`. It is the first module
+  whose functions call one another, which the stdlib expansion supports
+  by rewriting intra-module sibling calls to their namespaced names; see
+  that spec for the detail.
+
 ## Out of scope
 
 * The aliased import form `import std/io as io` with `io.member(...)`

--- a/examples/v2/use_string.rv
+++ b/examples/v2/use_string.rv
@@ -1,0 +1,23 @@
+// golden:skip
+// Import the bundled std/string module and exercise its functions. The
+// selective import binds each name to the namespaced stdlib function the
+// compiler merges into the program. std/io provides println for output
+// and println_int to observe an Int result.
+import std/string { to_upper, to_lower, trim, repeat, contains, index_of, replace, substring }
+import std/io { println, println_int }
+
+fun main() {
+    println(to_upper("hello"))
+    println(to_lower("WORLD"))
+    println(trim("  spaced  "))
+    println(repeat("ab", 3))
+    println(replace("a-b-c", "-", "+"))
+    println(substring("raven", 1, 4))
+    if contains("hello world", "world") {
+        println("contains: yes")
+    } else {
+        println("contains: no")
+    }
+    println_int(index_of("hello", "llo"))
+    println_int(index_of("hello", "zzz"))
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -27,11 +27,12 @@ pub use object::{
     raven_closure_captures, raven_closure_fn_ptr, raven_closure_new, raven_float_to_string,
     raven_int_to_string, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,
     raven_map_bucket_count, raven_map_buckets, raven_map_new, raven_set_bucket_count,
-    raven_set_buckets, raven_set_new, raven_string_bytes, raven_string_concat,
-    raven_string_from_bytes, raven_string_len, raven_string_new, raven_struct_fields,
-    raven_struct_new, Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap,
-    MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, GC_MARK_BIT,
-    OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING, TAG_STRUCT,
+    raven_set_buckets, raven_set_new, raven_string_byte_at, raven_string_bytes,
+    raven_string_concat, raven_string_from_byte, raven_string_from_bytes, raven_string_len,
+    raven_string_new, raven_string_substring, raven_struct_fields, raven_struct_new,
+    Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap, MapEntry,
+    ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, GC_MARK_BIT, OBJECT_ALIGN,
+    TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING, TAG_STRUCT,
 };
 
 use std::alloc::{self, Layout};

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -27,8 +27,8 @@ pub use map::{raven_map_bucket_count, raven_map_buckets, raven_map_new, Map, Map
 pub use set::{raven_set_bucket_count, raven_set_buckets, raven_set_new, Set, SetEntry};
 pub use string::{
     raven_bool_to_string, raven_char_to_string, raven_float_to_string, raven_int_to_string,
-    raven_string_bytes, raven_string_concat, raven_string_from_bytes, raven_string_len,
-    raven_string_new, String,
+    raven_string_byte_at, raven_string_bytes, raven_string_concat, raven_string_from_byte,
+    raven_string_from_bytes, raven_string_len, raven_string_new, raven_string_substring, String,
 };
 pub use structval::{
     raven_struct_fields, raven_struct_new, STRUCT_FIELDS_OFFSET, STRUCT_FIELD_SLOT,

--- a/raven-runtime/src/object/string.rs
+++ b/raven-runtime/src/object/string.rs
@@ -156,6 +156,68 @@ pub extern "C" fn raven_string_from_bytes(ptr: *const u8, len: usize) -> *mut St
     out
 }
 
+/// Return the byte at index `i` of `s` as a value in `0..=255`, or `-1`
+/// when `i` is out of range (or `s` is null). The index is a byte
+/// offset, not a code point or grapheme index; see the `std/string`
+/// spec for the byte-vs-codepoint semantics.
+///
+/// Backs the `__str_byte_at` compiler intrinsic, which the bundled
+/// `std/string` source uses to scan a string byte by byte.
+#[no_mangle]
+pub extern "C" fn raven_string_byte_at(s: *const String, i: usize) -> i32 {
+    let len = raven_string_len(s) as usize;
+    if i >= len {
+        return -1;
+    }
+    let bytes = raven_string_bytes(s);
+    if bytes.is_null() {
+        return -1;
+    }
+    // SAFETY: `i < len` and the buffer holds `len` valid bytes.
+    let byte = unsafe { *bytes.add(i) };
+    byte as i32
+}
+
+/// Allocate a fresh `String` holding the half-open byte range
+/// `[start, end)` of `s`. The bounds are clamped to `0..=len` and a
+/// `start` past `end` yields an empty string, so the function never
+/// reads out of range. The range is in bytes; slicing through the
+/// middle of a multi-byte UTF-8 sequence produces a string whose bytes
+/// are not valid UTF-8, which the byte-oriented `std/string` surface
+/// documents as the caller's responsibility.
+///
+/// Backs the `__str_substring` compiler intrinsic.
+#[no_mangle]
+pub extern "C" fn raven_string_substring(
+    s: *const String,
+    start: usize,
+    end: usize,
+) -> *mut String {
+    let len = raven_string_len(s) as usize;
+    let start = start.min(len);
+    let end = end.min(len);
+    if start >= end {
+        return raven_string_new(0);
+    }
+    let bytes = raven_string_bytes(s);
+    if bytes.is_null() {
+        return raven_string_new(0);
+    }
+    // SAFETY: `start < end <= len`, so the source range is in bounds.
+    unsafe { raven_string_from_bytes(bytes.add(start), end - start) }
+}
+
+/// Allocate a fresh one-byte `String` from the low eight bits of
+/// `byte`. Used by the `std/string` case-mapping and builder paths to
+/// turn a computed byte value back into a string before concatenation.
+///
+/// Backs the `__str_from_byte` compiler intrinsic.
+#[no_mangle]
+pub extern "C" fn raven_string_from_byte(byte: i32) -> *mut String {
+    let b = (byte & 0xff) as u8;
+    raven_string_from_bytes(&b as *const u8, 1)
+}
+
 /// Allocate a GC `String` whose bytes are the decimal rendering of a
 /// signed 64-bit integer. Negatives carry a leading `-`; zero renders
 /// as `0`.
@@ -449,6 +511,52 @@ mod tests {
             drop_string_for_test(a);
             drop_string_for_test(euro);
             drop_string_for_test(invalid);
+        }
+    }
+
+    #[test]
+    fn byte_at_returns_byte_or_minus_one() {
+        let s = raven_string_from_bytes(b"abc".as_ptr(), 3);
+        assert_eq!(raven_string_byte_at(s, 0), b'a' as i32);
+        assert_eq!(raven_string_byte_at(s, 2), b'c' as i32);
+        assert_eq!(raven_string_byte_at(s, 3), -1);
+        assert_eq!(raven_string_byte_at(s, 99), -1);
+        assert_eq!(raven_string_byte_at(std::ptr::null(), 0), -1);
+        unsafe { drop_string_for_test(s) };
+    }
+
+    #[test]
+    fn substring_extracts_clamped_range() {
+        let s = raven_string_from_bytes(b"hello".as_ptr(), 5);
+        let mid = raven_string_substring(s, 1, 4);
+        assert_eq!(read(mid), "ell");
+        // Bounds are clamped, and start past end yields empty.
+        let tail = raven_string_substring(s, 3, 99);
+        assert_eq!(read(tail), "lo");
+        let empty = raven_string_substring(s, 4, 2);
+        assert_eq!(read(empty), "");
+        let whole = raven_string_substring(s, 0, 5);
+        assert_eq!(read(whole), "hello");
+        unsafe {
+            drop_string_for_test(s);
+            drop_string_for_test(mid);
+            drop_string_for_test(tail);
+            drop_string_for_test(empty);
+            drop_string_for_test(whole);
+        }
+    }
+
+    #[test]
+    fn from_byte_builds_one_byte_string() {
+        let a = raven_string_from_byte(b'Z' as i32);
+        assert_eq!(read(a), "Z");
+        assert_eq!(raven_string_len(a), 1);
+        // Only the low eight bits are used.
+        let masked = raven_string_from_byte(0x141); // low byte is 0x41 = 'A'
+        assert_eq!(read(masked), "A");
+        unsafe {
+            drop_string_for_test(a);
+            drop_string_for_test(masked);
         }
     }
 

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -340,6 +340,19 @@ impl ModuleCx {
         sig = self.make_sig(&[ptr], &[i32t]);
         self.declare_runtime(intrinsics::RUNTIME_STRING_LEN, &sig)?;
 
+        // raven_string_byte_at(String ptr, index: usize) -> i32
+        sig = self.make_sig(&[ptr, ptr], &[i32t]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_BYTE_AT, &sig)?;
+
+        // raven_string_substring(String ptr, start: usize, end: usize)
+        //   -> String ptr
+        sig = self.make_sig(&[ptr, ptr, ptr], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_SUBSTRING, &sig)?;
+
+        // raven_string_from_byte(byte: i32) -> String ptr
+        sig = self.make_sig(&[i32t], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_FROM_BYTE, &sig)?;
+
         // raven_string_concat(String ptr, String ptr) -> String ptr
         sig = self.make_sig(&[ptr, ptr], &[ptr]);
         self.declare_runtime(intrinsics::RUNTIME_STRING_CONCAT, &sig)?;

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -1095,10 +1095,147 @@ fn lower_intrinsic(
             builder.ins().call(local_ref, &[v]);
             Ok(None)
         }
+        intrinsics::STR_LEN => {
+            // `raven_string_len` returns a u32; the bundled source treats
+            // the result as a native `Int` (i64), so zero-extend it.
+            if args.len() != 1 {
+                return Err(CodegenError::Unsupported(format!(
+                    "__str_len intrinsic expects 1 arg, got {}",
+                    args.len()
+                )));
+            }
+            let s = require_value(
+                lower_operand(cx, builder, &args[0], slots)?,
+                "__str_len argument",
+            )?;
+            let func_id = cx
+                .runtime_id(intrinsics::RUNTIME_STRING_LEN)
+                .expect("string-len runtime symbol declared at module init");
+            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+            let inst = builder.ins().call(local_ref, &[s]);
+            let len_u32 = builder.inst_results(inst)[0];
+            Ok(Some(builder.ins().uextend(types::I64, len_u32)))
+        }
+        intrinsics::STR_BYTE_AT => {
+            // `raven_string_byte_at(String ptr, index: usize) -> i32`.
+            // The index is a native `Int` (i64); reduce it to pointer
+            // width for the ABI, and sign-extend the i32 result back to a
+            // native `Int` so the -1 sentinel survives.
+            if args.len() != 2 {
+                return Err(CodegenError::Unsupported(format!(
+                    "__str_byte_at intrinsic expects 2 args, got {}",
+                    args.len()
+                )));
+            }
+            let s = require_value(
+                lower_operand(cx, builder, &args[0], slots)?,
+                "__str_byte_at string argument",
+            )?;
+            let idx = require_value(
+                lower_operand(cx, builder, &args[1], slots)?,
+                "__str_byte_at index argument",
+            )?;
+            let idx = to_pointer_width(builder, idx, cx.pointer_type());
+            let func_id = cx
+                .runtime_id(intrinsics::RUNTIME_STRING_BYTE_AT)
+                .expect("string-byte-at runtime symbol declared at module init");
+            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+            let inst = builder.ins().call(local_ref, &[s, idx]);
+            let byte_i32 = builder.inst_results(inst)[0];
+            Ok(Some(builder.ins().sextend(types::I64, byte_i32)))
+        }
+        intrinsics::STR_SUBSTRING => {
+            // `raven_string_substring(String ptr, start, end) -> String`.
+            // Both indices are native `Int` reduced to pointer width.
+            if args.len() != 3 {
+                return Err(CodegenError::Unsupported(format!(
+                    "__str_substring intrinsic expects 3 args, got {}",
+                    args.len()
+                )));
+            }
+            let s = require_value(
+                lower_operand(cx, builder, &args[0], slots)?,
+                "__str_substring string argument",
+            )?;
+            let start = require_value(
+                lower_operand(cx, builder, &args[1], slots)?,
+                "__str_substring start argument",
+            )?;
+            let end = require_value(
+                lower_operand(cx, builder, &args[2], slots)?,
+                "__str_substring end argument",
+            )?;
+            let start = to_pointer_width(builder, start, cx.pointer_type());
+            let end = to_pointer_width(builder, end, cx.pointer_type());
+            let func_id = cx
+                .runtime_id(intrinsics::RUNTIME_STRING_SUBSTRING)
+                .expect("string-substring runtime symbol declared at module init");
+            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+            let inst = builder.ins().call(local_ref, &[s, start, end]);
+            Ok(builder.inst_results(inst).first().copied())
+        }
+        intrinsics::STR_FROM_BYTE => {
+            // `raven_string_from_byte(byte: i32) -> String`. The argument
+            // is a native `Int`; reduce it to i32 for the ABI.
+            if args.len() != 1 {
+                return Err(CodegenError::Unsupported(format!(
+                    "__str_from_byte intrinsic expects 1 arg, got {}",
+                    args.len()
+                )));
+            }
+            let b = require_value(
+                lower_operand(cx, builder, &args[0], slots)?,
+                "__str_from_byte argument",
+            )?;
+            let b_i32 = builder.ins().ireduce(types::I32, b);
+            let func_id = cx
+                .runtime_id(intrinsics::RUNTIME_STRING_FROM_BYTE)
+                .expect("string-from-byte runtime symbol declared at module init");
+            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+            let inst = builder.ins().call(local_ref, &[b_i32]);
+            Ok(builder.inst_results(inst).first().copied())
+        }
+        intrinsics::STR_CONCAT_FN => {
+            // `raven_string_concat(String ptr, String ptr) -> String`.
+            if args.len() != 2 {
+                return Err(CodegenError::Unsupported(format!(
+                    "__str_concat intrinsic expects 2 args, got {}",
+                    args.len()
+                )));
+            }
+            let a = require_value(
+                lower_operand(cx, builder, &args[0], slots)?,
+                "__str_concat first argument",
+            )?;
+            let b = require_value(
+                lower_operand(cx, builder, &args[1], slots)?,
+                "__str_concat second argument",
+            )?;
+            let func_id = cx
+                .runtime_id(intrinsics::RUNTIME_STRING_CONCAT)
+                .expect("string-concat runtime symbol declared at module init");
+            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+            let inst = builder.ins().call(local_ref, &[a, b]);
+            Ok(builder.inst_results(inst).first().copied())
+        }
         _ => Err(CodegenError::Unsupported(format!(
             "unknown intrinsic: {}",
             mangled
         ))),
+    }
+}
+
+/// Reduce or extend a native `Int` (i64) value to the platform pointer
+/// width so it can be passed where the runtime ABI expects a `usize`.
+/// On a 64-bit target the value passes through unchanged.
+fn to_pointer_width(builder: &mut FunctionBuilder<'_>, v: Value, ptr: CType) -> Value {
+    let got = builder.func.dfg.value_type(v);
+    if got == ptr {
+        v
+    } else if ptr.bytes() < got.bytes() {
+        builder.ins().ireduce(ptr, v)
+    } else {
+        builder.ins().sextend(ptr, v)
     }
 }
 

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -23,6 +23,27 @@ pub const IO_PRINTLN_STR: &str = "__io_println_str";
 /// `__io_read_line() -> String` reads one line from stdin (no newline).
 pub const IO_READ_LINE: &str = "__io_read_line";
 
+/// Internal stdlib string intrinsics. The bundled `std/string` source
+/// calls these byte-level primitives to build the higher-level utilities
+/// (case mapping, search, trim, ...) in pure Raven. The leading `__str_`
+/// marks them internal; a user calls the exported `std/string` functions
+/// instead. See `docs/v2/specs/std-string.md`.
+///
+/// `__str_len(s: String) -> Int` returns the byte length of `s`.
+pub const STR_LEN: &str = "__str_len";
+/// `__str_byte_at(s: String, i: Int) -> Int` returns the byte at index
+/// `i` as a value in `0..=255`, or `-1` when `i` is out of range.
+pub const STR_BYTE_AT: &str = "__str_byte_at";
+/// `__str_substring(s: String, start: Int, end: Int) -> String` returns
+/// the half-open byte range `[start, end)` of `s` (bounds clamped).
+pub const STR_SUBSTRING: &str = "__str_substring";
+/// `__str_from_byte(b: Int) -> String` builds a one-byte `String` from
+/// the low eight bits of `b`.
+pub const STR_FROM_BYTE: &str = "__str_from_byte";
+/// `__str_concat(a: String, b: String) -> String` concatenates two
+/// strings into a fresh `String`.
+pub const STR_CONCAT_FN: &str = "__str_concat";
+
 /// Runtime C symbol the `print` intrinsic dispatches to.
 pub const RUNTIME_PRINTLN_STR: &str = "raven_println_str";
 
@@ -44,6 +65,15 @@ pub const RUNTIME_STRING_BYTES: &str = "raven_string_bytes";
 
 /// Runtime C symbol returning a heap `String`'s byte length.
 pub const RUNTIME_STRING_LEN: &str = "raven_string_len";
+
+/// Runtime C symbol returning the byte at an index (or -1 out of range).
+pub const RUNTIME_STRING_BYTE_AT: &str = "raven_string_byte_at";
+
+/// Runtime C symbol returning a clamped half-open byte sub-range.
+pub const RUNTIME_STRING_SUBSTRING: &str = "raven_string_substring";
+
+/// Runtime C symbol building a one-byte `String` from a byte value.
+pub const RUNTIME_STRING_FROM_BYTE: &str = "raven_string_from_byte";
 
 /// Runtime C symbols backing the interpolation desugaring intrinsics.
 /// Each MIR mangled name on the left dispatches to the runtime symbol on
@@ -98,6 +128,15 @@ pub const RUNTIME_CLOSURE_CAPTURES: &str = "raven_closure_captures";
 pub fn is_intrinsic(mangled: &str) -> bool {
     matches!(
         mangled,
-        PRINT | PRINT_INT | IO_PRINT_STR | IO_PRINTLN_STR | IO_READ_LINE
+        PRINT
+            | PRINT_INT
+            | IO_PRINT_STR
+            | IO_PRINTLN_STR
+            | IO_READ_LINE
+            | STR_LEN
+            | STR_BYTE_AT
+            | STR_SUBSTRING
+            | STR_FROM_BYTE
+            | STR_CONCAT_FN
     )
 }

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -20,7 +20,10 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::ast::{DeclKind, File, ImportSource};
+use crate::ast::{
+    Block, DeclKind, ElseBranch, Expr, ExprKind, File, FunctionBody, ImportSource, LambdaBody,
+    MatchArm, Stmt, StmtKind, StrFragment,
+};
 use crate::error::{RavenError, ResolveError};
 use crate::lexer::Lexer;
 use crate::parser::parse;
@@ -29,7 +32,10 @@ use crate::parser::parse;
 /// path under `std/`. A `std/io` import maps to the `"io"` entry. The
 /// list grows as later modules (issues #72 to #80) land; each adds one
 /// `include_str!` row here.
-pub const BUNDLED_MODULES: &[(&str, &str)] = &[("io", include_str!("../../stdlib/std/io.rv"))];
+pub const BUNDLED_MODULES: &[(&str, &str)] = &[
+    ("io", include_str!("../../stdlib/std/io.rv")),
+    ("string", include_str!("../../stdlib/std/string.rv")),
+];
 
 /// The separator used when namespacing a bundled function name. The
 /// resulting name (for example `std.io.println`) is unwritable by a user
@@ -83,8 +89,24 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
             .map_err(|e| bundled_error(module, format!("lex: {e}")))?;
         let module_file =
             parse(&tokens).map_err(|e| bundled_error(module, format!("parse: {e}")))?;
+
+        // Collect the module's own top level function names so a call to
+        // a sibling function (for example `trim` calling `is_space_byte`)
+        // can be rewritten to the namespaced name. The declarations are
+        // renamed below; without rewriting the call sites a sibling call
+        // would resolve to a bare name that no longer exists.
+        let siblings: BTreeSet<String> = module_file
+            .items
+            .iter()
+            .filter_map(|d| match &d.kind {
+                DeclKind::Function(f) => Some(f.name.clone()),
+                _ => None,
+            })
+            .collect();
+
         for mut decl in module_file.items {
             if let DeclKind::Function(f) = &mut decl.kind {
+                rewrite_fn_body_calls(&mut f.body, module, &siblings);
                 f.name = mangle_stdlib_fn(module, &f.name);
             }
             combined_items.push(decl);
@@ -101,6 +123,160 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
         items: combined_items,
         span: user.span.clone(),
     })
+}
+
+/// Rewrite every reference to a sibling stdlib function inside a bundled
+/// module's function body to its namespaced name.
+///
+/// A bundled module declares free functions that call one another by
+/// their bare names (for example `index_of` calls `matches_at`). The
+/// declarations are renamed to `std.<module>.<name>`, so a call site must
+/// use the same namespaced name to resolve. This walk renames any bare
+/// identifier whose name is one of the module's own functions; local
+/// variables and parameters never share a name with a sibling function in
+/// the bundled sources, so the rename is unambiguous.
+fn rewrite_fn_body_calls(body: &mut FunctionBody, module: &str, siblings: &BTreeSet<String>) {
+    match body {
+        FunctionBody::Block(block) => rewrite_block(block, module, siblings),
+        FunctionBody::Expr(expr) => rewrite_expr(expr, module, siblings),
+        FunctionBody::None => {}
+    }
+}
+
+fn rewrite_block(block: &mut Block, module: &str, siblings: &BTreeSet<String>) {
+    for stmt in &mut block.stmts {
+        rewrite_stmt(stmt, module, siblings);
+    }
+    if let Some(trailing) = &mut block.trailing {
+        rewrite_expr(trailing, module, siblings);
+    }
+}
+
+fn rewrite_stmt(stmt: &mut Stmt, module: &str, siblings: &BTreeSet<String>) {
+    match &mut stmt.kind {
+        StmtKind::Let { init, .. } => {
+            if let Some(e) = init {
+                rewrite_expr(e, module, siblings);
+            }
+        }
+        StmtKind::Return(e) | StmtKind::Break(e) => {
+            if let Some(e) = e {
+                rewrite_expr(e, module, siblings);
+            }
+        }
+        StmtKind::Defer(e) | StmtKind::Expr(e) => rewrite_expr(e, module, siblings),
+        StmtKind::Assign { target, value, .. } => {
+            rewrite_expr(target, module, siblings);
+            rewrite_expr(value, module, siblings);
+        }
+        StmtKind::Continue => {}
+    }
+}
+
+fn rewrite_expr(expr: &mut Expr, module: &str, siblings: &BTreeSet<String>) {
+    match &mut expr.kind {
+        ExprKind::Ident { name, .. } => {
+            if siblings.contains(name) {
+                *name = mangle_stdlib_fn(module, name);
+            }
+        }
+        ExprKind::InterpolatedString(fragments) => {
+            for frag in fragments {
+                if let StrFragment::Expr(e) = frag {
+                    rewrite_expr(e, module, siblings);
+                }
+            }
+        }
+        ExprKind::Array(items) | ExprKind::Tuple(items) => {
+            for e in items {
+                rewrite_expr(e, module, siblings);
+            }
+        }
+        ExprKind::StructLit { fields, .. } => {
+            for f in fields {
+                rewrite_expr(&mut f.value, module, siblings);
+            }
+        }
+        ExprKind::Paren(inner) | ExprKind::Try(inner) => rewrite_expr(inner, module, siblings),
+        ExprKind::Block(block) => rewrite_block(block, module, siblings),
+        ExprKind::Unary { operand, .. } => rewrite_expr(operand, module, siblings),
+        ExprKind::Binary { lhs, rhs, .. } => {
+            rewrite_expr(lhs, module, siblings);
+            rewrite_expr(rhs, module, siblings);
+        }
+        ExprKind::Range { start, end, .. } => {
+            rewrite_expr(start, module, siblings);
+            rewrite_expr(end, module, siblings);
+        }
+        ExprKind::Call { callee, args } => {
+            rewrite_expr(callee, module, siblings);
+            for a in args {
+                rewrite_expr(a, module, siblings);
+            }
+        }
+        ExprKind::MethodCall { receiver, args, .. } => {
+            rewrite_expr(receiver, module, siblings);
+            for a in args {
+                rewrite_expr(a, module, siblings);
+            }
+        }
+        ExprKind::Field { receiver, .. } => rewrite_expr(receiver, module, siblings),
+        ExprKind::Index { receiver, index } => {
+            rewrite_expr(receiver, module, siblings);
+            rewrite_expr(index, module, siblings);
+        }
+        ExprKind::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            rewrite_expr(cond, module, siblings);
+            rewrite_block(then_branch, module, siblings);
+            if let Some(else_branch) = else_branch {
+                match else_branch.as_mut() {
+                    ElseBranch::If(e) => rewrite_expr(e, module, siblings),
+                    ElseBranch::Block(b) => rewrite_block(b, module, siblings),
+                }
+            }
+        }
+        ExprKind::Match { scrutinee, arms } => {
+            rewrite_expr(scrutinee, module, siblings);
+            for arm in arms.iter_mut() {
+                rewrite_match_arm(arm, module, siblings);
+            }
+        }
+        ExprKind::Loop(block) => rewrite_block(block, module, siblings),
+        ExprKind::While { cond, body } => {
+            rewrite_expr(cond, module, siblings);
+            rewrite_block(body, module, siblings);
+        }
+        ExprKind::For { iter, body, .. } => {
+            rewrite_expr(iter, module, siblings);
+            rewrite_block(body, module, siblings);
+        }
+        ExprKind::Lambda { body, .. } => match body {
+            LambdaBody::Block(b) => rewrite_block(b, module, siblings),
+            LambdaBody::Expr(e) => rewrite_expr(e, module, siblings),
+        },
+        // Leaf literals and the `self`/`Self` keywords carry no nested
+        // expressions to rewrite.
+        ExprKind::Int(_)
+        | ExprKind::Float(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Str(_)
+        | ExprKind::BlockStr(_)
+        | ExprKind::Char(_)
+        | ExprKind::CStr(_)
+        | ExprKind::SelfLower
+        | ExprKind::SelfUpper => {}
+    }
+}
+
+fn rewrite_match_arm(arm: &mut MatchArm, module: &str, siblings: &BTreeSet<String>) {
+    if let Some(guard) = &mut arm.guard {
+        rewrite_expr(guard, module, siblings);
+    }
+    rewrite_expr(&mut arm.body, module, siblings);
 }
 
 /// Build a resolve error for a bundled module that failed to load. A
@@ -138,6 +314,98 @@ mod tests {
     fn io_module_is_bundled() {
         assert!(bundled_source("io").is_some());
         assert!(bundled_source("nope").is_none());
+    }
+
+    #[test]
+    fn string_module_is_bundled() {
+        assert!(bundled_source("string").is_some());
+    }
+
+    #[test]
+    fn intra_module_sibling_calls_are_namespaced() {
+        // `std/string`'s `trim` calls its sibling `is_space_byte`. After
+        // expansion the call site must reference the namespaced name so it
+        // resolves to the renamed declaration. Collect every identifier in
+        // `trim`'s body and assert the sibling call was renamed.
+        let user = parse_src("import std/string { trim }\nfun main() {}\n");
+        let combined = expand_with_stdlib(&user).expect("expand");
+        let trim_fn = combined
+            .items
+            .iter()
+            .find_map(|d| match &d.kind {
+                DeclKind::Function(f) if f.name == "std.string.trim" => Some(f),
+                _ => None,
+            })
+            .expect("std.string.trim present");
+        let mut idents = Vec::new();
+        if let FunctionBody::Block(b) = &trim_fn.body {
+            collect_block_idents(b, &mut idents);
+        } else {
+            panic!("trim has a block body");
+        }
+        assert!(
+            idents.iter().any(|n| n == "std.string.is_space_byte"),
+            "trim body should call the namespaced sibling, got: {idents:?}"
+        );
+        assert!(
+            !idents.iter().any(|n| n == "is_space_byte"),
+            "no bare sibling call should remain, got: {idents:?}"
+        );
+    }
+
+    fn collect_block_idents(block: &Block, out: &mut Vec<String>) {
+        for stmt in &block.stmts {
+            match &stmt.kind {
+                StmtKind::Let { init: Some(e), .. } => collect_expr_idents(e, out),
+                StmtKind::Return(Some(e)) | StmtKind::Expr(e) => collect_expr_idents(e, out),
+                StmtKind::Assign { target, value, .. } => {
+                    collect_expr_idents(target, out);
+                    collect_expr_idents(value, out);
+                }
+                _ => {}
+            }
+        }
+        if let Some(t) = &block.trailing {
+            collect_expr_idents(t, out);
+        }
+    }
+
+    fn collect_expr_idents(expr: &Expr, out: &mut Vec<String>) {
+        match &expr.kind {
+            ExprKind::Ident { name, .. } => out.push(name.clone()),
+            ExprKind::Call { callee, args } => {
+                collect_expr_idents(callee, out);
+                for a in args {
+                    collect_expr_idents(a, out);
+                }
+            }
+            ExprKind::Binary { lhs, rhs, .. } => {
+                collect_expr_idents(lhs, out);
+                collect_expr_idents(rhs, out);
+            }
+            ExprKind::Unary { operand, .. } => collect_expr_idents(operand, out),
+            ExprKind::Paren(e) => collect_expr_idents(e, out),
+            ExprKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                collect_expr_idents(cond, out);
+                collect_block_idents(then_branch, out);
+                if let Some(eb) = else_branch {
+                    match eb.as_ref() {
+                        ElseBranch::If(e) => collect_expr_idents(e, out),
+                        ElseBranch::Block(b) => collect_block_idents(b, out),
+                    }
+                }
+            }
+            ExprKind::While { cond, body } => {
+                collect_expr_idents(cond, out);
+                collect_block_idents(body, out);
+            }
+            ExprKind::Block(b) => collect_block_idents(b, out),
+            _ => {}
+        }
     }
 
     #[test]

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -644,11 +644,12 @@ fn is_builtin_type_name(name: &str) -> bool {
 /// treated the same way: they are built in free function intrinsics
 /// whose call sites are wired to the runtime by the codegen back end.
 ///
-/// The `__io_*` names are internal stdlib intrinsics: the bundled
-/// `std/io` source calls them to reach the runtime's byte-level I/O
-/// symbols. The leading `__` marks them internal; users do not write
-/// them directly (they use `std/io`'s exported functions). They bypass
-/// scope lookup the same way the print builtins do.
+/// The `__io_*` and `__str_*` names are internal stdlib intrinsics: the
+/// bundled `std/io` and `std/string` sources call them to reach the
+/// runtime's byte-level symbols. The leading `__` marks them internal;
+/// users do not write them directly (they use the modules' exported
+/// functions). They bypass scope lookup the same way the print builtins
+/// do.
 fn is_builtin_ctor_name(name: &str) -> bool {
     matches!(
         name,
@@ -661,5 +662,10 @@ fn is_builtin_ctor_name(name: &str) -> bool {
             | "__io_print_str"
             | "__io_println_str"
             | "__io_read_line"
+            | "__str_len"
+            | "__str_byte_at"
+            | "__str_substring"
+            | "__str_from_byte"
+            | "__str_concat"
     )
 }

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1100,11 +1100,76 @@ impl<'a, 'b> Checker<'a, 'b> {
                 }
                 Ok(Ty::Str)
             }
+            // Internal stdlib string intrinsics. The bundled `std/string`
+            // source calls these byte-level primitives; the codegen back
+            // end recognizes the mangled names and emits the matching
+            // runtime calls. The leading `__str_` marks them internal.
+            "__str_len" => {
+                self.check_intrinsic_arity(name, args, 1, span)?;
+                let s = self.check_expr(&args[0])?;
+                self.unify(&Ty::Str, &s, &args[0].span)?;
+                Ok(Ty::Int)
+            }
+            "__str_byte_at" => {
+                self.check_intrinsic_arity(name, args, 2, span)?;
+                let s = self.check_expr(&args[0])?;
+                self.unify(&Ty::Str, &s, &args[0].span)?;
+                let i = self.check_expr(&args[1])?;
+                self.unify(&Ty::Int, &i, &args[1].span)?;
+                Ok(Ty::Int)
+            }
+            "__str_substring" => {
+                self.check_intrinsic_arity(name, args, 3, span)?;
+                let s = self.check_expr(&args[0])?;
+                self.unify(&Ty::Str, &s, &args[0].span)?;
+                let start = self.check_expr(&args[1])?;
+                self.unify(&Ty::Int, &start, &args[1].span)?;
+                let end = self.check_expr(&args[2])?;
+                self.unify(&Ty::Int, &end, &args[2].span)?;
+                Ok(Ty::Str)
+            }
+            "__str_from_byte" => {
+                self.check_intrinsic_arity(name, args, 1, span)?;
+                let b = self.check_expr(&args[0])?;
+                self.unify(&Ty::Int, &b, &args[0].span)?;
+                Ok(Ty::Str)
+            }
+            "__str_concat" => {
+                self.check_intrinsic_arity(name, args, 2, span)?;
+                let a = self.check_expr(&args[0])?;
+                self.unify(&Ty::Str, &a, &args[0].span)?;
+                let b = self.check_expr(&args[1])?;
+                self.unify(&Ty::Str, &b, &args[1].span)?;
+                Ok(Ty::Str)
+            }
             other => Err(RavenError::ty(
                 TypeError::Custom(format!("identifier `{}` has no type binding", other)),
                 span.clone(),
             )),
         }
+    }
+
+    /// Reject a stdlib intrinsic call whose argument count differs from
+    /// `expected`, with the same `WrongArity` diagnostic the other
+    /// intrinsic arms use.
+    fn check_intrinsic_arity(
+        &self,
+        name: &str,
+        args: &[Expr],
+        expected: usize,
+        span: &Span,
+    ) -> Result<(), RavenError> {
+        if args.len() != expected {
+            return Err(RavenError::ty(
+                TypeError::WrongArity {
+                    func: name.to_string(),
+                    expected,
+                    actual: args.len(),
+                },
+                span.clone(),
+            ));
+        }
+        Ok(())
     }
 
     fn check_method_call(

--- a/stdlib/std/string.rv
+++ b/stdlib/std/string.rv
@@ -1,0 +1,262 @@
+// std/string: byte-oriented string utilities.
+//
+// This is bundled Raven source compiled into the program when a user
+// writes `import std/string { ... }`. The functions are ordinary Raven
+// built on a small set of compiler intrinsics whose names begin with
+// `__str_`. Those intrinsics are recognized by the compiler and lowered
+// to the matching `raven-runtime` C ABI symbols. See
+// `docs/v2/specs/std-string.md`.
+//
+// Semantics are byte oriented: indices, lengths, and slices count UTF-8
+// bytes, not code points or grapheme clusters. Case mapping is ASCII
+// only. Multi-byte text passes through search and trim unchanged because
+// the operations compare whole byte sequences, but `char_at`, `substring`,
+// and the case functions act on individual bytes. See the spec for the
+// full byte versus codepoint discussion and the out of scope items.
+
+// Return the byte length of `s`. This counts UTF-8 bytes, not code
+// points or grapheme clusters, so a string of multi-byte characters
+// reports a length larger than its visible character count.
+fun length(s: String) -> Int {
+    return __str_len(s)
+}
+
+// True when `s` has zero bytes.
+fun is_empty(s: String) -> Bool {
+    return __str_len(s) == 0
+}
+
+// Return the `i`-th byte of `s` as a one-byte `String`. `i` is a byte
+// offset; for a multi-byte character this returns a single byte of its
+// UTF-8 encoding, which on its own is not valid UTF-8. An out of range
+// index yields the empty string.
+fun char_at(s: String, i: Int) -> String {
+    return __str_substring(s, i, i + 1)
+}
+
+// Return the half-open byte range `[start, end)` of `s`. Bounds are
+// clamped to `0..length(s)` and a `start` past `end` yields the empty
+// string, so this never reads out of range. Slicing through the middle
+// of a multi-byte character produces bytes that are not valid UTF-8.
+fun substring(s: String, start: Int, end: Int) -> String {
+    return __str_substring(s, start, end)
+}
+
+// Concatenate `a` and `b` into a fresh `String`.
+fun concat(a: String, b: String) -> String {
+    return __str_concat(a, b)
+}
+
+// ASCII upper case. Bytes in `a`..`z` are mapped to `A`..`Z`; every
+// other byte (including the upper half of any multi-byte UTF-8
+// sequence) is copied unchanged. Non ASCII case is out of scope.
+fun to_upper(s: String) -> String {
+    let n = __str_len(s)
+    let out = ""
+    let i = 0
+    while i < n {
+        let b = __str_byte_at(s, i)
+        if b >= 97 {
+            if b <= 122 {
+                out = __str_concat(out, __str_from_byte(b - 32))
+            } else {
+                out = __str_concat(out, __str_from_byte(b))
+            }
+        } else {
+            out = __str_concat(out, __str_from_byte(b))
+        }
+        i = i + 1
+    }
+    return out
+}
+
+// ASCII lower case. Bytes in `A`..`Z` are mapped to `a`..`z`; every
+// other byte is copied unchanged. Non ASCII case is out of scope.
+fun to_lower(s: String) -> String {
+    let n = __str_len(s)
+    let out = ""
+    let i = 0
+    while i < n {
+        let b = __str_byte_at(s, i)
+        if b >= 65 {
+            if b <= 90 {
+                out = __str_concat(out, __str_from_byte(b + 32))
+            } else {
+                out = __str_concat(out, __str_from_byte(b))
+            }
+        } else {
+            out = __str_concat(out, __str_from_byte(b))
+        }
+        i = i + 1
+    }
+    return out
+}
+
+// True when the byte at index `i` of `s` is ASCII whitespace: space,
+// tab, newline, carriage return, vertical tab, or form feed.
+fun is_space_byte(b: Int) -> Bool {
+    if b == 32 {
+        return true
+    }
+    if b == 9 {
+        return true
+    }
+    if b == 10 {
+        return true
+    }
+    if b == 13 {
+        return true
+    }
+    if b == 11 {
+        return true
+    }
+    if b == 12 {
+        return true
+    }
+    return false
+}
+
+// Remove leading and trailing ASCII whitespace. Interior whitespace is
+// preserved. Whitespace is the ASCII set listed in `is_space_byte`;
+// Unicode whitespace is out of scope. A string that is empty or all
+// whitespace trims to the empty string.
+fun trim(s: String) -> String {
+    let n = __str_len(s)
+    // Advance `start` past leading whitespace.
+    let start = 0
+    let scanning = true
+    while scanning {
+        if start >= n {
+            scanning = false
+        } else {
+            if is_space_byte(__str_byte_at(s, start)) {
+                start = start + 1
+            } else {
+                scanning = false
+            }
+        }
+    }
+    // Retreat `end` past trailing whitespace.
+    let end = n
+    scanning = true
+    while scanning {
+        if end <= start {
+            scanning = false
+        } else {
+            if is_space_byte(__str_byte_at(s, end - 1)) {
+                end = end - 1
+            } else {
+                scanning = false
+            }
+        }
+    }
+    return __str_substring(s, start, end)
+}
+
+// True when `s` is empty or contains only ASCII whitespace.
+fun is_blank(s: String) -> Bool {
+    let n = __str_len(s)
+    let i = 0
+    while i < n {
+        if is_space_byte(__str_byte_at(s, i)) {
+            i = i + 1
+        } else {
+            return false
+        }
+    }
+    return true
+}
+
+// Repeat `s` `n` times. A non positive `n` yields the empty string.
+fun repeat(s: String, n: Int) -> String {
+    let out = ""
+    let i = 0
+    while i < n {
+        out = __str_concat(out, s)
+        i = i + 1
+    }
+    return out
+}
+
+// True when the bytes of `needle` occur in `s` starting exactly at byte
+// index `at`. A `needle` that runs past the end of `s` is not a match.
+fun matches_at(s: String, needle: String, at: Int) -> Bool {
+    let m = __str_len(needle)
+    let n = __str_len(s)
+    if at + m > n {
+        return false
+    }
+    let j = 0
+    while j < m {
+        if __str_byte_at(s, at + j) == __str_byte_at(needle, j) {
+            j = j + 1
+        } else {
+            return false
+        }
+    }
+    return true
+}
+
+// Byte index of the first occurrence of `needle` in `s`, or -1 when
+// `needle` does not occur. An empty `needle` matches at index 0.
+fun index_of(s: String, needle: String) -> Int {
+    let n = __str_len(s)
+    let m = __str_len(needle)
+    if m == 0 {
+        return 0
+    }
+    let i = 0
+    while i + m <= n {
+        if matches_at(s, needle, i) {
+            return i
+        }
+        i = i + 1
+    }
+    return -1
+}
+
+// True when `needle` occurs anywhere in `s`. An empty `needle` is
+// always contained.
+fun contains(s: String, needle: String) -> Bool {
+    return index_of(s, needle) >= 0
+}
+
+// True when `s` begins with the bytes of `prefix`. An empty prefix
+// always matches.
+fun starts_with(s: String, prefix: String) -> Bool {
+    return matches_at(s, prefix, 0)
+}
+
+// True when `s` ends with the bytes of `suffix`. An empty suffix always
+// matches.
+fun ends_with(s: String, suffix: String) -> Bool {
+    let n = __str_len(s)
+    let m = __str_len(suffix)
+    if m > n {
+        return false
+    }
+    return matches_at(s, suffix, n - m)
+}
+
+// Replace every non overlapping occurrence of `from` in `s` with `to`,
+// scanning left to right. When `from` is empty the input is returned
+// unchanged so the scan cannot loop forever.
+fun replace(s: String, from: String, to: String) -> String {
+    let m = __str_len(from)
+    if m == 0 {
+        return s
+    }
+    let n = __str_len(s)
+    let out = ""
+    let i = 0
+    while i < n {
+        if matches_at(s, from, i) {
+            out = __str_concat(out, to)
+            i = i + m
+        } else {
+            out = __str_concat(out, __str_substring(s, i, i + 1))
+            i = i + 1
+        }
+    }
+    return out
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -139,6 +139,29 @@ fn std_io_program_compiles_and_runs() {
     compile_link_run_and_check("use_io.rv", "Hello from std/io!\n42\n", &runtime);
 }
 
+#[test]
+fn std_string_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // The std/string module end to end: `import std/string { ... }` merges
+    // the bundled source (which builds its utilities in pure Raven on top
+    // of the `__str_*` byte intrinsics) into the program, namespaced as
+    // `std.string.*`. Exercises case mapping, trim, repeat, replace,
+    // substring, contains, and index_of, with the last two observed
+    // through println and println_int.
+    let expected = "HELLO\n\
+                    world\n\
+                    spaced\n\
+                    ababab\n\
+                    a+b+c\n\
+                    ave\n\
+                    contains: yes\n\
+                    2\n\
+                    -1\n";
+    compile_link_run_and_check("use_string.rv", expected, &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Add the bundled `std/string` module: a byte-oriented string-utility surface written in pure Raven on top of a minimal set of byte-level compiler intrinsics, built the same way `std/io` was.

Closes #73

## Spec

See `docs/v2/specs/std-string.md` (linked from `docs/v2/specs/stdlib.md`). It documents the surface, the byte-versus-codepoint semantics, the intrinsics, the repeated-concat build strategy, the intra-module sibling-call rewriting, and the out-of-scope items.

## Verified output

`examples/v2/use_string.rv` compiled with `raven build` and run on this host (Windows, x86_64-pc-windows-msvc) prints:

```
HELLO
world
spaced
ababab
a+b+c
ave
contains: yes
2
-1
```

That covers `to_upper`, `to_lower`, `trim`, `repeat`, `replace`, `substring`, `contains`, and `index_of` (the last two observed through `println` and `println_int`, including the `-1` absent sentinel). This is the assertion in the new `std_string_program_compiles_and_runs` smoke test.

## Surface shipped

`length`, `is_empty`, `char_at`, `substring`, `concat`, `to_upper`, `to_lower`, `trim`, `is_blank`, `repeat`, `index_of`, `contains`, `starts_with`, `ends_with`, `replace` (plus the internal helpers `is_space_byte` and `matches_at`).

## Byte versus codepoint semantics

All functions are byte oriented: indices, lengths, and slices count UTF-8 bytes, not code points or grapheme clusters. `length("é")` is 2. `char_at` and `substring` cut on byte boundaries. Search (`index_of`, `contains`, `starts_with`, `ends_with`, `replace`) compares whole byte sequences, so it works on valid-UTF-8 multi-byte text. `to_upper`/`to_lower` map ASCII letters only; other bytes pass through. `trim`/`is_blank` use the ASCII whitespace set.

## Intrinsics added

The module builds on five internal `__str_*` intrinsics, wired through the resolver scope bypass, the type-checker signatures, and the codegen lowering, the same way the `__io_*` intrinsics are:

| Intrinsic | Runtime symbol |
|-----------|----------------|
| `__str_len(s) -> Int` | `raven_string_len` (existed) |
| `__str_byte_at(s, i) -> Int` | `raven_string_byte_at` (new) |
| `__str_substring(s, start, end) -> String` | `raven_string_substring` (new) |
| `__str_from_byte(b) -> String` | `raven_string_from_byte` (new) |
| `__str_concat(a, b) -> String` | `raven_string_concat` (existed) |

No mutable string builder was added: the transforms use repeated `concat`, keeping the runtime ABI surface minimal. A builder is noted as a future optimization.

## Design notes

`std/string` is the first bundled module whose functions call one another, so the stdlib expansion now rewrites intra-module sibling call sites to their namespaced names (`trim` calling `is_space_byte` resolves to `std.string.is_space_byte`). This is general for any future multi-function module.

## Deferred

Unicode-aware case, normalization (NFC/NFD/...), grapheme-cluster and code-point indexing, split/join, regex, and a runtime string builder.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (273 lib, 12 codegen smoke incl. `std_string_program_compiles_and_runs`, 84 runtime lib)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `raven build examples/v2/use_string.rv` compiled, linked, and ran with the expected literal output above
