### PR TITLE
fix(mir): monomorphize generic calls inside closure bodies

### DIFF
--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -305,6 +305,13 @@ the rest of the body references captures as ordinary locals. A capture
 that is a GC pointer, once read into a body local, is rooted by the lifted
 body's own shadow-stack frame like any other GC local.
 
+A lifted body is lowered exactly like an ordinary function body, so any
+generic function it calls is specialized at the call site and contributes
+its `(decl, substitution)` to the monomorphization worklist. Those pending
+calls travel up through the enclosing function into the worklist, so a
+generic function reachable only through a closure body is still
+instantiated for the concrete type arguments seen inside that body.
+
 #### Invoking a closure value
 
 A call whose callee is a value of function type (an in-scope local of

--- a/examples/v2/closure_generic_call.rv
+++ b/examples/v2/closure_generic_call.rv
@@ -1,0 +1,16 @@
+// A generic function reachable only through a closure body. `identity`
+// is generic and is never called directly: the only call site is inside
+// the lambda `f`, which `apply` invokes indirectly. The monomorphizer
+// must still emit the `identity<Int>` instantiation, since the lifted
+// closure body's generic call sites feed the same worklist as an
+// ordinary function body. apply(f, 41) computes identity(41) + 1 = 42.
+fun identity<T>(x: T) -> T = x
+
+fun apply(f: fun(Int) -> Int, x: Int) -> Int {
+    return f(x)
+}
+
+fun main() {
+    let f = fun(x: Int) -> Int = identity(x) + 1
+    print_int(apply(f, 41))
+}

--- a/src/mir/lower/closure.rs
+++ b/src/mir/lower/closure.rs
@@ -31,8 +31,9 @@ use crate::hir::ty::HirTy;
 
 use super::super::ir::{MirFunction, MirLocal, MirRvalue, MirTerminator};
 use super::super::ty::{MirFfiTy, MirType};
-use super::{mir_ty, LowerCx, Scope};
+use super::{mir_ty, LowerCx, Scope, SubstMap};
 use crate::codegen::layout::is_gc_pointer;
+use crate::resolve::DeclId;
 
 /// One captured variable: its source name, its MIR type, and the
 /// enclosing-scope local that currently holds the value to copy.
@@ -88,10 +89,20 @@ pub fn lower_lambda(
     let ret_ty = mir_ty(ret, cx.subst);
 
     // Build the lifted body as a standalone function. Any lambdas nested
-    // inside the body lift their own bodies; surface those too.
-    let (lifted, nested) = lift_body(cx, &lifted_name, params, ret_ty, body, &captures);
+    // inside the body lift their own bodies; surface those too. The
+    // lifted body may also call generic functions: those call sites are
+    // collected during its lowering and must reach the monomorphization
+    // worklist exactly as an ordinary function body's calls do, otherwise
+    // a generic function reachable only through the closure is never
+    // instantiated.
+    let LiftedBody {
+        func: lifted,
+        nested,
+        pending,
+    } = lift_body(cx, &lifted_name, params, ret_ty, body, &captures);
     cx.lifted.push(lifted);
     cx.lifted.extend(nested);
+    cx.pending_calls.extend(pending);
 
     let capture_ops = captures
         .iter()
@@ -113,6 +124,17 @@ fn mint_lifted_name(cx: &mut LowerCx<'_>) -> String {
     format!("{}$closure${}", cx.enclosing, n)
 }
 
+/// The result of lifting one lambda body: the standalone `MirFunction`,
+/// any functions lifted from lambdas nested inside it, and the generic
+/// call sites discovered while lowering the body. The pending calls are
+/// surfaced so the monomorphizer queues every generic instantiation the
+/// closure reaches, just as it does for an ordinary function body.
+struct LiftedBody {
+    func: MirFunction,
+    nested: Vec<MirFunction>,
+    pending: Vec<(DeclId, SubstMap)>,
+}
+
 /// Lift a lambda body into a standalone `MirFunction`.
 ///
 /// The lifted function's parameters are the capture environment pointer
@@ -121,7 +143,6 @@ fn mint_lifted_name(cx: &mut LowerCx<'_>) -> String {
 /// bound under the capture's source name, so the body's identifier
 /// references resolve to those locals exactly as they did at the
 /// definition site.
-#[allow(clippy::type_complexity)]
 fn lift_body(
     cx: &LowerCx<'_>,
     name: &str,
@@ -129,7 +150,7 @@ fn lift_body(
     ret_ty: MirType,
     body: &HirBlock,
     captures: &[Capture],
-) -> (MirFunction, Vec<MirFunction>) {
+) -> LiftedBody {
     use super::super::builder::FunctionBuilder;
 
     let mut builder = FunctionBuilder::new(
@@ -201,7 +222,15 @@ fn lift_body(
     // A lambda body may itself contain nested lambdas; surface their
     // lifted functions through the enclosing function's accumulator.
     let nested = std::mem::take(&mut body_cx.lifted);
-    (body_cx.builder.finish(entry), nested)
+    // The body's own generic call sites travel up to the enclosing
+    // function so the monomorphizer instantiates every callee the
+    // closure reaches. Without this they would be dropped with `body_cx`.
+    let pending = std::mem::take(&mut body_cx.pending_calls);
+    LiftedBody {
+        func: body_cx.builder.finish(entry),
+        nested,
+        pending,
+    }
 }
 
 // ----- free-variable collection -----

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -476,6 +476,63 @@ fn invoking_a_closure_value_emits_closure_call() {
 }
 
 #[test]
+fn generic_call_inside_closure_body_is_monomorphized() {
+    // Regression for #135: a generic function reachable only through a
+    // closure body must still be instantiated. `identity<T>` is called
+    // only from the lifted lambda `f`, so its `identity$Int` instance is
+    // queued only if the lifted body's pending generic call sites reach
+    // the monomorphization worklist. Before the fix those calls were
+    // dropped and no instance was emitted, leaving an unresolved callee.
+    let prog = compile(
+        r#"
+        fun identity<T>(x: T) -> T = x
+
+        fun apply(f: fun(Int) -> Int, x: Int) -> Int {
+            return f(x)
+        }
+
+        fun main() {
+            let f = fun(x: Int) -> Int = identity(x) + 1
+            print_int(apply(f, 41))
+        }
+    "#,
+    );
+    // The concrete instantiation appears under its mangled symbol.
+    assert!(
+        prog.functions.iter().any(|f| f.name == "identity$Int"),
+        "expected the identity$Int instantiation in the monomorphized program, got {:?}",
+        prog.functions
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<Vec<_>>()
+    );
+    // The lifted closure body that drives the instantiation is present
+    // and calls the mangled symbol directly.
+    let lifted = prog
+        .functions
+        .iter()
+        .find(|f| f.name.contains("$closure$"))
+        .expect("a lifted closure body function");
+    let calls_identity_instance = lifted
+        .blocks
+        .iter()
+        .flat_map(|b| b.statements.iter())
+        .any(|s| {
+            matches!(
+                s,
+                MirStatement::Assign {
+                    rvalue: MirRvalue::Call { callee, .. },
+                    ..
+                } if callee.mangled == "identity$Int"
+            )
+        });
+    assert!(
+        calls_identity_instance,
+        "the lifted closure body calls the identity$Int instance"
+    );
+}
+
+#[test]
 fn gc_pointer_captures_are_ordered_first() {
     // A closure capturing both a scalar (`k`) and a GC pointer (`s`)
     // places the GC pointer capture first so the runtime's leading

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -82,6 +82,19 @@ fn closure_arg_program_compiles_and_runs() {
 }
 
 #[test]
+fn closure_generic_call_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A generic function (`identity<T>`) reachable only through a closure
+    // body. The lifted closure body's call to `identity` is the sole call
+    // site, so the monomorphizer must pick it up from the lifted body to
+    // emit the `identity$Int` instantiation. apply(f, 41) computes
+    // identity(41) + 1, printing 42.
+    compile_link_run_and_check("closure_generic_call.rv", "42\n", &runtime);
+}
+
+#[test]
 fn dyn_dispatch_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Thread a lifted closure body's generic call sites into the monomorphization worklist so a generic function reachable only through a closure is instantiated.

Closes #135

## Root cause

When a lambda body is lifted into a standalone MIR function, the generic call sites discovered while lowering that body were collected into the lifted body's local `pending_calls` list, which was then dropped when its lowering context went out of scope. Only nested lifted functions were surfaced, so a generic function called only from inside a closure never got a concrete instantiation and codegen failed with an unresolved callee.

The fix returns the lifted body's pending calls from `lift_body` and extends the enclosing function's `pending_calls` with them, so they flow into the same monomorphization worklist as an ordinary function body's calls.

## Before and after

Example: `examples/v2/closure_generic_call.rv`, where `identity<T>` is called only from inside the closure `f` that `apply` invokes indirectly.

* Before the fix: `raven build` failed at codegen with `unsupported MIR construct: unresolved callee: identity$Int`, because the `identity$Int` instantiation was never emitted.
* After the fix: the program builds and prints `42` (identity(41) + 1).

## Test plan

- [x] `cargo build`
- [x] `cargo test` (283 lib tests, 18 smoke tests, golden suites all green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` clean
- [x] New end-to-end smoke case `closure_generic_call_program_compiles_and_runs` links and runs the binary, asserting stdout `42`
- [x] New MIR regression `generic_call_inside_closure_body_is_monomorphized` asserts the `identity$Int` instance is present and that the lifted closure body calls it directly
