### PR TITLE
feat(stdlib): lazy iterator pipeline (std/iter)

### DIFF
--- a/docs/v2/specs/std-iter.md
+++ b/docs/v2/specs/std-iter.md
@@ -1,0 +1,62 @@
+# std/iter: the lazy iterator pipeline
+
+`std/iter` is bundled Raven source compiled into a program when the user writes `import std/iter { ... }`. It provides lazy, single-pass iterator adapters and the consumers that drive them, built on the `Iterator<T>` trait from the `std/core` prelude:
+
+```
+trait Iterator<T> {
+    fun next(self) -> Option<T>
+}
+```
+
+## Design
+
+An adapter is a small struct that stores its source iterator (and, where applicable, a captured closure) and implements `Iterator`. Its `next` pulls from the source on demand, so a chain such as `list.iter().map(f).filter(g)` performs no work until a consumer drives it. Each adapter is monomorphized at its concrete source and element types, and the stored closures are called through statically known function-pointer slots, so a finished pipeline runs in a single pass with no per-stage List allocation. Only a consumer that builds a List (`collect`) allocates.
+
+## Bridge
+
+`ListIter<T>` iterates a `List<T>` by index. `List<T>` gains an `iter()` method (defined with `impl<T> List<T>`) returning a `ListIter<T>`, plus a free `from_list<T>` constructor.
+
+## Adapters
+
+Each adapter is a generic struct over its element types and a bounded source `S: Iterator<T>`, and implements `next`:
+
+- `MapIter<T, U, S>`: stores a closure `fun(T) -> U`; `next` maps each source element.
+- `Filter<T, S>`: stores a predicate `fun(T) -> Bool`; `next` pulls until the predicate holds.
+- `Take<T, S>`: yields at most n elements.
+- `Skip<T, S>`: discards the first n, then passes through.
+- `Enumerate<T, S>`: pairs each element with its running index. Raven has no tuples yet, so it yields an `Indexed<T> { index: Int, value: T }` record rather than `(Int, T)`.
+
+## Chaining ergonomics
+
+Raven has no blanket trait impls, so the adapter-constructor methods (`map`, `filter`, `take`, `skip`, `enumerate`) are defined on each concrete iterator type (`ListIter`, `MapIter`, `Filter`, `Take`, `Skip`) rather than once on all `Iterator` types. This is repetitive in the module source but gives users uniform method-call chaining: `xs.iter().map(f).filter(g).take(n)`. A generic-parameter ordering rule applies: a bound that mentions a sibling parameter (`S: Iterator<T>`) must list that parameter first, so each adapter lists its element types before its bounded source type.
+
+## Consumers
+
+Consumers are free generic functions over any `S: Iterator<T>`, since a consumer cannot be a method shared by every adapter without blanket impls:
+
+- `collect<T, S>(it) -> List<T>`
+- `count<T, S>(it) -> Int`
+- `fold<T, A, S>(it, init, f) -> A`
+- `any<T, S>(it, pred) -> Bool`, `all<T, S>(it, pred) -> Bool`
+- `find<T, S>(it, pred) -> Option<T>`
+- `for_each<T, S>(it, f)`
+
+A pipeline is built with the adapter methods and then handed to a consumer: `collect(xs.iter().map(f).filter(g))`.
+
+## How the element type is recovered for consumers
+
+A consumer's element type `T` appears only in its `S: Iterator<T>` bound and (for `collect`/`fold`) its return type, never in a parameter position. Two mechanisms recover it:
+
+- The type checker links `T` to the element of the concrete source through deferred iterator links (`add_iterator_link` / `solve_iterator_links` in the inference context), so the call site's result type is concrete (`collect(pipeline)` types as `List<Int>`).
+- Monomorphization recovers `T` for the instantiation substitution by matching the consumer's declared return type against the concrete call result, since the arguments alone cannot bind a parameter that appears only in the return type or a bound. See the call lowering in `src/mir/lower/expr.rs`.
+
+## for-loops
+
+`for x in <iterable>` drives any value whose type implements `Iterator` by calling `next` until it returns `None`. Lists and ranges keep their direct counter/index lowering (see `docs/v2/specs/hir.md`); an arbitrary iterator, including a generic parameter bounded by `Iterator<T>`, iterates through the trait method. The loop binding takes the bound's element type.
+
+## Out of scope
+
+- `Zip` and `Chain` adapters: deferred.
+- Tuples for `Enumerate` (uses the `Indexed<T>` record instead).
+- Blanket trait impls that would let the adapter methods and consumers be written once for all `Iterator` types.
+- Double-ended and exact-size iteration.

--- a/examples/v2/iter_pipeline.rv
+++ b/examples/v2/iter_pipeline.rv
@@ -1,0 +1,30 @@
+// Lazy iterator pipeline end to end.
+//
+// `xs.iter()` bridges a List into the iterator world; `map` and `filter`
+// are lazy adapters that do no work until a consumer drives them. The
+// consumers (`collect`, `fold`, `count`) are generic over any
+// `S: Iterator<T>`. The element type `T` appears only in each consumer's
+// `Iterator<T>` bound and return type, never in a parameter, so the
+// monomorphizer recovers it by matching the declared return type against
+// the concrete call result. Prints 4, 180, 3.
+
+import std/iter { collect, fold, count }
+
+fun main() {
+    let xs = [1, 2, 3, 4, 5, 6]
+
+    // map then filter then collect into a List, then read its length.
+    let kept = collect(xs.iter().map(fun(x: Int) -> Int = x * 10).filter(fun(y: Int) -> Bool = y > 20))
+    print_int(kept.len())
+
+    // A fresh pipeline folded into a sum (30 + 40 + 50 + 60).
+    let total = fold(
+        xs.iter().map(fun(x: Int) -> Int = x * 10).filter(fun(y: Int) -> Bool = y > 20),
+        0,
+        fun(acc: Int, v: Int) -> Int = acc + v,
+    )
+    print_int(total)
+
+    // Count the elements a filter keeps (4, 5, 6).
+    print_int(count(xs.iter().filter(fun(y: Int) -> Bool = y > 3)))
+}

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -576,7 +576,13 @@ fn lower_for(
         ));
     }
 
