### PR TITLE
feat(tycheck,codegen): methods on built-in types

### DIFF
--- a/docs/v2/specs/tycheck.md
+++ b/docs/v2/specs/tycheck.md
@@ -75,9 +75,10 @@ Walk every body expression in declaration order. For each expression, synthesize
 
 Method calls are looked up by the receiver's resolved type:
 
-1. Search inherent impls of the receiver type for a method with that name.
+1. Search user declared inherent impls of the receiver type for a method with that name. The receiver type may be a user struct or enum, or a built in type (`Int`, `Float`, `Bool`, `Char`, `String`, `List<T>`, `Set<T>`, `Map<K, V>`, `Option<T>`, `Result<T, E>`).
 2. If none, search trait impls of the receiver type for a method with that name.
-3. Multiple matches raise `AmbiguousMethod`; zero matches raise `UndefinedMethod`.
+3. If still none, fall back to the hard coded built in fast path methods (`Option`/`Result`/`List`/`String`).
+4. Multiple impl matches raise `AmbiguousMethod`; zero matches raise `UndefinedMethod`.
 
 For struct literals, every field declared on the struct must be initialized exactly once; unknown fields raise `UndefinedField`; missing fields raise a `TypeError::Custom` describing what is missing.
 
@@ -119,10 +120,39 @@ Method dispatch is statically resolved. When the user writes `r.m(...)` and `r: 
 
 1. Look up inherent methods of `T` (impl blocks with no `for` clause).
 2. Look up methods of any trait `Tr` such that `impl Tr for T` exists.
-3. If exactly one candidate has the name `m`, use it.
-4. If more than one matches, raise `AmbiguousMethod` listing the candidates. The user disambiguates by calling `Tr::m(r, ...)` (qualified call syntax). Qualified calls are accepted as a regular function call.
+3. If no user `impl` method matched, fall back to the hard coded built in fast path methods.
+4. If exactly one candidate has the name `m`, use it.
+5. If more than one impl matches, raise `AmbiguousMethod` listing the candidates. The user disambiguates by calling `Tr::m(r, ...)` (qualified call syntax). Qualified calls are accepted as a regular function call.
 
-A method call on a value of `Self` type inside an `impl` block resolves through the implementing type. `Option<T>` and `Result<T, E>` get a small inherent method table: `is_some`, `is_none`, `unwrap`, `unwrap_or`, `is_ok`, `is_err`. `List<T>` exposes `len`, `push`, `pop`, `is_empty`, `get`.
+A method call on a value of `Self` type inside an `impl` block resolves through the implementing type. Each impl's generic parameters get fresh inference variables and the substituted `self_ty` is unified against the receiver, so a generic impl such as `impl<T> List<T>` matches a concrete `List<Int>` receiver and the method's `T` binds to `Int`.
+
+### `impl` on built in types
+
+An `impl` block may target a built in type, not just a user struct or enum:
+
+```
+impl Int {
+    fun doubled(self) -> Int = self * 2
+}
+```
+
+The implementing type is resolved the same way any type path is resolved, so `impl Int`, `impl String`, `impl<T> List<T>`, `impl Bool`, `impl Char`, `impl Float`, `impl<T> Set<T>`, and `impl<K, V> Map<K, V>` all collect into the same method table the type checker uses for user structs. Inside the body, `self` is the built in receiver and `Self` is the built in type. Resolution then matches the receiver against the impl's `self_ty` exactly as for a user type, so `21.doubled()` resolves to the `Int` impl method.
+
+`Set` and `Map` are recognized as built in type names for the purpose of accepting an `impl` head, but their value types are not yet wired through lowering; an `impl<T> Set<T>` collects and resolves but is not exercised end to end until those types land.
+
+### Precedence vs hard coded inherent methods
+
+The hard coded built in fast path methods (`Option`/`Result`/`List`/`String`) are only consulted when no user `impl` method matched. A user `impl` method therefore always wins over a hard coded method of the same name. This keeps the checked signature in step with code generation: a method call lowers to the per type symbol `<RecvType>$<method>` (see below), and a user `impl` method defines exactly that symbol, so the type the checker assigns is the type of the method that actually runs.
+
+The hard coded tables remain available for receivers with no user impl: `Option<T>` and `Result<T, E>` expose `is_some`, `is_none`, `unwrap`, `unwrap_or`, `is_ok`, `is_err`; `List<T>` exposes `len`, `push`, `pop`, `is_empty`, `get`; `String` exposes `len`, `is_empty`.
+
+### Symbol naming
+
+A statically dispatched method lowers to the symbol `<TypeMangle>$<method>`, where `<TypeMangle>` is the receiver type's identifier safe mangling (`Int`, `Str`, `Bool`, `Char`, `Float`, `List_Int`, `Option_Int`, a struct or enum name, and so on). So `impl Int { fun doubled }` defines `Int$doubled` and `impl String { fun shout }` defines `Str$shout`. The definition site (HIR lowering of the impl) and the call site (MIR lowering of the method call) both compute this name from the same receiver type, so they always agree, and methods of the same name on different types never collide. Generic built in impls monomorphize per concrete element type through the same path that specializes generic user types: `impl<T> List<T>` produces one method instance per element type the program uses.
+
+### Methods in bundled stdlib modules
+
+A bundled stdlib module (loaded by `expand_with_stdlib` when a program writes `import std/<module>`) may declare `impl` blocks on built in types. Unlike the module's free functions, which are renamed to `std.<module>.<name>` to avoid colliding with user names, an `impl` method keeps its name: it is dispatched by the receiver's type through the `<RecvType>$<method>` symbol, not by a free function name, so it never collides with user code and needs no namespacing. The expander still rewrites sibling free function calls inside an impl method body to their namespaced names (a stdlib `impl String` method calling the module's own `to_upper` reaches `std.string.to_upper`). A user calls the method by writing `value.method()` after importing the module; no name needs to be brought into scope with a selector, because resolution is by receiver type.
 
 ## Exhaustiveness check
 

--- a/examples/v2/builtin_method.rv
+++ b/examples/v2/builtin_method.rv
@@ -1,0 +1,9 @@
+// A method declared on a built-in type via an `impl` block.
+// Compiling and running this prints 42.
+impl Int {
+    fun doubled(self) -> Int = self * 2
+}
+
+fun main() {
+    print_int(21.doubled())
+}

--- a/examples/v2/stdlib_string_method.rv
+++ b/examples/v2/stdlib_string_method.rv
@@ -1,0 +1,12 @@
+// golden:skip
+// A method defined on the built in `String` type inside the bundled
+// std/string module, called from user code. Importing the module merges
+// its `impl String` block into the program; the `shout` method is then
+// resolved by the receiver's type, not by an imported name, so calling
+// "hi".shout() dispatches to the stdlib method and prints HI.
+import std/string { to_upper }
+import std/io { println }
+
+fun main() {
+    println("hi".shout())
+}

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -105,9 +105,26 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
             .collect();
 
         for mut decl in module_file.items {
-            if let DeclKind::Function(f) = &mut decl.kind {
-                rewrite_fn_body_calls(&mut f.body, module, &siblings);
-                f.name = mangle_stdlib_fn(module, &f.name);
+            match &mut decl.kind {
+                DeclKind::Function(f) => {
+                    rewrite_fn_body_calls(&mut f.body, module, &siblings);
+                    f.name = mangle_stdlib_fn(module, &f.name);
+                }
+                DeclKind::Impl(i) => {
+                    // An `impl` on a built in type (for example
+                    // `impl String { ... }`) keeps its method names: a
+                    // method is dispatched by the receiver's type through
+                    // the per type symbol `<RecvType>$<method>`, not by a
+                    // free function name, so it never collides with user
+                    // code and needs no namespacing. Its body, however,
+                    // may call sibling free functions of the same module,
+                    // which were renamed above; rewrite those call sites
+                    // the same way a free function body is rewritten.
+                    for m in &mut i.items {
+                        rewrite_fn_body_calls(&mut m.body, module, &siblings);
+                    }
+                }
+                _ => {}
             }
             combined_items.push(decl);
         }

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1201,27 +1201,19 @@ impl<'a, 'b> Checker<'a, 'b> {
             return self.check_dyn_method_call(trait_name, name, args, span);
         }
 
-        // Built in methods first (Option/Result/List/String). These are
-        // matched directly against the resolved receiver shape; their
-        // signatures already substitute the element type.
-        if let Some((params, ret)) = builtin::lookup_method(&recv_stripped, name) {
-            if params.len() != args.len() {
-                return Err(RavenError::ty(
-                    TypeError::WrongArity {
-                        func: name.to_string(),
-                        expected: params.len(),
-                        actual: args.len(),
-                    },
-                    span.clone(),
-                ));
-            }
-            for (pt, arg) in params.iter().zip(args.iter()) {
-                let a = self.check_expr(arg)?;
-                self.unify(pt, &a, &arg.span)?;
-            }
-            return Ok(ret);
-        }
-
+        // User declared `impl` methods are searched first, including
+        // impls on built in receiver types (`impl Int`, `impl String`,
+        // `impl<T> List<T>`, ...). This is the same path that resolves
+        // methods on user structs; built in receivers fall out of it
+        // because their `self_ty` is the matching built in `Ty`.
+        //
+        // Precedence: a user `impl` method always wins over a hard coded
+        // built in fast path method of the same name (the fall back at
+        // the end of this function). This keeps the checked signature in
+        // step with code generation, where a method call lowers to the
+        // per type symbol `<RecvType>$<method>` and any user `impl`
+        // method defines exactly that symbol.
+        //
         // Gather candidate impls. For each impl, allocate fresh
         // inference variables for its declared generic parameters and
         // unify the substituted self_ty against the receiver type. An
@@ -1264,6 +1256,27 @@ impl<'a, 'b> Checker<'a, 'b> {
 
         let total = inherent_matches.len() + trait_matches.len();
         if total == 0 {
+            // No user `impl` method matched. Fall back to the hard coded
+            // built in fast path methods (Option/Result/List/String).
+            // These match directly against the resolved receiver shape;
+            // their signatures already substitute the element type.
+            if let Some((params, ret)) = builtin::lookup_method(&recv_stripped, name) {
+                if params.len() != args.len() {
+                    return Err(RavenError::ty(
+                        TypeError::WrongArity {
+                            func: name.to_string(),
+                            expected: params.len(),
+                            actual: args.len(),
+                        },
+                        span.clone(),
+                    ));
+                }
+                for (pt, arg) in params.iter().zip(args.iter()) {
+                    let a = self.check_expr(arg)?;
+                    self.unify(pt, &a, &arg.span)?;
+                }
+                return Ok(ret);
+            }
             return Err(RavenError::ty(
                 TypeError::UndefinedMethod {
                     receiver_ty: format!("{}", recv_stripped),

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -244,6 +244,48 @@ fn unknown_method_is_error() {
 }
 
 #[test]
+fn impl_method_on_builtin_int_resolves() {
+    // `impl Int { ... }` collects against the built in `Int` receiver and
+    // a call on an integer expression resolves to the impl method.
+    check("impl Int { fun doubled(self) -> Int = self * 2 }\nfun f() -> Int = 21.doubled()\n")
+        .expect("impl Int method resolves");
+}
+
+#[test]
+fn impl_method_on_builtin_string_resolves() {
+    check(
+        "impl String { fun first(self) -> Int = __str_byte_at(self, 0) }\n\
+         fun f() -> Int = \"A\".first()\n",
+    )
+    .expect("impl String method resolves");
+}
+
+#[test]
+fn impl_method_on_generic_list_resolves() {
+    // A generic impl on the built in `List<T>` introduces the impl's type
+    // parameter and resolves the method per element type.
+    check(
+        "impl<T> List<T> { fun head(self) -> T = self.get(0) }\n\
+         fun f() -> Int {\n    let xs = [1, 2, 3]\n    return xs.head()\n}\n",
+    )
+    .expect("impl List<T> method resolves");
+}
+
+#[test]
+fn impl_method_on_builtin_shadows_hardcoded_fast_path() {
+    // A user `impl String { fun len(self) -> Int }` takes precedence over
+    // the hard coded built in `String::len` fast path. The signature
+    // checked is the user impl's, so a return type mismatch against it is
+    // reported (the impl returns Int, used where Bool is expected).
+    let err = check("impl String { fun len(self) -> Int = 0 }\nfun f() -> Bool = \"hi\".len()\n")
+        .unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::TypeMismatch { .. })),
+        other => panic!("expected TypeMismatch, got {:?}", other),
+    }
+}
+
+#[test]
 fn wrong_arity_is_error() {
     let err =
         check("fun f() -> Int = add(1)\nfun add(a: Int, b: Int) -> Int = a + b\n").unwrap_err();

--- a/stdlib/std/string.rv
+++ b/stdlib/std/string.rv
@@ -178,6 +178,18 @@ fun repeat(s: String, n: Int) -> String {
     return out
 }
 
+// A method on the built in `String` type, declared in a bundled stdlib
+// module. It exercises method resolution for a built in receiver and a
+// sibling free function call from inside an `impl` body. The body calls
+// the module's own `to_upper`, which the stdlib expander rewrites to its
+// namespaced name. A user writes `"hi".shout()` after importing this
+// module and gets the upper cased string back.
+impl String {
+    fun shout(self) -> String {
+        return to_upper(self)
+    }
+}
+
 // True when the bytes of `needle` occur in `s` starting exactly at byte
 // index `at`. A `needle` that runs past the end of `s` is not a match.
 fun matches_at(s: String, needle: String, at: Int) -> Bool {

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -162,6 +162,32 @@ fn std_string_program_compiles_and_runs() {
     compile_link_run_and_check("use_string.rv", expected, &runtime);
 }
 
+#[test]
+fn builtin_method_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A method declared on the built in `Int` type via `impl Int { fun
+    // doubled(self) -> Int = self * 2 }`. The call `21.doubled()`
+    // resolves to the impl method and dispatches statically to the per
+    // type symbol `Int$doubled`, printing 42.
+    compile_link_run_and_check("builtin_method.rv", "42\n", &runtime);
+}
+
+#[test]
+fn stdlib_string_method_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A method declared on the built in `String` type inside the bundled
+    // std/string module: `impl String { fun shout(self) -> String }`.
+    // Importing the module merges the `impl` block into the program; the
+    // method is resolved by the receiver's type, not by an imported name.
+    // `shout` calls the module's sibling `to_upper`, so "hi".shout()
+    // prints HI.
+    compile_link_run_and_check("stdlib_string_method.rv", "HI\n", &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Allows `impl` blocks on built-in types (`String`, `List<T>`, `Int`, `Float`, `Bool`, `Char`), so the standard library can be method-first. This is the foundational enabler for the OOP stdlib described in the charter (`docs/v2/specs/stdlib-modules.md`).

Closes #116.

## What this adds

- The type checker collects `impl <BuiltinType> { ... }` blocks and resolves `value.method(args)` when the receiver is a built-in type, alongside the existing user-struct method resolution.
- Methods on built-in types dispatch through the existing per-type method symbol convention (`Int$doubled`, `String$shout`) introduced with trait objects, so no new codegen path was required: tycheck resolves the method, MIR monomorphizes it, codegen emits the direct call.
- `impl` blocks inside bundled stdlib modules are collected and their methods resolved by receiver type (not by an imported free-function name), so the stdlib can attach methods to built-in types.

## Verification (built and run on windows-msvc)

- `examples/v2/builtin_method.rv`: `impl Int { fun doubled(self) -> Int = self * 2 }`, then `21.doubled()` prints `42`.
- `examples/v2/stdlib_string_method.rv`: a `shout` method declared via `impl String` inside `std/string`, called as `"hi".shout()`, prints `HI` (it calls the module's sibling `to_upper`).

## Deferred

- Converting the existing `std/io` and `std/string` free functions to methods is issue #120.
- Generic built-in method monomorphization beyond what the existing generic machinery covers is exercised as those modules are built.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` (277 lib + 14 codegen smoke + golden suites) pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `21.doubled()` prints 42, `"hi".shout()` prints HI (end-to-end)
