### PR TITLE
feat(codegen): capturing closures and closure-value invocation

### DIFF
--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -9,12 +9,13 @@ selection and register allocation. The covered surface is primitives,
 binary and unary operators, branches, switches, function calls with
 static dispatch, returns, the `print` and `print_int` intrinsics, and
 heap value construction: structs, enums (including `Option` and
-`Result`), field access, enum dispatch, and non-capturing closures, all
-with garbage collector root frames.
+`Result`), field access, enum dispatch, and closures (capturing,
+returned, passed, and invoked through their value), all with garbage
+collector root frames.
 
-Trait object (`dyn Trait`) dispatch, calling and capturing closures,
-`defer`, string interpolation, C FFI, and rich stdlib collection methods
-are out of scope here and tracked by the follow up issues listed below.
+Rich stdlib collection methods (`List` and `Map` operations beyond
+construction) are out of scope here and tracked by the follow up issues
+listed below.
 
 ## Pipeline position
 
@@ -108,7 +109,7 @@ lifetimes); `Nop` is also a no op.
 | `UnaryOp(Not)` on `Bool` | `bxor` with the constant `1`. |
 | `UnaryOp(Ref)` | Deferred; emits `Unreachable`. |
 | `Call { callee, args }` | Loads each argument from its slot, declares the callee through `cranelift-module`, emits `call` with the resulting `FuncRef`, stores the return value. |
-| `StructCreate`, `EnumCreate`, `FieldAccess`, `ClosureCreate` | Lowered. See the heap value section below. |
+| `StructCreate`, `EnumCreate`, `FieldAccess`, `ClosureCreate`, `EnvLoad`, `ClosureCall` | Lowered. See the heap value and closure sections below. |
 | `Cast` | Integer and float conversions through `sextend`, `ireduce`, `fcvt_from_sint`, `fcvt_to_sint_sat`. |
 | `IndexAccess`, `ArrayLit` | Deferred to the stdlib collection issues. |
 
@@ -248,19 +249,83 @@ undefined symbols.
 
 ### Closures
 
-`ClosureCreate { fn_name, captures }` allocates a `Closure` object
-through `raven_closure_new(fn_ptr, size, align, count, ptr_count)`. The
-MVP supports the non-capturing shape the front end emits today: the
-captures list is empty, the capture buffer is zero sized, and the
-function pointer is the lifted body's address when `fn_name` resolves to
-a defined function (or null while lambda body lifting is pending). A
-non-empty captures list returns a `CodegenError::Unsupported`.
+Closures are fully first class: a lambda is allocated as a heap `Closure`
+object, captures the free variables it references, and can be returned,
+passed as an argument, stored in a local or struct field, and invoked
+through its value.
 
