### PR TITLE
feat(mir,codegen): generic struct and method monomorphization

### DIFF
--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -271,6 +271,34 @@ through a pointer, a `self.field = ...` write inside a method mutates the
 object the caller still holds, so the change is observed after the call
 returns.
 
+### Per-instantiation struct descriptors (generic structs)
+
+A generic struct (`struct Box<T> { value: T }`) is monomorphized in MIR
+lowering, which grounds each field type per instantiation (see `mir.md`).
+The back end needs no separate code path: each instantiation arrives as a
+`StructCreate` whose `ty` is a distinct `MirType::Struct` carrying the
+concrete type arguments and whose `field_tys` are the ground field types.
+
+Two consequences follow from the uniform 8-byte slot model:
+
+* The slot layout is identical across instantiations. Every field, scalar
+  or GC pointer, occupies one 8-byte slot, so `Box<Int>` and
+  `Box<String>` have the same field count and the same offsets. No
+  per-instantiation offset table is needed.
+* The GC pointer descriptor differs per instantiation. The descriptor is
+  keyed by the mangled type name (`intern_descriptor(ty.mangle(), mask)`),
+  and a generic struct's instantiations mangle distinctly (`Box_Int`,
+  `Box_Str`). Each interns its own descriptor id with its own pointer
+  mask: `Box_Int` has mask `0` (the `Int` slot is opaque to the
+  collector), while `Box_Str` has bit 0 set (the `String` slot is a traced
+  pointer). The program entry shim registers every interned descriptor, so
+  the collector traces each instantiation's slots correctly.
+
+Because the mangle and mask are derived from the ground field types the
+MIR lowering already produced, the existing `lower_struct_create` path
+handles generic structs without change; monomorphization is what makes the
+field types concrete.
+
 ### Enum construction and dispatch
 
 An enum value reuses the struct value layout. Slot 0 holds the variant

--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -201,10 +201,36 @@ while let Some(item) = worklist.pop():
 return MirProgram { functions: output }
 ```
 
-Generic methods on `impl` blocks are looked up by `(self_type, method_name)`
-in a table built once at the start of the pass; the lookup result is
-the same generic `HirFn`, which the worklist then specializes with the
-caller's concrete type arguments.
+Generic methods on `impl` blocks are looked up by method name in a table
+built once at the start of the pass (`MethodIndex`); each entry carries
+the implementing type as written on the `impl` (which may carry the
+impl's `Ty::Param`s, for example `Box<T>`). At a method call site, the
+declared implementing type is matched against the concrete receiver type
+to build the substitution, and the entry whose substituted implementing
+type equals the receiver is queued for the worklist. The worklist
+specializes the same generic `HirFn` with that substitution.
+
+### Generic structs
+
+A generic struct (`struct Box<T> { value: T }`) is monomorphized at each
+struct-literal use site. The literal's resolved type carries the concrete
+type arguments; matching the struct declaration's generic parameters
+against those arguments builds a per-instantiation substitution that
+grounds every field type. A `Box<Int>` lays out an `Int` slot and a
+`Box<String>` lays out a traced `String` slot. The instantiation is not a
+separate MIR function: the layout and the per-instantiation GC pointer
+descriptor are computed by the back end from the ground field types
+carried on the `MirType::Struct` (see `codegen.md`). Because each
+instantiation's `MirType::Struct` carries distinct concrete arguments, the
+back end mangles each to a distinct descriptor name (`Box_Int`,
+`Box_String`) with the right pointer mask.
+
+A generic method's `self` and other declared types reference the impl's
+generic parameters. The HIR lowering resolves those parameters with the
+impl block as their owner span (matching how the implementing type
+resolves them and how the type checker scopes them), so a method that
+returns the impl's `T` and the impl's `Self<T>` agree on one `ParamId`
+and the call-site substitution grounds both consistently.
 
 ### Caching
 
@@ -232,6 +258,15 @@ swap$Int$String             (swap::<Int, String>)
 Vec_push$Int                (impl Vec<Int>::push)
 ```
 