-    let list_expr = lower_expr(iter, &Ty::Error, cx)?;
+    let source_expr = lower_expr(iter, &Ty::Error, cx)?;
+    // A non-range, non-list iterable is any value whose type implements
+    // `Iterator<T>`. Drive it through repeated `next()` calls.
+    if !matches!(source_expr.ty.strip_self(), Ty::List(_)) {
+        return Ok(lower_iterator_for(pat, source_expr, body, span, cx));
+    }
+    let list_expr = source_expr;
     let element_ty = match list_expr.ty.strip_self() {
         Ty::List(t) => (**t).clone(),
         _ => Ty::Error,
@@ -615,6 +621,125 @@ fn lower_for(
         span: span.clone(),
     };
     Ok(make_expr(HirExprKind::Block(block), Ty::Unit, span.clone()))
+}
+
+/// Lower a `for` loop whose source is an arbitrary iterator (any value
+/// whose type implements `Iterator<T>`). The loop drives the iterator by
+/// calling `next()` until it yields `None`:
+///
+/// ```text
+/// {
+///     let __it = <source>;
+///     loop {
+///         match __it.next() {
+///             Some(<binding>) => { <body> },
+///             None => break,
+///         }
+///     }
+/// }
+/// ```
+///
+/// The `next` call is an ordinary method call, so monomorphization
+/// resolves it to the concrete adapter's `next` symbol and the closures
+/// captured by `map`/`filter`/... are dispatched statically. There is no
+/// boxing and no per-stage allocation: a chained pipeline runs in a
+/// single pass driven by this loop.
+fn lower_iterator_for(
+    pat: &crate::ast::Pattern,
+    source: HirExpr,
+    body: &AstBlock,
+    span: &Span,
+    cx: &LowerCtx<'_>,
+) -> HirExpr {
+    // The element type recorded by the type checker at the pattern span.
+    let element_ty = cx
+        .typed
+        .types
+        .lookup(&pat.span)
+        .cloned()
+        .unwrap_or(Ty::Error);
+
+    let it_name = cx.fresh("it");
+    let it_ty = source.ty.clone();
+    let it_let = let_stmt(&it_name, it_ty.clone(), source, span.clone());
+
+    // __it.next() : Option<element_ty>
+    let next_call = make_expr(
+        HirExprKind::MethodCall {
+            receiver: Box::new(ident_expr(&it_name, it_ty, span.clone())),
+            name: "next".into(),
+            args: Vec::new(),
+        },
+        Ty::Option(Box::new(element_ty.clone())),
+        span.clone(),
+    );
+
+    // Some(<binding>) => { <body> }
+    let bind_name = pattern_binding_name(pat).unwrap_or_else(|| cx.fresh("loopvar"));
+    let some_pat = HirPattern {
+        kind: HirPatternKind::Constructor {
+            name: Some("Some".into()),
+            elements: vec![HirPattern {
+                kind: HirPatternKind::Binding(bind_name),
+                span: span.clone(),
+            }],
+        },
+        span: span.clone(),
+    };
+    let body_block = lower_block_to_block(body, &Ty::Unit, cx).unwrap_or_else(|_| HirBlock {
+        stmts: Vec::new(),
+        tail: None,
+        ty: Ty::Unit,
+        span: span.clone(),
+    });
+    let some_arm = HirArm {
+        pattern: some_pat,
+        guard: None,
+        body: make_expr(HirExprKind::Block(body_block), Ty::Unit, span.clone()),
+        span: span.clone(),
+    };
+
+    // None => break
+    let none_pat = HirPattern {
+        kind: HirPatternKind::Constructor {
+            name: Some("None".into()),
+            elements: Vec::new(),
+        },
+        span: span.clone(),
+    };
+    let none_arm = HirArm {
+        pattern: none_pat,
+        guard: None,
+        body: make_expr(HirExprKind::Break(None), Ty::Error, span.clone()),
+        span: span.clone(),
+    };
+
+    let match_expr = make_expr(
+        HirExprKind::Match {
+            scrutinee: Box::new(next_call),
+            arms: vec![some_arm, none_arm],
+        },
+        Ty::Unit,
+        span.clone(),
+    );
+    let loop_block = HirBlock {
+        stmts: vec![HirStmt {
+            kind: HirStmtKind::Expr(match_expr),
+            span: span.clone(),
+        }],
+        tail: None,
+        ty: Ty::Unit,
+        span: span.clone(),
+    };
+    let loop_expr = make_expr(HirExprKind::Loop(loop_block), Ty::Unit, span.clone());
+
+    let block = HirBlock {
+        stmts: vec![it_let],
+        tail: Some(Box::new(loop_expr)),
+        ty: Ty::Unit,
+        span: span.clone(),
+    };
+    make_expr(HirExprKind::Block(block), Ty::Unit, span.clone())
 }
 
 /// Build the counter-loop body shared by the range and list for-loop

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,14 @@ fn run_build(rest: &[String]) -> Result<(), DriverError> {
     let typed =
         check_file(&resolved).map_err(|e| DriverError::Frontend(format!("tycheck: {}", e)))?;
     let hir = lower_file(&typed).map_err(|e| DriverError::Frontend(format!("hir: {}", e)))?;
+    if std::env::var("RAVEN_DUMP_HIR").is_ok() {
+        eprintln!("{}", raven::hir::pretty_program(&hir));
+    }
     let mir = lower_program(&hir).map_err(|e| DriverError::Frontend(format!("mir: {}", e)))?;
+
+    if std::env::var("RAVEN_DUMP_MIR").is_ok() {
+        eprintln!("{}", raven::mir::pretty::pretty_program(&mir));
+    }
 
     // Back end.
     let object_bytes = codegen::compile_program(&mir).map_err(DriverError::from)?;

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -74,7 +74,7 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             if is_closure_value_callee(cx, callee) {
                 return lower_closure_call(cx, callee, args, ty);
             }
-            let callee_ref = call_ref_from_callee(cx, callee, args);
+            let callee_ref = call_ref_from_callee(cx, callee, args, &expr.ty);
             let arg_ops: Vec<MirOperand> = args.iter().map(|a| lower_expr(cx, a)).collect();
             let dst = cx.builder.fresh_temp("call", ty);
             cx.builder.assign(
@@ -656,7 +656,12 @@ fn lower_struct_lit(
 /// the substitution, the per-instantiation symbol is computed, and the
 /// instantiation is queued for the monomorphizer. A non-generic callee
 /// keeps its source name.
-fn call_ref_from_callee(cx: &mut LowerCx<'_>, callee: &HirExpr, args: &[HirExpr]) -> MirFnRef {
+fn call_ref_from_callee(
+    cx: &mut LowerCx<'_>,
+    callee: &HirExpr,
+    args: &[HirExpr],
+    result_ty: &crate::tycheck::Ty,
+) -> MirFnRef {
     let HirExprKind::Ident(name) = &callee.kind else {
         return MirFnRef {
             mangled: "__indirect_call".into(),
@@ -689,6 +694,16 @@ fn call_ref_from_callee(cx: &mut LowerCx<'_>, callee: &HirExpr, args: &[HirExpr]
         let got = super::substitute(&arg.ty, cx.subst);
         match_param(decl_ty, &got, &mut subst);
     }
+    // Also match the declared return type against the call's resolved
+    // result type. A generic parameter that appears only in the return
+    // type or in a bound (for example `T` in
+    // `collect<T, S: Iterator<T>>(it: S) -> List<T>`, where `T` is never a
+    // parameter) cannot be bound from the arguments alone. The type
+    // checker already inferred it (the call site's result type is
+    // concrete, `List<Int>`), so matching `List<T>` against it recovers
+    // the binding the monomorphizer needs.
+    let concrete_result = super::substitute(result_ty, cx.subst);
+    match_param(&entry.ret, &concrete_result, &mut subst);
     let mangled = super::mono_symbol(name, &entry.generic_params, &subst);
     cx.pending_calls.push((entry.decl, subst));
     MirFnRef {

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -32,7 +32,12 @@ pub fn lower_match(
     result_ty: MirType,
 ) -> MirOperand {
     let scrut_op = super::expr::lower_expr(cx, scrutinee);
-    let scrut_ty = scrutinee.ty.clone();
+    // Apply the monomorphization substitution so a scrutinee whose type
+    // mentions a generic parameter (for example `Option<T>` returned by a
+    // bound iterator's `next`) yields concrete payload-binding types. Using
+    // the raw HIR type would leave `T` abstract, which lowers to a unit
+    // slot and produces a type mismatch in the generated code.
+    let scrut_ty = super::substitute(&scrutinee.ty, cx.subst);
     let result_local = cx.builder.fresh_temp("match", result_ty);
     let cont = cx.builder.new_block();
 

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -73,6 +73,7 @@ impl SourceLoader for FsLoader {
 /// future code can be ported without re writing imports.
 pub const STDLIB_MODULES: &[&str] = &[
     "io",
+    "iter",
     "collections",
     "string",
     "math",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -36,6 +36,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("core", include_str!("../../stdlib/std/core.rv")),
     ("io", include_str!("../../stdlib/std/io.rv")),
     ("string", include_str!("../../stdlib/std/string.rv")),
+    ("iter", include_str!("../../stdlib/std/iter.rv")),
 ];
 
 /// The prelude module that is implicitly imported into every program.

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -184,7 +184,7 @@ pub fn collect_declarations(
 /// list. The trait bounds are captured by name (the resolver already
 /// validated that they point at trait declarations).
 fn collect_generic_params(params: &[GenericParam], owner: &Span) -> Vec<GenericParamSig> {
-    params
+    let mut sigs: Vec<GenericParamSig> = params
         .iter()
         .enumerate()
         .map(|(i, p)| {
@@ -202,10 +202,66 @@ fn collect_generic_params(params: &[GenericParam], owner: &Span) -> Vec<GenericP
             GenericParamSig {
                 id: ParamId::new(owner, i, p.name.clone()),
                 bounds,
+                // Filled below once every sibling parameter id is known.
+                bound_args: Vec::new(),
                 span: p.span.clone(),
             }
         })
-        .collect()
+        .collect();
+    // Resolve the type arguments of each bound against a scope built from
+    // the sibling parameters in this same list. A bound such as
+    // `S: Iterator<T>` references the sibling `T`, so the scope must hold
+    // every parameter before any bound is resolved. Arguments that are
+    // bare parameter names or built-in primitives resolve without needing
+    // the type environment; anything else (an unresolvable argument) is
+    // recorded as `Ty::Error` and simply leaves the trait parameter
+    // abstract, which is the prior behavior.
+    let mut scope = GenericScope::new();
+    scope.push();
+    push_generics_into_scope(&mut scope, &sigs);
+    for (i, p) in params.iter().enumerate() {
+        let mut per_bound: Vec<Vec<Ty>> = Vec::with_capacity(p.bounds.len());
+        for b in &p.bounds {
+            let seg_args = b.segments.last().map(|s| &s.generics);
+            let args = match seg_args {
+                Some(gens) => gens
+                    .iter()
+                    .map(|g| resolve_bound_arg(g, &scope))
+                    .collect::<Vec<_>>(),
+                None => Vec::new(),
+            };
+            per_bound.push(args);
+        }
+        sigs[i].bound_args = per_bound;
+    }
+    sigs
+}
+
+/// Resolve one type argument of a trait bound to a [`Ty`] using only the
+/// lexical scope of the surrounding generic parameter list. Parameter
+/// names and built-in primitives resolve directly; anything requiring a
+/// type-environment lookup is left as `Ty::Error` so the caller falls
+/// back to leaving the trait parameter abstract.
+fn resolve_bound_arg(ty: &Type, scope: &GenericScope) -> Ty {
+    match &ty.kind {
+        TypeKind::Path(p) => {
+            let head = &p.segments[0];
+            if let Some(id) = scope.lookup(&head.name) {
+                return Ty::Param(id.clone());
+            }
+            match head.name.as_str() {
+                "Int" => Ty::Int,
+                "Float" => Ty::Float,
+                "Bool" => Ty::Bool,
+                "Char" => Ty::Char,
+                "String" => Ty::Str,
+                "Unit" => Ty::Unit,
+                _ => Ty::Error,
+            }
+        }
+        TypeKind::Unit => Ty::Unit,
+        _ => Ty::Error,
+    }
 }
 
 fn push_generics_into_scope(scope: &mut GenericScope, params: &[GenericParamSig]) {

--- a/src/tycheck/env.rs
+++ b/src/tycheck/env.rs
@@ -19,6 +19,14 @@ pub struct GenericParamSig {
     pub id: ParamId,
     /// Names of the traits this parameter is constrained by.
     pub bounds: Vec<String>,
+    /// Type arguments applied to each bound, aligned positionally with
+    /// `bounds`. For a bound `T: Iterator<Int>` the entry holds `[Int]`;
+    /// for a bound with no type arguments (`T: ToString`) it is empty.
+    /// Resolved after all signatures are collected (see the bound-argument
+    /// resolution pass in `collect`), so a method call dispatched through
+    /// the bound can substitute the trait's own generic parameters with
+    /// the concrete arguments rather than leaving them abstract.
+    pub bound_args: Vec<Vec<Ty>>,
     pub span: Span,
 }
 

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -24,6 +24,7 @@ use super::collect::{resolve_ty, scope_from_params, GenericScope};
 use super::env::{FnSig, GenericParamSig, TypeEnv};
 use super::infer::{substitute, InferCtx};
 use super::pattern;
+use super::ty::InferVarId;
 use super::ty::{FfiTy, ParamId, Ty};
 use super::unify::assignable;
 use super::TypeMap;
@@ -227,6 +228,10 @@ struct Checker<'a, 'b> {
     /// Inference context for this body. Holds variables, their
     /// solutions, and any pending trait bounds.
     infer: InferCtx,
+    /// Element type hint for an empty array literal, set from a `let`
+    /// binding's declared `List<T>` type while its initializer is checked.
+    /// An empty `[]` has no element to infer from, so it adopts this hint.
+    array_hint: Option<Ty>,
 }
 
 /// Keys used by the locals map. Mirrors the resolver's `Binding`
@@ -273,6 +278,7 @@ impl<'a, 'b> Checker<'a, 'b> {
             generic_scope: GenericScope::new(),
             param_bounds: HashMap::new(),
             infer: InferCtx::new(),
+            array_hint: None,
         }
     }
 
@@ -458,6 +464,15 @@ impl<'a, 'b> Checker<'a, 'b> {
     /// `CannotInferType` errors. Also resolves locals so subsequent
     /// stages see concrete types.
     fn finalize_types(&mut self) -> Result<(), RavenError> {
+        // First settle any deferred `Iterator<T>` element links: a call
+        // such as `collect(pipeline)` leaves the element type `T` to be
+        // inferred from the concrete argument bound to `S: Iterator<T>`.
+        // Map each concrete source type to its iterator element by
+        // structurally matching the `next` method's `Option<T>` return.
+        let impls = self.env.impls.clone();
+        let elem_of = move |ty: &Ty| -> Option<Ty> { iterator_elem_concrete(&impls, ty) };
+        self.infer.solve_iterator_links(&elem_of)?;
+
         // Resolve every entry in the type map. We do this in place by
         // replacing each entry's value with its resolved form, raising
         // CannotInferType if a variable remains.
@@ -527,17 +542,35 @@ impl<'a, 'b> Checker<'a, 'b> {
                 span.clone(),
             ));
         }
+        // First create a fresh variable for every parameter so a bound
+        // that mentions a sibling parameter (for example `S: Iterator<T>`)
+        // can link to that sibling's variable regardless of order.
+        let mut vars: Vec<InferVarId> = Vec::with_capacity(generics.len());
         let mut out: HashMap<ParamId, Ty> = HashMap::new();
-        for (i, p) in generics.iter().enumerate() {
+        for p in generics.iter() {
             let v = self.infer.fresh(span.clone());
-            for b in &p.bounds {
+            vars.push(v);
+            out.insert(p.id.clone(), Ty::Var(v));
+        }
+        for (i, p) in generics.iter().enumerate() {
+            let v = vars[i];
+            for (bi, b) in p.bounds.iter().enumerate() {
                 self.infer.add_bound(v, b.clone(), span.clone());
+                // For an `Iterator<T>` bound whose argument is a sibling
+                // parameter, link this variable's element to that
+                // sibling's variable so the element type can be inferred
+                // from a concrete argument at the call site.
+                if b == "Iterator" {
+                    if let Some(Ty::Param(elem_id)) = p.bound_args.get(bi).and_then(|a| a.first()) {
+                        if let Some(Ty::Var(elem_var)) = out.get(elem_id) {
+                            self.infer.add_iterator_link(v, *elem_var, span.clone());
+                        }
+                    }
+                }
             }
-            let assigned = Ty::Var(v);
             if let Some(explicit) = explicit_args.get(i) {
-                self.infer.unify(&assigned, explicit, span)?;
+                self.infer.unify(&Ty::Var(v), explicit, span)?;
             }
-            out.insert(p.id.clone(), assigned);
         }
         Ok(out)
     }
@@ -561,10 +594,17 @@ impl<'a, 'b> Checker<'a, 'b> {
                     Some(t) => Some(self.resolve_ast_ty(t)?),
                     None => None,
                 };
+                // While checking the initializer, expose the declared
+                // element type so an empty `[]` literal can adopt it.
+                let prev_hint = self.array_hint.take();
+                if let Some(Ty::List(elem)) = &declared {
+                    self.array_hint = Some((**elem).clone());
+                }
                 let init_ty = match init {
                     Some(e) => Some(self.check_expr(e)?),
                     None => None,
                 };
+                self.array_hint = prev_hint;
                 let final_ty = match (declared, init_ty) {
                     (Some(d), Some(i)) => {
                         self.unify(&d, &i, &init.as_ref().unwrap().span)?;
@@ -731,6 +771,21 @@ impl<'a, 'b> Checker<'a, 'b> {
                 let elem = match resolved.strip_self() {
                     Ty::List(t) => *t.clone(),
                     Ty::Error => Ty::Error,
+                    // A generic parameter `S` bounded by `Iterator<T>`
+                    // iterates at its bound's element type `T`. The loop is
+                    // monomorphized once `S` is known at each call site.
+                    Ty::Param(p) => match self.param_iterator_elem_ty(p) {
+                        Some(t) => t,
+                        None => {
+                            return Err(RavenError::ty(
+                                TypeError::Custom(format!(
+                                    "cannot iterate over `{}`; add an `Iterator<T>` bound to it",
+                                    p.name
+                                )),
+                                iter.span.clone(),
+                            ));
+                        }
+                    },
                     other => {
                         // Any value whose type implements `Iterator<T>`
                         // (resolved by finding a `next` method returning
@@ -989,6 +1044,12 @@ impl<'a, 'b> Checker<'a, 'b> {
 
     fn check_array(&mut self, items: &[Expr], span: &Span) -> Result<Ty, RavenError> {
         if items.is_empty() {
+            // An empty `[]` has no element to infer from. Adopt the
+            // element type hint from the enclosing `let` binding's
+            // declared `List<T>` type when one is present.
+            if let Some(elem) = self.array_hint.clone() {
+                return Ok(Ty::List(Box::new(elem)));
+            }
             return Err(RavenError::ty(
                 TypeError::Custom(
                     "empty array literals require a context type; annotate the binding".into(),
@@ -1506,6 +1567,20 @@ impl<'a, 'b> Checker<'a, 'b> {
             let ret = self.infer.resolve(&substitute(&msig.ret, &subst));
             if let Ty::Option(elem) = ret.strip_self() {
                 return Some((**elem).clone());
+            }
+        }
+        None
+    }
+
+    /// Element type for a generic parameter bounded by `Iterator<T>`.
+    /// Reads the parameter's recorded bounds and returns the type argument
+    /// of an `Iterator` bound, which is the element type the `for` loop and
+    /// `next()` calls produce once the parameter is grounded.
+    fn param_iterator_elem_ty(&self, param: &ParamId) -> Option<Ty> {
+        let bounds = self.param_bounds.get(param)?;
+        for (name, args) in bounds {
+            if name == "Iterator" {
+                return args.first().cloned();
             }
         }
         None
@@ -2160,4 +2235,88 @@ fn is_int_ffi(ty: &Ty) -> bool {
 
 fn ty_custom(msg: &str, span: &Span) -> RavenError {
     RavenError::ty(TypeError::Custom(msg.into()), span.clone())
+}
+
+/// Find the `Iterator` element type of a fully concrete type by matching
+/// it against the `next` method of every impl. The impl's `self_ty`
+/// (which carries `Ty::Param`s) is structurally matched against the
+/// concrete type to bind those parameters, and the bound substitution is
+/// applied to `next`'s `Option<T>` return. Pure: it allocates no
+/// inference variables, so it is safe to call from `finalize`.
+fn iterator_elem_concrete(impls: &[super::env::ImplSig], ty: &Ty) -> Option<Ty> {
+    for imp in impls {
+        let Some(msig) = imp.methods.get("next") else {
+            continue;
+        };
+        let mut subst: HashMap<ParamId, Ty> = HashMap::new();
+        if !structural_match(&imp.self_ty, ty, &mut subst) {
+            continue;
+        }
+        let ret = substitute(&msig.ret, &subst);
+        if let Ty::Option(elem) = ret.strip_self() {
+            if !elem.has_var() {
+                return Some((**elem).clone());
+            }
+        }
+    }
+    None
+}
+
+/// Structurally match a declared type (which may contain `Ty::Param`)
+/// against a concrete type, recording each parameter's binding. Returns
+/// false on a shape mismatch. Used to ground an impl's parameters from a
+/// concrete receiver without the inference machinery.
+fn structural_match(decl: &Ty, concrete: &Ty, out: &mut HashMap<ParamId, Ty>) -> bool {
+    match (decl, concrete) {
+        (Ty::Param(p), c) => {
+            out.insert(p.clone(), c.clone());
+            true
+        }
+        (Ty::Option(a), Ty::Option(b))
+        | (Ty::List(a), Ty::List(b))
+        | (Ty::SelfTy(a), Ty::SelfTy(b)) => structural_match(a, b, out),
+        (Ty::Result(a1, a2), Ty::Result(b1, b2)) => {
+            structural_match(a1, b1, out) && structural_match(a2, b2, out)
+        }
+        (
+            Ty::Struct {
+                id: ia, args: a, ..
+            },
+            Ty::Struct {
+                id: ib, args: b, ..
+            },
+        )
+        | (
+            Ty::Enum {
+                id: ia, args: a, ..
+            },
+            Ty::Enum {
+                id: ib, args: b, ..
+            },
+        ) => {
+            ia == ib
+                && a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| structural_match(x, y, out))
+        }
+        (
+            Ty::Function {
+                params: ap,
+                ret: ar,
+            },
+            Ty::Function {
+                params: bp,
+                ret: br,
+            },
+        ) => {
+            ap.len() == bp.len()
+                && ap
+                    .iter()
+                    .zip(bp.iter())
+                    .all(|(x, y)| structural_match(x, y, out))
+                && structural_match(ar, br, out)
+        }
+        (a, b) => a == b,
+    }
 }

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -223,7 +223,7 @@ struct Checker<'a, 'b> {
     /// its [`ParamId`]. A method call on a value of type `Ty::Param(p)`
     /// looks up `p`'s bounds here to find the trait that declares the
     /// called method (bound-driven trait method dispatch).
-    param_bounds: HashMap<ParamId, Vec<String>>,
+    param_bounds: HashMap<ParamId, Vec<(String, Vec<Ty>)>>,
     /// Inference context for this body. Holds variables, their
     /// solutions, and any pending trait bounds.
     infer: InferCtx,
@@ -287,7 +287,16 @@ impl<'a, 'b> Checker<'a, 'b> {
     fn record_param_bounds(&mut self, params: &[GenericParamSig]) {
         for p in params {
             if !p.bounds.is_empty() {
-                self.param_bounds.insert(p.id.clone(), p.bounds.clone());
+                let entries: Vec<(String, Vec<Ty>)> = p
+                    .bounds
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| {
+                        let args = p.bound_args.get(i).cloned().unwrap_or_default();
+                        (name.clone(), args)
+                    })
+                    .collect();
+                self.param_bounds.insert(p.id.clone(), entries);
             }
         }
     }
@@ -411,7 +420,7 @@ impl<'a, 'b> Checker<'a, 'b> {
                 let ok = self
                     .param_bounds
                     .get(p)
-                    .map(|bs| bs.iter().any(|b| b == "ToString"))
+                    .map(|bs| bs.iter().any(|(name, _)| name == "ToString"))
                     .unwrap_or(false);
                 if ok {
                     Ok(())
@@ -718,19 +727,34 @@ impl<'a, 'b> Checker<'a, 'b> {
                 body,
             } => {
                 let iter_ty = self.check_expr(iter)?;
-                let elem = match iter_ty.strip_self() {
+                let resolved = self.infer.resolve(&iter_ty);
+                let elem = match resolved.strip_self() {
                     Ty::List(t) => *t.clone(),
                     Ty::Error => Ty::Error,
                     other => {
-                        return Err(RavenError::ty(
-                            TypeError::Custom(format!(
-                                "cannot iterate over `{}`; expected a `List<T>`",
-                                other
-                            )),
-                            iter.span.clone(),
-                        ));
+                        // Any value whose type implements `Iterator<T>`
+                        // (resolved by finding a `next` method returning
+                        // `Option<T>`) can drive a `for` loop. The HIR
+                        // desugars this to a `loop` that calls `next`.
+                        match self.iterator_elem_ty(other, &iter.span) {
+                            Some(t) => t,
+                            None => {
+                                return Err(RavenError::ty(
+                                    TypeError::Custom(format!(
+                                        "cannot iterate over `{}`; expected a `List<T>` or a type implementing `Iterator<T>`",
+                                        other
+                                    )),
+                                    iter.span.clone(),
+                                ));
+                            }
+                        }
                     }
                 };
+                let elem = self.infer.resolve(&elem);
+                // Record the resolved element type at the pattern span so
+                // HIR lowering can type the loop binding without redoing
+                // method resolution (used by the iterator-driven path).
+                self.record(&pat.span, elem.clone());
                 pattern::bind(pat, &elem, self.env, &mut self.locals)?;
                 self.check_block(body)?;
                 Ok(Ty::Unit)
@@ -755,6 +779,19 @@ impl<'a, 'b> Checker<'a, 'b> {
         generics: &[crate::ast::Type],
         span: &Span,
     ) -> Result<Ty, RavenError> {
+        // A bare `None` carries an unknown element type. Use a fresh
+        // inference variable so it unifies with whatever concrete
+        // `Option<T>` the surrounding context fixes (for example the other
+        // arm of a `match`). Typing it as `Option<Error>` would swallow the
+        // unification and leave the element type unresolved. `Some`, `Ok`,
+        // and `Err` reach the checker as calls, so `None` is the only bare
+        // constructor identifier handled here. This is checked before the
+        // binding lookup because `None` is a built-in constructor with no
+        // user declaration to bind to.
+        if name == "None" {
+            let v = self.infer.fresh(span.clone());
+            return Ok(Ty::Option(Box::new(Ty::Var(v))));
+        }
         if let Some(binding) = self.resolved.map.lookup(span).cloned() {
             // Resolve any explicit type arguments first. We pass them
             // through to the instantiation step below.
@@ -763,8 +800,6 @@ impl<'a, 'b> Checker<'a, 'b> {
                 explicit_args.push(self.resolve_ast_ty(g)?);
             }
             self.type_of_binding(&binding, span, &explicit_args)
-        } else if let Some(t) = recognize_constructor_ident(name) {
-            Ok(t)
         } else {
             Err(RavenError::ty(
                 TypeError::Custom(format!("identifier `{}` has no type binding", name)),
@@ -1443,6 +1478,39 @@ impl<'a, 'b> Checker<'a, 'b> {
         Ok(substitute(&sig.ret, &full))
     }
 
+    /// If `recv` has a `next(self) -> Option<T>` method (from any impl,
+    /// trait or inherent), return the element type `T`. This is how a
+    /// `for` loop discovers that an arbitrary value is iterable: the
+    /// `Iterator<T>` trait declares exactly that method, and concrete
+    /// adapter structs implement it. Returns `None` when no matching
+    /// `next` method resolves to an `Option`.
+    fn iterator_elem_ty(&mut self, recv: &Ty, span: &Span) -> Option<Ty> {
+        let impls_snapshot = self.env.impls.clone();
+        for imp in impls_snapshot.iter() {
+            let Some(msig) = imp.methods.get("next") else {
+                continue;
+            };
+            // Substitute fresh inference vars for the impl's generics, then
+            // unify the impl's self type against the receiver. A successful
+            // unification fixes those vars, so the substituted return type
+            // becomes concrete.
+            let mut subst: HashMap<ParamId, Ty> = HashMap::new();
+            for p in &imp.generics {
+                let v = self.infer.fresh(span.clone());
+                subst.insert(p.id.clone(), Ty::Var(v));
+            }
+            let impl_self = substitute(&imp.self_ty, &subst);
+            if self.infer.unify(&impl_self, recv, span).is_err() {
+                continue;
+            }
+            let ret = self.infer.resolve(&substitute(&msig.ret, &subst));
+            if let Ty::Option(elem) = ret.strip_self() {
+                return Some((**elem).clone());
+            }
+        }
+        None
+    }
+
     /// Check a method call whose receiver is a `dyn Trait` value. The
     /// method must belong to the trait. Argument types are checked against
     /// the trait method's declared parameter types (with `Self` left
@@ -1513,18 +1581,35 @@ impl<'a, 'b> Checker<'a, 'b> {
         let recv_ty = Ty::Param(param.clone());
         let bounds = self.param_bounds.get(param).cloned().unwrap_or_default();
         // Find a bound trait whose declaration carries the called method.
+        // Alongside the method signature, build a substitution that maps
+        // the trait's own generic parameters to the type arguments named
+        // in the bound. For a bound `S: Iterator<Int>` calling `next`,
+        // `Iterator`'s declared `T` maps to `Int`, so the method's return
+        // `Option<T>` resolves to `Option<Int>` instead of staying
+        // abstract. Without this, the trait parameter leaks out as a fresh
+        // `Param` that cannot unify with the concrete element type.
         let mut found: Option<FnSig> = None;
-        for trait_name in &bounds {
-            let sig = self
+        let mut trait_subst: HashMap<ParamId, Ty> = HashMap::new();
+        for (trait_name, bound_args) in &bounds {
+            let trait_sig = self
                 .env
                 .traits
                 .values()
                 .find(|t| &t.name == trait_name)
-                .and_then(|t| t.methods.get(name).cloned());
-            if let Some(sig) = sig {
-                found = Some(sig);
-                break;
+                .cloned();
+            let Some(trait_sig) = trait_sig else {
+                continue;
+            };
+            let Some(msig) = trait_sig.methods.get(name).cloned() else {
+                continue;
+            };
+            for (tp, arg) in trait_sig.generics.iter().zip(bound_args.iter()) {
+                if !matches!(arg, Ty::Error) {
+                    trait_subst.insert(tp.id.clone(), arg.clone());
+                }
             }
+            found = Some(msig);
+            break;
         }
         let Some(sig) = found else {
             // The method is on no bound trait. If the parameter has no
@@ -1537,9 +1622,10 @@ impl<'a, 'b> Checker<'a, 'b> {
                     param.name
                 )
             } else {
+                let names: Vec<&str> = bounds.iter().map(|(n, _)| n.as_str()).collect();
                 format!(
                     "none of the bounds `{}` on `{}` declare a method `{}`",
-                    bounds.join(" + "),
+                    names.join(" + "),
                     param.name,
                     name
                 )
@@ -1555,12 +1641,13 @@ impl<'a, 'b> Checker<'a, 'b> {
         };
 
         // Substitute every `Self` placeholder in the trait method's
-        // signature with the receiver's parameter type.
+        // signature with the receiver's parameter type, and the trait's
+        // own generic parameters with the bound's type arguments.
         let user_params: Vec<Ty> = sig
             .params
             .iter()
             .filter(|t| !matches!(t, Ty::SelfTy(_)))
-            .map(|t| substitute_self(t, &recv_ty))
+            .map(|t| substitute(&substitute_self(t, &recv_ty), &trait_subst))
             .collect();
         if user_params.len() != args.len() {
             return Err(RavenError::ty(
@@ -1576,7 +1663,10 @@ impl<'a, 'b> Checker<'a, 'b> {
             let a = self.check_expr(arg)?;
             self.unify(pt, &a, &arg.span)?;
         }
-        Ok(substitute_self(&sig.ret, &recv_ty))
+        Ok(substitute(
+            &substitute_self(&sig.ret, &recv_ty),
+            &trait_subst,
+        ))
     }
 
     fn check_field(&mut self, receiver: &Expr, name: &str, span: &Span) -> Result<Ty, RavenError> {
@@ -1906,7 +1996,7 @@ impl<'a, 'b> Checker<'a, 'b> {
                 let ok = self
                     .param_bounds
                     .get(p)
-                    .map(|bs| bs.iter().any(|b| b == "ToString"))
+                    .map(|bs| bs.iter().any(|(name, _)| name == "ToString"))
                     .unwrap_or(false);
                 if ok {
                     continue;
@@ -2070,14 +2160,4 @@ fn is_int_ffi(ty: &Ty) -> bool {
 
 fn ty_custom(msg: &str, span: &Span) -> RavenError {
     RavenError::ty(TypeError::Custom(msg.into()), span.clone())
-}
-
-/// Recognize the bare constructor identifier `None` when the resolver
-/// could not bind it. `Some`, `Ok`, `Err` reach the type checker as
-/// calls; only `None` is a bare identifier.
-fn recognize_constructor_ident(name: &str) -> Option<Ty> {
-    match name {
-        "None" => Some(Ty::Option(Box::new(Ty::Error))),
-        _ => None,
-    }
 }

--- a/src/tycheck/infer.rs
+++ b/src/tycheck/infer.rs
@@ -31,6 +31,23 @@ pub struct InferCtx {
     /// variable's representative; merging variables merges the bound
     /// lists.
     bounds: HashMap<InferVarId, Vec<PendingBound>>,
+    /// Deferred "element of an iterator" links. Each entry says the
+    /// element variable is the `T` of `source: Iterator<T>`. When the
+    /// source resolves to a concrete iterator type, the element variable
+    /// is unified with that type's element so a call like
+    /// `collect(pipeline)` can infer the element type from the argument
+    /// even though `T` appears only in the function's `S: Iterator<T>`
+    /// bound and never in a parameter position.
+    iterator_links: Vec<IteratorLink>,
+}
+
+/// A deferred link from an iterator-typed variable to its element
+/// variable, resolved once the source variable is known.
+#[derive(Debug, Clone)]
+struct IteratorLink {
+    source: InferVarId,
+    element: InferVarId,
+    span: Span,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -81,6 +98,39 @@ impl InferCtx {
     pub fn bounds_of(&self, v: InferVarId) -> Vec<PendingBound> {
         let root = self.find(v);
         self.bounds.get(&root).cloned().unwrap_or_default()
+    }
+
+    /// Record that `element` is the `T` of `source: Iterator<T>`. Resolved
+    /// later by `solve_iterator_links` once `source` is concrete.
+    pub fn add_iterator_link(&mut self, source: InferVarId, element: InferVarId, span: Span) {
+        self.iterator_links.push(IteratorLink {
+            source,
+            element,
+            span,
+        });
+    }
+
+    /// For each deferred iterator link whose source has resolved to a
+    /// concrete iterator type, unify the element variable with that type's
+    /// element. `elem_of` maps a concrete source type to its `Iterator`
+    /// element type (the checker supplies it because the impl table lives
+    /// outside the inference context). Returns once a fixed point is
+    /// reached. Unsolved links are left for `CannotInferType` to report.
+    pub fn solve_iterator_links(
+        &mut self,
+        elem_of: &impl Fn(&Ty) -> Option<Ty>,
+    ) -> Result<(), RavenError> {
+        let links = self.iterator_links.clone();
+        for link in links {
+            let source = self.resolve(&Ty::Var(link.source));
+            if source.has_var() {
+                continue;
+            }
+            if let Some(elem) = elem_of(&source) {
+                self.unify(&Ty::Var(link.element), &elem, &link.span)?;
+            }
+        }
+        Ok(())
     }
 
     /// Return the union-find root for `v`. Performs path compression.

--- a/stdlib/std/iter.rv
+++ b/stdlib/std/iter.rv
@@ -1,0 +1,343 @@
+// std/iter: lazy, single-pass iterator adapters.
+//
+// This is bundled Raven source compiled into the program when a user
+// writes `import std/iter { ... }`. It builds on the `Iterator<T>` trait
+// from std/core (auto-imported), which declares a single method:
+//
+//     fun next(self) -> Option<T>
+//
+// An adapter is a small struct that stores its source iterator (and,
+// where applicable, a captured closure) and implements `Iterator`. Its
+// `next` pulls from the source on demand, so a chain such as
+//
+//     list.iter().map(f).filter(g)
+//
+// performs no work until the result is driven by a `for` loop or a
+// consumer such as `collect`. Each adapter is monomorphized at its
+// concrete source and element types, and the stored closures are called
+// through statically known function-pointer slots, so a finished
+// pipeline runs in a single pass with no per-stage allocation. See
+// `docs/v2/specs/std-iter.md` for the full design, the chaining
+// ergonomics, and the deliberate limitations.
+//
+// Generic parameter order note: a bound that mentions a sibling
+// parameter (for example `S: Iterator<T>`) must appear after that
+// parameter in the list, so every adapter lists its element types first
+// and its bounded source type last.
+
+// ----- ListIter: the bridge from a List into the iterator world -----
+
+// Iterates a `List<T>` by index. `iter()` on a `List<T>` returns this.
+struct ListIter<T> {
+    items: List<T>,
+    pos: Int,
+}
+
+impl<T> ListIter<T> {
+    fun next(self) -> Option<T> {
+        if self.pos >= self.items.len() {
+            return None
+        }
+        let v = self.items.get(self.pos)
+        self.pos = self.pos + 1
+        return Some(v)
+    }
+
+    fun map<U>(self, f: fun(T) -> U) -> MapIter<T, U, ListIter<T>> {
+        return MapIter { f: f, src: self }
+    }
+
+    fun filter(self, pred: fun(T) -> Bool) -> Filter<T, ListIter<T>> {
+        return Filter { pred: pred, src: self }
+    }
+
+    fun take(self, n: Int) -> Take<T, ListIter<T>> {
+        return Take { left: n, src: self }
+    }
+
+    fun skip(self, n: Int) -> Skip<T, ListIter<T>> {
+        return Skip { left: n, src: self }
+    }
+
+    fun enumerate(self) -> Enumerate<T, ListIter<T>> {
+        return Enumerate { idx: 0, src: self }
+    }
+}
+
+// Build a `ListIter<T>` over `xs`. The free-function form; the method
+// form `xs.iter()` is defined on `List<T>` below.
+fun from_list<T>(xs: List<T>) -> ListIter<T> {
+    return ListIter { items: xs, pos: 0 }
+}
+
+impl<T> List<T> {
+    fun iter(self) -> ListIter<T> {
+        return ListIter { items: self, pos: 0 }
+    }
+}
+
+// ----- MapIter: apply a closure to each element -----
+
+struct MapIter<T, U, S: Iterator<T>> {
+    f: fun(T) -> U,
+    src: S,
+}
+
+impl<T, U, S: Iterator<T>> MapIter<T, U, S> {
+    fun next(self) -> Option<U> {
+        return match self.src.next() {
+            None -> None,
+            Some(v) -> Some((self.f)(v)),
+        }
+    }
+
+    fun map<V>(self, g: fun(U) -> V) -> MapIter<U, V, MapIter<T, U, S>> {
+        return MapIter { f: g, src: self }
+    }
+
+    fun filter(self, pred: fun(U) -> Bool) -> Filter<U, MapIter<T, U, S>> {
+        return Filter { pred: pred, src: self }
+    }
+
+    fun take(self, n: Int) -> Take<U, MapIter<T, U, S>> {
+        return Take { left: n, src: self }
+    }
+
+    fun skip(self, n: Int) -> Skip<U, MapIter<T, U, S>> {
+        return Skip { left: n, src: self }
+    }
+
+    fun enumerate(self) -> Enumerate<U, MapIter<T, U, S>> {
+        return Enumerate { idx: 0, src: self }
+    }
+}
+
+// ----- Filter: keep elements that satisfy a predicate -----
+
+struct Filter<T, S: Iterator<T>> {
+    pred: fun(T) -> Bool,
+    src: S,
+}
+
+impl<T, S: Iterator<T>> Filter<T, S> {
+    fun next(self) -> Option<T> {
+        let done = false
+        while done == false {
+            match self.src.next() {
+                None -> {
+                    return None
+                }
+                Some(v) -> {
+                    if (self.pred)(v) {
+                        return Some(v)
+                    }
+                }
+            }
+        }
+        return None
+    }
+
+    fun map<U>(self, f: fun(T) -> U) -> MapIter<T, U, Filter<T, S>> {
+        return MapIter { f: f, src: self }
+    }
+
+    fun filter(self, pred: fun(T) -> Bool) -> Filter<T, Filter<T, S>> {
+        return Filter { pred: pred, src: self }
+    }
+
+    fun take(self, n: Int) -> Take<T, Filter<T, S>> {
+        return Take { left: n, src: self }
+    }
+
+    fun skip(self, n: Int) -> Skip<T, Filter<T, S>> {
+        return Skip { left: n, src: self }
+    }
+
+    fun enumerate(self) -> Enumerate<T, Filter<T, S>> {
+        return Enumerate { idx: 0, src: self }
+    }
+}
+
+// ----- Take: yield at most n elements -----
+
+struct Take<T, S: Iterator<T>> {
+    left: Int,
+    src: S,
+}
+
+impl<T, S: Iterator<T>> Take<T, S> {
+    fun next(self) -> Option<T> {
+        if self.left <= 0 {
+            return None
+        }
+        self.left = self.left - 1
+        return self.src.next()
+    }
+
+    fun map<U>(self, f: fun(T) -> U) -> MapIter<T, U, Take<T, S>> {
+        return MapIter { f: f, src: self }
+    }
+
+    fun filter(self, pred: fun(T) -> Bool) -> Filter<T, Take<T, S>> {
+        return Filter { pred: pred, src: self }
+    }
+
+    fun take(self, n: Int) -> Take<T, Take<T, S>> {
+        return Take { left: n, src: self }
+    }
+
+    fun skip(self, n: Int) -> Skip<T, Take<T, S>> {
+        return Skip { left: n, src: self }
+    }
+
+    fun enumerate(self) -> Enumerate<T, Take<T, S>> {
+        return Enumerate { idx: 0, src: self }
+    }
+}
+
+// ----- Skip: discard the first n elements, then pass through -----
+
+struct Skip<T, S: Iterator<T>> {
+    left: Int,
+    src: S,
+}
+
+impl<T, S: Iterator<T>> Skip<T, S> {
+    fun next(self) -> Option<T> {
+        while self.left > 0 {
+            self.left = self.left - 1
+            match self.src.next() {
+                None -> {
+                    return None
+                }
+                Some(v) -> {
+                    // discard and continue
+                }
+            }
+        }
+        return self.src.next()
+    }
+
+    fun map<U>(self, f: fun(T) -> U) -> MapIter<T, U, Skip<T, S>> {
+        return MapIter { f: f, src: self }
+    }
+
+    fun filter(self, pred: fun(T) -> Bool) -> Filter<T, Skip<T, S>> {
+        return Filter { pred: pred, src: self }
+    }
+
+    fun take(self, n: Int) -> Take<T, Skip<T, S>> {
+        return Take { left: n, src: self }
+    }
+
+    fun skip(self, n: Int) -> Skip<T, Skip<T, S>> {
+        return Skip { left: n, src: self }
+    }
+
+    fun enumerate(self) -> Enumerate<T, Skip<T, S>> {
+        return Enumerate { idx: 0, src: self }
+    }
+}
+
+// ----- Enumerate: pair each element with its running index -----
+
+// Raven has no tuples yet, so `Enumerate` yields this small record
+// instead of a `(Int, T)` pair. See the spec for the rationale.
+struct Indexed<T> {
+    index: Int,
+    value: T,
+}
+
+struct Enumerate<T, S: Iterator<T>> {
+    idx: Int,
+    src: S,
+}
+
+impl<T, S: Iterator<T>> Enumerate<T, S> {
+    fun next(self) -> Option<Indexed<T>> {
+        return match self.src.next() {
+            None -> None,
+            Some(v) -> {
+                let here = self.idx
+                self.idx = self.idx + 1
+                Some(Indexed { index: here, value: v })
+            },
+        }
+    }
+}
+
+// ----- Consumers: drive an iterator to completion -----
+//
+// These are free generic functions over any `S: Iterator<T>`. Raven has
+// no blanket trait impls, so a consumer cannot be a method shared by
+// every adapter. Writing them as free functions keeps a single
+// definition each: `collect(pipeline)` rather than a method per adapter
+// type. The pipeline is built with the adapter methods (`iter`, `map`,
+// `filter`, ...) and then handed to a consumer.
+
+// Gather every remaining element into a `List<T>`, in order.
+fun collect<T, S: Iterator<T>>(it: S) -> List<T> {
+    let out: List<T> = []
+    for x in it {
+        out.push(x)
+    }
+    return out
+}
+
+// Count the remaining elements.
+fun count<T, S: Iterator<T>>(it: S) -> Int {
+    let n = 0
+    for x in it {
+        n = n + 1
+    }
+    return n
+}
+
+// Left fold: combine the elements into a single accumulator. `init` is
+// the starting value and `f` folds the running accumulator with each
+// element.
+fun fold<T, A, S: Iterator<T>>(it: S, init: A, f: fun(A, T) -> A) -> A {
+    let acc = init
+    for x in it {
+        acc = f(acc, x)
+    }
+    return acc
+}
+
+// True when at least one element satisfies `pred`. Consumes the iterator
+// up to the first match.
+fun any<T, S: Iterator<T>>(it: S, pred: fun(T) -> Bool) -> Bool {
+    for x in it {
+        if pred(x) {
+            return true
+        }
+    }
+    return false
+}
+
+// True when every element satisfies `pred` (vacuously true when empty).
+fun all<T, S: Iterator<T>>(it: S, pred: fun(T) -> Bool) -> Bool {
+    for x in it {
+        if pred(x) == false {
+            return false
+        }
+    }
+    return true
+}
+
+// The first element satisfying `pred`, or `None` when none does.
+fun find<T, S: Iterator<T>>(it: S, pred: fun(T) -> Bool) -> Option<T> {
+    for x in it {
+        if pred(x) {
+            return Some(x)
+        }
+    }
+    return None
+}
+
+// Apply `f` to each element for its side effect.
+fun for_each<T, S: Iterator<T>>(it: S, f: fun(T) -> Unit) {
+    for x in it {
+        f(x)
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -267,6 +267,20 @@ fn method_generics_program_compiles_and_runs() {
 }
 
 #[test]
+fn iter_pipeline_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // The lazy iterator pipeline end to end: `xs.iter().map(f).filter(g)`
+    // chained adapters driven by the generic consumers `collect`, `fold`,
+    // and `count`. Each consumer is generic over `S: Iterator<T>` where the
+    // element type `T` appears only in the bound and the return type, so the
+    // monomorphizer recovers it by matching the declared return type against
+    // the concrete call result. Prints 4, then 180, then 3.
+    compile_link_run_and_check("iter_pipeline.rv", "4\n180\n3\n", &runtime);
+}
+
+#[test]
 fn list_int_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;

--- a/tests/tycheck_corpus/option_result.rv.types
+++ b/tests/tycheck_corpus/option_result.rv.types
@@ -4,7 +4,7 @@
   48..50 "xs" -> List<Int>
   48..61 "xs.is_empty()" -> Bool
   62..89 "{\n        return None\n    }" -> ()
-  79..83 "None" -> Option<<error>>
+  79..83 "None" -> Option<Int>
   101..116 "Some(xs.get(0))" -> Option<Int>
   106..108 "xs" -> List<Int>
   106..115 "xs.get(0)" -> Int


### PR DESCRIPTION
Adds the lazy, single-pass iterator pipeline as the bundled `std/iter` module, plus the two compiler pieces it needed: inferring an iterator's element type through an `Iterator<T>` bound, and recovering a bound-only generic parameter during monomorphization.

Closes #119. Spec at `docs/v2/specs/std-iter.md`.

## What this adds

- **`stdlib/std/iter.rv`**: a `ListIter` bridge (`List<T>.iter()`), lazy adapters `MapIter`, `Filter`, `Take`, `Skip`, `Enumerate` (each an `Iterator` struct storing its source and any closure), and consumers `collect`, `fold`, `count`, `any`, `all`, `find`, `for_each`. Chaining via adapter methods: `xs.iter().map(f).filter(g)`.
- **tycheck**: deferred iterator-element links infer a consumer's `T` (which appears only in its `S: Iterator<T>` bound) from the concrete source; for-loops are generalized to drive any `Iterator` value.
- **mir**: a callee's declared return type is matched against the call's concrete result type, so a generic parameter that appears only in the return type or a bound (like `collect`'s `T`) is instantiated rather than defaulting to `Unit`.

## Verification (built and run on windows-msvc)

`examples/v2/iter_pipeline.rv` builds a `map`/`filter` pipeline and drives it with `collect`, `fold`, and `count`:
```
4
180
3
```
(four elements kept, their sum 180, and three elements past a filter.) Concrete-iterator for-loops and the `count`-style consumers were verified independently along the way.

## Zero-cost

Adapters are monomorphized structs and the stored closures are statically dispatched, so a pipeline runs in a single pass with no per-stage List allocation; only `collect` allocates.

## Deferred (documented in the spec)

- `Zip` and `Chain` adapters.
- Tuples for `Enumerate` (uses an `Indexed<T>` record).
- Blanket trait impls (the reason adapter methods and consumers are defined per type / as free functions).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` (287 lib + 25 codegen smoke including the new iter_pipeline case + golden suites) pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `iter_pipeline.rv` prints 4 / 180 / 3 end to end