-Calling a closure value (indirect dispatch through the stored function
-pointer) and capturing closures both require front-end lambda body
-lifting and capture analysis. They are tracked separately; the closure
-smoke program builds a closure value and prints a sentinel to show the
-allocation and GC root frame run.
+#### Capture analysis
+
+Capture analysis runs in HIR-to-MIR lowering (`src/mir/lower/closure.rs`).
+For a lambda it walks the body and collects every free identifier: a name
+that is neither one of the lambda's own parameters nor a binding
+introduced inside the body. A free name is a capture exactly when it
+resolves to a local or parameter that is in scope at the definition site
+(found through the lowering context's scope stack). A free name that does
+not resolve to an in-scope local is a reference to a top-level function or
+constant, which codegen addresses by symbol rather than capturing.
+
+#### Capture-by-value semantics
+
+Captures are by value: the value at closure-creation time is copied into
+the capture environment. For a scalar (`Int`, `Float`, `Bool`, `Char`)
+that copy is the bits. For a GC-managed value (`Str`, `Struct`, `Enum`,
+`Option`, `Result`, `List`, a closure `Function`, or a `dyn Trait`) the
+copied value is the same pointer, so the captured object aliases the
+original; mutations made through that heap object after the closure is
+built remain visible inside the closure. Capture-by-reference (rebinding a
+captured variable so a later assignment to the original is seen) would
+need upvalue or cell machinery and is not provided in this release.
+
+#### Environment layout
+
+The capture environment is a positional record of pointer-width (8 byte)
+slots stored in the `Closure` object's owned capture buffer. Capture
+analysis orders GC-pointer captures first, then scalar captures, so the
+leading `capture_ptr_count` slots are exactly the traced GC pointers the
+collector follows (see the runtime closure layout in
+`docs/v2/specs/object-layout.md`). `ClosureCreate { fn_name, captures,
+capture_tys }` allocates the closure through `raven_closure_new(fn_ptr,
+size, align, count, ptr_count)` where `size = 8 * count`, `align = 8` (or
+zero when there are no captures), and `ptr_count` is the number of
+GC-pointer captures. It then loads the capture buffer base through
+`raven_closure_captures` and stores each capture value into slot `i` at
+byte offset `i * 8`. Scalars narrower than a pointer and floats are
+widened to a slot the same way struct fields are.
+
+#### Lifted body and the env parameter
+
+Each lambda body is lifted into a standalone MIR function whose leading
+parameter is the capture environment (`__env`, a raw pointer-width value
+the GC does not trace), followed by the lambda's own parameters. The
+lifted body opens by reading each capture from the env with an `EnvLoad
+{ env, slot, ty }` rvalue (a pointer-width load at `slot * 8`, narrowed to
+the capture's type) into a local bound under the capture's source name, so
+the rest of the body references captures as ordinary locals. A capture
+that is a GC pointer, once read into a body local, is rooted by the lifted
+body's own shadow-stack frame like any other GC local.
+
+#### Invoking a closure value
+
+A call whose callee is a value of function type (an in-scope local of
+`fun(T) -> U` type, a returned closure, a closure stored in a field, ...)
+lowers to `ClosureCall { closure, args, param_tys, ret_ty }`. Codegen
+loads the function pointer through `raven_closure_fn_ptr` and the capture
+env base through `raven_closure_captures`, builds the indirect signature
+`(env_ptr, <user params...>) -> ret`, and emits a `call_indirect` passing
+the env base as the leading argument followed by the user arguments. The
+signature is uniform regardless of the capture count or types, so the call
+site needs only the user parameter and return types; a top-level function
+reference is still dispatched directly by symbol.
+
+#### GC
+
+A closure local is a GC pointer rooted in the enclosing function's shadow
+stack frame like any other GC local. The captured GC pointers inside the
+env are traced by the collector through the `Closure` descriptor: the
+runtime's closure-tracing arm reads `capture_ptr_count` and traces the
+leading pointer slots, which is why capture analysis places GC-pointer
+captures first.
 
 ## GC root frames
 
@@ -399,8 +464,11 @@ that only consult MIR lowering do not depend on a linker.
   as read-only data, and a `dyn` method call dispatches through the
   vtable. See `docs/v2/specs/dyn-trait.md`. Static trait method calls are
   monomorphized by MIR into direct calls.
-* Calling closure values and capturing closures (lambda body lifting and
-  capture analysis); non-capturing closure allocation is supported.
+* ~~Calling closure values and capturing closures (lambda body lifting and
+  capture analysis).~~ Implemented: capture analysis lifts each lambda
+  body into a standalone function, captures free variables by value, and
+  invokes closure values through an indirect call. See the Closures
+  section above.
 * `defer` ordering and runtime hooks (issue #68).
 * String interpolation (issue #69) and C FFI (issue #70).
 * Rich stdlib collection methods (`push`, `get`, and so on) beyond
@@ -417,8 +485,11 @@ that only consult MIR lowering do not depend on a linker.
 * End to end smoke tests that compile, link, run, and check the stdout of
   `examples/v2/hello.rv` (`Hello, Raven!`), `point.rv` (a struct,
   prints `7`), `option_sum.rv` (Option construction and matching, prints
-  `104`), and `closure_value.rv` (a non-capturing closure allocation,
-  prints `42`). Each gates on linker and runtime staticlib presence and
+  `104`), `closure_value.rv` (a non-capturing closure allocation, prints
+  `42`), `closure_capture.rv` (a returned closure capturing a local by
+  value, prints `15` then `42`), and `closure_arg.rv` (a capturing closure
+  passed as an argument and invoked indirectly, prints `21`). Each gates
+  on linker and runtime staticlib presence and
   emits an `eprintln!` plus a successful exit only when one is missing;
   on a correctly configured host it links and runs the program for real.
 

--- a/examples/v2/closure_arg.rv
+++ b/examples/v2/closure_arg.rv
@@ -1,0 +1,12 @@
+// Passing a capturing closure as a function argument. `apply` takes a
+// closure parameter `f: fun(Int) -> Int` and invokes it indirectly. The
+// closure `triple` captures the local `factor` by value. Prints 21.
+fun apply(f: fun(Int) -> Int, x: Int) -> Int {
+    return f(x)
+}
+
+fun main() {
+    let factor = 3
+    let triple = fun(x: Int) -> Int = x * factor
+    print_int(apply(triple, 7))
+}

--- a/examples/v2/closure_capture.rv
+++ b/examples/v2/closure_capture.rv
@@ -1,0 +1,12 @@
+// A capturing closure: make_adder returns a closure that captures the
+// local `n` by value. Invoking the returned closure value adds the
+// captured amount to its argument. Prints 15 then 42.
+fun make_adder(n: Int) -> fun(Int) -> Int {
+    return fun(x: Int) -> Int = x + n
+}
+
+fun main() {
+    let add10 = make_adder(10)
+    print_int(add10(5))
+    print_int(add10(32))
+}

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -330,9 +330,18 @@ fn lower_rvalue(
         MirRvalue::FieldAccess { base, index } => {
             lower_field_access(cx, builder, base, *index, slots)
         }
-        MirRvalue::ClosureCreate { fn_name, captures } => {
-            lower_closure_create(cx, builder, fn_name, captures, slots)
-        }
+        MirRvalue::ClosureCreate {
+            fn_name,
+            captures,
+            capture_tys,
+        } => lower_closure_create(cx, builder, fn_name, captures, capture_tys, slots),
+        MirRvalue::EnvLoad { env, slot, ty } => lower_env_load(cx, builder, env, *slot, ty, slots),
+        MirRvalue::ClosureCall {
+            closure,
+            args,
+            param_tys,
+            ret_ty,
+        } => lower_closure_call(cx, builder, closure, args, param_tys, ret_ty, slots),
         MirRvalue::DynCoerce {
             value,
             concrete_ty,
@@ -368,6 +377,8 @@ fn rvalue_kind(r: &MirRvalue) -> &'static str {
         MirRvalue::ArrayLit { .. } => "ArrayLit",
         MirRvalue::Cast { .. } => "Cast",
         MirRvalue::ClosureCreate { .. } => "ClosureCreate",
+        MirRvalue::EnvLoad { .. } => "EnvLoad",
+        MirRvalue::ClosureCall { .. } => "ClosureCall",
         MirRvalue::DynCoerce { .. } => "DynCoerce",
         MirRvalue::VirtualCall { .. } => "VirtualCall",
     }
@@ -732,29 +743,34 @@ fn lower_field_access(
     Ok(Some(raw))
 }
 
-/// Lower a closure construction. The MVP supports the non-capturing
-/// shape the front end currently emits: a `Closure` object wrapping the
-/// lifted body's function pointer with an empty capture buffer.
-/// Capturing closures require front-end capture analysis and a lifted
-/// body function, tracked separately.
+/// Width in bytes of one capture slot in the closure env. Every capture,
+/// scalar or GC pointer, occupies one pointer-width slot, so the env is a
+/// uniform array of pointer-width words. The lifted body and the indirect
+/// call agree on this layout.
+const CAPTURE_SLOT: i32 = 8;
+
+/// Lower a closure construction.
+///
+/// Allocates a `Closure` object sized for the captured environment,
+/// stores the lifted body's function pointer, and copies each captured
+/// value into its env slot. Captures are by value: the value at
+/// closure-creation time is copied into the env. For a GC-managed value
+/// the copied value is the same pointer, so the captured object aliases
+/// the original. Capture analysis orders GC-pointer captures first, so
+/// the leading `capture_ptr_count` slots are the traced GC pointers the
+/// collector follows through the closure descriptor.
 fn lower_closure_create(
     cx: &mut ModuleCx,
     builder: &mut FunctionBuilder<'_>,
     fn_name: &str,
     captures: &[MirOperand],
-    _slots: &[LocalSlot],
+    capture_tys: &[MirType],
+    slots: &[LocalSlot],
 ) -> Result<RValue, CodegenError> {
-    if !captures.is_empty() {
-        return Err(CodegenError::Unsupported(
-            "capturing closures are not yet lowered; only non-capturing lambdas are supported"
-                .into(),
-        ));
-    }
     let ptr = cx.pointer_type();
-    // Resolve the lifted body's function pointer. The front end emits a
-    // placeholder name until lambda body lifting lands; without a real
-    // function to point at, a null function pointer is stored so the
-    // object is still well formed and the program links.
+    // Resolve the lifted body's function pointer. A missing function is a
+    // lowering bug, but keep the program well formed with a null pointer
+    // rather than aborting the whole build.
     let fn_ptr = match cx.function_id(fn_name) {
         Some(id) => {
             let fref = cx.module().declare_func_in_func(id, builder.func);
@@ -762,14 +778,136 @@ fn lower_closure_create(
         }
         None => builder.ins().iconst(ptr, 0),
     };
+
+    // Evaluate every capture operand before the allocation so their
+    // values are in registers; each operand is a copy of an already
+    // rooted local or a constant.
+    let mut capture_vals = Vec::with_capacity(captures.len());
+    for c in captures {
+        let v = lower_operand(cx, builder, c, slots)?;
+        capture_vals.push(widen_to_slot(builder, v, ptr));
+    }
+
+    let count = captures.len() as i64;
+    let capture_size = (captures.len() as i32) * CAPTURE_SLOT;
+    let ptr_count = capture_tys
+        .iter()
+        .filter(|t| layout::is_gc_pointer(t))
+        .count() as i64;
+    let align: i64 = if captures.is_empty() { 0 } else { 8 };
+
     let new_id = cx
         .runtime_id(intrinsics::RUNTIME_CLOSURE_NEW)
         .expect("closure new declared at module init");
     let new_ref = cx.module().declare_func_in_func(new_id, builder.func);
-    let zero32 = builder.ins().iconst(types::I32, 0);
+    let size_v = builder.ins().iconst(types::I32, capture_size as i64);
+    let align_v = builder.ins().iconst(types::I32, align);
+    let count_v = builder.ins().iconst(types::I32, count);
+    let ptr_count_v = builder.ins().iconst(types::I32, ptr_count);
     let inst = builder
         .ins()
-        .call(new_ref, &[fn_ptr, zero32, zero32, zero32, zero32]);
+        .call(new_ref, &[fn_ptr, size_v, align_v, count_v, ptr_count_v]);
+    let closure = builder.inst_results(inst)[0];
+
+    // Copy each capture value into its env slot. The env base is the
+    // closure's owned capture buffer.
+    if !captures.is_empty() {
+        let captures_id = cx
+            .runtime_id(intrinsics::RUNTIME_CLOSURE_CAPTURES)
+            .expect("closure captures declared at module init");
+        let captures_ref = cx.module().declare_func_in_func(captures_id, builder.func);
+        let env_inst = builder.ins().call(captures_ref, &[closure]);
+        let env_base = builder.inst_results(env_inst)[0];
+        for (i, v) in capture_vals.into_iter().enumerate() {
+            builder
+                .ins()
+                .store(MemFlags::new(), v, env_base, (i as i32) * CAPTURE_SLOT);
+        }
+    }
+
+    Ok(Some(closure))
+}
+
+/// Lower an env load: read a capture from the lifted body's env pointer.
+/// The env is the function's leading parameter (a raw pointer-width
+/// value); slot `slot` lives at byte offset `slot * CAPTURE_SLOT`. The
+/// word is loaded pointer-width and narrowed back to the capture's
+/// machine type (a `Float` or narrow scalar capture is reinterpreted by
+/// `store_local`).
+fn lower_env_load(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    env: &MirOperand,
+    slot: usize,
+    _ty: &MirType,
+    slots: &[LocalSlot],
+) -> Result<RValue, CodegenError> {
+    let ptr = cx.pointer_type();
+    let env_base = require_value(lower_operand(cx, builder, env, slots)?, "env load base")?;
+    let raw = builder
+        .ins()
+        .load(ptr, MemFlags::new(), env_base, (slot as i32) * CAPTURE_SLOT);
+    Ok(Some(raw))
+}
+
+/// Lower a closure-value call: dispatch indirectly through a `Closure`
+/// object. Loads the function pointer and the capture env from the
+/// closure, then emits an indirect call passing the env as the leading
+/// argument followed by the user arguments. The lifted body's signature
+/// is `(env_ptr, <user params...>) -> ret`.
+#[allow(clippy::too_many_arguments)]
+fn lower_closure_call(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    closure: &MirOperand,
+    args: &[MirOperand],
+    param_tys: &[MirType],
+    ret_ty: &MirType,
+    slots: &[LocalSlot],
+) -> Result<RValue, CodegenError> {
+    let ptr = cx.pointer_type();
+    let closure_ptr = require_value(
+        lower_operand(cx, builder, closure, slots)?,
+        "closure call receiver",
+    )?;
+
+    // Load the function pointer from the closure.
+    let fn_ptr_id = cx
+        .runtime_id(intrinsics::RUNTIME_CLOSURE_FN_PTR)
+        .expect("closure fn ptr declared at module init");
+    let fn_ptr_ref = cx.module().declare_func_in_func(fn_ptr_id, builder.func);
+    let fn_inst = builder.ins().call(fn_ptr_ref, &[closure_ptr]);
+    let fn_ptr = builder.inst_results(fn_inst)[0];
+
+    // Load the capture env base from the closure (null when no captures).
+    let captures_id = cx
+        .runtime_id(intrinsics::RUNTIME_CLOSURE_CAPTURES)
+        .expect("closure captures declared at module init");
+    let captures_ref = cx.module().declare_func_in_func(captures_id, builder.func);
+    let env_inst = builder.ins().call(captures_ref, &[closure_ptr]);
+    let env_base = builder.inst_results(env_inst)[0];
+
+    // Build the indirect signature: the env pointer plus each user
+    // parameter, returning the closure's return type.
+    let mut sig = Signature::new(cx.module().target_config().default_call_conv);
+    sig.params.push(cranelift_codegen::ir::AbiParam::new(ptr));
+    for pt in param_tys {
+        if let Some(t) = cranelift_ty(pt, ptr) {
+            sig.params.push(cranelift_codegen::ir::AbiParam::new(t));
+        }
+    }
+    if let Some(t) = cranelift_ty(ret_ty, ptr) {
+        sig.returns.push(cranelift_codegen::ir::AbiParam::new(t));
+    }
+    let sig_ref = builder.import_signature(sig);
+
+    let mut call_args = vec![env_base];
+    for a in args {
+        if let Some(v) = lower_operand(cx, builder, a, slots)? {
+            call_args.push(v);
+        }
+    }
+    let inst = builder.ins().call_indirect(sig_ref, fn_ptr, &call_args);
     Ok(builder.inst_results(inst).first().copied())
 }
 

--- a/src/mir/ir.rs
+++ b/src/mir/ir.rs
@@ -129,6 +129,36 @@ pub enum MirRvalue {
     ClosureCreate {
         fn_name: String,
         captures: Vec<MirOperand>,
+        /// Capture types, parallel to `captures`. The back end uses these
+        /// to size the capture record, decide which capture slots hold GC
+        /// pointers, and copy each value into its slot. Capture analysis
+        /// orders GC-pointer captures first so the runtime's leading
+        /// `capture_ptr_count` pointer-slot contract holds.
+        capture_tys: Vec<MirType>,
+    },
+    /// Read a captured value from the env record of a lifted closure body.
+    /// The env is the lifted body's leading parameter (a raw pointer-width
+    /// value). Slot `slot` lives at byte offset `slot * 8`; the back end
+    /// loads a pointer-width word and narrows it to `ty`.
+    EnvLoad {
+        env: MirOperand,
+        slot: usize,
+        ty: MirType,
+    },
+    /// Invoke a closure value through its function pointer. The back end
+    /// loads the function pointer and the capture env from the `Closure`
+    /// object, then emits an indirect call passing the env as the leading
+    /// argument followed by `args`. The lifted body's signature is
+    /// uniformly `(env_ptr, <user params...>) -> ret`, independent of the
+    /// capture count or types, so the call site needs only the user
+    /// parameter and return types.
+    ClosureCall {
+        closure: MirOperand,
+        args: Vec<MirOperand>,
+        /// The user (non-env) parameter types, used to build the indirect
+        /// call signature.
+        param_tys: Vec<MirType>,
+        ret_ty: MirType,
     },
     /// Unsize a concrete value to a `dyn Trait` value. The back end
     /// allocates a two-slot fat pointer `{ data, vtable }`: slot 0 holds

--- a/src/mir/lower/closure.rs
+++ b/src/mir/lower/closure.rs
@@ -1,0 +1,410 @@
+//! Closure capture analysis and lambda-body lifting for MIR lowering.
+//!
+//! A lambda expression becomes two things in MIR:
+//!
+//! * a `ClosureCreate` rvalue at the definition site that allocates a
+//!   `Closure` object, stores the lifted body's function pointer, and
+//!   copies each captured value into the capture environment, and
+//! * a standalone, top-level `MirFunction` (the "lifted body") whose
+//!   leading parameter is the capture environment and whose remaining
+//!   parameters are the lambda's own parameters.
+//!
+//! Capture analysis walks the lambda body and collects every free
+//! variable: an identifier that resolves to a local or parameter of an
+//! enclosing function (one that is in scope at the definition site) and
+//! is neither a lambda parameter nor a binding introduced inside the
+//! lambda body. Top-level functions and constants are referenced by
+//! symbol, not captured.
+//!
+//! Captures are by value: the value is copied into the environment at
+//! closure-creation time. For a GC-managed value the copied value is the
+//! same pointer, so the captured object aliases the original and
+//! mutations through the heap object stay visible.
+//!
+//! See `docs/v2/specs/codegen.md` and `docs/v2/specs/object-layout.md`.
+
+use std::collections::HashSet;
+
+use crate::hir::expr::{HirBlock, HirExpr, HirExprKind, InterpolPart};
+use crate::hir::stmt::{HirAssignTarget, HirStmt, HirStmtKind};
+use crate::hir::ty::HirTy;
+
+use super::super::ir::{MirFunction, MirLocal, MirRvalue, MirTerminator};
+use super::super::ty::{MirFfiTy, MirType};
+use super::{mir_ty, LowerCx, Scope};
+use crate::codegen::layout::is_gc_pointer;
+
+/// One captured variable: its source name, its MIR type, and the
+/// enclosing-scope local that currently holds the value to copy.
+pub struct Capture {
+    pub name: String,
+    pub ty: MirType,
+    pub source: MirLocal,
+}
+
+/// The MIR type used for a lifted body's leading env parameter: a raw
+/// pointer-width value the GC does not trace (the capture environment is
+/// owned by the `Closure` object and traced through its descriptor).
+pub fn env_param_ty() -> MirType {
+    MirType::Ffi(MirFfiTy::CSize)
+}
+
+/// Lower a lambda expression. Returns the closure-create rvalue plus the
+/// lifted function name. The lifted body is pushed onto `cx.lifted`.
+pub fn lower_lambda(
+    cx: &mut LowerCx<'_>,
+    params: &[(String, HirTy, crate::span::Span)],
+    ret: &HirTy,
+    body: &HirBlock,
+) -> MirRvalue {
+    // Names bound by the lambda's own parameters never count as captures.
+    let mut bound: HashSet<String> = params.iter().map(|(n, _, _)| n.clone()).collect();
+    // Collect free identifier names referenced by the body.
+    let mut free: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    collect_free_block(body, &mut bound, &mut seen, &mut free);
+
+    // A free name is a capture only when it resolves to a local or
+    // parameter that is in scope at the definition site. Names that do
+    // not resolve in the enclosing scopes are references to top-level
+    // functions or constants, which codegen addresses by symbol.
+    let mut captures: Vec<Capture> = Vec::new();
+    for name in free {
+        if let Some(local) = cx.lookup(&name) {
+            let ty = cx.builder.locals()[local.0 as usize].ty.clone();
+            captures.push(Capture {
+                name,
+                ty,
+                source: local,
+            });
+        }
+    }
+
+    // Order GC-pointer captures first so the runtime's contract that the
+    // leading `capture_ptr_count` slots are traced GC pointers holds.
+    captures.sort_by_key(|c| !is_gc_pointer(&c.ty));
+
+    let lifted_name = mint_lifted_name(cx);
+    let ret_ty = mir_ty(ret, cx.subst);
+
+    // Build the lifted body as a standalone function. Any lambdas nested
+    // inside the body lift their own bodies; surface those too.
+    let (lifted, nested) = lift_body(cx, &lifted_name, params, ret_ty, body, &captures);
+    cx.lifted.push(lifted);
+    cx.lifted.extend(nested);
+
+    let capture_ops = captures
+        .iter()
+        .map(|c| super::super::ir::MirOperand::Copy(c.source))
+        .collect();
+    let capture_tys = captures.iter().map(|c| c.ty.clone()).collect();
+
+    MirRvalue::ClosureCreate {
+        fn_name: lifted_name,
+        captures: capture_ops,
+        capture_tys,
+    }
+}
+
+/// Mint a globally unique name for a lifted closure body.
+fn mint_lifted_name(cx: &mut LowerCx<'_>) -> String {
+    let n = cx.lambda_seq;
+    cx.lambda_seq += 1;
+    format!("{}$closure${}", cx.enclosing, n)
+}
+
+/// Lift a lambda body into a standalone `MirFunction`.
+///
+/// The lifted function's parameters are the capture environment pointer
+/// first, then the lambda's declared parameters. The body opens by
+/// reading each captured value from the environment into a fresh local
+/// bound under the capture's source name, so the body's identifier
+/// references resolve to those locals exactly as they did at the
+/// definition site.
+#[allow(clippy::type_complexity)]
+fn lift_body(
+    cx: &LowerCx<'_>,
+    name: &str,
+    params: &[(String, HirTy, crate::span::Span)],
+    ret_ty: MirType,
+    body: &HirBlock,
+    captures: &[Capture],
+) -> (MirFunction, Vec<MirFunction>) {
+    use super::super::builder::FunctionBuilder;
+
+    let mut builder = FunctionBuilder::new(
+        name.to_string(),
+        name.to_string(),
+        ret_ty.clone(),
+        body.span.clone(),
+    );
+
+    // Leading env parameter: a raw pointer-width value.
+    let env_local = builder.add_param("__env".to_string(), env_param_ty());
+
+    // The lambda's declared parameters follow the env parameter.
+    let mut param_scope = Scope::new();
+    for (pname, pty, _) in params {
+        let mty = mir_ty(pty, cx.subst);
+        let local = builder.add_param(pname.clone(), mty);
+        param_scope.insert(pname.clone(), local);
+    }
+
+    let entry = builder.new_block();
+    let mut body_cx = LowerCx {
+        builder,
+        current: entry,
+        subst: cx.subst,
+        scopes: vec![param_scope],
+        loops: Vec::new(),
+        pending_calls: Vec::new(),
+        decls: cx.decls,
+        diverged: false,
+        defers: Vec::new(),
+        lifted: Vec::new(),
+        lambda_seq: 0,
+        enclosing: name.to_string(),
+    };
+
+    // Read each capture from the env into a local bound under its source
+    // name. The body then references captures as ordinary locals.
+    for (slot, cap) in captures.iter().enumerate() {
+        let local = body_cx
+            .builder
+            .named_local(cap.name.clone(), cap.ty.clone());
+        body_cx.builder.assign(
+            body_cx.current,
+            local,
+            MirRvalue::EnvLoad {
+                env: super::super::ir::MirOperand::Copy(env_local),
+                slot,
+                ty: cap.ty.clone(),
+            },
+        );
+        body_cx.bind(cap.name.clone(), local);
+    }
+
+    let result = super::stmt::lower_block(&mut body_cx, body);
+
+    if !body_cx.builder.is_closed(body_cx.current) {
+        if body_cx.diverged && body_cx.builder.is_empty_open(body_cx.current) {
+            body_cx
+                .builder
+                .close_block(body_cx.current, MirTerminator::Unreachable);
+        } else {
+            body_cx
+                .builder
+                .close_block(body_cx.current, MirTerminator::Return(result));
+        }
+    }
+
+    // A lambda body may itself contain nested lambdas; surface their
+    // lifted functions through the enclosing function's accumulator.
+    let nested = std::mem::take(&mut body_cx.lifted);
+    (body_cx.builder.finish(entry), nested)
+}
+
+// ----- free-variable collection -----
+
+fn collect_free_block(
+    block: &HirBlock,
+    bound: &mut HashSet<String>,
+    seen: &mut HashSet<String>,
+    out: &mut Vec<String>,
+) {
+    // A block introduces its own bindings; names bound inside shadow the
+    // enclosing scope for the rest of the block. Track them so they are
+    // not mistaken for captures, and restore the set on exit.
+    let snapshot: Vec<String> = bound.iter().cloned().collect();
+    for stmt in &block.stmts {
+        collect_free_stmt(stmt, bound, seen, out);
+    }
+    if let Some(tail) = &block.tail {
+        collect_free_expr(tail, bound, seen, out);
+    }
+    *bound = snapshot.into_iter().collect();
+}
+
+fn collect_free_stmt(
+    stmt: &HirStmt,
+    bound: &mut HashSet<String>,
+    seen: &mut HashSet<String>,
+    out: &mut Vec<String>,
+) {
+    match &stmt.kind {
+        HirStmtKind::Let { name, init, .. } => {
+            collect_free_expr(init, bound, seen, out);
+            // The binding is visible after its initializer.
+            bound.insert(name.clone());
+        }
+        HirStmtKind::Expr(e) => collect_free_expr(e, bound, seen, out),
+        HirStmtKind::Assign { target, value } => {
+            match target {
+                HirAssignTarget::Ident { name, .. } => record_use(name, bound, seen, out),
+                HirAssignTarget::Field { recv, .. } => collect_free_expr(recv, bound, seen, out),
+                HirAssignTarget::Index { recv, index } => {
+                    collect_free_expr(recv, bound, seen, out);
+                    collect_free_expr(index, bound, seen, out);
+                }
+            }
+            collect_free_expr(value, bound, seen, out);
+        }
+        HirStmtKind::Defer(e) => collect_free_expr(e, bound, seen, out),
+    }
+}
+
+fn record_use(
+    name: &str,
+    bound: &HashSet<String>,
+    seen: &mut HashSet<String>,
+    out: &mut Vec<String>,
+) {
+    if bound.contains(name) {
+        return;
+    }
+    if seen.insert(name.to_string()) {
+        out.push(name.to_string());
+    }
+}
+
+fn collect_free_expr(
+    expr: &HirExpr,
+    bound: &mut HashSet<String>,
+    seen: &mut HashSet<String>,
+    out: &mut Vec<String>,
+) {
+    match &expr.kind {
+        HirExprKind::Int(_)
+        | HirExprKind::Float(_)
+        | HirExprKind::Bool(_)
+        | HirExprKind::Str(_)
+        | HirExprKind::Char(_)
+        | HirExprKind::CStr(_)
+        | HirExprKind::Unit
+        | HirExprKind::SelfValue
+        | HirExprKind::NoneCtor
+        | HirExprKind::Continue => {}
+        HirExprKind::Ident(name) => record_use(name, bound, seen, out),
+        HirExprKind::Array(items) => {
+            for it in items {
+                collect_free_expr(it, bound, seen, out);
+            }
+        }
+        HirExprKind::StructLit { fields, .. } => {
+            for (_, e) in fields {
+                collect_free_expr(e, bound, seen, out);
+            }
+        }
+        HirExprKind::Paren(inner)
+        | HirExprKind::IterNew(inner)
+        | HirExprKind::IterNext(inner)
+        | HirExprKind::OkCtor(inner)
+        | HirExprKind::ErrCtor(inner)
+        | HirExprKind::SomeCtor(inner) => collect_free_expr(inner, bound, seen, out),
+        HirExprKind::Block(b) => collect_free_block(b, bound, seen, out),
+        HirExprKind::Unary { operand, .. } => collect_free_expr(operand, bound, seen, out),
+        HirExprKind::Binary { lhs, rhs, .. } => {
+            collect_free_expr(lhs, bound, seen, out);
+            collect_free_expr(rhs, bound, seen, out);
+        }
+        HirExprKind::Call { callee, args } => {
+            collect_free_expr(callee, bound, seen, out);
+            for a in args {
+                collect_free_expr(a, bound, seen, out);
+            }
+        }
+        HirExprKind::MethodCall { receiver, args, .. } => {
+            collect_free_expr(receiver, bound, seen, out);
+            for a in args {
+                collect_free_expr(a, bound, seen, out);
+            }
+        }
+        HirExprKind::Field { receiver, .. } => collect_free_expr(receiver, bound, seen, out),
+        HirExprKind::Index { receiver, index } => {
+            collect_free_expr(receiver, bound, seen, out);
+            collect_free_expr(index, bound, seen, out);
+        }
+        HirExprKind::If {
+            cond,
+            then_block,
+            else_block,
+        } => {
+            collect_free_expr(cond, bound, seen, out);
+            collect_free_block(then_block, bound, seen, out);
+            if let Some(e) = else_block {
+                collect_free_block(e, bound, seen, out);
+            }
+        }
+        HirExprKind::Match { scrutinee, arms } => {
+            collect_free_expr(scrutinee, bound, seen, out);
+            for arm in arms {
+                // Pattern bindings are local to the arm.
+                let snapshot: Vec<String> = bound.iter().cloned().collect();
+                bind_pattern_names(&arm.pattern, bound);
+                if let Some(g) = &arm.guard {
+                    collect_free_expr(g, bound, seen, out);
+                }
+                collect_free_expr(&arm.body, bound, seen, out);
+                *bound = snapshot.into_iter().collect();
+            }
+        }
+        HirExprKind::Loop(b) => collect_free_block(b, bound, seen, out),
+        HirExprKind::While { cond, body } => {
+            collect_free_expr(cond, bound, seen, out);
+            collect_free_block(body, bound, seen, out);
+        }
+        HirExprKind::Return(v) | HirExprKind::Break(v) => {
+            if let Some(e) = v {
+                collect_free_expr(e, bound, seen, out);
+            }
+        }
+        HirExprKind::Interpolate(parts) => {
+            for p in parts {
+                if let InterpolPart::Expr(e) = p {
+                    collect_free_expr(e, bound, seen, out);
+                }
+            }
+        }
+        HirExprKind::RangeNew { start, end, .. } => {
+            collect_free_expr(start, bound, seen, out);
+            collect_free_expr(end, bound, seen, out);
+        }
+        HirExprKind::Lambda { params, body, .. } => {
+            // A nested lambda introduces its own parameter bindings; names
+            // it captures from this lambda's scope are themselves free
+            // variables of this lambda (transitive capture).
+            let snapshot: Vec<String> = bound.iter().cloned().collect();
+            for (pname, _, _) in params {
+                bound.insert(pname.clone());
+            }
+            collect_free_block(body, bound, seen, out);
+            *bound = snapshot.into_iter().collect();
+        }
+        HirExprKind::DynCoerce { value, .. } => collect_free_expr(value, bound, seen, out),
+    }
+}
+
+/// Add every name a pattern introduces to the bound set.
+fn bind_pattern_names(pat: &crate::hir::pattern::HirPattern, bound: &mut HashSet<String>) {
+    use crate::hir::pattern::HirPatternKind;
+    match &pat.kind {
+        HirPatternKind::Wildcard | HirPatternKind::Literal(_) | HirPatternKind::Range { .. } => {}
+        HirPatternKind::Binding(name) => {
+            bound.insert(name.clone());
+        }
+        HirPatternKind::Constructor { elements, .. } => {
+            for e in elements {
+                bind_pattern_names(e, bound);
+            }
+        }
+        HirPatternKind::Struct { fields, .. } => {
+            for f in fields {
+                if let Some(inner) = &f.pattern {
+                    bind_pattern_names(inner, bound);
+                } else {
+                    bound.insert(f.name.clone());
+                }
+            }
+        }
+    }
+}

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -68,6 +68,12 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
         }
         HirExprKind::StructLit { name, fields } => lower_struct_lit(cx, name, fields, ty),
         HirExprKind::Call { callee, args } => {
+            // A callee that is an in-scope local of function type is a
+            // closure value: dispatch indirectly through its Closure
+            // object. Any other callee is a direct call by symbol.
+            if is_closure_value_callee(cx, callee) {
+                return lower_closure_call(cx, callee, args, ty);
+            }
             let callee_ref = call_ref_from_callee(cx, callee);
             let arg_ops: Vec<MirOperand> = args.iter().map(|a| lower_expr(cx, a)).collect();
             let dst = cx.builder.fresh_temp("call", ty);
@@ -264,23 +270,13 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             );
             MirOperand::Copy(dst)
         }
-        HirExprKind::Lambda {
-            params: _,
-            ret: _,
-            body: _,
-        } => {
-            // Closure capture analysis is deferred (issue #62). For
-            // now emit a placeholder operand and a ClosureCreate with
-            // no captures so the shape is visible in dumps.
+        HirExprKind::Lambda { params, ret, body } => {
+            // Run capture analysis, lift the body into a standalone
+            // function, and emit a ClosureCreate that allocates the
+            // closure and copies each captured value into the env.
+            let rvalue = super::closure::lower_lambda(cx, params, ret, body);
             let dst = cx.builder.fresh_temp("closure", ty);
-            cx.builder.assign(
-                cx.current,
-                dst,
-                MirRvalue::ClosureCreate {
-                    fn_name: "__closure".into(),
-                    captures: Vec::new(),
-                },
-            );
+            cx.builder.assign(cx.current, dst, rvalue);
             MirOperand::Copy(dst)
         }
     }
@@ -629,6 +625,59 @@ fn call_ref_from_callee(_cx: &mut LowerCx<'_>, callee: &HirExpr) -> MirFnRef {
             origin: None,
         },
     }
+}
+
+/// Decide whether a call's callee is a closure value to dispatch
+/// indirectly. A callee is a closure value when its type is a function
+/// type and it is not a bare reference to a top-level function. A bare
+/// identifier that is in scope as a local or parameter (so `cx.lookup`
+/// finds it) and has a function type is a closure value; an identifier
+/// that does not resolve to an in-scope local is a top-level function
+/// reference dispatched by symbol.
+fn is_closure_value_callee(cx: &LowerCx<'_>, callee: &HirExpr) -> bool {
+    if !matches!(callee.ty, crate::tycheck::Ty::Function { .. }) {
+        return false;
+    }
+    match &callee.kind {
+        // Only a local or parameter of function type is a closure value.
+        // A top-level function name is not in `cx.scopes`.
+        HirExprKind::Ident(name) => cx.lookup(name).is_some(),
+        // Any other expression of function type (a returned closure, a
+        // field holding a closure, an element of a list, ...) is a
+        // closure value.
+        _ => true,
+    }
+}
+
+/// Lower a closure-value call: evaluate the callee to a `Closure`
+/// pointer, then dispatch indirectly through it. The runtime loads the
+/// function pointer and capture env from the Closure object; the env is
+/// passed as the leading argument followed by the user arguments.
+fn lower_closure_call(
+    cx: &mut LowerCx<'_>,
+    callee: &HirExpr,
+    args: &[HirExpr],
+    ty: MirType,
+) -> MirOperand {
+    let closure = lower_expr(cx, callee);
+    let mut arg_ops = Vec::with_capacity(args.len());
+    let mut param_tys = Vec::with_capacity(args.len());
+    for a in args {
+        param_tys.push(mir_ty(&a.ty, cx.subst));
+        arg_ops.push(lower_expr(cx, a));
+    }
+    let dst = cx.builder.fresh_temp("ccall", ty.clone());
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::ClosureCall {
+            closure,
+            args: arg_ops,
+            param_tys,
+            ret_ty: ty,
+        },
+    );
+    MirOperand::Copy(dst)
 }
 
 /// Lower a method call. A concrete receiver dispatches statically to the

--- a/src/mir/lower/mod.rs
+++ b/src/mir/lower/mod.rs
@@ -8,6 +8,7 @@
 //! the [`LowerCx`] context defined here, which owns the in-progress
 //! [`FunctionBuilder`] and tracks the lexical loop and `Self` stack.
 
+pub mod closure;
 pub mod expr;
 pub mod pattern;
 pub mod stmt;
@@ -72,6 +73,20 @@ pub struct LowerCx<'a> {
     /// reverse (LIFO) order at each block exit and at every `return`.
     /// See `src/hir` defer lowering and `docs/v2/specs/defer.md`.
     pub defers: Vec<crate::hir::expr::HirExpr>,
+    /// Lifted closure bodies produced while lowering this function. Each
+    /// lambda expression lifts its body into a standalone `MirFunction`
+    /// whose leading parameter is the capture environment. The functions
+    /// are returned alongside the enclosing function so the monomorphizer
+    /// can add them to the program and codegen can resolve the closure's
+    /// function pointer.
+    pub lifted: Vec<MirFunction>,
+    /// Monotonic counter used to mint unique lifted closure names within
+    /// one enclosing function. Combined with the enclosing function's
+    /// mangled name to stay globally unique.
+    pub lambda_seq: u32,
+    /// Mangled name of the enclosing function, used to derive lifted
+    /// closure names so two enclosing functions never collide.
+    pub enclosing: String,
 }
 
 impl LowerCx<'_> {