+A method instantiation is named `<implementing_type_mangle>$<method>`,
+where the implementing type mangle already carries the concrete type
+arguments. A generic method specialized at `Box<Int>` and the call to it
+both name `Box_Int$unwrap`; a `Box<String>` instantiation names
+`Box_Str$unwrap`. Because the implementing type's mangle already
+distinguishes instantiations, a method takes no extra `$<typearg>` suffix.
+The call site recomputes the same name from the concrete receiver type, so
+the definition and the call always agree.
+
 The PR's golden tests pin the exact spelling so future changes are
 visible in diffs.
 
@@ -243,6 +278,13 @@ visible in diffs.
   concrete functions during type checking; `dyn` lowering is issue #66.
 * Async, generators, drop tracking, borrow analysis.
 * Cross-file monomorphization: the v2 pipeline still operates per file.
+* Method-level generic parameters that do not appear in the implementing
+  type (for example `impl Box<Int> { fun map<U>(self, f) -> U }`). The
+  call-site symbol is derived from the receiver type alone, so two
+  instantiations at different `U` would collide on one symbol. Generic
+  parameters that come from the implementing type (`impl<T> Box<T>`) are
+  fully supported because the implementing type's mangle distinguishes
+  them.
 
 ## Test coverage
 

--- a/examples/v2/generic_struct.rv
+++ b/examples/v2/generic_struct.rv
@@ -1,0 +1,30 @@
+// Generic struct monomorphization end to end.
+//
+// `Box<T>` is instantiated at three concrete types: Int and String exercise
+// the per-instantiation struct layout and GC pointer descriptor, and the
+// generic method `unwrap` on `impl<T> Box<T>` is specialized at each call
+// site for the concrete type argument. A concrete `impl Box<Int>` method
+// (`get`) shows the concrete-receiver impl path. Prints 42, 42, 7, raven.
+struct Box<T> {
+    value: T
+}
+
+impl Box<Int> {
+    fun get(self) -> Int = self.value
+}
+
+impl<T> Box<T> {
+    fun unwrap(self) -> T = self.value
+}
+
+fun main() {
+    let b = Box { value: 42 }
+    print_int(b.get())          // 42 (concrete impl Box<Int>)
+    print_int(b.unwrap())       // 42 (generic impl<T> Box<T> at T = Int)
+
+    let n = Box { value: 7 }
+    print_int(n.value)          // 7 (direct field access)
+
+    let s = Box { value: "raven" }
+    print(s.unwrap())           // raven (generic impl<T> Box<T> at T = String)
+}

