### PR TITLE
feat(hir): for-loops over ranges and lists

### DIFF
--- a/docs/v2/specs/hir.md
+++ b/docs/v2/specs/hir.md
@@ -43,7 +43,7 @@ translation pass that buys nothing for the desugarings in scope.
 
 | AST node                          | HIR equivalent                                          |
 |-----------------------------------|---------------------------------------------------------|
-| `ExprKind::For { pat, iter, body }` | Lowered to `Loop` containing a `Match` on iterator `next` |
+| `ExprKind::For { pat, iter, body }` | Lowered to a counter `Loop` over a range, or an index `Loop` over a `List<T>` |
 | `ExprKind::Try(inner)`            | Lowered to `Match` on `Ok/Err` (or `Some/None`)         |
 | `ExprKind::InterpolatedString(fragments)` | `Interpolate { parts: Vec<InterpolPart> }`      |
 | `ExprKind::Range { ... }`         | `RangeNew { start, end, inclusive }`                    |
@@ -61,28 +61,74 @@ source range.
 
 ### `for x in iter` loops
 
+The type checker accepts `for` only over a `List<T>` value or an integer
+range (which it shapes as `List<Int>`). HIR lowers each of these two
+built-in iterable forms directly to a concrete counter loop, so no
+iterator object, `RangeNew`, or `IterNext` reaches MIR or codegen.
+
+A range loop over `start..end` (exclusive) or `start..=end` (inclusive)
+lowers to a counter over the integer interval. The endpoints are each
+evaluated once into a local:
+
 ```
-for pat in iter { body }
+for x in start..end { body }
 ```
 
-becomes a `loop` over an iterator handle:
+becomes:
 
 ```
-let __iter = IterNew(iter);
+let __end = end;
+let __i = start;
+let __first = true;
 loop {
-    match IterNext(__iter) {
-        Some(pat) => body,
-        None      => break,
-    }
+    if __first { __first = false } else { __i = __i + 1 }
+    if __i >= __end { break }   // `>` for the inclusive form
+    let x = __i;
+    body
 }
 ```
 
-`IterNew` and `IterNext` are HIR built-ins. The type checker already
-accepts `for` only over `List<T>`. For `List<T>` they map to a hidden
-index counter; for `Range`/`RangeInclusive` (which the type checker
-currently shapes as `List<Int>`) they map to integer increments. User
-defined iterators are a follow up: a future PR adds the `Iterator`
-trait and threads it through the lowering.
+A list loop over a `List<T>` value lowers to an index loop. The list
+expression is evaluated once into a local, and the per-iteration binding
+reads `__list[__i]` using the built-in list length and indexing:
+
+```
+for x in list { body }
+```
+
+becomes:
+
+```
+let __list = list;
+let __end = __list.len();
+let __i = 0;
+let __first = true;
+loop {
+    if __first { __first = false } else { __i = __i + 1 }
+    if __i >= __end { break }
+    let x = __list[__i];
+    body
+}
+```
+
+The increment sits at the top of the loop body, guarded by a `__first`
+flag that skips it on the first pass so the counter starts at the lower
+bound. This placement is what makes `break` and `continue` behave: a
+user `break` exits to the loop continuation as usual, and a user
+`continue` re-enters the loop header, which is the increment-and-test
+step, so it always advances the counter before the next iteration rather
+than skipping it (which would loop forever). The body is the trailing
+statement of the loop, after the binding.
+
+Only a plain binding pattern (`for x in ...`) is bound by name. Richer
+destructuring patterns are type-checked upstream and reuse the same
+`let pat = element` machinery; a future change can expand them in place.
+
+Iteration over any other type is rejected by the type checker with a
+clear diagnostic before lowering runs, so no codegen-time failure is
+possible. User-defined iterators (`for x in <any Iterator>`) are out of
+scope here and are generalized by the `Iterator` trait work in issue
+#119, which will thread a trait-based protocol through this lowering.
 
 ### `?` operator
 
