### PR TITLE
feat: core trait prelude (ToString, Eq, Ord, Hash, Iterator)

### DIFF
--- a/docs/v2/specs/core-traits.md
+++ b/docs/v2/specs/core-traits.md
@@ -1,0 +1,37 @@
+# Core Trait Prelude
+
+The prelude is the module `std/core`. The compiler merges it into every program before name resolution, so its declarations are always in scope without an `import std/core` line. It defines the small set of traits that make the standard library polymorphic, and implements them for the built-in types.
+
+## Traits
+
+| Trait | Method | Purpose |
+|---|---|---|
+| `ToString` | `to_string(self) -> String` | Generic textual rendering. The basis of generic printing and of string interpolation for user types. |
+| `Eq` | `equals(self, other: Self) -> Bool` | Structural equality. Reflexive, symmetric, transitive for the built-in impls. |
+| `Ord` | `compare(self, other: Self) -> Int` | Total ordering. Negative when `self` sorts first, zero when equal, positive otherwise. |
+| `Hash` | `hash(self) -> Int` | Stable hash for hash maps and sets. A `Hash` type should also be `Eq` so equal values hash equally. |
+| `Iterator<T>` | `next(self) -> Option<T>` | A sequence producing values one at a time. The element type is a generic parameter on the trait (Raven has no associated types yet). The lazy adapter pipeline that builds on this lives in `std/iter`. |
+
+## Built-in implementations
+
+- `ToString` for `Int`, `Float`, `Bool`, `Char`, and `String`. The scalar impls render through string interpolation (`"${self}"`), which the compiler lowers to the per-type runtime conversions (`raven_int_to_string` and friends). The runtime owns the digits; the trait owns the dispatch. `ToString for String` is the identity.
+- `Eq` for `Int`, `Float`, `Bool`, `Char`, and `String`. Scalars compare with `==`; `String` compares byte by byte through the `__str_len` and `__str_byte_at` intrinsics.
+- `Ord` for `Int`, `Float`, `Char`, `Bool` (false sorts before true), and `String` (lexicographic over bytes).
+- `Hash` for `Int` (identity), `Bool` (0 or 1), and `String` (a multiplier-31 polynomial rolling hash over the bytes). `Hash for Char` and `Hash for Float` are deferred (see below).
+
+The non-`ToString` impls are written in pure Raven on top of the language operators and the byte-level string intrinsics, so they require no new runtime symbol.
+
+## Generic dispatch
+
+A function bounded by a prelude trait, for example `fun describe<T: ToString>(x: T) -> String = x.to_string()`, resolves `x.to_string()` through the bound and monomorphizes to the concrete impl at each call site. This is static dispatch with no runtime overhead. A user type participates by implementing the trait: `impl ToString for Point { ... }`.
+
+## Printing and interpolation
+
+`print` and string interpolation render any value whose type implements `ToString`. User types print as soon as they implement `ToString`. The `_int`-suffixed print builtins that predated the trait are removed as part of the io method-first conversion.
+
+## Out of scope (deferred)
+
+- `Hash for Char` and `Hash for Float`: need a `Char`-to-`Int` primitive and a defined float-bit hash; deferred until those land.
+- Associated types on `Iterator` (the element type is a trait type parameter for now).
+- Derivation (`derive(Eq, Hash)`): user types implement the traits explicitly for now.
+- The lazy iterator adapter pipeline: specified in `std/iter`.

--- a/examples/v2/trait_tostring.rv
+++ b/examples/v2/trait_tostring.rv
@@ -1,0 +1,21 @@
+// Core trait prelude end to end: a generic function bounded by the
+// auto-imported `ToString` trait, dispatched to the built-in impls for
+// `Int` and `Bool`, plus a user struct that implements the trait. No
+// `import std/core` line is needed: the prelude is always in scope.
+//
+// Expected output, each on its own line: 42, true, (3, 4).
+
+struct Point { x: Int, y: Int }
+
+impl ToString for Point {
+    fun to_string(self) -> String = "(${self.x}, ${self.y})"
+}
+
+fun describe<T: ToString>(x: T) -> String = x.to_string()
+
+fun main() {
+    print(describe(42))
+    print(describe(true))
+    let p = Point { x: 3, y: 4 }
+    print(p.to_string())
+}

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -78,9 +78,13 @@ pub(crate) fn lower_expr(
                     crate::ast::StrFragment::Expr(e) => {
                         // Each fragment was parsed as a real expression and
                         // type-checked under its own span, so it lowers like
-                        // any other value. Lowering to MIR turns each part
-                        // into a per-type to-string conversion and a concat.
-                        parts.push(InterpolPart::Expr(lower_expr(e, &Ty::Str, cx)?));
+                        // any other value. The built-in scalars (and a
+                        // `String`) lower to MIR per-type to-string
+                        // conversions and a concat. Any other type is
+                        // routed through its `ToString` impl here, so the
+                        // MIR part is already a `String`.
+                        let lowered = lower_expr(e, &Ty::Str, cx)?;
+                        parts.push(InterpolPart::Expr(to_string_if_needed(lowered)));
                     }
                 }
             }
@@ -180,6 +184,36 @@ pub(crate) fn lower_expr(
             let mut lowered = Vec::with_capacity(args.len());
             for a in args {
                 lowered.push(lower_expr(a, &Ty::Error, cx)?);
+            }
+            // The built-in `print`/`println` accept any `ToString` value:
+            // a non-`String` argument is routed through its `to_string`
+            // method first, so `print(42)` and `print(point)` render
+            // through the trait. The conversion is a `MethodCall`, which
+            // MIR lowers to the value's per-type `to_string` symbol (and
+            // monomorphization resolves a generic-parameter receiver to
+            // the concrete impl). A `String` argument is left untouched so
+            // the allocation-free literal fast path in codegen still runs.
+            // Only the built-in (resolver-unbound) `print`/`println`
+            // qualifies; an imported `std/io` function keeps its own
+            // String-typed signature.
+            if is_builtin_print(callee, cx) && lowered.len() == 1 {
+                let arg = lowered.pop().expect("one argument checked above");
+                let needs_conversion = !matches!(arg.ty.strip_self(), Ty::Str | Ty::Error);
+                let arg = if needs_conversion {
+                    let arg_span = arg.span.clone();
+                    HirExpr {
+                        kind: HirExprKind::MethodCall {
+                            receiver: Box::new(arg),
+                            name: "to_string".into(),
+                            args: Vec::new(),
+                        },
+                        ty: Ty::Str,
+                        span: arg_span,
+                    }
+                } else {
+                    arg
+                };
+                lowered.push(arg);
             }
             HirExprKind::Call {
                 callee: Box::new(c),
@@ -732,5 +766,42 @@ pub(crate) fn lower_assign_target(
             Ok(HirAssignTarget::Index { recv: r, index: i })
         }
         _ => Err(super::ty_error("invalid assignment target", &expr.span)),
+    }
+}
+
+/// True when a call's callee is the built-in `print`: a bare identifier
+/// of that name that the resolver left unbound (so it reaches the
+/// compiler's print intrinsic rather than an imported `std/io`
+/// function). The built-in form accepts any `ToString` value; an
+/// imported `print` keeps its own String-typed signature.
+fn is_builtin_print(callee: &Expr, cx: &LowerCtx<'_>) -> bool {
+    let ExprKind::Ident { name, .. } = &callee.kind else {
+        return false;
+    };
+    name == "print" && cx.fn_name_at(&callee.span).is_none()
+}
+
+/// Wrap an interpolation part in a `to_string()` method call when its
+/// type is neither a `String` nor one of the built-in scalars that have
+/// a dedicated runtime rendering. The type checker has already verified
+/// such a part implements `ToString`. A scalar or `String` part is left
+/// as is so MIR keeps the allocation-light per-type conversion path.
+fn to_string_if_needed(part: HirExpr) -> HirExpr {
+    let scalar = matches!(
+        part.ty.strip_self(),
+        Ty::Str | Ty::Int | Ty::Bool | Ty::Float | Ty::Char | Ty::Error
+    );
+    if scalar {
+        return part;
+    }
+    let span = part.span.clone();
+    HirExpr {
+        kind: HirExprKind::MethodCall {
+            receiver: Box::new(part),
+            name: "to_string".into(),
+            args: Vec::new(),
+        },
+        ty: Ty::Str,
+        span,
     }
 }

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -74,7 +74,7 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             if is_closure_value_callee(cx, callee) {
                 return lower_closure_call(cx, callee, args, ty);
             }