@@ -170,17 +185,27 @@ pub fn mir_ty(ty: &Ty, subst: &SubstMap) -> MirType {
     MirType::from_ty(&substitute(ty, subst))
 }
 
+/// The product of lowering one HIR function: the finished `MirFunction`,
+/// the nested call sites the monomorphizer should compile, and any lifted
+/// closure body functions produced while lowering lambda expressions.
+pub struct LoweredFunction {
+    pub func: MirFunction,
+    pub pending: Vec<(DeclId, Vec<Ty>)>,
+    pub lifted: Vec<MirFunction>,
+}
+
 /// Lower one HIR function under the given substitution. Returns the
-/// finished `MirFunction` plus the list of nested call sites the
-/// monomorphizer should compile.
+/// finished `MirFunction`, the list of nested call sites the
+/// monomorphizer should compile, and any lifted closure bodies.
 pub fn lower_function(
     mangled: String,
     hir: &HirFn,
     subst: &SubstMap,
     decls: &DeclTables<'_>,
-) -> (MirFunction, Vec<(DeclId, Vec<Ty>)>) {
+) -> LoweredFunction {
     let ret_ty = mir_ty(&hir.ret, subst);
-    let mut builder = FunctionBuilder::new(mangled, hir.name.clone(), ret_ty, hir.span.clone());
+    let mut builder =
+        FunctionBuilder::new(mangled.clone(), hir.name.clone(), ret_ty, hir.span.clone());
 
     let mut param_scope = Scope::new();
     for (name, ty, _) in &hir.params {
@@ -200,6 +225,9 @@ pub fn lower_function(
         decls,
         diverged: false,
         defers: Vec::new(),
+        lifted: Vec::new(),
+        lambda_seq: 0,
+        enclosing: mangled,
     };
 
     let body = hir
@@ -227,5 +255,10 @@ pub fn lower_function(
     }
 
     let pending = std::mem::take(&mut cx.pending_calls);
-    (cx.builder.finish(entry), pending)
+    let lifted = std::mem::take(&mut cx.lifted);
+    LoweredFunction {
+        func: cx.builder.finish(entry),
+        pending,
+        lifted,
+    }
 }

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -63,9 +63,15 @@ pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
             .unwrap_or_else(|| hir_fn.name.clone());
         let subst = build_subst(hir_fn, &args);
         let mangled = mangle_name(&base, &args);
-        let (mir_fn, pending) = lower_function(mangled, hir_fn, &subst, &decls);
-        program.functions.push(mir_fn);
-        for next in pending {
+        let lowered = lower_function(mangled, hir_fn, &subst, &decls);
+        program.functions.push(lowered.func);
+        // Lifted closure bodies are already monomorphic standalone
+        // functions; add them directly so codegen can resolve each
+        // closure's function pointer.
+        for lifted in lowered.lifted {
+            program.functions.push(lifted);
+        }
+        for next in lowered.pending {
             worklist.push(next);
         }
     }

--- a/src/mir/pretty.rs
+++ b/src/mir/pretty.rs
@@ -192,11 +192,27 @@ fn pretty_rvalue(buf: &mut String, r: &MirRvalue) {
             pretty_operand(buf, operand);
             write!(buf, " {})", target).unwrap();
         }
-        MirRvalue::ClosureCreate { fn_name, captures } => {
+        MirRvalue::ClosureCreate {
+            fn_name, captures, ..
+        } => {
             write!(buf, "(closure {}", quote(fn_name)).unwrap();
             for c in captures {
                 buf.push(' ');
                 pretty_operand(buf, c);
+            }
+            buf.push(')');
+        }
+        MirRvalue::EnvLoad { env, slot, ty } => {
+            write!(buf, "(env-load slot={} ty={} ", slot, ty).unwrap();
+            pretty_operand(buf, env);
+            buf.push(')');
+        }
+        MirRvalue::ClosureCall { closure, args, .. } => {
+            buf.push_str("(closure-call ");
+            pretty_operand(buf, closure);
+            for a in args {
+                buf.push(' ');
+                pretty_operand(buf, a);
             }
             buf.push(')');
         }

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -348,3 +348,158 @@ fn only_reached_defers_run_on_each_return_path() {
         return_blocks
     );
 }
+
+// ----- closure capture and invocation -----
+
+/// Find the single `ClosureCreate` rvalue in a function's blocks.
+fn closure_create_in(f: &MirFunction) -> &MirRvalue {
+    f.blocks
+        .iter()
+        .flat_map(|b| b.statements.iter())
+        .find_map(|s| match s {
+            MirStatement::Assign {
+                rvalue: rv @ MirRvalue::ClosureCreate { .. },
+                ..
+            } => Some(rv),
+            _ => None,
+        })
+        .expect("expected a ClosureCreate")
+}
+
+#[test]
+fn capturing_lambda_records_captured_local() {
+    // The lambda references the enclosing local `n`, so capture analysis
+    // records exactly one capture and emits a ClosureCreate carrying it.
+    let prog = compile(
+        r#"
+        fun make_adder(n: Int) -> fun(Int) -> Int {
+            return fun(x: Int) -> Int = x + n
+        }
+    "#,
+    );
+    let f = find_fn(&prog, "make_adder");
+    match closure_create_in(f) {
+        MirRvalue::ClosureCreate {
+            captures,
+            capture_tys,
+            ..
+        } => {
+            assert_eq!(captures.len(), 1, "exactly the captured `n`");
+            assert_eq!(capture_tys, &vec![MirType::Int]);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn non_capturing_lambda_has_no_captures() {
+    // The lambda references only its own parameter, so it captures
+    // nothing and the ClosureCreate carries an empty capture list.
+    let prog = compile(
+        r#"
+        fun make() -> fun(Int) -> Int {
+            return fun(x: Int) -> Int = x + 1
+        }
+    "#,
+    );
+    let f = find_fn(&prog, "make");
+    match closure_create_in(f) {
+        MirRvalue::ClosureCreate { captures, .. } => {
+            assert!(captures.is_empty(), "no enclosing locals referenced");
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn lambda_body_is_lifted_to_standalone_function() {
+    // The lambda body becomes its own MIR function whose leading
+    // parameter is the capture environment.
+    let prog = compile(
+        r#"
+        fun make_adder(n: Int) -> fun(Int) -> Int {
+            return fun(x: Int) -> Int = x + n
+        }
+    "#,
+    );
+    let lifted = prog
+        .functions
+        .iter()
+        .find(|f| f.name.contains("$closure$"))
+        .expect("a lifted closure body function");
+    // env pointer + the lambda's own parameter.
+    assert_eq!(lifted.params.len(), 2, "env param plus lambda param");
+    let env_decl = lifted.local_decl(lifted.params[0]);
+    assert_eq!(env_decl.name, "__env");
+    // The body reads the capture from the env.
+    let saw_env_load = lifted
+        .blocks
+        .iter()
+        .flat_map(|b| b.statements.iter())
+        .any(|s| {
+            matches!(
+                s,
+                MirStatement::Assign {
+                    rvalue: MirRvalue::EnvLoad { .. },
+                    ..
+                }
+            )
+        });
+    assert!(saw_env_load, "lifted body reads its captures from the env");
+}
+
+#[test]
+fn invoking_a_closure_value_emits_closure_call() {
+    // Calling a local of function type dispatches indirectly through the
+    // Closure object via a ClosureCall rvalue, not a direct Call.
+    let prog = compile(
+        r#"
+        fun apply(f: fun(Int) -> Int, x: Int) -> Int {
+            return f(x)
+        }
+    "#,
+    );
+    let f = find_fn(&prog, "apply");
+    let saw_closure_call = f.blocks.iter().flat_map(|b| b.statements.iter()).any(|s| {
+        matches!(
+            s,
+            MirStatement::Assign {
+                rvalue: MirRvalue::ClosureCall { .. },
+                ..
+            }
+        )
+    });
+    assert!(
+        saw_closure_call,
+        "calling a closure value lowers to ClosureCall"
+    );
+}
+
+#[test]
+fn gc_pointer_captures_are_ordered_first() {
+    // A closure capturing both a scalar (`k`) and a GC pointer (`s`)
+    // places the GC pointer capture first so the runtime's leading
+    // `capture_ptr_count` traced-slot contract holds. The lambda is
+    // declared with `k` first in source, yet capture ordering puts the
+    // String capture ahead of the Int.
+    let prog = compile(
+        r#"
+        fun build(k: Int, s: String) -> fun() -> String {
+            return fun() -> String = "${k}${s}"
+        }
+    "#,
+    );
+    let f = find_fn(&prog, "build");
+    match closure_create_in(f) {
+        MirRvalue::ClosureCreate { capture_tys, .. } => {
+            assert_eq!(capture_tys.len(), 2);
+            assert_eq!(
+                capture_tys[0],
+                MirType::Str,
+                "the GC pointer capture comes first"
+            );
+            assert_eq!(capture_tys[1], MirType::Int);
+        }
+        _ => unreachable!(),
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -60,6 +60,28 @@ fn closure_value_program_compiles_and_runs() {
 }
 
 #[test]
+fn closure_capture_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // make_adder(10) returns a closure capturing the local `n = 10` by
+    // value. Invoking the returned closure value adds the captured amount:
+    // add10(5) prints 15 and add10(32) prints 42.
+    compile_link_run_and_check("closure_capture.rv", "15\n42\n", &runtime);
+}
+
+#[test]
+fn closure_arg_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A capturing closure passed as a function argument and invoked
+    // indirectly: `triple` captures `factor = 3`, and apply(triple, 7)
+    // returns 7 * 3, printing 21.
+    compile_link_run_and_check("closure_arg.rv", "21\n", &runtime);
+}
+
+#[test]
 fn dyn_dispatch_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
## Summary

Finishes closures so they are fully first class: capture analysis (by value), populated capture environments, and closure-value invocation through an indirect call. This is the prerequisite for the lazy iterator pipeline (#119).

Closes #117.

## Observed output (key evidence)

`examples/v2/closure_capture.rv` returns a closure capturing the local `n` by value and invokes the returned closure value twice:

```
15
42
```

`examples/v2/closure_arg.rv` passes a capturing closure (`triple`, capturing `factor = 3`) to `apply(f, x) = f(x)` and invokes it indirectly:

```
21
```

Both built with `raven build <file> -o <exe>` and run on Windows x86_64-pc-windows-msvc.

## Design

* **Capture analysis** runs in HIR-to-MIR lowering (`src/mir/lower/closure.rs`). It walks the lambda body for free identifiers and treats a name as a capture exactly when it resolves to a local or parameter in scope at the definition site; names that do not resolve to an in-scope local are top-level functions or constants addressed by symbol.
* **Capture-by-value semantics.** Each capture copies the value at closure-creation time. For a scalar that is the bits; for a GC-managed value the copied value is the same pointer, so the captured object aliases the original and mutations through the heap object stay visible. Capture-by-reference is not provided (it would need cell/upvalue machinery).
* **Env layout.** The environment is a positional record of pointer-width slots in the `Closure` object's owned capture buffer. GC-pointer captures are ordered first so the runtime's leading `capture_ptr_count` traced-slot contract holds. `ClosureCreate` sizes the buffer (`8 * count`, align 8), sets `capture_ptr_count`, and stores each value at slot `i` (byte offset `i * 8`).
* **Lifted-body env parameter.** Each lambda body is lifted into a standalone MIR function whose leading parameter is the env (a raw pointer-width value the GC does not trace), followed by the lambda's own parameters. The body reads each capture with an `EnvLoad` rvalue into a local bound under its source name.
* **Indirect-call dispatch.** A call to a value of function type lowers to `ClosureCall`. Codegen loads the function pointer and env base from the `Closure`, builds the uniform signature `(env_ptr, user params...) -> ret`, and emits a `call_indirect` passing the env first. The uniform signature decouples the call site from the capture shape.
* **GC.** A closure local is rooted in the enclosing shadow-stack frame like any GC local. Captured GC pointers in the env are traced by the existing closure-tracing arm via `capture_ptr_count` (no runtime change needed; the layout and GC already supported populated captures).

## Spec

`docs/v2/specs/codegen.md` documents capture analysis, by-value semantics, env layout, the lifted-body env parameter, indirect-call dispatch, and GC tracing of captures. `docs/v2/specs/object-layout.md` already described the closure layout and the GC-captures-first convention this implements.

## Deferrals

* Capture-by-reference (rebinding semantics).
* The `{ x -> body }` lambda shorthand without parameter annotations still requires the type checker's context-type inference (issue #59); lambdas use the `fun(x: T) -> U = ...` form.
* Generic function calls inside a lifted lambda body are not surfaced to the monomorphizer.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (282 lib, 16 codegen smoke, all golden)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] MIR unit tests: captured local recorded, GC captures ordered first, body lifted with env parameter, closure value lowered to `ClosureCall`, non-capturing lambda has no captures
- [x] End-to-end smoke tests: `closure_capture.rv` (15 then 42), `closure_arg.rv` (21), existing `closure_value.rv` (42) still green
