### PR TITLE
feat(codegen): list literals, indexing, and List methods

### DIFF
--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -111,7 +111,7 @@ lifetimes); `Nop` is also a no op.
 | `Call { callee, args }` | Loads each argument from its slot, declares the callee through `cranelift-module`, emits `call` with the resulting `FuncRef`, stores the return value. |
 | `StructCreate`, `EnumCreate`, `FieldAccess`, `ClosureCreate`, `EnvLoad`, `ClosureCall` | Lowered. See the heap value and closure sections below. |
 | `Cast` | Integer and float conversions through `sextend`, `ireduce`, `fcvt_from_sint`, `fcvt_to_sint_sat`. |
-| `IndexAccess`, `ArrayLit` | Deferred to the stdlib collection issues. |
+| `ArrayLit`, `IndexAccess`, `ListMethod` | Lowered. See the List section below. |
 
 ## Terminator lowering
 
@@ -334,6 +334,87 @@ runtime's closure-tracing arm reads `capture_ptr_count` and traces the
 leading pointer slots, which is why capture analysis places GC-pointer
 captures first.
 
+### Lists
+
+A `List<T>` value is a single GC pointer to a heap `List` object (header,
+`element_size`, `element_align`, `elements_are_gc_ptrs`, and an owned
+element buffer; see `docs/v2/specs/object-layout.md`). Codegen stores
+every element in a uniform eight-byte slot, the same slot width struct
+and enum fields use, so `element_size == element_align == 8` for all
+element types. Scalars narrower than eight bytes are widened on store and
+narrowed on load; a GC pointer is already eight bytes. The
+`elements_are_gc_ptrs` flag is set from the static element type
+(`layout::is_gc_pointer`): nonzero for heap element types (`String`,
+`List`, `Map`, `Set`, struct, enum, closure, `Box`, `dyn`) and zero for
+the scalars (`Int`, `Float`, `Bool`, `Char`). The flag is independent of
+the slot size: an eight-byte `Int` slot is not a pointer, while an
+eight-byte `String` slot is.
+
+#### Element representation and the GC-pointer flag
+
+The flag drives the collector's element tracing. The runtime's
+`TAG_LIST` arm reads `elements_are_gc_ptrs` and, when nonzero, traces the
+first `len` pointer slots of the buffer; when zero, the buffer is opaque
+scalar bytes and is not traced. So a `List<String>` keeps its elements
+reachable, and a `List<Int>` never misreads an integer as a pointer.
+
+#### `ArrayLit`
+
+`[a, b, c]` (MIR `ArrayLit { ty, elements }`, where `ty` is `List<T>`)
+lowers to:
+
+1. Evaluate every element operand into a register and widen each to an
+   eight-byte slot value.
+2. `raven_list_new(8, 8, len, gc_ptrs)` to allocate the list, where
+   `gc_ptrs` is the element type's GC-pointer flag.
+3. For each element, write the widened value into a one-slot scratch
+   stack slot and call `raven_list_push(list, scratch_addr)`, which
+   copies the eight bytes into the list (growing the buffer when needed).
+
+The result is the list pointer.
+
+#### `IndexAccess`
+
+`xs[i]` (MIR `IndexAccess { base, index }`) lowers to:
+
+1. Load the element count with `raven_list_len(list)` and the buffer base
+   with `raven_list_elements(list)`.
+2. Bounds-check the index: an unsigned `i < len` compare. On the
+   out-of-bounds path, call `raven_panic("list index out of bounds")`
+   (which writes the message to stderr and exits 101) and `trap`; the
+   in-bounds path continues.
+3. Load the eight-byte slot at `base + i * 8`. The loaded value is
+   pointer-width and is narrowed to the destination local's machine type
+   on store (a `Float` or narrow scalar element is reinterpreted there).
+
+#### List methods
+
+The built-in `List<T>` methods are recognized during MIR lowering and
+routed to a `ListMethod { op, receiver, arg, elem_ty }` rvalue (rather
+than to an unresolved per-type method symbol), so codegen has the element
+type at hand. The mapping to runtime calls:
+
+| Method | Lowering |
+|--------|----------|
+| `len(self) -> Int` | `raven_list_len`, zero-extended to `Int`. |
+| `is_empty(self) -> Bool` | `raven_list_len` compared `== 0`. |
+| `push(self, x)` | Widen `x` to an eight-byte slot, spill it, call `raven_list_push`. `List` is a heap object, so the push mutates the shared object through the pointer and every alias observes the new element; the list pointer itself is unchanged across a buffer grow. |
+| `pop(self) -> T` | `raven_list_pop(list, out)` copies the last element into a scratch slot and shrinks the list, returning a success flag; a zero flag (empty list) calls `raven_panic` and traps, otherwise the scratch slot is loaded as the result. |
+| `get(self, i) -> T` | `raven_list_get(list, i, out)` copies the element at `i` into a scratch slot, returning a success flag; a zero flag (out of range) calls `raven_panic` and traps, otherwise the scratch slot is loaded as the result. |
+
+`pop` and `get` return the element type `T` directly (the type checker's
+built-in `List` signatures), so an empty `pop` or an out-of-range `get`
+panics rather than returning a sentinel, matching the index bounds check.
+
+#### GC
+
+A `List` local is a GC pointer rooted in the function's shadow-stack
+frame like any other GC local, so a collection during list building still
+sees the list rooted. Because the list object roots its own elements
+through `elements_are_gc_ptrs`, a pushed GC-pointer element stays
+reachable for as long as it is in the list, and a popped element is no
+longer traced once `len` drops below its slot.
+
 ## GC root frames
 
 The collector finds its roots through a shadow stack the back end