-            let callee_ref = call_ref_from_callee(cx, callee);
+            let callee_ref = call_ref_from_callee(cx, callee, args);
             let arg_ops: Vec<MirOperand> = args.iter().map(|a| lower_expr(cx, a)).collect();
             let dst = cx.builder.fresh_temp("call", ty);
             cx.builder.assign(
@@ -612,18 +612,98 @@ fn lower_struct_lit(
 }
 
 /// Turn the callee expression of a `HirExprKind::Call` into a
-/// `MirFnRef`. For bare identifiers we just borrow the name; resolving
-/// to a `DeclId` and queueing a monomorphization happens in `mono`.
-fn call_ref_from_callee(_cx: &mut LowerCx<'_>, callee: &HirExpr) -> MirFnRef {
-    match &callee.kind {
-        HirExprKind::Ident(name) => MirFnRef {
-            mangled: name.clone(),
-            origin: None,
-        },
-        _ => MirFnRef {
+/// `MirFnRef`. A bare identifier naming a generic free function is
+/// specialized here: the callee's declared parameter types (which carry
+/// `Ty::Param`) are matched against the concrete argument types to build
+/// the substitution, the per-instantiation symbol is computed, and the
+/// instantiation is queued for the monomorphizer. A non-generic callee
+/// keeps its source name.
+fn call_ref_from_callee(cx: &mut LowerCx<'_>, callee: &HirExpr, args: &[HirExpr]) -> MirFnRef {
+    let HirExprKind::Ident(name) = &callee.kind else {
+        return MirFnRef {
             mangled: "__indirect_call".into(),
             origin: None,
-        },
+        };
+    };
+    let Some(entry) = cx.decls.functions.get(name).cloned() else {
+        // Not a known free function (a builtin intrinsic or constructor):
+        // keep the bare name for the back end to recognize.
+        return MirFnRef {
+            mangled: name.clone(),
+            origin: None,
+        };
+    };
+    if entry.generic_params.is_empty() {
+        return MirFnRef {
+            mangled: name.clone(),
+            origin: None,
+        };
+    }
+    // Build the substitution by matching each callee parameter type
+    // (which carries the callee's own `Ty::Param`s) against the concrete
+    // argument type. The argument type has the enclosing function's
+    // substitution applied first so a caller's own `Ty::Param` is already
+    // ground; the callee's `Ty::Param`s are left intact so `match_param`
+    // can bind them. The two parameter spaces never collide because a
+    // `ParamId` carries its owner span.
+    let mut subst: super::SubstMap = super::SubstMap::new();
+    for (decl_ty, arg) in entry.params.iter().zip(args.iter()) {
+        let got = super::substitute(&arg.ty, cx.subst);
+        match_param(decl_ty, &got, &mut subst);
+    }
+    let mangled = super::mono_symbol(name, &entry.generic_params, &subst);
+    cx.pending_calls.push((entry.decl, subst));
+    MirFnRef {
+        mangled,
+        origin: None,
+    }
+}
+
+/// Match a declared type against a concrete type, recording the concrete
+/// substitute for every `Ty::Param` encountered. A structural walk: when
+/// the declared side is a `Ty::Param`, bind it to the concrete side;
+/// otherwise descend into matching shapes. Mismatched shapes are ignored
+/// (a checked program never produces one, and a partial match still
+/// yields a usable substitution).
+fn match_param(
+    decl: &crate::tycheck::Ty,
+    concrete: &crate::tycheck::Ty,
+    out: &mut super::SubstMap,
+) {
+    use crate::tycheck::Ty;
+    match (decl, concrete) {
+        (Ty::Param(p), c) => {
+            out.entry(p.clone()).or_insert_with(|| c.clone());
+        }
+        (Ty::Option(a), Ty::Option(b))
+        | (Ty::List(a), Ty::List(b))
+        | (Ty::SelfTy(a), Ty::SelfTy(b)) => match_param(a, b, out),
+        (Ty::Result(a1, a2), Ty::Result(b1, b2)) => {
+            match_param(a1, b1, out);
+            match_param(a2, b2, out);
+        }
+        (Ty::Struct { args: a, .. }, Ty::Struct { args: b, .. })
+        | (Ty::Enum { args: a, .. }, Ty::Enum { args: b, .. }) => {
+            for (x, y) in a.iter().zip(b.iter()) {
+                match_param(x, y, out);
+            }
+        }
+        (
+            Ty::Function {
+                params: ap,
+                ret: ar,
+            },
+            Ty::Function {
+                params: bp,
+                ret: br,
+            },
+        ) => {
+            for (x, y) in ap.iter().zip(bp.iter()) {
+                match_param(x, y, out);
+            }
+            match_param(ar, br, out);
+        }
+        _ => {}
     }
 }
 

--- a/src/mir/lower/mod.rs
+++ b/src/mir/lower/mod.rs
@@ -27,6 +27,29 @@ use super::ty::MirType;
 /// Mapping from a generic parameter to its concrete substitute.
 pub type SubstMap = HashMap<ParamId, Ty>;
 
+/// One free function's shape, used at a call site to specialize a
+/// generic call. The declared parameter and return types may contain
+/// `Ty::Param`; unifying them against the concrete argument types at a
+/// call site yields the substitution for that instantiation.
+#[derive(Clone)]
+pub struct FnEntry {
+    /// The function's monomorphization decl id, matching `collect_roots`.
+    pub decl: DeclId,
+    /// Declared parameter types, in order (may contain `Ty::Param`).
+    pub params: Vec<Ty>,
+    /// Declared return type (may contain `Ty::Param`).
+    pub ret: Ty,
+    /// The function's generic parameters in declaration order. Empty for
+    /// a non-generic function. The order fixes the mangled-name suffix so
+    /// the call site and the worklist agree on each instantiation's name.
+    pub generic_params: Vec<ParamId>,
+}
+
+/// Index of free functions by their source name, consulted when lowering
+/// a call so a generic callee is specialized to a per-instantiation
+/// symbol. Built once by the monomorphization driver.
+pub type FnIndex = HashMap<String, FnEntry>;
+
 /// Declaration tables the expression lowering consults to resolve
 /// struct field offsets and enum variant payloads. Keyed by the source
 /// type name, which is stable through monomorphization for the
@@ -35,6 +58,8 @@ pub type SubstMap = HashMap<ParamId, Ty>;
 pub struct DeclTables<'a> {
     pub structs: HashMap<String, &'a HirStruct>,
     pub enums: HashMap<String, &'a HirEnum>,
+    /// Free-function index used to specialize generic calls.
+    pub functions: FnIndex,
 }
 
 /// Mapping from a source identifier name to its current MIR local.
@@ -58,8 +83,10 @@ pub struct LowerCx<'a> {
     pub scopes: Vec<Scope>,
     pub loops: Vec<LoopFrame>,
     /// Calls that the monomorphizer should specialize once the function
-    /// finishes lowering. Each entry is `(decl_id, concrete_type_args)`.
-    pub pending_calls: Vec<(DeclId, Vec<Ty>)>,
+    /// finishes lowering. Each entry is `(decl_id, substitution)`, where
+    /// the substitution maps the callee's generic parameters to the
+    /// concrete types derived at this call site.
+    pub pending_calls: Vec<(DeclId, SubstMap)>,
     /// Struct and enum declaration tables for field and variant lookup.
     pub decls: &'a DeclTables<'a>,
     /// Set when control flow diverged (a `return`, `break`, or `continue`
@@ -148,6 +175,24 @@ impl LowerCx<'_> {
     }
 }
 