@@ -126,8 +172,12 @@ a..b       becomes RangeNew { start: a, end: b, inclusive: false }
 a..=b      becomes RangeNew { start: a, end: b, inclusive: true  }
 ```
 
-`Range` is treated as a built-in iterable in HIR. Its element type is
-`Int` (the type checker enforces integer bounds).
+A bare range expression (one not in the `iter` position of a `for`)
+lowers to `RangeNew`. Its element type is `Int` (the type checker
+enforces integer bounds). A range used directly as a `for` loop's
+iterable never produces a `RangeNew`: the for-loop lowering reads the
+range endpoints straight off the AST and emits the counter loop above,
+so `RangeNew` carries no iteration responsibility.
 
 ### Compound assignment
 
@@ -212,8 +262,9 @@ the result type; the surface form does not appear at HIR level.
 
 ## Out of scope
 
-* User-defined `Iterator` trait protocol. Built-in iteration over
-  `List<T>` and ranges only.
+* User-defined `Iterator` trait protocol (issue #119). Built-in
+  iteration over `List<T>` and integer ranges only, lowered to concrete
+  counter and index loops.
 * Closure capture analysis (defer to MIR).
 * C FFI lowering.
 * `dyn Trait` virtual dispatch.

--- a/examples/v2/for_loops.rv
+++ b/examples/v2/for_loops.rv
@@ -1,0 +1,33 @@
+// For loops over ranges and lists, lowered to counter and index loops.
+// Compiling and running this prints 10, 15, then 7 on their own lines.
+fun main() {
+    // Range loop: sum 0 + 1 + 2 + 3 + 4 = 10.
+    let sum = 0
+    for x in 0..5 {
+        sum = sum + x
+    }
+    print_int(sum)            // 10
+
+    // List loop: sum the three elements 3 + 5 + 7 = 15.
+    let xs = [3, 5, 7]
+    let total = 0
+    for v in xs {
+        total = total + v
+    }
+    print_int(total)          // 15
+
+    // break and continue: continue still advances the counter. Over
+    // 0..10 we skip i == 5 with continue and stop at i == 8 with break,
+    // so we count 0, 1, 2, 3, 4, 6, 7 = 7 iterations.
+    let count = 0
+    for i in 0..10 {
+        if i == 5 {
+            continue
+        }
+        if i == 8 {
+            break
+        }
+        count = count + 1
+    }
+    print_int(count)          // 7
+}

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -505,19 +505,45 @@ fn ctor_pat(name: &str, elements: Vec<HirPattern>, span: Span) -> HirPattern {
     }
 }
 
-/// Lower a `for pat in iter { body }` into:
+/// Lower a `for pat in iter { body }` into a concrete counter loop.
+///
+/// Two iterable forms are supported here without any iterator object:
+///
+/// * A range `start..end` (exclusive) or `start..=end` (inclusive) is
+///   lowered to a counter loop over the half-open or closed integer
+///   interval. The endpoints are each evaluated once into a local.
+/// * A `List<T>` value is lowered to an index loop driven by the list's
+///   `len()` and element indexing (issue #138). The list expression is
+///   evaluated once into a local.
+///
+/// Both forms produce the same shape:
 ///
 /// ```text
 /// {
-///     let __iter = IterNew(iter);
+///     let __start = <start>;          // range: start; list: 0
+///     let __end = <end>;              // range: end;   list: __list.len()
+///     let __i = __start;
+///     let __first = true;
 ///     loop {
-///         match IterNext(__iter) {
-///             Some(pat) => body,
-///             None => break,
-///         }
+///         // The increment sits at the top of the loop body so that a
+///         // user `continue` (which jumps to the loop header) still
+///         // advances the counter before the next iteration. The
+///         // `__first` flag skips the increment on the very first pass so
+///         // the counter starts at `__start`.
+///         if __first { __first = false } else { __i = __i + 1 }
+///         if __i >= __end { break }   // `>` for an inclusive range
+///         let pat = __i;              // range: __i; list: __list[__i]
+///         <body>
 ///     }
 /// }
 /// ```