--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -116,7 +116,7 @@ impl<'a> LowerCtx<'a> {
 fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenError> {
     match &decl.kind {
         DeclKind::Function(f) => {
-            let lowered = lower_function(f, None, &[], cx)?;
+            let lowered = lower_function(f, None, &[], None, cx)?;
             Ok(Some(HirItem {
                 span: decl.span.clone(),
                 kind: HirItemKind::Function(lowered),
@@ -186,7 +186,13 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
             let abstract_self = Ty::Error;
             let mut methods = Vec::with_capacity(t.members.len());
             for m in &t.members {
-                methods.push(lower_function(m, Some(&abstract_self), &t.generics, cx)?);
+                methods.push(lower_function(
+                    m,
+                    Some(&abstract_self),
+                    &t.generics,
+                    Some(&t.span),
+                    cx,
+                )?);
             }
             Ok(Some(HirItem {
                 span: decl.span.clone(),
@@ -206,7 +212,13 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
             };
             let mut methods = Vec::with_capacity(i.items.len());
             for m in &i.items {
-                methods.push(lower_function(m, Some(&self_ty), &i.generics, cx)?);
+                methods.push(lower_function(
+                    m,
+                    Some(&self_ty),
+                    &i.generics,
+                    Some(&i.span),
+                    cx,
+                )?);
             }
             Ok(Some(HirItem {
                 span: decl.span.clone(),
@@ -298,11 +310,21 @@ fn lower_function(
     f: &AstFunction,
     self_ty: Option<&Ty>,
     extra_generics: &[GenericParam],
+    extra_owner: Option<&Span>,
     cx: &LowerCtx<'_>,
 ) -> Result<HirFn, RavenError> {
     let mut sigs = Vec::new();
     if !extra_generics.is_empty() {
-        sigs.extend(collect_generic_params_for_owner(extra_generics, &f.span));
+        // The enclosing impl or trait owns its generic parameters: their
+        // owner is the impl/trait span, not the method span. This must
+        // match how the implementing type (`impl_self_ty`) and the type
+        // checker (`fill_impl`) resolve the same parameters, so a method
+        // that returns the impl's `T` and the impl's `Self<T>` agree on
+        // one `ParamId`. Falling back to the method span would mint a
+        // distinct `T` per method and break monomorphization's
+        // substitution.
+        let owner = extra_owner.unwrap_or(&f.span);
+        sigs.extend(collect_generic_params_for_owner(extra_generics, owner));
     }
     sigs.extend(collect_generic_params_for_owner(&f.generics, &f.span));
     let scope = scope_from_params(&sigs);

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -66,7 +66,7 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
                 .assign(cx.current, dst, MirRvalue::ArrayLit { ty, elements });
             MirOperand::Copy(dst)
         }
-        HirExprKind::StructLit { name, fields } => lower_struct_lit(cx, name, fields, ty),
+        HirExprKind::StructLit { name, fields } => lower_struct_lit(cx, name, fields, &expr.ty, ty),
         HirExprKind::Call { callee, args } => {
             // A callee that is an in-scope local of function type is a
             // closure value: dispatch indirectly through its Closure
@@ -550,19 +550,57 @@ fn enum_ctor_unary(
 /// into the struct's declaration order so the field slot offsets match
 /// what `FieldAccess` reads, and records each field's concrete type so
 /// the back-end can build the GC pointer descriptor.
+///
+/// A generic struct (`struct Box<T> { value: T }`) is instantiated here:
+/// the literal's resolved type carries the concrete type arguments, which
+/// are matched against the struct declaration's own generic parameters to
+/// build a per-instantiation substitution. Each declared field type is
+/// then substituted to a ground type, so a `Box<Int>` lays out an `Int`
+/// slot and a `Box<String>` lays out a traced `String` slot. The
+/// per-instantiation `MirType::Struct` carries the concrete arguments, so
+/// the back end mangles each instantiation to a distinct descriptor with
+/// the right GC pointer mask.
 fn lower_struct_lit(
     cx: &mut LowerCx<'_>,
     name: &str,
     fields: &[(String, HirExpr)],
+    expr_ty: &crate::tycheck::Ty,
     ty: MirType,
 ) -> MirOperand {
-    // Declaration order from the struct table, when available. Generic
-    // structs are out of scope for the MVP, so the source name keys the
-    // single monomorphic declaration directly.
+    // Build the per-instantiation field substitution from the literal's
+    // resolved type. The struct's declared field types carry the struct's
+    // own `Ty::Param`s; matching the declaration's generic parameters
+    // against the concrete type arguments at this site binds each to a
+    // ground type. The literal's type has the enclosing function's
+    // substitution applied first so a caller's own `Ty::Param` is already
+    // ground.
+    let struct_subst = cx.decls.structs.get(name).map(|s| {
+        let mut subst: super::SubstMap = super::SubstMap::new();
+        let params = struct_generic_params(s);
+        if let crate::tycheck::Ty::Struct { args, .. } = super::substitute(expr_ty, cx.subst) {
+            for (p, arg) in params.iter().zip(args.iter()) {
+                subst.insert(p.clone(), arg.clone());
+            }
+        }
+        subst
+    });
+
+    // Declaration order from the struct table, when available. Each field
+    // type is substituted under the per-instantiation struct substitution
+    // (a generic field `T` becomes its concrete type) and then under the
+    // enclosing function's substitution so any remaining parameter is
+    // ground.
     let decl_order: Option<Vec<(String, MirType)>> = cx.decls.structs.get(name).map(|s| {
+        let struct_subst = struct_subst.as_ref();
         s.fields
             .iter()
-            .map(|(fname, fty, _)| (fname.clone(), mir_ty(fty, cx.subst)))
+            .map(|(fname, fty, _)| {
+                let ground = match struct_subst {
+                    Some(sub) => super::substitute(fty, sub),
+                    None => fty.clone(),
+                };
+                (fname.clone(), mir_ty(&ground, cx.subst))
+            })
             .collect()
     });
 
@@ -656,6 +694,51 @@ fn call_ref_from_callee(cx: &mut LowerCx<'_>, callee: &HirExpr, args: &[HirExpr]
     MirFnRef {
         mangled,
         origin: None,
+    }
+}
+
+/// Recover a struct declaration's generic parameters in declaration
+/// order. The HIR struct carries no explicit parameter list, so the
+/// parameters are recovered by scanning the field types for `Ty::Param`
+/// occurrences and ordering them by their declaration index. The order
+/// fixes how the literal's concrete type arguments map onto the
+/// parameters, matching how the type checker built the argument list.
+fn struct_generic_params(s: &crate::hir::HirStruct) -> Vec<crate::tycheck::ty::ParamId> {
+    let mut found: Vec<crate::tycheck::ty::ParamId> = Vec::new();
+    for (_, ty, _) in &s.fields {
+        collect_ty_params(ty, &mut found);
+    }
+    found.sort_by_key(|p| p.index);
+    found.dedup();
+    found
+}
+
+/// Walk a type and push every distinct `Ty::Param` into `out`.
+fn collect_ty_params(t: &crate::tycheck::Ty, out: &mut Vec<crate::tycheck::ty::ParamId>) {
+    use crate::tycheck::Ty;
+    match t {
+        Ty::Param(p) => {
+            if !out.contains(p) {
+                out.push(p.clone());
+            }
+        }
+        Ty::Option(t) | Ty::List(t) | Ty::SelfTy(t) => collect_ty_params(t, out),
+        Ty::Result(a, b) => {
+            collect_ty_params(a, out);
+            collect_ty_params(b, out);
+        }
+        Ty::Struct { args, .. } | Ty::Enum { args, .. } => {
+            for a in args {
+                collect_ty_params(a, out);
+            }
+        }
+        Ty::Function { params, ret } => {
+            for p in params {
+                collect_ty_params(p, out);
+            }
+            collect_ty_params(ret, out);
+        }
+        _ => {}
     }
 }
 
@@ -823,7 +906,13 @@ fn lower_method_call(
     }
 
     // Static dispatch: build the per-type method symbol from the receiver
-    // type so it matches the impl method's definition symbol.
+    // type so it matches the impl method's definition symbol. When the
+    // method is generic (a method on `impl<T> Box<T>`, whose declared
+    // types carry `Ty::Param`), queue its instantiation so the worklist
+    // emits the body specialized for this receiver. The symbol is the same
+    // `<RecvType>$<method>` either way: the worklist recomputes it from the
+    // concrete implementing type, which the receiver type fixes here.
+    queue_generic_method(cx, &receiver.ty, name, args);
     let symbol = recv_ty.method_symbol(name);
     let recv = lower_expr(cx, receiver);
     let mut arg_ops = vec![recv];
@@ -843,6 +932,53 @@ fn lower_method_call(
         },
     );
     MirOperand::Copy(dst)
+}
+
+/// Queue a generic method's instantiation for the monomorphizer.
+///
+/// A method on a generic implementing type (`impl<T> Box<T> { fun
+/// unwrap(self) -> T }`) carries `Ty::Param`s in its declared `self` and
+/// return types, so it must be specialized for each concrete receiver,
+/// the same way a generic free function is specialized at a call site.
+/// The concrete receiver type fixes the implementing type's arguments;
+/// matching the declared implementing type against it (and each declared
+/// parameter type against the concrete argument type) builds the
+/// substitution. The worklist recomputes the symbol from the substituted
+/// implementing type, so no symbol is returned here. A concrete-receiver
+/// method is already a monomorphization root and needs no queuing.
+fn queue_generic_method(
+    cx: &mut LowerCx<'_>,
+    receiver_ty: &crate::tycheck::Ty,
+    name: &str,
+    args: &[HirExpr],
+) {
+    let Some(entries) = cx.decls.methods.get(name).cloned() else {
+        return;
+    };
+    let recv = super::substitute(receiver_ty, cx.subst);
+    let recv = recv.strip_self().clone();
+    // Pick the generic method whose implementing type matches the concrete
+    // receiver. A concrete-receiver method is skipped: it is reached
+    // through its own root. The structural match against the implementing
+    // type both selects the entry and binds the impl's parameters.
+    for entry in entries.iter().filter(|e| e.generic) {
+        let mut subst: super::SubstMap = super::SubstMap::new();
+        match_param(&entry.self_ty, &recv, &mut subst);
+        // Also bind any method-level parameters from the concrete argument
+        // types.
+        for (decl_ty, arg) in entry.params.iter().zip(args.iter()) {
+            let got = super::substitute(&arg.ty, cx.subst);
+            match_param(decl_ty, &got, &mut subst);
+        }
+        // The match must have grounded the implementing type to the
+        // receiver; if it did not (a non-matching impl of the same method
+        // name on another type), skip this entry.
+        let concrete_self = super::substitute(&entry.self_ty, &subst);
+        if MirType::from_ty(&concrete_self) == MirType::from_ty(&recv) {
+            cx.pending_calls.push((entry.decl, subst));
+            return;
+        }
+    }
 }
 
 /// Resolve a field's slot index from the receiver's struct type and the

--- a/src/mir/lower/mod.rs
+++ b/src/mir/lower/mod.rs
@@ -50,6 +50,37 @@ pub struct FnEntry {
 /// symbol. Built once by the monomorphization driver.
 pub type FnIndex = HashMap<String, FnEntry>;
 
+/// One impl method's shape, consulted at a method call site so a generic
+/// method (a method whose declared types carry `Ty::Param`, for example
+/// `impl<T> Box<T> { fun unwrap(self) -> T }`) is specialized for the
+/// concrete receiver type. A concrete-receiver method (no `Ty::Param`)
+/// is already a monomorphization root, so the call site only queues an
+/// instantiation when the method is generic.
+#[derive(Clone)]
+pub struct MethodEntry {
+    /// The method's monomorphization decl id, matching `collect_roots`.
+    pub decl: DeclId,
+    /// The implementing type as written on the `impl` block. May carry
+    /// the impl's `Ty::Param`s (`Box<T>`); matching it against the
+    /// concrete receiver type binds them.
+    pub self_ty: Ty,
+    /// The method's user parameter types, in order, excluding the leading
+    /// `self`. May carry `Ty::Param`. Matched against the concrete
+    /// argument types to bind any method-level parameters.
+    pub params: Vec<Ty>,
+    /// True when the method's declared types carry any `Ty::Param`, so it
+    /// must be specialized at each call site. A concrete-receiver method
+    /// is `false` and is reached through its own root instead.
+    pub generic: bool,
+}
+
+/// Index of impl methods by method name, consulted at a method call site
+/// to specialize a generic method to its per-receiver symbol. Several
+/// impls may define a method of the same name on different types, so the
+/// call site picks the entry whose `self_ty` matches the concrete
+/// receiver. Built once by the monomorphization driver.
+pub type MethodIndex = HashMap<String, Vec<MethodEntry>>;
+
 /// Declaration tables the expression lowering consults to resolve
 /// struct field offsets and enum variant payloads. Keyed by the source
 /// type name, which is stable through monomorphization for the
@@ -60,6 +91,9 @@ pub struct DeclTables<'a> {
     pub enums: HashMap<String, &'a HirEnum>,
     /// Free-function index used to specialize generic calls.
     pub functions: FnIndex,
+    /// Impl-method index used to specialize generic methods at their call
+    /// sites, the same way `functions` specializes generic free calls.
+    pub methods: MethodIndex,
 }
 
 /// Mapping from a source identifier name to its current MIR local.

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -27,7 +27,9 @@ use crate::tycheck::ty::ParamId;
 use crate::tycheck::Ty;
 
 use super::ir::MirProgram;
-use super::lower::{lower_function, mono_symbol, DeclTables, FnEntry, FnIndex, SubstMap};
+use super::lower::{
+    lower_function, mono_symbol, DeclTables, FnEntry, FnIndex, MethodEntry, MethodIndex, SubstMap,
+};
 
 /// One entry in the monomorphization worklist: a declaration plus the
 /// substitution that specializes its generic parameters.
@@ -47,12 +49,21 @@ type SymbolIndex = HashMap<DeclId, String>;
 /// declaration order. The order fixes the mangled-name suffix.
 type GenericIndex = HashMap<DeclId, Vec<ParamId>>;
 
+/// Map from an impl-method declaration to its implementing type and
+/// method name. The worklist computes a generic method's per-instantiation
+/// symbol by substituting the concrete type arguments into the
+/// implementing type and mangling the result, so the symbol matches what
+/// the method call site recomputes from the concrete receiver type
+/// (`Box_Int$unwrap`, and so on).
+type MethodSymbolIndex = HashMap<DeclId, (Ty, String)>;
+
 /// Run the full monomorphization pass.
 pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
     let mut program = MirProgram::new();
     program.externs = collect_externs(hir);
-    let (index, roots, symbols, generics, fn_index) = collect_roots(hir);
-    let decls = collect_decls(hir, fn_index);
+    let (index, roots, symbols, generics, fn_index, method_index, method_symbols) =
+        collect_roots(hir);
+    let decls = collect_decls(hir, fn_index, method_index);
 
     let mut seen: HashSet<(DeclId, Vec<MangleKey>)> = HashSet::new();
     let mut worklist: Vec<Item> = roots;
@@ -73,11 +84,32 @@ pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
             Some(f) => *f,
             None => continue,
         };
-        let base = symbols
-            .get(&decl)
-            .cloned()
-            .unwrap_or_else(|| hir_fn.name.clone());
-        let mangled = mono_symbol(&base, &generic_params, &subst);
+        // A method's symbol is the concrete implementing type followed by
+        // `$<method>`, computed by substituting the instantiation's type
+        // arguments into the declared implementing type. This matches what
+        // the call site recomputes from the concrete receiver type, so a
+        // generic method specialized at `Box<Int>` and the call to it both
+        // name `Box_Int$unwrap`. A free function uses its base symbol with
+        // the generic-parameter suffix. Because the implementing type
+        // already carries the concrete arguments, a method takes no extra
+        // `mono_symbol` suffix; its instantiations are distinguished by the
+        // implementing type's mangle.
+        let mangled = match method_symbols.get(&decl) {
+            Some((self_ty, method)) => {
+                let concrete_self = super::lower::substitute(self_ty, &subst);
+                super::ty::method_symbol(
+                    &super::ty::MirType::from_ty(&concrete_self).mangle(),
+                    method,
+                )
+            }
+            None => {
+                let base = symbols
+                    .get(&decl)
+                    .cloned()
+                    .unwrap_or_else(|| hir_fn.name.clone());
+                mono_symbol(&base, &generic_params, &subst)
+            }
+        };
         let lowered = lower_function(mangled, hir_fn, &subst, &decls);
         program.functions.push(lowered.func);
         // Lifted closure bodies are already monomorphic standalone
@@ -118,9 +150,10 @@ fn collect_externs(hir: &HirProgram) -> Vec<super::ir::MirExternFn> {
 /// expression lowering can resolve field offsets and variant payloads.
 /// The free-function index built by [`collect_roots`] is folded in so a
 /// generic call can be specialized at its call site.
-fn collect_decls(hir: &HirProgram, functions: FnIndex) -> DeclTables<'_> {
+fn collect_decls(hir: &HirProgram, functions: FnIndex, methods: MethodIndex) -> DeclTables<'_> {
     let mut tables = DeclTables {
         functions,
+        methods,
         ..DeclTables::default()
     };
     for item in &hir.items {
@@ -143,14 +176,25 @@ fn collect_decls(hir: &HirProgram, functions: FnIndex) -> DeclTables<'_> {
 /// end, the per-declaration generic-parameter order, and the by-name
 /// free-function index a call site consults to specialize a generic
 /// call.
+#[allow(clippy::type_complexity)]
 fn collect_roots(
     hir: &HirProgram,
-) -> (HirIndex<'_>, Vec<Item>, SymbolIndex, GenericIndex, FnIndex) {
+) -> (
+    HirIndex<'_>,
+    Vec<Item>,
+    SymbolIndex,
+    GenericIndex,
+    FnIndex,
+    MethodIndex,
+    MethodSymbolIndex,
+) {
     let mut index: HirIndex<'_> = HashMap::new();
     let mut roots: Vec<Item> = Vec::new();
     let mut symbols: SymbolIndex = HashMap::new();
     let mut generics: GenericIndex = HashMap::new();
     let mut fn_index: FnIndex = FnIndex::new();
+    let mut method_index: MethodIndex = MethodIndex::new();
+    let mut method_symbols: MethodSymbolIndex = MethodSymbolIndex::new();
     let mut next_id: usize = 0;
 
     for item in &hir.items {
@@ -189,12 +233,40 @@ fn collect_roots(
                     symbols.insert(id, super::ty::method_symbol(&type_mangle, &m.name));
                     let gp = generic_params_of(m);
                     generics.insert(id, gp.clone());
-                    // A concrete-receiver method with no generic
-                    // parameters of its own is a root: it lowers to its
-                    // per-type symbol (`Int$to_string`, and so on), which
-                    // a static call site references directly. Generic
-                    // methods are specialized through their call sites,
-                    // a follow-up beyond the free-function path here.
+                    // Record the implementing type so the worklist can
+                    // recompute a generic method's per-instantiation symbol
+                    // from the concrete type arguments, matching the call
+                    // site.
+                    method_symbols.insert(id, (imp.self_ty.clone(), m.name.clone()));
+                    // Index the method by name so a call site can find and
+                    // specialize it. The user parameter types exclude the
+                    // leading `self`, which the call site supplies from the
+                    // receiver type.
+                    if m.body.is_some() {
+                        let user_params: Vec<Ty> = m
+                            .params
+                            .iter()
+                            .filter(|(n, _, _)| n != "self")
+                            .map(|(_, t, _)| t.clone())
+                            .collect();
+                        method_index
+                            .entry(m.name.clone())
+                            .or_default()
+                            .push(MethodEntry {
+                                decl: id,
+                                self_ty: imp.self_ty.clone(),
+                                params: user_params,
+                                generic: !gp.is_empty(),
+                            });
+                    }
+                    // A concrete-receiver method with no generic parameters
+                    // of its own is a root: it lowers to its per-type symbol
+                    // (`Int$to_string`, and so on), which a static call site
+                    // references directly. A generic method (one whose
+                    // declared types carry `Ty::Param`, for example a method
+                    // on `impl<T> Box<T>`) is specialized through its call
+                    // sites, like a generic free function, so it is not
+                    // rooted here.
                     if gp.is_empty() && m.body.is_some() {
                         roots.push((id, SubstMap::new()));
                     }
@@ -213,7 +285,15 @@ fn collect_roots(
             _ => {}
         }
     }
-    (index, roots, symbols, generics, fn_index)
+    (
+        index,
+        roots,
+        symbols,
+        generics,
+        fn_index,
+        method_index,
+        method_symbols,
+    )
 }
 
 /// Collect a function's generic parameters in declaration order. The

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -236,6 +236,21 @@ fn core_trait_prelude_program_compiles_and_runs() {
 }
 
 #[test]
+fn generic_struct_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Generic struct monomorphization end to end. `Box<T>` is instantiated
+    // at Int and String, exercising the per-instantiation struct layout and
+    // GC pointer descriptor (the String slot is a traced pointer, the Int
+    // slot is opaque). The concrete `impl Box<Int>` method `get` and the
+    // generic `impl<T> Box<T>` method `unwrap`, specialized at T = Int and
+    // T = String, both resolve to per-instantiation symbols. Prints 42, 42,
+    // 7, then raven.
+    compile_link_run_and_check("generic_struct.rv", "42\n42\n7\nraven\n", &runtime);
+}
+
+#[test]
 fn list_int_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Monomorphize generic struct instantiations and generic methods on generic implementing types from their use sites, the last backend gap blocking the iterator pipeline (#119) and generic collections (#72).

Closes #141.

## What landed

Generic free functions already monomorphized. This extends the same worklist machinery:

* **Generic structs.** A struct literal of a generic struct (`Box { value: 5 }`) builds a per-instantiation substitution from the literal's resolved type arguments and grounds each field type, so `Box<Int>` and `Box<String>` lay out the right slots. The resulting `MirType::Struct` carries the concrete arguments.
* **Generic methods.** A generic method on a generic implementing type (`impl<T> Box<T> { fun unwrap(self) -> T }`) is indexed by name with its declared implementing type. At a call site the implementing type is matched against the concrete receiver to build the substitution, the instantiation is queued, and the worklist names it `<implementing_type_mangle>$<method>` (`Box_Int$unwrap`, `Box_Str$unwrap`), matching what the call site recomputes from the receiver. Concrete-receiver methods (`impl Box<Int>`) keep working as roots.
* **HIR owner-span fix.** An impl method's enclosing generic parameters now resolve with the impl block as their owner span, so a method that returns the impl's `T` and the impl's `Self<T>` agree on one `ParamId` and the call-site substitution grounds both consistently. This is what made the generic method body lower with the correct (non-Unit) return type.

## Per-instantiation GC descriptor

The uniform 8-byte slot model keeps the struct layout identical across instantiations, so no per-instantiation offset table is needed. The GC pointer descriptor differs per instantiation: each interns its own descriptor keyed by the mangled type name with its own pointer mask. `Box_Int` has mask `0` (the `Int` slot is opaque to the collector), while `Box_Str` has bit 0 set (the `String` slot is a traced pointer). The program entry shim registers every interned descriptor, so the collector traces each instantiation correctly. The existing `lower_struct_create` codegen path handles this without change; monomorphization is what makes the field types concrete.

## Mangling and caching

Method instantiations are named `<implementing_type_mangle>$<method>`; the implementing type mangle already carries the concrete arguments, so a method needs no extra `$<typearg>` suffix and the call site and definition always agree. The worklist dedups on `(decl, concrete type args)`, so each instantiation is emitted once.

## Specs

Updated `docs/v2/specs/mir.md` (generic struct and method monomorphization, method naming) and `docs/v2/specs/codegen.md` (per-instantiation struct layout and GC descriptor).

## Generic method support level

* Supported: concrete-type impls (`impl Box<Int>`) and generic methods whose type parameters come from the implementing type (`impl<T> Box<T>`).
* Deferred (documented in `mir.md`): method-level generic parameters that do not appear in the implementing type (`impl Box<Int> { fun map<U>(self, f) -> U }`), since two `U` instantiations would collide on one call-site symbol.

## Literal program output

`examples/v2/generic_struct.rv` compiled with `raven build` and run on windows-msvc (x86_64) prints:

```
42
42
7
raven
```

(`b.get()` via concrete `impl Box<Int>`, `b.unwrap()` via generic `impl<T> Box<T>` at T = Int, `n.value` direct field access, and `s.unwrap()` at T = String through the per-instantiation traced-pointer GC descriptor.)

## Test plan

- [x] `cargo build`
- [x] `cargo test` (287 lib + 23 codegen smoke + golden suites, all green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] New end-to-end case `generic_struct_program_compiles_and_runs` in `tests/codegen_smoke.rs` compiles, links, runs, and checks stdout
- [x] Existing examples and golden snapshots stay green