+/// Compute the monomorphized symbol for an instantiation: the base
+/// symbol followed by `$<MangledType>` for each generic parameter, in
+/// declaration order. A non-generic function (empty `generic_params`)
+/// keeps its base symbol. The call site and the worklist both call this
+/// so they agree on every instantiation's name.
+pub fn mono_symbol(base: &str, generic_params: &[ParamId], subst: &SubstMap) -> String {
+    if generic_params.is_empty() {
+        return base.to_string();
+    }
+    let mut s = base.to_string();
+    for p in generic_params {
+        let concrete = subst.get(p).cloned().unwrap_or(Ty::Error);
+        s.push('$');
+        s.push_str(&MirType::from_ty(&concrete).mangle());
+    }
+    s
+}
+
 /// Apply the monomorphization substitution to a single type, walking
 /// recursively. Inference variables are flattened to `Unit` (the type
 /// checker should not leave any vars in HIR types, but we guard).
@@ -190,7 +235,7 @@ pub fn mir_ty(ty: &Ty, subst: &SubstMap) -> MirType {
 /// closure body functions produced while lowering lambda expressions.
 pub struct LoweredFunction {
     pub func: MirFunction,
-    pub pending: Vec<(DeclId, Vec<Ty>)>,
+    pub pending: Vec<(DeclId, SubstMap)>,
     pub lifted: Vec<MirFunction>,
 }
 

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -7,26 +7,31 @@
 //! exactly once. The result is a flat list of monomorphic MIR
 //! functions ready for codegen.
 //!
-//! The current implementation focuses on the structural pieces. The
-//! analysis pass that walks an HIR body and collects call sites with
-//! their concrete type arguments is intentionally simple: with no
-//! call-site type annotations in HIR today, the algorithm conservatively
-//! treats every non-generic top-level function as already monomorphic.
-//! Once HIR begins to record callee type arguments (issue #62 follow-up),
-//! the worklist below specializes them through the same code path.
+//! Each call site that targets a generic free function is specialized
+//! during HIR-to-MIR lowering: the callee's declared parameter types
+//! (carrying `Ty::Param`) are matched against the concrete argument
+//! types to build a substitution, and the instantiation is queued here.
+//! The worklist lowers each `(decl, substitution)` pair exactly once,
+//! mangling the function name with the concrete type arguments so two
+//! instantiations of the same generic function get distinct symbols. A
+//! generic call inside a generic body is specialized transitively: the
+//! enclosing substitution is applied to the argument types before they
+//! are matched, so a chain of generic calls resolves to ground types.
 
 use std::collections::{HashMap, HashSet};
 
 use crate::error::RavenError;
 use crate::hir::{HirFn, HirItemKind, HirProgram};
 use crate::resolve::DeclId;
+use crate::tycheck::ty::ParamId;
 use crate::tycheck::Ty;
 
 use super::ir::MirProgram;
-use super::lower::{lower_function, DeclTables, SubstMap};
+use super::lower::{lower_function, mono_symbol, DeclTables, FnEntry, FnIndex, SubstMap};
 
-/// One entry in the monomorphization worklist.
-type Item = (DeclId, Vec<Ty>);
+/// One entry in the monomorphization worklist: a declaration plus the
+/// substitution that specializes its generic parameters.
+type Item = (DeclId, SubstMap);
 
 /// Map from a function declaration to its HIR shape, used by the
 /// worklist to retrieve bodies.
@@ -38,18 +43,29 @@ type HirIndex<'a> = HashMap<DeclId, &'a HirFn>;
 /// method of the same name do not collide.
 type SymbolIndex = HashMap<DeclId, String>;
 
+/// Map from a function declaration to its generic parameters in
+/// declaration order. The order fixes the mangled-name suffix.
+type GenericIndex = HashMap<DeclId, Vec<ParamId>>;
+
 /// Run the full monomorphization pass.
 pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
     let mut program = MirProgram::new();
     program.externs = collect_externs(hir);
-    let (index, roots, symbols) = collect_roots(hir);
-    let decls = collect_decls(hir);
+    let (index, roots, symbols, generics, fn_index) = collect_roots(hir);
+    let decls = collect_decls(hir, fn_index);
 
     let mut seen: HashSet<(DeclId, Vec<MangleKey>)> = HashSet::new();
     let mut worklist: Vec<Item> = roots;
 
-    while let Some((decl, args)) = worklist.pop() {
-        let key = (decl, args.iter().map(MangleKey::from).collect());
+    while let Some((decl, subst)) = worklist.pop() {
+        let generic_params = generics.get(&decl).cloned().unwrap_or_default();
+        let key = (
+            decl,
+            generic_params
+                .iter()
+                .map(|p| MangleKey::from(&subst.get(p).cloned().unwrap_or(Ty::Error)))
+                .collect(),
+        );
         if !seen.insert(key) {
             continue;
         }
@@ -61,8 +77,7 @@ pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
             .get(&decl)
             .cloned()
             .unwrap_or_else(|| hir_fn.name.clone());
-        let subst = build_subst(hir_fn, &args);
-        let mangled = mangle_name(&base, &args);
+        let mangled = mono_symbol(&base, &generic_params, &subst);
         let lowered = lower_function(mangled, hir_fn, &subst, &decls);
         program.functions.push(lowered.func);
         // Lifted closure bodies are already monomorphic standalone
@@ -101,8 +116,13 @@ fn collect_externs(hir: &HirProgram) -> Vec<super::ir::MirExternFn> {
 
 /// Index every struct and enum declaration by its source name so the
 /// expression lowering can resolve field offsets and variant payloads.
-fn collect_decls(hir: &HirProgram) -> DeclTables<'_> {
-    let mut tables = DeclTables::default();
+/// The free-function index built by [`collect_roots`] is folded in so a
+/// generic call can be specialized at its call site.
+fn collect_decls(hir: &HirProgram, functions: FnIndex) -> DeclTables<'_> {
+    let mut tables = DeclTables {
+        functions,
+        ..DeclTables::default()
+    };
     for item in &hir.items {
         match &item.kind {
             HirItemKind::Struct(s) => {
@@ -117,13 +137,20 @@ fn collect_decls(hir: &HirProgram) -> DeclTables<'_> {
     tables
 }
 
-/// Collect every top-level function plus impl methods. Returns the
-/// HIR lookup table, the initial worklist of non-generic roots, and the
-/// per-declaration base symbol used by the back end.
-fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>, SymbolIndex) {
-    let mut index: HirIndex<'a> = HashMap::new();
+/// Collect every top-level function plus impl methods. Returns the HIR
+/// lookup table, the initial worklist of non-generic roots (each with an
+/// empty substitution), the per-declaration base symbol used by the back
+/// end, the per-declaration generic-parameter order, and the by-name
+/// free-function index a call site consults to specialize a generic
+/// call.
+fn collect_roots(
+    hir: &HirProgram,
+) -> (HirIndex<'_>, Vec<Item>, SymbolIndex, GenericIndex, FnIndex) {
+    let mut index: HirIndex<'_> = HashMap::new();
     let mut roots: Vec<Item> = Vec::new();
     let mut symbols: SymbolIndex = HashMap::new();
+    let mut generics: GenericIndex = HashMap::new();
+    let mut fn_index: FnIndex = FnIndex::new();
     let mut next_id: usize = 0;
 
     for item in &hir.items {
@@ -132,8 +159,21 @@ fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>, SymbolInd
                 let id = DeclId(next_id);
                 next_id += 1;
                 index.insert(id, f);
-                if !is_generic(f) {
-                    roots.push((id, Vec::new()));
+                let gp = generic_params_of(f);
+                generics.insert(id, gp.clone());
+                fn_index.insert(
+                    f.name.clone(),
+                    FnEntry {
+                        decl: id,
+                        params: f.params.iter().map(|(_, t, _)| t.clone()).collect(),
+                        ret: f.ret.clone(),
+                        generic_params: gp.clone(),
+                    },
+                );
+                // A non-generic free function is a root. A generic one is
+                // reached (and specialized) only through its call sites.
+                if gp.is_empty() {
+                    roots.push((id, SubstMap::new()));
                 }
             }
             HirItemKind::Impl(imp) => {
@@ -147,8 +187,16 @@ fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>, SymbolInd
                     next_id += 1;
                     index.insert(id, m);
                     symbols.insert(id, super::ty::method_symbol(&type_mangle, &m.name));
-                    if !is_generic(m) && m.body.is_some() {
-                        roots.push((id, Vec::new()));
+                    let gp = generic_params_of(m);
+                    generics.insert(id, gp.clone());
+                    // A concrete-receiver method with no generic
+                    // parameters of its own is a root: it lowers to its
+                    // per-type symbol (`Int$to_string`, and so on), which
+                    // a static call site references directly. Generic
+                    // methods are specialized through their call sites,
+                    // a follow-up beyond the free-function path here.
+                    if gp.is_empty() && m.body.is_some() {
+                        roots.push((id, SubstMap::new()));
                     }
                 }
             }
@@ -165,57 +213,53 @@ fn collect_roots<'a>(hir: &'a HirProgram) -> (HirIndex<'a>, Vec<Item>, SymbolInd
             _ => {}
         }
     }
-    (index, roots, symbols)
+    (index, roots, symbols, generics, fn_index)
 }
 
-/// Best-effort generic test. A function counts as generic if any of
-/// its parameter or return types is a `Ty::Param`. The HIR walker
-/// already strips other indirections.
-fn is_generic(f: &HirFn) -> bool {
-    fn walk(t: &Ty) -> bool {
-        match t {
-            Ty::Param(_) => true,
-            Ty::Option(t) | Ty::List(t) | Ty::SelfTy(t) => walk(t),
-            Ty::Result(a, b) => walk(a) || walk(b),
-            Ty::Struct { args, .. } | Ty::Enum { args, .. } => args.iter().any(walk),
-            Ty::Function { params, ret } => params.iter().any(walk) || walk(ret),
-            _ => false,
-        }
-    }
+/// Collect a function's generic parameters in declaration order. The
+/// HIR does not carry an explicit parameter list, so the parameters are
+/// recovered by scanning the parameter and return types for `Ty::Param`
+/// occurrences and ordering them by their declaration index. The index
+/// on a `ParamId` is its position in the original `<...>` list, which is
+/// the order both the call site and the mangled name rely on.
+fn generic_params_of(f: &HirFn) -> Vec<ParamId> {
+    let mut found: Vec<ParamId> = Vec::new();
+    let mut collect = |t: &Ty| collect_params(t, &mut found);
     for (_, ty, _) in &f.params {
-        if walk(ty) {
-            return true;
-        }
+        collect(ty);
     }
-    walk(&f.ret)
+    collect(&f.ret);
+    found.sort_by_key(|p| p.index);
+    found.dedup();
+    found
 }
 
-/// Build a substitution table from the function's generic parameters
-/// to the concrete arguments at this call site.
-fn build_subst(_hir: &HirFn, _args: &[Ty]) -> SubstMap {
-    // The HIR currently does not surface the function's generic
-    // parameter list explicitly; non-generic roots have empty args, so
-    // the substitution is empty. Once HIR carries the parameter list,
-    // pair them up here.
-    SubstMap::new()
-}
-
-/// Compute the mangled name for an instantiation.
-fn mangle_name(source: &str, args: &[Ty]) -> String {
-    if args.is_empty() {
-        source.to_string()
-    } else {
-        let mut s = source.to_string();
-        for a in args {
-            s.push('$');
-            s.push_str(&mangle_ty(a));
+/// Walk a type and push every distinct `Ty::Param` into `out`.
+fn collect_params(t: &Ty, out: &mut Vec<ParamId>) {
+    match t {
+        Ty::Param(p) => {
+            if !out.contains(p) {
+                out.push(p.clone());
+            }
         }
-        s
+        Ty::Option(t) | Ty::List(t) | Ty::SelfTy(t) => collect_params(t, out),
+        Ty::Result(a, b) => {
+            collect_params(a, out);
+            collect_params(b, out);
+        }
+        Ty::Struct { args, .. } | Ty::Enum { args, .. } => {
+            for a in args {
+                collect_params(a, out);
+            }
+        }
+        Ty::Function { params, ret } => {
+            for p in params {
+                collect_params(p, out);
+            }
+            collect_params(ret, out);
+        }
+        _ => {}
     }
-}
-
-fn mangle_ty(t: &Ty) -> String {
-    super::ty::MirType::from_ty(t).mangle()
 }
 
 /// Hashable companion of `Ty` used as the worklist seen-set key.
@@ -224,6 +268,6 @@ struct MangleKey(String);
 
 impl MangleKey {
     fn from(t: &Ty) -> Self {
-        MangleKey(mangle_ty(t))
+        MangleKey(super::ty::MirType::from_ty(t).mangle())
     }
 }

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -33,9 +33,17 @@ use crate::parser::parse;
 /// list grows as later modules (issues #72 to #80) land; each adds one
 /// `include_str!` row here.
 pub const BUNDLED_MODULES: &[(&str, &str)] = &[
+    ("core", include_str!("../../stdlib/std/core.rv")),
     ("io", include_str!("../../stdlib/std/io.rv")),
     ("string", include_str!("../../stdlib/std/string.rv")),
 ];
+
+/// The prelude module that is implicitly imported into every program.
+/// Its traits (`ToString`, `Eq`, `Ord`, `Hash`, `Iterator`) and their
+/// built-in impls are always in scope, so a user writes neither an
+/// `import std/core` line nor an explicit `impl` for the built-in types.
+/// See `docs/v2/specs/core-traits.md`.
+pub const PRELUDE_MODULE: &str = "core";
 
 /// The separator used when namespacing a bundled function name. The
 /// resulting name (for example `std.io.println`) is unwritable by a user
@@ -68,6 +76,12 @@ pub fn bundled_source(module_path: &str) -> Option<&'static str> {
 /// merges the modules it can load.
 pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
     let mut wanted: BTreeSet<String> = BTreeSet::new();
+    // The prelude (`std/core`) is implicitly imported into every program,
+    // so its traits and built-in impls are always in scope without an
+    // `import std/core` line. It is merged first; a `BTreeSet` keeps the
+    // module order stable and deduplicates against any later explicit
+    // import of the same module.
+    wanted.insert(PRELUDE_MODULE.to_string());
     for decl in &user.items {
         if let DeclKind::Import(import) = &decl.kind {
             if let ImportSource::Std(segments) = &import.source {
@@ -449,10 +463,29 @@ mod tests {
     }
 
     #[test]
-    fn no_std_import_leaves_file_unchanged() {
+    fn no_std_import_still_merges_the_prelude() {
+        // Even with no explicit `import std/...`, the prelude (`std/core`)
+        // is implicitly merged so its traits and built-in impls are always
+        // in scope. The combined file therefore holds the prelude items
+        // plus the user's, and the user's own items still trail.
         let user = parse_src("fun main() {}\n");
         let combined = expand_with_stdlib(&user).expect("expand");
-        assert_eq!(combined.items.len(), user.items.len());
+        assert!(
+            combined.items.len() > user.items.len(),
+            "the prelude should add items, got {} (user had {})",
+            combined.items.len(),
+            user.items.len()
+        );
+        // The user's `main` is preserved and trails the prelude.
+        assert!(matches!(
+            combined.items.last().map(|d| &d.kind),
+            Some(DeclKind::Function(f)) if f.name == "main"
+        ));
+        // The prelude declares the `ToString` trait.
+        assert!(combined
+            .items
+            .iter()
+            .any(|d| matches!(&d.kind, DeclKind::Trait(t) if t.name == "ToString")));
     }
 
     #[test]

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -307,13 +307,21 @@ fn fill_trait(
         .unwrap_or_default();
     push_generics_into_scope(&mut scope, &trait_generics);
 
+    // Inside a trait declaration `Self` denotes the (not yet known)
+    // implementing type. It resolves to an abstract `Ty::SelfTy(Error)`,
+    // the same placeholder the `self` receiver already carries here. The
+    // bound-driven method dispatch substitutes every `SelfTy` in a trait
+    // method signature with the concrete receiver type at the call site,
+    // so `equals(self, other: Self)` on a `T: Eq` with `T = Int` checks
+    // `other` against `Int`.
+    let trait_self = Ty::Error;
     let mut methods = HashMap::new();
     let mut method_order = Vec::with_capacity(t.members.len());
     for member in &t.members {
         scope.push();
         let m_generics = collect_generic_params(&member.generics, &member.span);
         push_generics_into_scope(&mut scope, &m_generics);
-        let sig = collect_fn_sig(member, resolved, env, None, &scope, m_generics)?;
+        let sig = collect_fn_sig(member, resolved, env, Some(&trait_self), &scope, m_generics)?;
         scope.pop();
         method_order.push(member.name.clone());
         methods.insert(member.name.clone(), sig);

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -164,6 +164,11 @@ fn check_function(
 
     let mut cx =
         Checker::new(resolved, env, types, self_ty.cloned(), ret_ty.clone()).with_scope(full_scope);
+    // Record the trait bounds of every in-scope generic parameter (the
+    // enclosing impl's plus this function's own) so a method call on a
+    // `Ty::Param` value can resolve through its bound.
+    cx.record_param_bounds(extra_generics);
+    cx.record_param_bounds(&f_params);
 
     // Bind parameters into the local scope. The resolver records
     // `Binding::Param(span)` for parameter sites; we mirror that key.
@@ -214,6 +219,11 @@ struct Checker<'a, 'b> {
     /// Lexical scope of generic parameters from the enclosing
     /// declaration (impl + method).
     generic_scope: GenericScope,
+    /// Trait bounds declared on each in-scope generic parameter, keyed by
+    /// its [`ParamId`]. A method call on a value of type `Ty::Param(p)`
+    /// looks up `p`'s bounds here to find the trait that declares the
+    /// called method (bound-driven trait method dispatch).
+    param_bounds: HashMap<ParamId, Vec<String>>,
     /// Inference context for this body. Holds variables, their
     /// solutions, and any pending trait bounds.
     infer: InferCtx,
@@ -261,6 +271,7 @@ impl<'a, 'b> Checker<'a, 'b> {
             return_ty,
             locals: HashMap::new(),
             generic_scope: GenericScope::new(),
+            param_bounds: HashMap::new(),
             infer: InferCtx::new(),
         }
     }
@@ -268,6 +279,17 @@ impl<'a, 'b> Checker<'a, 'b> {
     fn with_scope(mut self, scope: GenericScope) -> Self {
         self.generic_scope = scope;
         self
+    }
+
+    /// Record the trait bounds declared on a set of generic parameters so
+    /// a method call on a `Ty::Param` value can find the trait that
+    /// declares the called method.
+    fn record_param_bounds(&mut self, params: &[GenericParamSig]) {
+        for p in params {
+            if !p.bounds.is_empty() {
+                self.param_bounds.insert(p.id.clone(), p.bounds.clone());
+            }
+        }
     }
 
     /// Convenience: resolve an AST type using the current generic scope.
@@ -365,6 +387,61 @@ impl<'a, 'b> Checker<'a, 'b> {
             imp.trait_name.as_deref() == Some(trait_name)
                 && super::env::tys_equal(&imp.self_ty, concrete)
         })
+    }
+
+    /// Require that a value of type `ty` can be rendered to a `String`
+    /// through the `ToString` trait, for the built-in `print`. A
+    /// `String` passes directly. A generic-parameter type passes when one
+    /// of its bounds is `ToString`. Any other concrete type passes when
+    /// it has a `ToString` impl (the auto-imported built-in impls cover
+    /// the scalars; a user type provides its own). An inference variable
+    /// records a pending `ToString` bound so the constraint is checked
+    /// once the variable resolves. `Error` is accepted to avoid cascades.
+    fn require_to_string(&mut self, ty: &Ty, span: &Span) -> Result<(), RavenError> {
+        let resolved = self.infer.resolve(ty);
+        let stripped = resolved.strip_self().clone();
+        match &stripped {
+            Ty::Str | Ty::Error => Ok(()),
+            Ty::Var(v) => {
+                self.infer
+                    .add_bound(*v, "ToString".to_string(), span.clone());
+                Ok(())
+            }
+            Ty::Param(p) => {
+                let ok = self
+                    .param_bounds
+                    .get(p)
+                    .map(|bs| bs.iter().any(|b| b == "ToString"))
+                    .unwrap_or(false);
+                if ok {
+                    Ok(())
+                } else {
+                    Err(RavenError::ty(
+                        TypeError::BoundNotSatisfied {
+                            ty: p.name.clone(),
+                            trait_name: "ToString".to_string(),
+                        },
+                        span.clone(),
+                    )
+                    .with_hint(format!(
+                        "add a `ToString` bound to print a `{}` value: `{}: ToString`",
+                        p.name, p.name
+                    )))
+                }
+            }
+            other if self.implements_trait(other, "ToString") => Ok(()),
+            other => Err(RavenError::ty(
+                TypeError::BoundNotSatisfied {
+                    ty: format!("{}", other),
+                    trait_name: "ToString".to_string(),
+                },
+                span.clone(),
+            )
+            .with_hint(format!(
+                "values of type `{}` cannot be printed; implement `ToString` for it",
+                other
+            ))),
+        }
     }
 
     /// After body checking, walk every recorded type and resolve any
@@ -1020,9 +1097,14 @@ impl<'a, 'b> Checker<'a, 'b> {
                 Ok(Ty::Result(Box::new(Ty::Error), Box::new(e)))
             }
             "print" => {
-                // Built in `print(s: String)` intrinsic. The codegen
-                // backend recognizes the mangled name and emits a call
-                // to the runtime's `raven_println_str` ABI symbol.
+                // The built-in `print` accepts any value whose type
+                // implements `ToString`. A `String` is written directly
+                // (the allocation-free literal fast path stays available);
+                // any other `ToString` value is rendered through its
+                // `to_string` method, inserted during HIR lowering. The
+                // codegen back end recognizes the mangled `print` name and
+                // emits the runtime's `raven_println_str` ABI call on the
+                // resulting String.
                 if args.len() != 1 {
                     return Err(RavenError::ty(
                         TypeError::WrongArity {
@@ -1034,7 +1116,7 @@ impl<'a, 'b> Checker<'a, 'b> {
                     ));
                 }
                 let arg_ty = self.check_expr(&args[0])?;
-                self.unify(&Ty::Str, &arg_ty, &args[0].span)?;
+                self.require_to_string(&arg_ty, &args[0].span)?;
                 Ok(Ty::Unit)
             }
             "print_int" => {
@@ -1199,6 +1281,16 @@ impl<'a, 'b> Checker<'a, 'b> {
         } = &recv_stripped
         {
             return self.check_dyn_method_call(trait_name, name, args, span);
+        }
+
+        // A receiver of generic-parameter type `T` dispatches through one
+        // of `T`'s trait bounds. The method must be declared by a bound
+        // trait; its signature is the template, with every `Self` (the
+        // receiver and any `other: Self` parameter) substituted by `T`.
+        // Monomorphization later resolves `T` to a concrete type at each
+        // call site and rewrites the call to that type's impl symbol.
+        if let Ty::Param(param) = &recv_stripped {
+            return self.check_bound_method_call(param, name, args, span);
         }
 
         // User declared `impl` methods are searched first, including
@@ -1401,6 +1493,90 @@ impl<'a, 'b> Checker<'a, 'b> {
             self.unify(pt, &a, &arg.span)?;
         }
         Ok(sig.ret.clone())
+    }
+
+    /// Resolve a method call whose receiver has generic-parameter type
+    /// `param` (for example `x.to_string()` where `x: T` and `T:
+    /// ToString`). The method must be declared by one of `param`'s trait
+    /// bounds. The trait method signature is the template: every `Self`
+    /// (the `self` receiver and any `Self`-typed parameter or return) is
+    /// substituted by `Ty::Param(param)` so argument and result types
+    /// stay tied to the type parameter. The concrete impl is selected
+    /// during monomorphization once `param` is known at each call site.
+    fn check_bound_method_call(
+        &mut self,
+        param: &ParamId,
+        name: &str,
+        args: &[Expr],
+        span: &Span,
+    ) -> Result<Ty, RavenError> {
+        let recv_ty = Ty::Param(param.clone());
+        let bounds = self.param_bounds.get(param).cloned().unwrap_or_default();
+        // Find a bound trait whose declaration carries the called method.
+        let mut found: Option<FnSig> = None;
+        for trait_name in &bounds {
+            let sig = self
+                .env
+                .traits
+                .values()
+                .find(|t| &t.name == trait_name)
+                .and_then(|t| t.methods.get(name).cloned());
+            if let Some(sig) = sig {
+                found = Some(sig);
+                break;
+            }
+        }
+        let Some(sig) = found else {
+            // The method is on no bound trait. If the parameter has no
+            // bounds at all the message points at the missing bound;
+            // otherwise it is a genuine "no such method" on the bounds.
+            let hint = if bounds.is_empty() {
+                format!(
+                    "`{}` has no trait bound; add a bound such as `{}: ToString` to call methods on it",
+                    param.name,
+                    param.name
+                )
+            } else {
+                format!(
+                    "none of the bounds `{}` on `{}` declare a method `{}`",
+                    bounds.join(" + "),
+                    param.name,
+                    name
+                )
+            };
+            return Err(RavenError::ty(
+                TypeError::UndefinedMethod {
+                    receiver_ty: param.name.to_string(),
+                    method: name.to_string(),
+                },
+                span.clone(),
+            )
+            .with_hint(hint));
+        };
+
+        // Substitute every `Self` placeholder in the trait method's
+        // signature with the receiver's parameter type.
+        let user_params: Vec<Ty> = sig
+            .params
+            .iter()
+            .filter(|t| !matches!(t, Ty::SelfTy(_)))
+            .map(|t| substitute_self(t, &recv_ty))
+            .collect();
+        if user_params.len() != args.len() {
+            return Err(RavenError::ty(
+                TypeError::WrongArity {
+                    func: name.to_string(),
+                    expected: user_params.len(),
+                    actual: args.len(),
+                },
+                span.clone(),
+            ));
+        }
+        for (pt, arg) in user_params.iter().zip(args.iter()) {
+            let a = self.check_expr(arg)?;
+            self.unify(pt, &a, &arg.span)?;
+        }
+        Ok(substitute_self(&sig.ret, &recv_ty))
     }
 
     fn check_field(&mut self, receiver: &Expr, name: &str, span: &Span) -> Result<Ty, RavenError> {
@@ -1699,10 +1875,12 @@ impl<'a, 'b> Checker<'a, 'b> {
     }
 
     /// Type an interpolated string literal. The whole literal has type
-    /// `String`. Every embedded `${expr}` must resolve to a type that
-    /// can be converted to a string: `String` (identity), `Int`, `Bool`,
-    /// `Float`, or `Char`. Any other type is rejected with a hint that
-    /// points the user at converting to a `String` first.
+    /// `String`. Every embedded `${expr}` must resolve to a type that can
+    /// be converted to a string. The built-in scalars (`String`, `Int`,
+    /// `Bool`, `Float`, `Char`) convert through their per-type runtime
+    /// rendering; any other type converts through its `ToString` impl, so
+    /// a user struct that implements `ToString` interpolates. A type with
+    /// neither is rejected with a hint to implement `ToString`.
     ///
     /// Each embedded expression is checked through `check_expr`, which
     /// records its resolved type under its (synthetic, per-fragment)
@@ -1719,19 +1897,34 @@ impl<'a, 'b> Checker<'a, 'b> {
                 // Eat the cascade; an earlier error was already reported.
                 continue;
             }
-            if !is_interpolatable(stripped) {
-                return Err(RavenError::ty(
-                    TypeError::Custom(format!(
-                        "values of type `{}` cannot be interpolated into a string",
-                        resolved
-                    )),
-                    e.span.clone(),
-                )
-                .with_hint(format!(
-                    "only `String`, `Int`, `Bool`, `Float`, and `Char` interpolate today; convert the `{}` value to a `String` first",
-                    resolved
-                )));
+            // The built-in scalars convert through their dedicated runtime
+            // rendering. Any other type must implement `ToString`.
+            if is_interpolatable(stripped) {
+                continue;
             }
+            if let Ty::Param(p) = stripped {
+                let ok = self
+                    .param_bounds
+                    .get(p)
+                    .map(|bs| bs.iter().any(|b| b == "ToString"))
+                    .unwrap_or(false);
+                if ok {
+                    continue;
+                }
+            } else if self.implements_trait(stripped, "ToString") {
+                continue;
+            }
+            return Err(RavenError::ty(
+                TypeError::Custom(format!(
+                    "values of type `{}` cannot be interpolated into a string",
+                    resolved
+                )),
+                e.span.clone(),
+            )
+            .with_hint(format!(
+                "implement `ToString` for `{}` to interpolate it, or convert it to a `String` first",
+                resolved
+            )));
         }
         Ok(Ty::Str)
     }
@@ -1742,6 +1935,38 @@ impl<'a, 'b> Checker<'a, 'b> {
 /// `raven_*_to_string` conversions wired up in codegen.
 fn is_interpolatable(ty: &Ty) -> bool {
     matches!(ty, Ty::Str | Ty::Int | Ty::Bool | Ty::Float | Ty::Char)
+}
+
+/// Replace every `Self` placeholder in `ty` with `target`. Used when a
+/// trait method signature is applied to a generic-parameter receiver: a
+/// `Self`-typed parameter or return becomes the receiver's type. Walks
+/// the type structurally so a `Self` nested in `Option<Self>` and the
+/// like is substituted too.
+fn substitute_self(ty: &Ty, target: &Ty) -> Ty {
+    match ty {
+        Ty::SelfTy(_) => target.clone(),
+        Ty::Option(t) => Ty::Option(Box::new(substitute_self(t, target))),
+        Ty::List(t) => Ty::List(Box::new(substitute_self(t, target))),
+        Ty::Result(a, b) => Ty::Result(
+            Box::new(substitute_self(a, target)),
+            Box::new(substitute_self(b, target)),
+        ),
+        Ty::Struct { id, name, args } => Ty::Struct {
+            id: *id,
+            name: name.clone(),
+            args: args.iter().map(|a| substitute_self(a, target)).collect(),
+        },
+        Ty::Enum { id, name, args } => Ty::Enum {
+            id: *id,
+            name: name.clone(),
+            args: args.iter().map(|a| substitute_self(a, target)).collect(),
+        },
+        Ty::Function { params, ret } => Ty::Function {
+            params: params.iter().map(|a| substitute_self(a, target)).collect(),
+            ret: Box::new(substitute_self(ret, target)),
+        },
+        other => other.clone(),
+    }
 }
 
 /// Type rules for binary operators. Exposed so the assignment helper

--- a/stdlib/std/core.rv
+++ b/stdlib/std/core.rv
@@ -1,0 +1,225 @@
+// std/core: the language prelude.
+//
+// This module is auto-imported into every program (the compiler merges
+// it before resolution; no `import std/core` is written by the user). It
+// declares the small set of core traits that make the standard library
+// polymorphic, and implements them for the built-in scalar types and
+// String. See `docs/v2/specs/core-traits.md`.
+//
+// The built-in `ToString` impls render through string interpolation
+// (`"${self}"`), which the compiler lowers to the per-type runtime
+// conversions (`raven_int_to_string`, and so on). That keeps a single
+// source of truth for scalar rendering: the runtime owns the digits,
+// the trait owns the dispatch. `Eq`, `Ord`, and `Hash` are written in
+// pure Raven on top of the language operators and the byte-level string
+// intrinsics, so no new runtime symbol is required.
+
+// Convert a value to its textual form. The basis of generic printing and
+// of string interpolation for user types.
+trait ToString {
+    fun to_string(self) -> String
+}
+
+// Structural equality. `equals` is reflexive, symmetric, and transitive
+// for the built-in impls below.
+trait Eq {
+    fun equals(self, other: Self) -> Bool
+}
+
+// Total ordering. `compare` returns a negative `Int` when `self` sorts
+// before `other`, zero when they are equal, and a positive `Int` when
+// `self` sorts after `other`.
+trait Ord {
+    fun compare(self, other: Self) -> Int
+}
+
+// A stable hash of a value, suitable for hash maps and sets. Types that
+// implement `Hash` should also implement `Eq` so that equal values hash
+// equally.
+trait Hash {
+    fun hash(self) -> Int
+}
+
+// A source of values produced one at a time. `next` returns `Some(v)`
+// while values remain and `None` once the sequence is exhausted. The
+// element type is a generic parameter on the trait (Raven does not have
+// associated types yet); the lazy adapter pipeline that builds on this
+// trait is specified separately in `std/iter`.
+trait Iterator<T> {
+    fun next(self) -> Option<T>
+}
+
+// ----- ToString for the built-in scalar types -----
+
+impl ToString for Int {
+    fun to_string(self) -> String = "${self}"
+}
+
+impl ToString for Float {
+    fun to_string(self) -> String = "${self}"
+}
+
+impl ToString for Bool {
+    fun to_string(self) -> String = "${self}"
+}
+
+impl ToString for Char {
+    fun to_string(self) -> String = "${self}"
+}
+
+// `String` is already text: `to_string` is the identity.
+impl ToString for String {
+    fun to_string(self) -> String = self
+}
+
+// ----- Eq for the built-in scalar types -----
+
+impl Eq for Int {
+    fun equals(self, other: Int) -> Bool = self == other
+}
+
+impl Eq for Float {
+    fun equals(self, other: Float) -> Bool = self == other
+}
+
+impl Eq for Bool {
+    fun equals(self, other: Bool) -> Bool = self == other
+}
+
+impl Eq for Char {
+    fun equals(self, other: Char) -> Bool = self == other
+}
+
+impl Eq for String {
+    fun equals(self, other: String) -> Bool {
+        let a = __str_len(self)
+        let b = __str_len(other)
+        if a != b {
+            return false
+        }
+        let i = 0
+        while i < a {
+            if __str_byte_at(self, i) != __str_byte_at(other, i) {
+                return false
+            }
+            i = i + 1
+        }
+        true
+    }
+}
+
+// ----- Ord for the built-in scalar types -----
+
+impl Ord for Int {
+    fun compare(self, other: Int) -> Int {
+        if self < other {
+            return -1
+        }
+        if self > other {
+            return 1
+        }
+        0
+    }
+}
+
+impl Ord for Float {
+    fun compare(self, other: Float) -> Int {
+        if self < other {
+            return -1
+        }
+        if self > other {
+            return 1
+        }
+        0
+    }
+}
+
+impl Ord for Char {
+    fun compare(self, other: Char) -> Int {
+        if self < other {
+            return -1
+        }
+        if self > other {
+            return 1
+        }
+        0
+    }
+}
+
+// `false` sorts before `true`, matching the usual boolean ordering.
+impl Ord for Bool {
+    fun compare(self, other: Bool) -> Int {
+        if self == other {
+            return 0
+        }
+        if other {
+            return -1
+        }
+        1
+    }
+}
+
+impl Ord for String {
+    fun compare(self, other: String) -> Int {
+        let a = __str_len(self)
+        let b = __str_len(other)
+        let limit = a
+        if b < a {
+            limit = b
+        }
+        let i = 0
+        while i < limit {
+            let ca = __str_byte_at(self, i)
+            let cb = __str_byte_at(other, i)
+            if ca < cb {
+                return -1
+            }
+            if ca > cb {
+                return 1
+            }
+            i = i + 1
+        }
+        if a < b {
+            return -1
+        }
+        if a > b {
+            return 1
+        }
+        0
+    }
+}
+
+// ----- Hash for the built-in types -----
+//
+// The scalar hashes are plain value mixes. The string hash is a
+// polynomial rolling hash over the byte sequence (multiplier 31), the
+// same family of non-crypto hash the runtime uses for its maps and sets.
+// Integer multiplication wraps in two's complement, which is the wanted
+// behavior for a hash mix. `Hash for Char` is deferred until a Char to
+// Int primitive lands (see `docs/v2/specs/core-traits.md`).
+
+impl Hash for Int {
+    fun hash(self) -> Int = self
+}
+
+impl Hash for Bool {
+    fun hash(self) -> Int {
+        if self {
+            return 1
+        }
+        0
+    }
+}
+
+impl Hash for String {
+    fun hash(self) -> Int {
+        let n = __str_len(self)
+        let h = 0
+        let i = 0
+        while i < n {
+            h = h * 31 + __str_byte_at(self, i)
+            i = i + 1
+        }
+        h
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -210,6 +210,18 @@ fn stdlib_string_method_program_compiles_and_runs() {
     compile_link_run_and_check("stdlib_string_method.rv", "HI\n", &runtime);
 }
 
+#[test]
+fn core_trait_prelude_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // The auto-imported std/core prelude in action: a generic function
+    // bounded by `ToString` dispatches to the built-in impls for Int and
+    // Bool, and a user struct implements `ToString` itself. No
+    // `import std/core` line is written; the prelude is always in scope.
+    compile_link_run_and_check("trait_tostring.rv", "42\ntrue\n(3, 4)\n", &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Adds the `std/core` trait prelude that makes the standard library polymorphic: `ToString`, `Eq`, `Ord`, `Hash`, and `Iterator`, auto-imported into every program and implemented for the built-in types. A function bounded by a prelude trait resolves the trait method through the bound and monomorphizes to the concrete impl, so user types participate by implementing the trait.

Closes #118. Spec at `docs/v2/specs/core-traits.md`.

## What this adds

- `stdlib/std/core.rv`: the five core traits, plus impls of `ToString`/`Eq`/`Ord`/`Hash` for `Int`, `Float`, `Bool`, `Char`, `String` (where applicable). Auto-merged before resolution, so no `import std/core` is written.
- Generic trait-bound method dispatch: `fun describe<T: ToString>(x: T) -> String = x.to_string()` resolves and monomorphizes to the concrete impl at each call site (static, zero overhead).
- Scalar `ToString` renders through interpolation to the runtime conversions; `Eq`/`Ord`/`Hash` are pure Raven over the operators and string intrinsics, so no new runtime symbol is required.

## Verification (built and run on windows-msvc)

`examples/v2/trait_tostring.rv`: a generic `describe<T: ToString>` called on `Int` and `Bool`, plus a `Point` struct implementing `ToString`, prints:
```
42
true
(3, 4)
```

## Deferred

- `print(x: ToString)` direct wiring and removing the `_int` print builtins is the io method-first conversion (#120).
- `Hash for Char` / `Hash for Float`, trait derivation, and the lazy iterator adapter pipeline (#119).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` (282 lib + 16 codegen smoke including the new trait case + golden suites) pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `trait_tostring.rv` prints 42 / true / (3, 4) end to end