+///
+/// `break` exits to the loop continuation as usual, and `continue`
+/// re-enters the loop header, which is the increment-and-test step, so
+/// it never skips the counter advance. Iteration over any type other
+/// than a range or a `List<T>` is rejected by the type checker before
+/// lowering, so the arbitrary-iterator path (the `Iterator` trait, issue
+/// #119) does not reach here.
 fn lower_for(
     pat: &crate::ast::Pattern,
     iter: &Expr,
@@ -526,82 +552,255 @@ fn lower_for(
     span: &Span,
     cx: &LowerCtx<'_>,
 ) -> Result<HirExpr, RavenError> {
-    let iter_expr = lower_expr(iter, &Ty::Error, cx)?;
-    let element_ty = match &iter_expr.ty {
+    // A `start..end` / `start..=end` source range lowers to a counter
+    // loop directly from its endpoints; any other iterable is treated as
+    // a list value driven by `len()` and indexing.
+    if let ExprKind::Range {
+        start,
+        end,
+        inclusive,
+    } = &iter.kind
+    {
+        let start_lowered = lower_expr(start, &Ty::Int, cx)?;
+        let end_lowered = lower_expr(end, &Ty::Int, cx)?;
+        return Ok(lower_counter_for(
+            pat,
+            start_lowered,
+            end_lowered,
+            *inclusive,
+            None,
+            Ty::Int,
+            body,
+            span,
+            cx,
+        ));
+    }
+
+    let list_expr = lower_expr(iter, &Ty::Error, cx)?;
+    let element_ty = match list_expr.ty.strip_self() {
         Ty::List(t) => (**t).clone(),
         _ => Ty::Error,
     };
-    let body_block = lower_block_to_block(body, &Ty::Unit, cx)?;
-    let iter_name = cx.fresh("iter");
-    let iter_ty = iter_expr.ty.clone();
-    let iter_let = let_stmt(
-        &iter_name,
-        iter_ty.clone(),
+    let list_ty = list_expr.ty.clone();
+    let list_name = cx.fresh("list");
+    let list_let = let_stmt(&list_name, list_ty.clone(), list_expr, span.clone());
+
+    // start = 0, end = __list.len(), element = __list[__i].
+    let start_lowered = make_expr(HirExprKind::Int(0), Ty::Int, span.clone());
+    let len_recv = ident_expr(&list_name, list_ty, span.clone());
+    let end_lowered = make_expr(
+        HirExprKind::MethodCall {
+            receiver: Box::new(len_recv),
+            name: "len".into(),
+            args: Vec::new(),
+        },
+        Ty::Int,
+        span.clone(),
+    );
+    let counter_loop = lower_counter_for(
+        pat,
+        start_lowered,
+        end_lowered,
+        false,
+        Some(&list_name),
+        element_ty,
+        body,
+        span,
+        cx,
+    );
+    let block = HirBlock {
+        stmts: vec![list_let],
+        tail: Some(Box::new(counter_loop)),
+        ty: Ty::Unit,
+        span: span.clone(),
+    };
+    Ok(make_expr(HirExprKind::Block(block), Ty::Unit, span.clone()))
+}
+
+/// Build the counter-loop body shared by the range and list for-loop
+/// forms. `start`/`end` are the already-lowered bounds, `inclusive`
+/// selects `>` over `>=` for the break test, and `list_name` (when
+/// `Some`) makes the per-iteration binding `__list[__i]` instead of the
+/// raw counter `__i`. `element_ty` is the loop variable's type.
+#[allow(clippy::too_many_arguments)]
+fn lower_counter_for(
+    pat: &crate::ast::Pattern,
+    start: HirExpr,
+    end: HirExpr,
+    inclusive: bool,
+    list_name: Option<&str>,
+    element_ty: Ty,
+    body: &AstBlock,
+    span: &Span,
+    cx: &LowerCtx<'_>,
+) -> HirExpr {
+    let i_name = cx.fresh("i");
+    let end_name = cx.fresh("end");
+    let first_name = cx.fresh("first");
+
+    let end_let = let_stmt(&end_name, Ty::Int, end, span.clone());
+    let i_let = let_stmt(&i_name, Ty::Int, start, span.clone());
+    let first_let = let_stmt(
+        &first_name,
+        Ty::Bool,
+        make_expr(HirExprKind::Bool(true), Ty::Bool, span.clone()),
+        span.clone(),
+    );
+
+    // if __first { __first = false } else { __i = __i + 1 }
+    let set_first_false = assign_stmt(
+        HirAssignTarget::Ident {
+            name: first_name.clone(),
+            span: span.clone(),
+        },
+        make_expr(HirExprKind::Bool(false), Ty::Bool, span.clone()),
+        span.clone(),
+    );
+    let inc = assign_stmt(
+        HirAssignTarget::Ident {
+            name: i_name.clone(),
+            span: span.clone(),
+        },
         make_expr(
-            HirExprKind::IterNew(Box::new(iter_expr)),
-            iter_ty.clone(),
+            HirExprKind::Binary {
+                op: HirBinaryOp::Add,
+                lhs: Box::new(ident_expr(&i_name, Ty::Int, span.clone())),
+                rhs: Box::new(make_expr(HirExprKind::Int(1), Ty::Int, span.clone())),
+            },
+            Ty::Int,
             span.clone(),
         ),
         span.clone(),
     );
-    let iter_ref = ident_expr(&iter_name, iter_ty.clone(), span.clone());
-    let next_expr = make_expr(
-        HirExprKind::IterNext(Box::new(iter_ref)),
-        Ty::Option(Box::new(element_ty.clone())),
-        span.clone(),
-    );
-
-    let some_pat = HirPattern {
-        kind: HirPatternKind::Constructor {
-            name: Some("Some".to_string()),
-            elements: vec![lower_pattern(pat, cx)?],
-        },
-        span: span.clone(),
-    };
-    let none_pat = HirPattern {
-        kind: HirPatternKind::Constructor {
-            name: Some("None".to_string()),
-            elements: Vec::new(),
-        },
-        span: span.clone(),
-    };
-    let some_arm = HirArm {
-        pattern: some_pat,
-        guard: None,
-        body: make_expr(HirExprKind::Block(body_block), Ty::Unit, span.clone()),
-        span: span.clone(),
-    };
-    let none_arm = HirArm {
-        pattern: none_pat,
-        guard: None,
-        body: make_expr(HirExprKind::Break(None), Ty::Error, span.clone()),
-        span: span.clone(),
-    };
-    let match_expr = make_expr(
-        HirExprKind::Match {
-            scrutinee: Box::new(next_expr),
-            arms: vec![some_arm, none_arm],
+    let advance = make_expr(
+        HirExprKind::If {
+            cond: Box::new(ident_expr(&first_name, Ty::Bool, span.clone())),
+            then_block: block_of_stmt(set_first_false, span),
+            else_block: Some(block_of_stmt(inc, span)),
         },
         Ty::Unit,
         span.clone(),
     );
+
+    // if __i >= __end { break }   (or `>` for an inclusive range)
+    let break_op = if inclusive {
+        HirBinaryOp::Gt
+    } else {
+        HirBinaryOp::Ge
+    };
+    let break_cond = make_expr(
+        HirExprKind::Binary {
+            op: break_op,
+            lhs: Box::new(ident_expr(&i_name, Ty::Int, span.clone())),
+            rhs: Box::new(ident_expr(&end_name, Ty::Int, span.clone())),
+        },
+        Ty::Bool,
+        span.clone(),
+    );
+    let break_stmt = HirStmt {
+        kind: HirStmtKind::Expr(make_expr(HirExprKind::Break(None), Ty::Error, span.clone())),
+        span: span.clone(),
+    };
+    let break_guard = make_expr(
+        HirExprKind::If {
+            cond: Box::new(break_cond),
+            then_block: HirBlock {
+                stmts: vec![break_stmt],
+                tail: None,
+                ty: Ty::Unit,
+                span: span.clone(),
+            },
+            else_block: None,
+        },
+        Ty::Unit,
+        span.clone(),
+    );
+
+    // The per-iteration element: `__list[__i]` for a list, else `__i`.
+    let element_init = match list_name {
+        Some(name) => make_expr(
+            HirExprKind::Index {
+                receiver: Box::new(ident_expr(
+                    name,
+                    Ty::List(Box::new(element_ty.clone())),
+                    span.clone(),
+                )),
+                index: Box::new(ident_expr(&i_name, Ty::Int, span.clone())),
+            },
+            element_ty.clone(),
+            span.clone(),
+        ),
+        None => ident_expr(&i_name, element_ty.clone(), span.clone()),
+    };
+
+    // The pattern binding is the loop variable. The basic `for x in ...`
+    // form binds a single name; richer destructuring patterns are
+    // type-checked but reuse the same `let pat = element` machinery, so
+    // a simple binding pattern lowers to a plain `let`.
+    let bind_name = pattern_binding_name(pat).unwrap_or_else(|| cx.fresh("loopvar"));
+    let bind_let = let_stmt(&bind_name, element_ty, element_init, span.clone());
+
+    // The user body becomes the trailing statements of the loop body.
+    let body_block = lower_block_to_block(body, &Ty::Unit, cx).unwrap_or_else(|_| HirBlock {
+        stmts: Vec::new(),
+        tail: None,
+        ty: Ty::Unit,
+        span: span.clone(),
+    });
+    let body_expr = make_expr(HirExprKind::Block(body_block), Ty::Unit, span.clone());
+
     let loop_block = HirBlock {
-        stmts: vec![HirStmt {
-            kind: HirStmtKind::Expr(match_expr),
-            span: span.clone(),
-        }],
+        stmts: vec![
+            HirStmt {
+                kind: HirStmtKind::Expr(advance),
+                span: span.clone(),
+            },
+            HirStmt {
+                kind: HirStmtKind::Expr(break_guard),
+                span: span.clone(),
+            },
+            bind_let,
+            HirStmt {
+                kind: HirStmtKind::Expr(body_expr),
+                span: span.clone(),
+            },
+        ],
         tail: None,
         ty: Ty::Unit,
         span: span.clone(),
     };
     let loop_expr = make_expr(HirExprKind::Loop(loop_block), Ty::Unit, span.clone());
+
     let block = HirBlock {
-        stmts: vec![iter_let],
+        stmts: vec![end_let, i_let, first_let],
         tail: Some(Box::new(loop_expr)),
         ty: Ty::Unit,
         span: span.clone(),
     };
-    Ok(make_expr(HirExprKind::Block(block), Ty::Unit, span.clone()))
+    make_expr(HirExprKind::Block(block), Ty::Unit, span.clone())
+}
+
+/// Wrap a single statement in a block whose value is `Unit`. Used for the
+/// `if`/`else` arms of the for-loop counter advance.
+fn block_of_stmt(stmt: HirStmt, span: &Span) -> HirBlock {
+    HirBlock {
+        stmts: vec![stmt],
+        tail: None,
+        ty: Ty::Unit,
+        span: span.clone(),
+    }
+}
+
+/// Extract the single binding name from a `for` loop pattern, when the
+/// pattern is a plain binding (`for x in ...`). Returns `None` for
+/// wildcard or richer patterns so the caller can synthesize a fresh
+/// loop-variable name instead.
+fn pattern_binding_name(pat: &crate::ast::Pattern) -> Option<String> {
+    use crate::ast::PatternKind;
+    match &pat.kind {
+        PatternKind::Ident(name) => Some(name.clone()),
+        _ => None,
+    }
 }
 
 /// Lower a compound assignment `target op= value` into a flat

--- a/src/hir/tests.rs
+++ b/src/hir/tests.rs
@@ -81,30 +81,129 @@ fn range_lowers_to_range_new() {
 }
 
 #[test]
-fn for_lowers_to_loop_with_match() {
-    let p = lower("fun f() -> () { for x in [1, 2, 3] { } }");
+fn for_over_list_lowers_to_index_loop() {
+    // `for v in xs` lowers to a block that binds the list once, then a
+    // counter loop that drives the index from 0 to `xs.len()` and binds
+    // each element by indexing. No iterator object is produced.
+    let p = lower("fun f() -> () { for v in [1, 2, 3] { } }");
     let f = only_fn(&p, "f");
     let body = f.body.as_ref().expect("body");
-    // After lowering, the body holds a block containing the desugared
-    // for loop. The for can show up either as a statement-expression
-    // or as the trailing tail; tolerate both.
-    let target = if !body.stmts.is_empty() {
-        match &body.stmts[0].kind {
-            HirStmtKind::Expr(e) => e.clone(),
-            other => panic!("expected expr stmt, got {:?}", other),
-        }
-    } else {
-        let tail = body.tail.as_ref().expect("either stmt or tail");
-        (**tail).clone()
-    };
-    match &target.kind {
+    let desugared = first_for_block(body);
+    // The desugared form binds the list (`let __list = ...`) and tails
+    // into the counter-loop block.
+    match &desugared.kind {
         HirExprKind::Block(inner) => {
-            assert!(matches!(inner.stmts[0].kind, HirStmtKind::Let { .. }));
-            let tail = inner.tail.as_ref().expect("tail loop");
-            assert!(matches!(tail.kind, HirExprKind::Loop(_)));
+            assert!(
+                matches!(inner.stmts[0].kind, HirStmtKind::Let { .. }),
+                "list value is bound once before the loop"
+            );
+            let tail = inner.tail.as_ref().expect("counter-loop block tail");
+            assert_counter_loop(tail);
         }
         other => panic!("expected block after for desugaring, got {:?}", other),
     }
+    // The lowering must no longer mint any iterator/range intrinsic.
+    assert!(!hir_uses_iterator_intrinsics(&p));
+}
+
+#[test]
+fn for_over_range_lowers_to_counter_loop() {
+    // `for x in 0..3` lowers straight to a counter loop over the integer
+    // interval, with no range object and no iterator intrinsic.
+    let p = lower("fun f() -> () { for x in 0..3 { } }");
+    let f = only_fn(&p, "f");
+    let body = f.body.as_ref().expect("body");
+    let desugared = first_for_block(body);
+    assert_counter_loop(desugared);
+    assert!(!hir_uses_iterator_intrinsics(&p));
+}
+
+/// Pull the desugared `for` expression out of a function body. The `for`
+/// shows up either as a statement-expression or as the trailing tail.
+fn first_for_block(body: &crate::hir::expr::HirBlock) -> &crate::hir::expr::HirExpr {
+    if let Some(stmt) = body
+        .stmts
+        .iter()
+        .find(|s| matches!(s.kind, HirStmtKind::Expr(_)))
+    {
+        match &stmt.kind {
+            HirStmtKind::Expr(e) => return e,
+            _ => unreachable!(),
+        }
+    }
+    body.tail.as_ref().expect("for as stmt or tail")
+}
+
+/// Assert the given expression is a counter-loop block: a block whose
+/// tail is a `Loop` whose body's first statement is the increment-and-
+/// guard `if` (the advance step a `continue` re-enters).
+fn assert_counter_loop(expr: &crate::hir::expr::HirExpr) {
+    let HirExprKind::Block(block) = &expr.kind else {
+        panic!("expected counter-loop block, got {:?}", expr.kind);
+    };
+    let tail = block.tail.as_ref().expect("loop tail");
+    let HirExprKind::Loop(loop_body) = &tail.kind else {
+        panic!("expected Loop tail, got {:?}", tail.kind);
+    };
+    // The first loop-body statement is the `if __first { ... } else { __i
+    // = __i + 1 }` advance, so a `continue` (which re-enters the loop
+    // header) always runs the increment before the next iteration.
+    match &loop_body.stmts[0].kind {
+        HirStmtKind::Expr(e) => assert!(
+            matches!(e.kind, HirExprKind::If { .. }),
+            "loop body starts with the advance-step `if`"
+        ),
+        other => panic!("expected advance `if` first, got {:?}", other),
+    }
+}
+
+/// True when any HIR expression in the program is one of the iterator or
+/// range intrinsics that the for-loop lowering must no longer emit.
+fn hir_uses_iterator_intrinsics(p: &HirProgram) -> bool {
+    fn block_uses(b: &crate::hir::expr::HirBlock) -> bool {
+        b.stmts.iter().any(|s| stmt_uses(&s.kind))
+            || b.tail.as_ref().is_some_and(|e| expr_uses(&e.kind))
+    }
+    fn stmt_uses(s: &HirStmtKind) -> bool {
+        match s {
+            HirStmtKind::Let { init, .. } => expr_uses(&init.kind),
+            HirStmtKind::Expr(e) => expr_uses(&e.kind),
+            HirStmtKind::Assign { value, .. } => expr_uses(&value.kind),
+            HirStmtKind::Defer(e) => expr_uses(&e.kind),
+        }
+    }
+    fn expr_uses(k: &HirExprKind) -> bool {
+        match k {
+            HirExprKind::IterNew(_) | HirExprKind::IterNext(_) | HirExprKind::RangeNew { .. } => {
+                true
+            }
+            HirExprKind::Block(b) => block_uses(b),
+            HirExprKind::Loop(b) => block_uses(b),
+            HirExprKind::While { cond, body } => expr_uses(&cond.kind) || block_uses(body),
+            HirExprKind::If {
+                cond,
+                then_block,
+                else_block,
+            } => {
+                expr_uses(&cond.kind)
+                    || block_uses(then_block)
+                    || else_block.as_ref().is_some_and(block_uses)
+            }
+            HirExprKind::Paren(e) => expr_uses(&e.kind),
+            HirExprKind::Binary { lhs, rhs, .. } => expr_uses(&lhs.kind) || expr_uses(&rhs.kind),
+            HirExprKind::Index { receiver, index } => {
+                expr_uses(&receiver.kind) || expr_uses(&index.kind)
+            }
+            HirExprKind::MethodCall { receiver, args, .. } => {
+                expr_uses(&receiver.kind) || args.iter().any(|a| expr_uses(&a.kind))
+            }
+            _ => false,
+        }
+    }
+    p.items.iter().any(|item| match &item.kind {
+        HirItemKind::Function(f) => f.body.as_ref().is_some_and(block_uses),
+        _ => false,
+    })
 }
 
 #[test]

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -261,6 +261,19 @@ fn list_string_program_compiles_and_runs() {
 }
 
 #[test]
+fn for_loop_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // For loops over a range and a list, lowered to counter and index
+    // loops. The range loop sums 0..5 to 10, the list loop sums [3, 5, 7]
+    // to 15, and the third loop exercises break and continue: continue
+    // still advances the counter, so 0..10 minus the i == 5 skip and the
+    // i == 8 break counts 7 iterations. Prints 10, 15, 7.
+    compile_link_run_and_check("for_loops.rv", "10\n15\n7\n", &runtime);
+}
+
+#[test]
 fn mutation_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;

--- a/tests/hir_corpus/for_loop.rv.hir
+++ b/tests/hir_corpus/for_loop.rv.hir
@@ -6,21 +6,66 @@
       )
       (stmt-expr
                 (block ty=()
-          (let "__hir_iter_0" ty=List<Int>
-            (iter-new ty=List<Int>
-              (ident "xs" ty=List<Int>)
-            )
+          (let "__hir_list_0" ty=List<Int>
+            (ident "xs" ty=List<Int>)
           )
           (tail
-            (loop ty=()
-              (body ty=()
-                (stmt-expr
-                  (match ty=()
-                    (iter-next ty=Option<Int>
-                      (ident "__hir_iter_0" ty=List<Int>)
+                        (block ty=()
+              (let "__hir_end_2" ty=Int
+                (method-call "len" ty=Int
+                  (ident "__hir_list_0" ty=List<Int>)
+                )
+              )
+              (let "__hir_i_1" ty=Int
+                (int 0 ty=Int)
+              )
+              (let "__hir_first_3" ty=Bool
+                (bool true ty=Bool)
+              )
+              (tail
+                (loop ty=()
+                  (body ty=()
+                    (stmt-expr
+                      (if ty=()
+                        (ident "__hir_first_3" ty=Bool)
+                        (then ty=()
+                          (assign
+                            (target-ident "__hir_first_3")
+                            (bool false ty=Bool)
+                          )
+                        )
+                        (else ty=()
+                          (assign
+                            (target-ident "__hir_i_1")
+                            (binary + ty=Int
+                              (ident "__hir_i_1" ty=Int)
+                              (int 1 ty=Int)
+                            )
+                          )
+                        )
+                      )
                     )
-                    (arm
-                      (pat Some(x))
+                    (stmt-expr
+                      (if ty=()
+                        (binary >= ty=Bool
+                          (ident "__hir_i_1" ty=Int)
+                          (ident "__hir_end_2" ty=Int)
+                        )
+                        (then ty=()
+                          (stmt-expr
+                            (break ty=<error>
+                            )
+                          )
+                        )
+                      )
+                    )
+                    (let "x" ty=Int
+                      (index ty=Int
+                        (ident "__hir_list_0" ty=List<Int>)
+                        (ident "__hir_i_1" ty=Int)
+                      )
+                    )
+                    (stmt-expr
                                             (block ty=()
                         (assign
                           (target-ident "total")
@@ -29,11 +74,6 @@
                             (ident "x" ty=Int)
                           )
                         )
-                      )
-                    )
-                    (arm
-                      (pat None())
-                      (break ty=<error>
                       )
                     )
                   )


### PR DESCRIPTION
## Summary

`for` loops over integer ranges and `List<T>` values now compile and run by lowering each built-in iterable form to a concrete counter or index loop in HIR, with no iterator object reaching the backend.

Closes #140. See `docs/v2/specs/hir.md` (the `for x in iter` loops section) for the full lowering.

## What changed

- A range loop `for x in start..end` (exclusive) or `start..=end` (inclusive) lowers to a counter over the integer interval, evaluating each endpoint once.
- A list loop `for x in list` lowers to an index loop driven by the list's `len()` and indexing (building on the list codegen from #138), evaluating the list expression once.
- The previously unbacked `__range_new`, `__iter_new`, and `__iter_next` intrinsics no longer reach codegen for these two cases. A bare range expression outside a `for` still lowers to `RangeNew`; a range in `for` position does not.

## break and continue

The counter increment sits at the top of the loop body, guarded by a first-iteration flag so the counter starts at the lower bound:

```
loop {
    if __first { __first = false } else { __i = __i + 1 }
    if __i >= __end { break }
    let x = __i;   // or __list[__i] for a list
    body
}
```

A user `break` exits to the loop continuation as usual. A user `continue` re-enters the loop header, which is the increment-and-test step, so it always advances the counter before the next iteration rather than skipping it (which would loop forever).

## Deferral

Iteration over any type other than a range or `List<T>` is rejected by the type checker with a clear diagnostic before lowering runs (no codegen-time failure). User-defined iterators (`for x in <any Iterator>`) are out of scope here and are generalized by the Iterator-trait work in #119.

## Observed output

Compiling and running `examples/v2/for_loops.rv` on windows-msvc prints:

```
10
15
7
```

The range loop sums `0..5` to 10, the list loop sums `[3, 5, 7]` to 15, and the third loop counts 7 iterations over `0..10` with `i == 5` skipped via `continue` and `i == 8` stopping via `break`.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` green (287 lib, 22 codegen smoke including the new for-loop case, all golden suites)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] Added `examples/v2/for_loops.rv` and an end-to-end smoke case asserting stdout `10`, `15`, `7`
- [x] Refreshed the for-loop HIR golden snapshot and updated lowering unit tests
- [x] Verified a `for` over a non-iterable produces a clear type error, not a crash