@@ -478,8 +559,11 @@ that only consult MIR lowering do not depend on a linker.
   section above.
 * `defer` ordering and runtime hooks (issue #68).
 * String interpolation (issue #69) and C FFI (issue #70).
-* Rich stdlib collection methods (`push`, `get`, and so on) beyond
-  constructing values (issues #71 onwards).
+* ~~`List<T>` literals, indexing, and the built-in methods (`len`,
+  `is_empty`, `push`, `pop`, `get`).~~ Implemented: see the Lists section
+  above.
+* `Map` and `Set` literals and methods, and richer iterator pipelines
+  built on the collections (issues #71 onwards).
 * Cross platform installer packaging (issue #92).
 
 ## Test coverage
@@ -494,8 +578,12 @@ that only consult MIR lowering do not depend on a linker.
   prints `7`), `option_sum.rv` (Option construction and matching, prints
   `104`), `closure_value.rv` (a non-capturing closure allocation, prints
   `42`), `closure_capture.rv` (a returned closure capturing a local by
-  value, prints `15` then `42`), and `closure_arg.rv` (a capturing closure
-  passed as an argument and invoked indirectly, prints `21`). Each gates
+  value, prints `15` then `42`), `closure_arg.rv` (a capturing closure
+  passed as an argument and invoked indirectly, prints `21`),
+  `list_ops.rv` (list literals, indexing, `len`, and `push` over `Int`
+  elements, prints `3`, `20`, `4`, `40`), and `list_strings.rv` (a list
+  of heap `String` elements exercising the GC-pointer element path,
+  prints `raven`, `bird`, `3`). Each gates
   on linker and runtime staticlib presence and
   emits an `eprintln!` plus a successful exit only when one is missing;
   on a correctly configured host it links and runs the program for real.

--- a/examples/v2/list_ops.rv
+++ b/examples/v2/list_ops.rv
@@ -1,0 +1,10 @@
+// List literals, indexing, and the built-in List methods end to end.
+// Compiling and running this prints 3, 20, 4, 40 on their own lines.
+fun main() {
+    let xs = [10, 20, 30]
+    print_int(xs.len())   // 3
+    print_int(xs[1])      // 20
+    xs.push(40)
+    print_int(xs.len())   // 4
+    print_int(xs[3])      // 40
+}

--- a/examples/v2/list_strings.rv
+++ b/examples/v2/list_strings.rv
@@ -1,0 +1,11 @@
+// A list whose elements are heap String values, exercising the
+// GC-pointer element path: the list traces each element pointer, so the
+// strings stay reachable through the list across allocations. Compiling
+// and running this prints raven, then bird, then 3.
+fun main() {
+    let words = ["raven", "crow"]
+    words.push("bird")
+    print(words[0])       // raven
+    print(words[2])       // bird
+    print_int(words.len()) // 3
+}

--- a/raven-runtime/src/object/list.rs
+++ b/raven-runtime/src/object/list.rs
@@ -144,6 +144,70 @@ pub extern "C" fn raven_list_push(l: *mut List, payload: *const u8) {
     }
 }
 
+/// Remove and return the last element of the list.
+///
+/// Copies `element_size` bytes from the slot at index `header.len - 1`
+/// into `out`, then decrements `header.len`. The freed slot keeps its
+/// bytes; the collector only traces the first `len` slots, so a removed
+/// GC pointer is no longer reachable through the list once `len` drops.
+///
+/// Returns `1` on success and `0` when the list is empty (in which case
+/// `out` is not written). Also returns `0` when `l` or `out` is null.
+#[no_mangle]
+pub extern "C" fn raven_list_pop(l: *mut List, out: *mut u8) -> u32 {
+    if l.is_null() || out.is_null() {
+        return 0;
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    let (len, elem_size) = unsafe { ((*l).header.len, (*l).element_size) };
+    if len == 0 {
+        return 0;
+    }
+    let new_len = len - 1;
+    if elem_size == 0 {
+        // Zero-sized elements never copy; just drop the count.
+        // SAFETY: bumping a counter on a live header.
+        unsafe { (*l).header.len = new_len };
+        return 1;
+    }
+    // SAFETY: the slot at `new_len` holds `elem_size` initialised bytes.
+    unsafe {
+        let src = (*l).elements.add((new_len as usize) * (elem_size as usize));
+        ptr::copy_nonoverlapping(src, out, elem_size as usize);
+        (*l).header.len = new_len;
+    }
+    1
+}
+
+/// Read the element at `index` into `out` without removing it.
+///
+/// Copies `element_size` bytes from the slot at `index` into `out`.
+/// Returns `1` on success and `0` when `index` is out of range
+/// (`index >= header.len`), in which case `out` is not written. Also
+/// returns `0` when `l` or `out` is null.
+#[no_mangle]
+pub extern "C" fn raven_list_get(l: *const List, index: u32, out: *mut u8) -> u32 {
+    if l.is_null() || out.is_null() {
+        return 0;
+    }
+    // SAFETY: caller passes a pointer obtained from a constructor.
+    let (len, elem_size) = unsafe { ((*l).header.len, (*l).element_size) };
+    if index >= len {
+        return 0;
+    }
+    if elem_size == 0 {
+        // Zero-sized elements have nothing to copy; the index is valid.
+        return 1;
+    }
+    // SAFETY: `index < len`, so the slot holds `elem_size` initialised
+    // bytes.
+    unsafe {
+        let src = (*l).elements.add((index as usize) * (elem_size as usize));
+        ptr::copy_nonoverlapping(src, out, elem_size as usize);
+    }
+    1
+}
+
 /// Size of the in-memory `List` object.
 pub(crate) const fn size_of_list() -> usize {
     std::mem::size_of::<List>()
@@ -345,11 +409,68 @@ mod tests {
     }
 
     #[test]
+    fn pop_returns_last_and_shrinks() {
+        let l = raven_list_new(8, 8, 0, 0);
+        for v in [10u64, 20, 30] {
+            raven_list_push(l, &v as *const u64 as *const u8);
+        }
+        let mut out: u64 = 0;
+        // Pop returns 30, then 20, then 10, shrinking each time.
+        assert_eq!(raven_list_pop(l, &mut out as *mut u64 as *mut u8), 1);
+        assert_eq!(out, 30);
+        assert_eq!(raven_list_len(l), 2);
+        assert_eq!(raven_list_pop(l, &mut out as *mut u64 as *mut u8), 1);
+        assert_eq!(out, 20);
+        assert_eq!(raven_list_pop(l, &mut out as *mut u64 as *mut u8), 1);
+        assert_eq!(out, 10);
+        assert_eq!(raven_list_len(l), 0);
+        // A pop on the empty list reports failure and leaves `out` alone.
+        out = 999;
+        assert_eq!(raven_list_pop(l, &mut out as *mut u64 as *mut u8), 0);
+        assert_eq!(out, 999);
+        unsafe { drop_list_for_test(l) };
+    }
+
+    #[test]
+    fn get_reads_in_range_only() {
+        let l = raven_list_new(8, 8, 0, 0);
+        for v in [7u64, 8, 9] {
+            raven_list_push(l, &v as *const u64 as *const u8);
+        }
+        let mut out: u64 = 0;
+        assert_eq!(raven_list_get(l, 0, &mut out as *mut u64 as *mut u8), 1);
+        assert_eq!(out, 7);
+        assert_eq!(raven_list_get(l, 2, &mut out as *mut u64 as *mut u8), 1);
+        assert_eq!(out, 9);
+        // Get does not remove: length is unchanged.
+        assert_eq!(raven_list_len(l), 3);
+        // Out-of-range index reports failure and leaves `out` alone.
+        out = 555;
+        assert_eq!(raven_list_get(l, 3, &mut out as *mut u64 as *mut u8), 0);
+        assert_eq!(out, 555);
+        unsafe { drop_list_for_test(l) };
+    }
+
+    #[test]
     fn null_accessors_are_safe() {
         assert_eq!(raven_list_len(std::ptr::null()), 0);
         assert!(raven_list_elements(std::ptr::null()).is_null());
         // Null inputs must not crash.
         raven_list_push(std::ptr::null_mut(), std::ptr::null());
+        let mut out: u64 = 0;
+        assert_eq!(
+            raven_list_pop(std::ptr::null_mut(), &mut out as *mut u64 as *mut u8),
+            0
+        );
+        assert_eq!(
+            raven_list_get(std::ptr::null(), 0, &mut out as *mut u64 as *mut u8),
+            0
+        );
+        // A null out pointer with a live list is also a no-op failure.
+        let l = raven_list_new(8, 8, 0, 0);
+        assert_eq!(raven_list_pop(l, std::ptr::null_mut()), 0);
+        assert_eq!(raven_list_get(l, 0, std::ptr::null_mut()), 0);
+        unsafe { drop_list_for_test(l) };
     }
 
     /// Test-only deallocator: unregister the object from the collector

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -311,6 +311,35 @@ impl ModuleCx {
         sig = self.make_sig(&[], &[]);
         self.declare_runtime(intrinsics::RUNTIME_GC_LEAVE_FRAME, &sig)?;
 
+        // raven_list_new(element_size: u32, element_align: u32, cap: u32,
+        //                elements_are_gc_ptrs: u32) -> List ptr
+        sig = self.make_sig(&[i32t, i32t, i32t, i32t], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_LIST_NEW, &sig)?;
+
+        // raven_list_len(List ptr) -> u32
+        sig = self.make_sig(&[ptr], &[i32t]);
+        self.declare_runtime(intrinsics::RUNTIME_LIST_LEN, &sig)?;
+
+        // raven_list_elements(List ptr) -> byte ptr
+        sig = self.make_sig(&[ptr], &[ptr]);
+        self.declare_runtime(intrinsics::RUNTIME_LIST_ELEMENTS, &sig)?;
+
+        // raven_list_push(List ptr, payload ptr)
+        sig = self.make_sig(&[ptr, ptr], &[]);
+        self.declare_runtime(intrinsics::RUNTIME_LIST_PUSH, &sig)?;
+
+        // raven_list_pop(List ptr, out ptr) -> u32
+        sig = self.make_sig(&[ptr, ptr], &[i32t]);
+        self.declare_runtime(intrinsics::RUNTIME_LIST_POP, &sig)?;
+
+        // raven_list_get(List ptr, index: u32, out ptr) -> u32
+        sig = self.make_sig(&[ptr, i32t, ptr], &[i32t]);
+        self.declare_runtime(intrinsics::RUNTIME_LIST_GET, &sig)?;
+
+        // raven_panic(msg ptr, len: usize) -> ! (no Cranelift return)
+        sig = self.make_sig(&[ptr, ptr], &[]);
+        self.declare_runtime(intrinsics::RUNTIME_PANIC, &sig)?;
+
         // raven_closure_new(fn_ptr, size: u32, align: u32, count: u32,
         //                   ptr_count: u32) -> ptr
         sig = self.make_sig(&[ptr, i32t, i32t, i32t, i32t], &[ptr]);

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -16,8 +16,8 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::Module;
 
 use crate::mir::{
-    MirBinOp, MirBlock, MirBlockId, MirConstant, MirFfiTy, MirFnRef, MirFunction, MirLocal,
-    MirOperand, MirRvalue, MirStatement, MirTerminator, MirType, MirUnOp,
+    ListMethodOp, MirBinOp, MirBlock, MirBlockId, MirConstant, MirFfiTy, MirFnRef, MirFunction,
+    MirLocal, MirOperand, MirRvalue, MirStatement, MirTerminator, MirType, MirUnOp,
 };
 
 use super::context::ModuleCx;
@@ -355,32 +355,16 @@ fn lower_rvalue(
             param_tys,
             ret_ty,
         } => lower_virtual_call(cx, builder, receiver, *slot, args, param_tys, ret_ty, slots),
-        MirRvalue::IndexAccess { .. } | MirRvalue::ArrayLit { .. } => {
-            Err(CodegenError::Unsupported(format!(
-                "rvalue not supported in MVP backend: {:?}",
-                rvalue_kind(rvalue)
-            )))
+        MirRvalue::ArrayLit { ty, elements } => lower_array_lit(cx, builder, ty, elements, slots),
+        MirRvalue::IndexAccess { base, index } => {
+            lower_index_access(cx, builder, base, index, slots)
         }
-    }
-}
-
-fn rvalue_kind(r: &MirRvalue) -> &'static str {
-    match r {
-        MirRvalue::Use(_) => "Use",
-        MirRvalue::BinaryOp(..) => "BinaryOp",
-        MirRvalue::UnaryOp(..) => "UnaryOp",
-        MirRvalue::Call { .. } => "Call",
-        MirRvalue::StructCreate { .. } => "StructCreate",
-        MirRvalue::EnumCreate { .. } => "EnumCreate",
-        MirRvalue::FieldAccess { .. } => "FieldAccess",
-        MirRvalue::IndexAccess { .. } => "IndexAccess",
-        MirRvalue::ArrayLit { .. } => "ArrayLit",
-        MirRvalue::Cast { .. } => "Cast",
-        MirRvalue::ClosureCreate { .. } => "ClosureCreate",
-        MirRvalue::EnvLoad { .. } => "EnvLoad",
-        MirRvalue::ClosureCall { .. } => "ClosureCall",
-        MirRvalue::DynCoerce { .. } => "DynCoerce",
-        MirRvalue::VirtualCall { .. } => "VirtualCall",
+        MirRvalue::ListMethod {
+            op,
+            receiver,
+            arg,
+            elem_ty,
+        } => lower_list_method(cx, builder, *op, receiver, arg.as_ref(), elem_ty, slots),
     }
 }
 
@@ -741,6 +725,336 @@ fn lower_field_access(
         .ins()
         .load(ptr, MemFlags::new(), fields, layout::slot_offset(index));
     Ok(Some(raw))
+}
+
+/// Width in bytes of one `List` element slot. Every element, scalar or GC
+/// pointer, occupies one pointer-width slot, the same uniform width
+/// struct and enum fields use. Scalars narrower than a pointer are
+/// widened on store and narrowed on load; a GC pointer is already this
+/// wide. Keeping a single slot width means indexing is a plain
+/// `base + i * ELEMENT_SLOT` and the collector's element tracing walks
+/// pointer-sized slots. See `docs/v2/specs/object-layout.md`.
+const ELEMENT_SLOT: i64 = 8;
+
+/// Lower a `List<T>` literal `[a, b, c]`.
+///
+/// Allocates a `List` sized for the element count, then appends each
+/// evaluated element through `raven_list_push`. The element slot is a
+/// uniform eight bytes (`element_size == element_align == ELEMENT_SLOT`);
+/// `elements_are_gc_ptrs` is set from the static element type so the
+/// collector traces pointer elements and treats scalar buffers as opaque
+/// bytes. Each element value is widened to a pointer-width slot, spilled
+/// to a one-slot scratch buffer, and the buffer's address is handed to
+/// `raven_list_push`, which copies the eight bytes into the list.
+fn lower_array_lit(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    ty: &MirType,
+    elements: &[MirOperand],
+    slots: &[LocalSlot],
+) -> Result<RValue, CodegenError> {
+    let ptr = cx.pointer_type();
+    let elem_ty = match ty {
+        MirType::List(inner) => inner.as_ref(),
+        // The front end only ever types an array literal as `List<T>`; a
+        // mismatch is a lowering bug, so fall back to a scalar element so
+        // the build stays well formed.
+        _ => &MirType::Int,
+    };
+    let gc_ptrs = layout::is_gc_pointer(elem_ty);
+
+    // Evaluate every element before the allocation so their values are in
+    // registers; each operand is a copy of an already-rooted local or a
+    // constant. The list is built right after, and each push copies the
+    // spilled value in, so no element pointer is left dangling across a
+    // collection the allocation may trigger.
+    let mut elem_vals = Vec::with_capacity(elements.len());
+    for e in elements {
+        let v = lower_operand(cx, builder, e, slots)?;
+        elem_vals.push(widen_to_slot(builder, v, ptr));
+    }
+
+    let list = call_list_new(cx, builder, elements.len() as i64, gc_ptrs);
+
+    // One reusable scratch slot the size of a single element; each push
+    // writes the next value into it and passes its address.
+    let scratch = builder.create_sized_stack_slot(StackSlotData::new(
+        StackSlotKind::ExplicitSlot,
+        ELEMENT_SLOT as u32,
+    ));
+    let scratch_addr = builder.ins().stack_addr(ptr, scratch, 0);
+    let push_id = cx
+        .runtime_id(intrinsics::RUNTIME_LIST_PUSH)
+        .expect("list push declared at module init");
+    for v in elem_vals {
+        builder.ins().stack_store(v, scratch, 0);
+        let push_ref = cx.module().declare_func_in_func(push_id, builder.func);
+        builder.ins().call(push_ref, &[list, scratch_addr]);
+    }
+    Ok(Some(list))
+}
+
+/// Lower `xs[i]`.
+///
+/// Loads the element buffer base and the length from the list, bounds
+/// checks `i` (an out-of-range index calls `raven_panic`), then loads the
+/// eight-byte element slot at `base + i * ELEMENT_SLOT`. The result is a
+/// pointer-width value; `store_local` narrows it to the destination
+/// local's machine type (a `Float` or narrow scalar element is
+/// reinterpreted there).
+fn lower_index_access(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    base: &MirOperand,
+    index: &MirOperand,
+    slots: &[LocalSlot],
+) -> Result<RValue, CodegenError> {
+    let ptr = cx.pointer_type();
+    let list = require_value(lower_operand(cx, builder, base, slots)?, "index base")?;
+    let idx = require_value(lower_operand(cx, builder, index, slots)?, "index value")?;
+    // The index is a native `Int` (i64); take it to pointer width for the
+    // address arithmetic and the unsigned bounds compare.
+    let idx = to_pointer_width(builder, idx, ptr);
+
+    let len = call_list_len(cx, builder, list, ptr);
+    emit_bounds_check(cx, builder, idx, len, "list index out of bounds");
+
+    let elements = call_list_elements(cx, builder, list);
+    let slot_size = builder.ins().iconst(ptr, ELEMENT_SLOT);
+    let offset = builder.ins().imul(idx, slot_size);
+    let addr = builder.ins().iadd(elements, offset);
+    let raw = builder.ins().load(ptr, MemFlags::new(), addr, 0);
+    Ok(Some(raw))
+}
+
+/// Lower a built-in `List<T>` method to its runtime call.
+///
+/// `len`/`is_empty` read the count; `push` appends through the shared
+/// heap object (mutating it in place, so every alias observes the new
+/// element); `pop`/`get` copy an element into a scratch slot and panic
+/// when the list is empty or the index is out of range, matching the
+/// element-returning method signatures the type checker assigns.
+fn lower_list_method(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    op: ListMethodOp,
+    receiver: &MirOperand,
+    arg: Option<&MirOperand>,
+    _elem_ty: &MirType,
+    slots: &[LocalSlot],
+) -> Result<RValue, CodegenError> {
+    let ptr = cx.pointer_type();
+    let list = require_value(
+        lower_operand(cx, builder, receiver, slots)?,
+        "list receiver",
+    )?;
+    match op {
+        ListMethodOp::Len => {
+            // `raven_list_len` returns a u32; `call_list_len` already
+            // widens it to pointer width, and `to_int64` reconciles it
+            // with the native `Int` (i64) the destination local expects.
+            let raw = call_list_len(cx, builder, list, ptr);
+            Ok(Some(to_int64(builder, raw)))
+        }
+        ListMethodOp::IsEmpty => {
+            let len = call_list_len(cx, builder, list, ptr);
+            let zero = builder.ins().iconst(ptr, 0);
+            // The result is a `Bool` (i8) in the value model.
+            let cmp = builder.ins().icmp(IntCC::Equal, len, zero);
+            Ok(Some(cmp))
+        }
+        ListMethodOp::Push => {
+            let value = require_value(
+                lower_operand(cx, builder, arg.expect("push has one argument"), slots)?,
+                "list push value",
+            )?;
+            let value = widen_to_slot(builder, Some(value), ptr);
+            let scratch = builder.create_sized_stack_slot(StackSlotData::new(
+                StackSlotKind::ExplicitSlot,
+                ELEMENT_SLOT as u32,
+            ));
+            builder.ins().stack_store(value, scratch, 0);
+            let scratch_addr = builder.ins().stack_addr(ptr, scratch, 0);
+            let push_id = cx
+                .runtime_id(intrinsics::RUNTIME_LIST_PUSH)
+                .expect("list push declared at module init");
+            let push_ref = cx.module().declare_func_in_func(push_id, builder.func);
+            builder.ins().call(push_ref, &[list, scratch_addr]);
+            Ok(None)
+        }
+        ListMethodOp::Pop => {
+            let scratch = builder.create_sized_stack_slot(StackSlotData::new(
+                StackSlotKind::ExplicitSlot,
+                ELEMENT_SLOT as u32,
+            ));
+            let scratch_addr = builder.ins().stack_addr(ptr, scratch, 0);
+            let pop_id = cx
+                .runtime_id(intrinsics::RUNTIME_LIST_POP)
+                .expect("list pop declared at module init");
+            let pop_ref = cx.module().declare_func_in_func(pop_id, builder.func);
+            let inst = builder.ins().call(pop_ref, &[list, scratch_addr]);
+            let ok = builder.inst_results(inst)[0];
+            emit_status_check(cx, builder, ok, "pop from empty list");
+            let raw = builder.ins().stack_load(ptr, scratch, 0);
+            Ok(Some(raw))
+        }
+        ListMethodOp::Get => {
+            let idx = require_value(
+                lower_operand(cx, builder, arg.expect("get has one argument"), slots)?,
+                "list get index",
+            )?;
+            // `raven_list_get` takes a u32 index; reduce the native Int.
+            let idx32 = narrow_to_u32(builder, idx);
+            let scratch = builder.create_sized_stack_slot(StackSlotData::new(
+                StackSlotKind::ExplicitSlot,
+                ELEMENT_SLOT as u32,
+            ));
+            let scratch_addr = builder.ins().stack_addr(ptr, scratch, 0);
+            let get_id = cx
+                .runtime_id(intrinsics::RUNTIME_LIST_GET)
+                .expect("list get declared at module init");
+            let get_ref = cx.module().declare_func_in_func(get_id, builder.func);
+            let inst = builder.ins().call(get_ref, &[list, idx32, scratch_addr]);
+            let ok = builder.inst_results(inst)[0];
+            emit_status_check(cx, builder, ok, "list index out of bounds");
+            let raw = builder.ins().stack_load(ptr, scratch, 0);
+            Ok(Some(raw))
+        }
+    }
+}
+
+/// Emit `raven_list_new(ELEMENT_SLOT, ELEMENT_SLOT, cap, gc_ptrs) ->
+/// List` and return the list pointer.
+fn call_list_new(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    cap: i64,
+    gc_ptrs: bool,
+) -> Value {
+    let new_id = cx
+        .runtime_id(intrinsics::RUNTIME_LIST_NEW)
+        .expect("list new declared at module init");
+    let new_ref = cx.module().declare_func_in_func(new_id, builder.func);
+    let size = builder.ins().iconst(types::I32, ELEMENT_SLOT);
+    let align = builder.ins().iconst(types::I32, ELEMENT_SLOT);
+    let cap = builder.ins().iconst(types::I32, cap);
+    let flag = builder
+        .ins()
+        .iconst(types::I32, if gc_ptrs { 1 } else { 0 });
+    let inst = builder.ins().call(new_ref, &[size, align, cap, flag]);
+    builder.inst_results(inst)[0]
+}
+
+/// Emit `raven_list_len(list) -> u32` and return the count zero-extended
+/// to pointer width for address arithmetic and comparisons.
+fn call_list_len(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    list: Value,
+    ptr: CType,
+) -> Value {
+    let len_id = cx
+        .runtime_id(intrinsics::RUNTIME_LIST_LEN)
+        .expect("list len declared at module init");
+    let len_ref = cx.module().declare_func_in_func(len_id, builder.func);
+    let inst = builder.ins().call(len_ref, &[list]);
+    let len_u32 = builder.inst_results(inst)[0];
+    builder.ins().uextend(ptr, len_u32)
+}
+
+/// Emit `raven_list_elements(list) -> ptr` and return the buffer base.
+fn call_list_elements(cx: &mut ModuleCx, builder: &mut FunctionBuilder<'_>, list: Value) -> Value {
+    let id = cx
+        .runtime_id(intrinsics::RUNTIME_LIST_ELEMENTS)
+        .expect("list elements declared at module init");
+    let fref = cx.module().declare_func_in_func(id, builder.func);
+    let inst = builder.ins().call(fref, &[list]);
+    builder.inst_results(inst)[0]
+}
+
+/// Branch on an unsigned `index < len` check, calling `raven_panic` with
+/// `message` on the out-of-bounds path and continuing otherwise.
+fn emit_bounds_check(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    index: Value,
+    len: Value,
+    message: &str,
+) {
+    let in_bounds = builder.ins().icmp(IntCC::UnsignedLessThan, index, len);
+    emit_status_check(cx, builder, in_bounds, message);
+}
+
+/// Branch on a nonzero `ok` flag, calling `raven_panic` with `message`
+/// when it is zero and continuing on the success path. Used both by the
+/// index bounds check and by the `pop`/`get` runtime status results.
+fn emit_status_check(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    ok: Value,
+    message: &str,
+) {
+    let panic_block = builder.create_block();
+    let continue_block = builder.create_block();
+    builder
+        .ins()
+        .brif(ok, continue_block, &[], panic_block, &[]);
+
+    // The panic path: write the message bytes and terminate. The block is
+    // sealed immediately since it has the single predecessor above.
+    builder.switch_to_block(panic_block);
+    builder.seal_block(panic_block);
+    emit_panic(cx, builder, message);
+    builder
+        .ins()
+        .trap(cranelift_codegen::ir::TrapCode::UnreachableCodeReached);
+
+    builder.switch_to_block(continue_block);
+    builder.seal_block(continue_block);
+}
+
+/// Emit a `raven_panic(msg_ptr, msg_len)` call for a static message.
+fn emit_panic(cx: &mut ModuleCx, builder: &mut FunctionBuilder<'_>, message: &str) {
+    let ptr = cx.pointer_type();
+    let bytes = message.as_bytes();
+    let id = cx
+        .intern_string(bytes)
+        .expect("panic message interns as static bytes");
+    let local_id = cx.module().declare_data_in_func(id, builder.func);
+    let msg_ptr = builder.ins().symbol_value(ptr, local_id);
+    let msg_len = builder.ins().iconst(ptr, bytes.len() as i64);
+    let panic_id = cx
+        .runtime_id(intrinsics::RUNTIME_PANIC)
+        .expect("panic declared at module init");
+    let panic_ref = cx.module().declare_func_in_func(panic_id, builder.func);
+    builder.ins().call(panic_ref, &[msg_ptr, msg_len]);
+}
+
+/// Widen or pass through an integer value to i64 (a native `Int`).
+fn to_int64(builder: &mut FunctionBuilder<'_>, v: Value) -> Value {
+    let got = builder.func.dfg.value_type(v);
+    if got == types::I64 {
+        v
+    } else if got.is_int() && got.bytes() < types::I64.bytes() {
+        builder.ins().uextend(types::I64, v)
+    } else {
+        v
+    }
+}
+
+/// Reduce a native `Int` (i64) value to a u32 for a runtime ABI that
+/// takes a `u32` index. A value already i32-wide passes through.
+fn narrow_to_u32(builder: &mut FunctionBuilder<'_>, v: Value) -> Value {
+    let got = builder.func.dfg.value_type(v);
+    if got == types::I32 {
+        v
+    } else if got.is_int() && got.bytes() > types::I32.bytes() {
+        builder.ins().ireduce(types::I32, v)
+    } else if got.is_int() {
+        builder.ins().uextend(types::I32, v)
+    } else {
+        v
+    }
 }
 
 /// Width in bytes of one capture slot in the closure env. Every capture,

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -115,6 +115,35 @@ pub const RUNTIME_GC_ENTER_FRAME: &str = "raven_gc_enter_frame";
 /// Runtime C symbol leaving the most recent GC root frame.
 pub const RUNTIME_GC_LEAVE_FRAME: &str = "raven_gc_leave_frame";
 
+/// Runtime C symbols backing `List<T>` literals, indexing, and methods.
+///
+/// A list value is a single GC pointer to a heap `List` object. Codegen
+/// stores every element in a uniform eight-byte slot (`element_size ==
+/// element_align == 8`), the same slot width struct and enum fields use,
+/// and sets `elements_are_gc_ptrs` from the static element type so the
+/// collector traces pointer elements and leaves scalar buffers opaque.
+/// See `docs/v2/specs/codegen.md` and `docs/v2/specs/object-layout.md`.
+///
+/// `raven_list_new(element_size, element_align, cap, gc_ptrs) -> List`.
+pub const RUNTIME_LIST_NEW: &str = "raven_list_new";
+/// `raven_list_len(List) -> u32` returns the element count.
+pub const RUNTIME_LIST_LEN: &str = "raven_list_len";
+/// `raven_list_elements(List) -> ptr` returns the element buffer base.
+pub const RUNTIME_LIST_ELEMENTS: &str = "raven_list_elements";
+/// `raven_list_push(List, payload_ptr)` appends one eight-byte slot.
+pub const RUNTIME_LIST_PUSH: &str = "raven_list_push";
+/// `raven_list_pop(List, out_ptr) -> u32` removes the last element into
+/// `out_ptr`, returning `1` on success and `0` when the list is empty.
+pub const RUNTIME_LIST_POP: &str = "raven_list_pop";
+/// `raven_list_get(List, index, out_ptr) -> u32` reads the element at
+/// `index` into `out_ptr`, returning `1` on success and `0` when the
+/// index is out of range.
+pub const RUNTIME_LIST_GET: &str = "raven_list_get";
+
+/// Runtime C symbol reporting a fatal panic and terminating the process.
+/// Used by the out-of-bounds index check.
+pub const RUNTIME_PANIC: &str = "raven_panic";
+
 /// Runtime C symbol allocating a closure object.
 pub const RUNTIME_CLOSURE_NEW: &str = "raven_closure_new";
 

--- a/src/mir/ir.rs
+++ b/src/mir/ir.rs
@@ -50,6 +50,26 @@ pub enum MirUnOp {
     Ref,
 }
 
+/// A built-in method on `List<T>`. The front end resolves these against
+/// the receiver type rather than a user `impl`, so the lowering routes
+/// them to a [`MirRvalue::ListMethod`] carrying the element type the
+/// back end needs to size slots and pick the GC-pointer flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ListMethodOp {
+    /// `len(self) -> Int`: the element count.
+    Len,
+    /// `is_empty(self) -> Bool`: `len == 0`.
+    IsEmpty,
+    /// `push(self, x)`: append `x`, mutating the shared heap object.
+    Push,
+    /// `pop(self) -> T`: remove and return the last element. Panics when
+    /// the list is empty.
+    Pop,
+    /// `get(self, i) -> T`: read the element at `i`. Panics when `i` is
+    /// out of range.
+    Get,
+}
+
 /// A compile-time constant.
 #[derive(Debug, Clone, PartialEq)]
 pub enum MirConstant {
@@ -121,6 +141,18 @@ pub enum MirRvalue {
     ArrayLit {
         ty: MirType,
         elements: Vec<MirOperand>,
+    },
+    /// A built-in `List<T>` method call. The receiver is the list value;
+    /// `arg` carries the single extra operand for `push` (the pushed
+    /// value) and `get` (the index), and is `None` for `len`, `is_empty`,
+    /// and `pop`. `elem_ty` is the element type `T`, which the back end
+    /// uses to size element slots uniformly and to decide whether the
+    /// elements are GC pointers.
+    ListMethod {
+        op: ListMethodOp,
+        receiver: MirOperand,
+        arg: Option<MirOperand>,
+        elem_ty: MirType,
     },
     Cast {
         operand: MirOperand,

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -9,8 +9,8 @@
 use crate::hir::expr::{HirBinaryOp, HirBlock, HirExpr, HirExprKind, HirUnaryOp, InterpolPart};
 
 use super::super::ir::{
-    MirBinOp, MirBlockId, MirConstant, MirFnRef, MirLocal, MirOperand, MirRvalue, MirStatement,
-    MirTerminator, MirUnOp,
+    ListMethodOp, MirBinOp, MirBlockId, MirConstant, MirFnRef, MirLocal, MirOperand, MirRvalue,
+    MirStatement, MirTerminator, MirUnOp,
 };
 use super::super::ty::MirType;
 use super::{mir_ty, stmt, LoopFrame, LowerCx};
@@ -797,6 +797,31 @@ fn lower_method_call(
         return MirOperand::Copy(dst);
     }
 
+    // A built-in `List<T>` method has no user `impl`; route it to a
+    // dedicated rvalue carrying the element type so the back end can size
+    // slots and pick the GC-pointer flag. Any user `impl` on a list type
+    // would have been resolved away before reaching the built-in set, so
+    // recognizing the fixed method names here is safe.
+    if let MirType::List(elem) = &recv_ty {
+        if let Some(op) = list_method_op(name) {
+            let elem_ty = (**elem).clone();
+            let recv = lower_expr(cx, receiver);
+            let arg = args.first().map(|a| lower_expr(cx, a));
+            let dst = cx.builder.fresh_temp("lmethod", ty);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::ListMethod {
+                    op,
+                    receiver: recv,
+                    arg,
+                    elem_ty,
+                },
+            );
+            return MirOperand::Copy(dst);
+        }
+    }
+
     // Static dispatch: build the per-type method symbol from the receiver
     // type so it matches the impl method's definition symbol.
     let symbol = recv_ty.method_symbol(name);
@@ -866,6 +891,20 @@ fn map_binary(op: HirBinaryOp) -> MirBinOp {
         HirBinaryOp::Shl => MirBinOp::Shl,
         HirBinaryOp::Shr => MirBinOp::Shr,
     }
+}
+
+/// Map a built-in `List<T>` method name to its [`ListMethodOp`], or
+/// `None` when the name is not one of the recognized list methods. The
+/// set mirrors `tycheck::builtin::list_methods`.
+fn list_method_op(name: &str) -> Option<ListMethodOp> {
+    Some(match name {
+        "len" => ListMethodOp::Len,
+        "is_empty" => ListMethodOp::IsEmpty,
+        "push" => ListMethodOp::Push,
+        "pop" => ListMethodOp::Pop,
+        "get" => ListMethodOp::Get,
+        _ => return None,
+    })
 }
 
 fn map_unary(op: HirUnaryOp) -> MirUnOp {

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -20,8 +20,9 @@ pub mod ty;
 mod tests;
 
 pub use ir::{
-    MirBinOp, MirBlock, MirBlockId, MirConstant, MirExternFn, MirFnRef, MirFunction, MirLocal,
-    MirLocalDecl, MirOperand, MirProgram, MirRvalue, MirStatement, MirTerminator, MirUnOp,
+    ListMethodOp, MirBinOp, MirBlock, MirBlockId, MirConstant, MirExternFn, MirFnRef, MirFunction,
+    MirLocal, MirLocalDecl, MirOperand, MirProgram, MirRvalue, MirStatement, MirTerminator,
+    MirUnOp,
 };
 pub use pretty::pretty_program;
 pub use ty::{MirFfiTy, MirType};

--- a/src/mir/pretty.rs
+++ b/src/mir/pretty.rs
@@ -187,6 +187,27 @@ fn pretty_rvalue(buf: &mut String, r: &MirRvalue) {
             }
             buf.push(')');
         }
+        MirRvalue::ListMethod {
+            op,
+            receiver,
+            arg,
+            elem_ty,
+        } => {
+            let name = match op {
+                crate::mir::ir::ListMethodOp::Len => "len",
+                crate::mir::ir::ListMethodOp::IsEmpty => "is_empty",
+                crate::mir::ir::ListMethodOp::Push => "push",
+                crate::mir::ir::ListMethodOp::Pop => "pop",
+                crate::mir::ir::ListMethodOp::Get => "get",
+            };
+            write!(buf, "(list.{} {} ", name, elem_ty).unwrap();
+            pretty_operand(buf, receiver);
+            if let Some(a) = arg {
+                buf.push(' ');
+                pretty_operand(buf, a);
+            }
+            buf.push(')');
+        }
         MirRvalue::Cast { operand, target } => {
             buf.push_str("(cast ");
             pretty_operand(buf, operand);

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -235,6 +235,31 @@ fn core_trait_prelude_program_compiles_and_runs() {
     compile_link_run_and_check("trait_tostring.rv", "42\ntrue\n(3, 4)\n", &runtime);
 }
 
+#[test]
+fn list_int_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // List literals, indexing, and the built-in methods over scalar
+    // elements: `[10, 20, 30]` is allocated, `len` reads 3, `xs[1]` reads
+    // 20, `push(40)` mutates the shared heap object, then `len` reads 4
+    // and `xs[3]` reads the appended 40.
+    compile_link_run_and_check("list_ops.rv", "3\n20\n4\n40\n", &runtime);
+}
+
+#[test]
+fn list_string_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A list of heap String values, exercising the GC-pointer element
+    // path: each element slot holds a traced pointer the collector
+    // follows, so the strings stay reachable through the list. Pushing
+    // "bird" then indexing words[0] and words[2] prints raven and bird,
+    // and `len` reads 3.
+    compile_link_run_and_check("list_strings.rv", "raven\nbird\n3\n", &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
## Summary

Lower `List<T>` literals, indexing, and the built-in List methods (`len`, `is_empty`, `push`, `pop`, `get`) in the Cranelift back end, the first of the backend gaps that were blocking the iterator pipeline and the collections module.

Closes #138. See the new List section in `docs/v2/specs/codegen.md` and the layout contract in `docs/v2/specs/object-layout.md`.

## Observed output

`examples/v2/list_ops.rv`, compiled with `raven build` and run on Windows x86_64-pc-windows-msvc:

```
3
20
4
40
```

`examples/v2/list_strings.rv` (the GC-pointer element path):

```
raven
bird
3
```

An out-of-bounds index panics and exits 101:

```
raven panic: list index out of bounds
```

## Element representation and the GC-pointer flag

A list value is a single GC pointer to a heap `List` object. Codegen stores every element in a uniform eight-byte slot, the same slot width struct and enum fields use, so `element_size == element_align == 8` for all element types. Scalars narrower than eight bytes are widened on store and narrowed on load; a GC pointer is already eight bytes. `elements_are_gc_ptrs` is set from the static element type (nonzero for `String`, `List`, struct, enum, closure, `dyn`, and the other heap kinds; zero for `Int`, `Float`, `Bool`, `Char`). The flag is independent of the slot size, so an eight-byte `Int` slot is not traced while an eight-byte `String` slot is. The runtime's existing `TAG_LIST` tracing arm reads the flag and traces the first `len` pointer slots when set.

## ArrayLit and IndexAccess lowering

`[a, b, c]` evaluates and widens each element, allocates with `raven_list_new(8, 8, len, gc_ptrs)`, then appends each element through a one-slot scratch buffer and `raven_list_push`.

`xs[i]` loads the length with `raven_list_len` and the buffer base with `raven_list_elements`, bounds-checks the index with an unsigned `i < len` compare (calling `raven_panic("list index out of bounds")` and trapping on the failure path), then loads the eight-byte slot at `base + i * 8`. The loaded value is narrowed to the destination local's machine type on store.

## Method mapping

The built-in List methods are recognized during MIR lowering and routed to a `ListMethod` rvalue carrying the element type, so codegen sizes slots and picks the GC-pointer flag without parsing mangled symbols.

| Method | Runtime |
|--------|---------|
| `len(self) -> Int` | `raven_list_len`, zero-extended |
| `is_empty(self) -> Bool` | `raven_list_len == 0` |
| `push(self, x)` | `raven_list_push` (mutates the shared heap object in place) |
| `pop(self) -> T` | `raven_list_pop` into a scratch slot, panic when empty |
| `get(self, i) -> T` | `raven_list_get` into a scratch slot, panic when out of range |

`pop` and `get` return the element type `T` directly (the type checker's built-in signatures), so an empty `pop` or an out-of-range `get` panics rather than returning a sentinel, consistent with the index bounds check.

## Push mutation through the heap object

`push` is a heap mutation through the list pointer. A buffer grow reallocates only the internal elements buffer; the `List` object pointer itself is unchanged, so the rooted local still points at the same object and every alias observes the new element. This is why `xs.push(40)` followed by `xs.len()` reads 4.

## GC handling

A list local is a GC pointer rooted in the function's shadow-stack frame like any other GC local, so a collection during list building still sees the list rooted. The list object roots its own elements through `elements_are_gc_ptrs`, so a pushed GC-pointer element stays reachable while in the list and a popped element is no longer traced once `len` drops.

## Runtime additions

Added `raven_list_pop` and `raven_list_get` to `raven-runtime/src/object/list.rs`, each copying an element into a caller buffer and returning a success flag (zero on empty or out of range), with inline tests for the success, empty, out-of-range, and null cases. `raven_list_new`, `raven_list_len`, `raven_list_elements`, and `raven_list_push` already existed.

## Deferrals

`Map` and `Set` literals and methods, and richer iterator pipelines built on the collections, remain out of scope here (tracked separately). String indexing (`Ty::Str`) is not lowered; only `List` indexing is.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (283 lib, 20 codegen smoke including the two new list cases, golden suites)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `examples/v2/list_ops.rv` compiled, linked, and run: prints 3, 20, 4, 40
- [x] `examples/v2/list_strings.rv` compiled, linked, and run: prints raven, bird, 3
- [x] Out-of-bounds index panics with a clear message and exits 101
- [x] `raven-runtime` list unit tests pass (pop, get, push, grow, null safety)
