### PR TITLE
feat(mir): monomorphize method-level generic parameters

### DIFF
--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -260,12 +260,27 @@ Vec_push$Int                (impl Vec<Int>::push)
 
 A method instantiation is named `<implementing_type_mangle>$<method>`,
 where the implementing type mangle already carries the concrete type
-arguments. A generic method specialized at `Box<Int>` and the call to it
-both name `Box_Int$unwrap`; a `Box<String>` instantiation names
-`Box_Str$unwrap`. Because the implementing type's mangle already
-distinguishes instantiations, a method takes no extra `$<typearg>` suffix.
-The call site recomputes the same name from the concrete receiver type, so
-the definition and the call always agree.
+arguments that come from the implementing type. A generic method
+specialized at `Box<Int>` and the call to it both name `Box_Int$unwrap`; a
+`Box<String>` instantiation names `Box_Str$unwrap`. The call site recomputes
+the same name from the concrete receiver type, so the definition and the
+call always agree.
+
+A method may also introduce its own generic parameters that do not appear
+in the implementing type (`impl<T> Box<T> { fun mapped<U>(self, f: fun(T)
+-> U) -> U }`, where `U` is the method's own parameter, distinct from the
+impl's `T`). These method-level type arguments are part of the
+instantiation: the monomorphization key is `(method declaration, receiver
+type arguments, method-level type arguments)`, so two calls to the same
+method on the same receiver type at different `U` dedupe to distinct
+instantiations. Each method-level argument is appended to the mangled name
+in declaration order, after the receiver-derived `$<method>` portion, so
+the two calls produce `Box_Int$mapped$Int` and `Box_Int$mapped$Bool`
+rather than colliding on `Box_Int$mapped`. The call site infers the
+concrete method-level arguments by matching the method's declared parameter
+types (which carry `U`) against the concrete argument types, then recomputes
+the same suffix, so the definition and the call still agree. The body
+substitution binds both the impl's `T` and the method's own `U`.
 
 The PR's golden tests pin the exact spelling so future changes are
 visible in diffs.
@@ -278,13 +293,6 @@ visible in diffs.
   concrete functions during type checking; `dyn` lowering is issue #66.
 * Async, generators, drop tracking, borrow analysis.
 * Cross-file monomorphization: the v2 pipeline still operates per file.
-* Method-level generic parameters that do not appear in the implementing
-  type (for example `impl Box<Int> { fun map<U>(self, f) -> U }`). The
-  call-site symbol is derived from the receiver type alone, so two
-  instantiations at different `U` would collide on one symbol. Generic
-  parameters that come from the implementing type (`impl<T> Box<T>`) are
-  fully supported because the implementing type's mangle distinguishes
-  them.
 
 ## Test coverage
 

--- a/examples/v2/method_generics.rv
+++ b/examples/v2/method_generics.rv
@@ -1,0 +1,23 @@
+// Method-level generic monomorphization end to end.
+//
+// `mapped<U>` introduces a type parameter `U` that does not appear in the
+// implementing type `Box<T>`. Calling it at two distinct `U` on the same
+// `Box<Int>` must compile to two distinct instantiations whose symbols do
+// not collide (`Box_Int$mapped$Int` and `Box_Int$mapped$Bool`). The
+// substitution for each body binds both the impl's `T` and the method's
+// own `U`. Prints 42 then true.
+struct Box<T> {
+    value: T
+}
+
+impl<T> Box<T> {
+    fun mapped<U>(self, f: fun(T) -> U) -> U = f(self.value)
+}
+
+fun main() {
+    let b = Box { value: 21 }
+    let doubled = b.mapped(fun(x: Int) -> Int = x * 2)
+    let is_big = b.mapped(fun(x: Int) -> Bool = x > 10)
+    print_int(doubled)
+    print(is_big)
+}

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -912,8 +912,14 @@ fn lower_method_call(
     // emits the body specialized for this receiver. The symbol is the same
     // `<RecvType>$<method>` either way: the worklist recomputes it from the
     // concrete implementing type, which the receiver type fixes here.
-    queue_generic_method(cx, &receiver.ty, name, args);
-    let symbol = recv_ty.method_symbol(name);
+    // A generic method's per-instantiation symbol carries any method-level
+    // type arguments as a suffix (`Box_Int$mapped$Bool`), so the call site
+    // uses the symbol the queuing step computes rather than the bare
+    // `<RecvType>$<method>` name, which would collide across method-level
+    // instantiations. A concrete-receiver method or one with no method-level
+    // parameters keeps the bare per-type symbol.
+    let symbol = queue_generic_method(cx, &receiver.ty, name, args)
+        .unwrap_or_else(|| recv_ty.method_symbol(name));
     let recv = lower_expr(cx, receiver);
     let mut arg_ops = vec![recv];
     for a in args {
@@ -951,10 +957,8 @@ fn queue_generic_method(
     receiver_ty: &crate::tycheck::Ty,
     name: &str,
     args: &[HirExpr],
-) {
-    let Some(entries) = cx.decls.methods.get(name).cloned() else {
-        return;
-    };
+) -> Option<String> {
+    let entries = cx.decls.methods.get(name).cloned()?;
     let recv = super::substitute(receiver_ty, cx.subst);
     let recv = recv.strip_self().clone();
     // Pick the generic method whose implementing type matches the concrete
@@ -965,7 +969,10 @@ fn queue_generic_method(
         let mut subst: super::SubstMap = super::SubstMap::new();
         match_param(&entry.self_ty, &recv, &mut subst);
         // Also bind any method-level parameters from the concrete argument
-        // types.
+        // types. A method's own `<U>` is grounded by matching its declared
+        // parameter types (which carry `U`) against the concrete argument
+        // types, so the substitution carries both the impl's `T` and the
+        // method's `U`.
         for (decl_ty, arg) in entry.params.iter().zip(args.iter()) {
             let got = super::substitute(&arg.ty, cx.subst);
             match_param(decl_ty, &got, &mut subst);
@@ -975,10 +982,23 @@ fn queue_generic_method(
         // name on another type), skip this entry.
         let concrete_self = super::substitute(&entry.self_ty, &subst);
         if MirType::from_ty(&concrete_self) == MirType::from_ty(&recv) {
+            // The instantiation symbol the worklist will emit: the concrete
+            // implementing type's mangle plus `$<method>`, with each
+            // method-level type argument appended. The call site references
+            // this exact symbol so it resolves to the instantiation lowered
+            // for these receiver and method-level type arguments.
+            let concrete_self_mangle = MirType::from_ty(&concrete_self).mangle();
+            let symbol = super::method_mono_symbol(
+                &concrete_self_mangle,
+                name,
+                &entry.method_params,
+                &subst,
+            );
             cx.pending_calls.push((entry.decl, subst));
-            return;
+            return Some(symbol);
         }
     }
+    None
 }
 
 /// Resolve a field's slot index from the receiver's struct type and the

--- a/src/mir/lower/mod.rs
+++ b/src/mir/lower/mod.rs
@@ -68,6 +68,13 @@ pub struct MethodEntry {
     /// `self`. May carry `Ty::Param`. Matched against the concrete
     /// argument types to bind any method-level parameters.
     pub params: Vec<Ty>,
+    /// The method's own generic parameters, in declaration order: those
+    /// the method introduces (`fun mapped<U>`) that do not appear in the
+    /// implementing type. They are encoded into the mangled symbol so two
+    /// instantiations of the method at different method-level type
+    /// arguments do not collide. Empty for a method whose only generic
+    /// parameters come from the implementing type.
+    pub method_params: Vec<ParamId>,
     /// True when the method's declared types carry any `Ty::Param`, so it
     /// must be specialized at each call site. A concrete-receiver method
     /// is `false` and is reached through its own root instead.
@@ -220,6 +227,33 @@ pub fn mono_symbol(base: &str, generic_params: &[ParamId], subst: &SubstMap) -> 
     }
     let mut s = base.to_string();
     for p in generic_params {
+        let concrete = subst.get(p).cloned().unwrap_or(Ty::Error);
+        s.push('$');
+        s.push_str(&MirType::from_ty(&concrete).mangle());
+    }
+    s
+}
+
+/// Compute the monomorphized symbol for a method instantiation. The base
+/// is the concrete implementing type's mangle followed by `$<method>`
+/// (`Box_Int$mapped`). When the method introduces its own generic
+/// parameters that do not appear in the implementing type (a method-level
+/// `<U>`, distinct from the impl's `<T>`), each is appended as
+/// `$<MangledType>` in declaration order, so two instantiations of the
+/// same method at different method-level type arguments get distinct
+/// symbols (`Box_Int$mapped$Int` and `Box_Int$mapped$Bool`). The call
+/// site and the worklist both call this so they agree on every
+/// instantiation's name. The implementing type's own arguments are
+/// already encoded by `concrete_self_mangle`, so only the method-level
+/// parameters contribute a suffix here.
+pub fn method_mono_symbol(
+    concrete_self_mangle: &str,
+    method: &str,
+    method_params: &[ParamId],
+    subst: &SubstMap,
+) -> String {
+    let mut s = super::ty::method_symbol(concrete_self_mangle, method);
+    for p in method_params {
         let concrete = subst.get(p).cloned().unwrap_or(Ty::Error);
         s.push('$');
         s.push_str(&MirType::from_ty(&concrete).mangle());

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -49,13 +49,30 @@ type SymbolIndex = HashMap<DeclId, String>;
 /// declaration order. The order fixes the mangled-name suffix.
 type GenericIndex = HashMap<DeclId, Vec<ParamId>>;
 
-/// Map from an impl-method declaration to its implementing type and
-/// method name. The worklist computes a generic method's per-instantiation
-/// symbol by substituting the concrete type arguments into the
-/// implementing type and mangling the result, so the symbol matches what
-/// the method call site recomputes from the concrete receiver type
-/// (`Box_Int$unwrap`, and so on).
-type MethodSymbolIndex = HashMap<DeclId, (Ty, String)>;
+/// Map from an impl-method declaration to its implementing type, method
+/// name, and method-level generic parameters. The worklist computes a
+/// generic method's per-instantiation symbol by substituting the concrete
+/// type arguments into the implementing type, mangling the result, and
+/// appending the concrete method-level type arguments, so the symbol
+/// matches what the method call site recomputes from the concrete receiver
+/// type and the inferred method-level arguments (`Box_Int$unwrap`, or
+/// `Box_Int$mapped$Bool` for a method-level `<U>` bound to `Bool`).
+type MethodSymbolIndex = HashMap<DeclId, MethodSymbolEntry>;
+
+/// The implementing type, method name, and method-level generic
+/// parameters the worklist needs to recompute a generic method's
+/// per-instantiation symbol.
+struct MethodSymbolEntry {
+    /// The implementing type as written on the `impl` block; may carry the
+    /// impl's `Ty::Param`s, grounded by the instantiation's substitution.
+    self_ty: Ty,
+    /// The method's source name.
+    method: String,
+    /// The method's own generic parameters (those absent from the
+    /// implementing type), in declaration order. Encoded into the symbol
+    /// suffix so distinct method-level type arguments do not collide.
+    method_params: Vec<ParamId>,
+}
 
 /// Run the full monomorphization pass.
 pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
@@ -90,16 +107,22 @@ pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
         // the call site recomputes from the concrete receiver type, so a
         // generic method specialized at `Box<Int>` and the call to it both
         // name `Box_Int$unwrap`. A free function uses its base symbol with
-        // the generic-parameter suffix. Because the implementing type
-        // already carries the concrete arguments, a method takes no extra
-        // `mono_symbol` suffix; its instantiations are distinguished by the
-        // implementing type's mangle.
+        // the generic-parameter suffix. The implementing type already
+        // carries its own concrete arguments, but a method-level generic
+        // parameter (a `<U>` the method introduces that is absent from the
+        // implementing type) contributes an extra suffix, so two
+        // instantiations of the same method at different method-level type
+        // arguments get distinct symbols (`Box_Int$mapped$Int` and
+        // `Box_Int$mapped$Bool`).
         let mangled = match method_symbols.get(&decl) {
-            Some((self_ty, method)) => {
-                let concrete_self = super::lower::substitute(self_ty, &subst);
-                super::ty::method_symbol(
-                    &super::ty::MirType::from_ty(&concrete_self).mangle(),
-                    method,
+            Some(entry) => {
+                let concrete_self = super::lower::substitute(&entry.self_ty, &subst);
+                let concrete_self_mangle = super::ty::MirType::from_ty(&concrete_self).mangle();
+                super::lower::method_mono_symbol(
+                    &concrete_self_mangle,
+                    &entry.method,
+                    &entry.method_params,
+                    &subst,
                 )
             }
             None => {
@@ -226,6 +249,13 @@ fn collect_roots(
                 // at the object level. The symbol matches what a call
                 // site recomputes from the receiver type.
                 let type_mangle = super::ty::MirType::from_ty(&imp.self_ty).mangle();
+                // The impl's own generic parameters are exactly those that
+                // appear in the implementing type (`T` in `impl<T>
+                // Box<T>`). A method's own parameters are the remainder of
+                // its generic parameters, those it introduces (`U` in `fun
+                // mapped<U>`).
+                let mut impl_params: Vec<ParamId> = Vec::new();
+                collect_params(&imp.self_ty, &mut impl_params);
                 for m in &imp.methods {
                     let id = DeclId(next_id);
                     next_id += 1;
@@ -233,11 +263,28 @@ fn collect_roots(
                     symbols.insert(id, super::ty::method_symbol(&type_mangle, &m.name));
                     let gp = generic_params_of(m);
                     generics.insert(id, gp.clone());
-                    // Record the implementing type so the worklist can
-                    // recompute a generic method's per-instantiation symbol
-                    // from the concrete type arguments, matching the call
-                    // site.
-                    method_symbols.insert(id, (imp.self_ty.clone(), m.name.clone()));
+                    // The method's own generic parameters: those it declares
+                    // that the implementing type does not. These contribute
+                    // the method-level suffix on the mangled symbol so two
+                    // instantiations of the method at different method-level
+                    // type arguments do not collide.
+                    let method_params: Vec<ParamId> = gp
+                        .iter()
+                        .filter(|p| !impl_params.contains(p))
+                        .cloned()
+                        .collect();
+                    // Record the implementing type and the method-level
+                    // parameters so the worklist can recompute a generic
+                    // method's per-instantiation symbol from the concrete
+                    // type arguments, matching the call site.
+                    method_symbols.insert(
+                        id,
+                        MethodSymbolEntry {
+                            self_ty: imp.self_ty.clone(),
+                            method: m.name.clone(),
+                            method_params: method_params.clone(),
+                        },
+                    );
                     // Index the method by name so a call site can find and
                     // specialize it. The user parameter types exclude the
                     // leading `self`, which the call site supplies from the
@@ -256,6 +303,7 @@ fn collect_roots(
                                 decl: id,
                                 self_ty: imp.self_ty.clone(),
                                 params: user_params,
+                                method_params: method_params.clone(),
                                 generic: !gp.is_empty(),
                             });
                     }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -251,6 +251,22 @@ fn generic_struct_program_compiles_and_runs() {
 }
 
 #[test]
+fn method_generics_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Method-level generic monomorphization end to end. The method
+    // `mapped<U>` on `impl<T> Box<T>` introduces a type parameter `U` that
+    // does not appear in the implementing type. Two calls on the same
+    // `Box<Int>` at distinct `U` (Int for the doubling closure, Bool for
+    // the comparison) must resolve to distinct per-instantiation symbols
+    // (`Box_Int$mapped$Int` and `Box_Int$mapped$Bool`) rather than colliding
+    // on the receiver-derived `Box_Int$mapped`. Each body substitution binds
+    // both the impl's `T` and the method's own `U`. Prints 42 then true.
+    compile_link_run_and_check("method_generics.rv", "42\ntrue\n", &runtime);
+}
+
+#[test]
 fn list_int_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Monomorphizes method-level generic parameters: a method's own type parameters that do not appear in the implementing type, for example `mapped<U>` on `impl<T> Box<T>`. This was the deferral noted in #145 and is a prerequisite for the iterator adapter API (`map<U>`, `fold<Acc>`).

Closes #146. Spec at `docs/v2/specs/mir.md`.

## The problem

#145 handled generic methods whose type parameters come from the implementing type. A method introducing its own `<U>` would collide on the receiver-derived symbol `Box_Int$mapped` when called at two distinct `U`.

## The fix

Method-level type arguments are now part of the instantiation key and the mangled symbol. Distinct `U` produce distinct symbols (`Box_Int$mapped$Int`, `Box_Int$mapped$Bool`). The method's own parameters are identified as the generic parameters absent from the implementing type, grounded at the call site by matching the method's declared parameter types against the concrete argument types, and each body substitution binds both the impl's `T` and the method's `U`.

## Verification (built and run on windows-msvc)

`examples/v2/method_generics.rv` calls `mapped<U>` at `U = Int` (a doubling closure) and `U = Bool` (a comparison) on the same `Box<Int>`, and prints:
```
42
true
```

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` (287 lib + 24 codegen smoke including the new method-generics case + golden suites) pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `method_generics.rv` prints 42 then true end to end
- [x] The #145 generic_struct example still prints 42/42/7/raven
