### PR TITLE
feat(stdlib): method-first std/string

### DIFF
--- a/docs/v2/specs/std-string.md
+++ b/docs/v2/specs/std-string.md
@@ -4,84 +4,84 @@
 
 Provide a useful string-utility surface for Raven v2 programs: case
 mapping, length and access, search, transforms, and validation. The
-module is bundled Raven source compiled into the program the same way
-`std/io` is (see `stdlib.md`). It is written in pure Raven on top of a
-small set of byte-level compiler intrinsics, so most of the logic
+surface is method-first: every operation is a method on `String`, defined
+in an `impl String` block in bundled Raven source compiled into the
+program the same way `std/io` is (see `stdlib.md`). It is written on top
+of a small set of byte-level compiler intrinsics, so most of the logic
 dogfoods the language itself.
 
 ## Import
 
-`std/string` uses the selective-import form the resolver supports:
+`std/string` is method-first, so there are no free names to import
+selectively. A bare module import merges its `impl String` block into the
+program; the methods are then resolved by the receiver type:
 
 ```raven
-import std/string { to_upper, trim, contains, repeat }
-```
+import std/string
 
-Each selector binds the bare name to the namespaced function
-(`std.string.to_upper`, ...) the compiler merges into the program. The
-aliased `import std/string as s` form with `s.member(...)` access is not
-supported, the same limitation `std/io` documents.
+fun main() {
+    print("hello".to_upper())
+}
+```
 
 ## Byte versus codepoint semantics
 
 Every function in this module is byte oriented. Indices, lengths, and
 slices count UTF-8 bytes, not Unicode code points or grapheme clusters.
 
-* `length(s)` returns the byte count. A string of multi-byte characters
-  reports a length larger than its visible character count: `length("é")`
+* `s.length()` returns the byte count. A string of multi-byte characters
+  reports a length larger than its visible character count: `"é".length()`
   is 2 because `é` is the two bytes `0xC3 0xA9` in UTF-8.
-* `char_at(s, i)` and `substring(s, start, end)` cut on byte boundaries.
+* `s.char_at(i)` and `s.substring(start, end)` cut on byte boundaries.
   Cutting through the middle of a multi-byte character yields a string
   whose bytes are not valid UTF-8; that is the caller's responsibility.
-* `index_of`, `contains`, `starts_with`, `ends_with`, and `replace`
-  compare whole byte sequences, so they work correctly on multi-byte
-  text as long as the needle and haystack are themselves valid UTF-8
-  (the common case). `contains("café", "fé")` is true because the byte
-  sequence of `fé` occurs in `café`.
-* `to_upper` and `to_lower` map only ASCII letters (`A`..`Z` <->
+* `s.index_of`, `s.contains`, `s.starts_with`, `s.ends_with`, and
+  `s.replace` compare whole byte sequences, so they work correctly on
+  multi-byte text as long as the needle and haystack are themselves valid
+  UTF-8 (the common case). `"café".contains("fé")` is true because the
+  byte sequence of `fé` occurs in `café`.
+* `s.to_upper()` and `s.to_lower()` map only ASCII letters (`A`..`Z` <->
   `a`..`z`); every other byte, including the bytes of a multi-byte
   character, passes through unchanged.
-* `trim` and `is_blank` treat the ASCII whitespace set (space, tab,
-  newline, carriage return, vertical tab, form feed) as whitespace.
+* `s.trim()` and `s.is_blank()` treat the ASCII whitespace set (space,
+  tab, newline, carriage return, vertical tab, form feed) as whitespace.
 
 This byte model keeps v2.0 small and predictable. Code-point and
 grapheme-aware operations are deferred (see Out of scope).
 
 ## The std/string surface
 
-`stdlib/std/string.rv` exports:
+`stdlib/std/string.rv` defines `impl String` with these methods (each
+takes `self`):
 
-* `length(s: String) -> Int`: byte length of `s`.
-* `is_empty(s: String) -> Bool`: true when `s` has zero bytes.
-* `char_at(s: String, i: Int) -> String`: the `i`-th byte as a one-byte
-  string; out of range yields the empty string.
-* `substring(s: String, start: Int, end: Int) -> String`: the half-open
-  byte range `[start, end)`, with bounds clamped to `0..length(s)` and a
-  `start` past `end` yielding the empty string.
-* `concat(a: String, b: String) -> String`: join two strings.
-* `to_upper(s: String) -> String`, `to_lower(s: String) -> String`:
-  ASCII case mapping.
-* `trim(s: String) -> String`: remove leading and trailing ASCII
-  whitespace; interior whitespace is kept.
-* `is_blank(s: String) -> Bool`: true when `s` is empty or all ASCII
-  whitespace.
-* `repeat(s: String, n: Int) -> String`: `s` repeated `n` times; a non
-  positive `n` yields the empty string.
-* `index_of(s: String, needle: String) -> Int`: byte index of the first
-  occurrence of `needle`, or `-1` when absent; an empty `needle` returns
-  `0`.
-* `contains(s: String, needle: String) -> Bool`: true when `needle`
-  occurs anywhere in `s`.
-* `starts_with(s: String, prefix: String) -> Bool`,
-  `ends_with(s: String, suffix: String) -> Bool`: prefix and suffix
-  tests; an empty prefix or suffix always matches.
-* `replace(s: String, from: String, to: String) -> String`: replace
-  every non-overlapping occurrence of `from` with `to`, scanning left to
-  right; an empty `from` returns `s` unchanged so the scan terminates.
+* `length() -> Int`: byte length.
+* `is_empty() -> Bool`: true when the string has zero bytes.
+* `char_at(i: Int) -> String`: the `i`-th byte as a one-byte string; out
+  of range yields the empty string.
+* `substring(start: Int, end: Int) -> String`: the half-open byte range
+  `[start, end)`, with bounds clamped to `0..length()` and a `start` past
+  `end` yielding the empty string.
+* `concat(other: String) -> String`: join two strings.
+* `to_upper() -> String`, `to_lower() -> String`: ASCII case mapping.
+* `trim() -> String`: remove leading and trailing ASCII whitespace;
+  interior whitespace is kept.
+* `is_blank() -> Bool`: true when empty or all ASCII whitespace.
+* `repeat(n: Int) -> String`: repeated `n` times; a non-positive `n`
+  yields the empty string.
+* `matches_at(needle: String, at: Int) -> Bool`: true when `needle`'s
+  bytes occur starting at byte index `at`.
+* `index_of(needle: String) -> Int`: byte index of the first occurrence
+  of `needle`, or `-1` when absent; an empty `needle` returns `0`.
+* `contains(needle: String) -> Bool`: true when `needle` occurs anywhere.
+* `starts_with(prefix: String) -> Bool`, `ends_with(suffix: String) ->
+  Bool`: prefix and suffix tests; an empty prefix or suffix always
+  matches.
+* `replace(from: String, to: String) -> String`: replace every
+  non-overlapping occurrence of `from` with `to`, scanning left to right;
+  an empty `from` returns the string unchanged so the scan terminates.
 
-Two helpers, `is_space_byte` and `matches_at`, are also exported because
-the bundled module calls them internally; they are documented but not
-part of the intended public surface.
+A free helper `is_space_byte(b: Int) -> Bool` classifies an ASCII
+whitespace byte; the methods call it internally.
 
 ## Intrinsic boundary
 
@@ -125,16 +125,13 @@ would not change this surface.
 
 ## Intra-module call resolution
 
-Unlike `std/io`, the `std/string` functions call one another (for
-example `trim` calls `is_space_byte`, and `index_of` calls
-`matches_at`). The stdlib expansion renames each declared function to
-`std.string.<name>` and, so a sibling call still resolves, rewrites any
-call-site identifier inside a bundled function body that names a sibling
-function to the same namespaced name. Local variables and parameters in
-the bundled sources never share a name with a sibling function, so the
-rewrite is unambiguous. This is implemented in `src/resolve/stdlib.rs`
-and is general: any later bundled module whose functions call each other
-benefits without extra work.
+Methods call each other through `self` (for example `contains` calls
+`self.index_of`, which calls `self.matches_at`), resolved by the receiver
+type. A method also calls the free helper `is_space_byte`; the stdlib
+expansion renames each declared free function to `std.string.<name>` and
+rewrites sibling free-function call sites inside bundled bodies to the
+same namespaced name, so the helper resolves from within a method body.
+This is implemented in `src/resolve/stdlib.rs`.
 
 ## Out of scope
 

--- a/examples/v2/stdlib_string_method.rv
+++ b/examples/v2/stdlib_string_method.rv
@@ -1,12 +1,9 @@
 // golden:skip
-// A method defined on the built in `String` type inside the bundled
-// std/string module, called from user code. Importing the module merges
-// its `impl String` block into the program; the `shout` method is then
-// resolved by the receiver's type, not by an imported name, so calling
-// "hi".shout() dispatches to the stdlib method and prints HI.
-import std/string { to_upper }
+// Importing std/string merges its `impl String` block; the method is
+// resolved by the receiver type, not by an imported name.
+import std/string
 import std/io { println }
 
 fun main() {
-    println("hi".shout())
+    println("hi".to_upper())
 }

--- a/examples/v2/use_string.rv
+++ b/examples/v2/use_string.rv
@@ -1,23 +1,19 @@
 // golden:skip
-// Import the bundled std/string module and exercise its functions. The
-// selective import binds each name to the namespaced stdlib function the
-// compiler merges into the program. std/io provides println for output
-// and println_int to observe an Int result.
-import std/string { to_upper, to_lower, trim, repeat, contains, index_of, replace, substring }
-import std/io { println, println_int }
+import std/string
+import std/io { println }
 
 fun main() {
-    println(to_upper("hello"))
-    println(to_lower("WORLD"))
-    println(trim("  spaced  "))
-    println(repeat("ab", 3))
-    println(replace("a-b-c", "-", "+"))
-    println(substring("raven", 1, 4))
-    if contains("hello world", "world") {
+    println("hello".to_upper())
+    println("WORLD".to_lower())
+    println("  spaced  ".trim())
+    println("ab".repeat(3))
+    println("a-b-c".replace("-", "+"))
+    println("raven".substring(1, 4))
+    if "hello world".contains("world") {
         println("contains: yes")
     } else {
         println("contains: no")
     }
-    println_int(index_of("hello", "llo"))
-    println_int(index_of("hello", "zzz"))
+    print("hello".index_of("llo"))
+    print("hello".index_of("zzz"))
 }

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -355,20 +355,22 @@ mod tests {
 
     #[test]
     fn intra_module_sibling_calls_are_namespaced() {
-        // `std/string`'s `trim` calls its sibling `is_space_byte`. After
-        // expansion the call site must reference the namespaced name so it
-        // resolves to the renamed declaration. Collect every identifier in
-        // `trim`'s body and assert the sibling call was renamed.
-        let user = parse_src("import std/string { trim }\nfun main() {}\n");
+        // `std/string`'s `trim` is a method on `impl String` that calls the
+        // module's free helper `is_space_byte`. After expansion the call
+        // site inside the method body must reference the namespaced name so
+        // it resolves to the renamed free declaration.
+        let user = parse_src("import std/string\nfun main() {}\n");
         let combined = expand_with_stdlib(&user).expect("expand");
         let trim_fn = combined
             .items
             .iter()
-            .find_map(|d| match &d.kind {
-                DeclKind::Function(f) if f.name == "std.string.trim" => Some(f),
+            .filter_map(|d| match &d.kind {
+                DeclKind::Impl(imp) => Some(imp),
                 _ => None,
             })
-            .expect("std.string.trim present");
+            .flat_map(|imp| imp.items.iter())
+            .find(|f| f.name == "trim")
+            .expect("trim method present");
         let mut idents = Vec::new();
         if let FunctionBody::Block(b) = &trim_fn.body {
             collect_block_idents(b, &mut idents);
@@ -377,7 +379,7 @@ mod tests {
         }
         assert!(
             idents.iter().any(|n| n == "std.string.is_space_byte"),
-            "trim body should call the namespaced sibling, got: {idents:?}"
+            "trim body should call the namespaced free sibling, got: {idents:?}"
         );
         assert!(
             !idents.iter().any(|n| n == "is_space_byte"),

--- a/stdlib/std/io.rv
+++ b/stdlib/std/io.rv
@@ -1,56 +1,38 @@
-// std/io: the standard input and output module.
-//
-// This is bundled Raven source compiled into the program when a user
-// writes `import std/io { ... }`. The functions are ordinary Raven, with
-// the operations that cannot be written in safe Raven (writing bytes to
-// stdout, reading a line from stdin) expressed through a small set of
-// compiler intrinsics whose names begin with `__io_`. Those intrinsics
-// are recognized by the compiler and lowered to the matching
-// `raven-runtime` C ABI symbols. See `docs/v2/specs/stdlib.md`.
+// std/io: standard input and output. The `__io_*` intrinsics are lowered
+// by the compiler to the raven-runtime C ABI symbols.
 
-// Write `s` to standard output with no trailing newline.
 fun print(s: String) {
     __io_print_str(s)
 }
 
-// Write `s` to standard output followed by a single newline.
 fun println(s: String) {
     __io_println_str(s)
 }
 
-// Write the base-ten rendering of `n` to standard output with no
-// trailing newline. Built on string interpolation, which the compiler
-// lowers to the runtime integer-to-string conversion.
 fun print_int(n: Int) {
     __io_print_str("${n}")
 }
 
-// Write the base-ten rendering of `n` followed by a single newline.
 fun println_int(n: Int) {
     __io_println_str("${n}")
 }
 
-// Render an `Int` as a `String`. A thin wrapper over interpolation so
-// callers have a named conversion without writing `"${n}"` by hand.
 fun int_to_string(n: Int) -> String {
     "${n}"
 }
 
-// Render a `Bool` as a `String` ("true" or "false").
 fun bool_to_string(b: Bool) -> String {
     "${b}"
 }
 
-// Print `prompt` (no trailing newline), then read one line from standard
-// input and return it without the trailing newline. At end of input the
-// returned `String` is empty.
+// Print `prompt` with no trailing newline, then read one line from stdin
+// without its newline. Empty at end of input.
 fun input(prompt: String) -> String {
     __io_print_str(prompt)
     __io_read_line()
 }
 
-// Read one line from standard input and return it without the trailing
-// newline. At end of input the returned `String` is empty.
+// Read one line from stdin without its newline. Empty at end of input.
 fun read_line() -> String {
     __io_read_line()
 }

--- a/stdlib/std/string.rv
+++ b/stdlib/std/string.rv
@@ -1,99 +1,206 @@
-// std/string: byte-oriented string utilities.
-//
-// This is bundled Raven source compiled into the program when a user
-// writes `import std/string { ... }`. The functions are ordinary Raven
-// built on a small set of compiler intrinsics whose names begin with
-// `__str_`. Those intrinsics are recognized by the compiler and lowered
-// to the matching `raven-runtime` C ABI symbols. See
-// `docs/v2/specs/std-string.md`.
-//
-// Semantics are byte oriented: indices, lengths, and slices count UTF-8
-// bytes, not code points or grapheme clusters. Case mapping is ASCII
-// only. Multi-byte text passes through search and trim unchanged because
-// the operations compare whole byte sequences, but `char_at`, `substring`,
-// and the case functions act on individual bytes. See the spec for the
-// full byte versus codepoint discussion and the out of scope items.
+// std/string: byte-oriented String methods. Indices, lengths, and slices
+// count UTF-8 bytes, not code points. Case mapping is ASCII only.
 
-// Return the byte length of `s`. This counts UTF-8 bytes, not code
-// points or grapheme clusters, so a string of multi-byte characters
-// reports a length larger than its visible character count.
-fun length(s: String) -> Int {
-    return __str_len(s)
-}
+impl String {
+    fun length(self) -> Int {
+        return __str_len(self)
+    }
 
-// True when `s` has zero bytes.
-fun is_empty(s: String) -> Bool {
-    return __str_len(s) == 0
-}
+    fun is_empty(self) -> Bool {
+        return __str_len(self) == 0
+    }
 
-// Return the `i`-th byte of `s` as a one-byte `String`. `i` is a byte
-// offset; for a multi-byte character this returns a single byte of its
-// UTF-8 encoding, which on its own is not valid UTF-8. An out of range
-// index yields the empty string.
-fun char_at(s: String, i: Int) -> String {
-    return __str_substring(s, i, i + 1)
-}
+    // Byte offset, not codepoint: for a multi-byte character this returns
+    // one byte of the encoding. Out of range yields the empty string.
+    fun char_at(self, i: Int) -> String {
+        return __str_substring(self, i, i + 1)
+    }
 
-// Return the half-open byte range `[start, end)` of `s`. Bounds are
-// clamped to `0..length(s)` and a `start` past `end` yields the empty
-// string, so this never reads out of range. Slicing through the middle
-// of a multi-byte character produces bytes that are not valid UTF-8.
-fun substring(s: String, start: Int, end: Int) -> String {
-    return __str_substring(s, start, end)
-}
+    // Half-open byte range, clamped to 0..length. A start past end yields
+    // the empty string.
+    fun substring(self, start: Int, end: Int) -> String {
+        return __str_substring(self, start, end)
+    }
 
-// Concatenate `a` and `b` into a fresh `String`.
-fun concat(a: String, b: String) -> String {
-    return __str_concat(a, b)
-}
+    fun concat(self, other: String) -> String {
+        return __str_concat(self, other)
+    }
 
-// ASCII upper case. Bytes in `a`..`z` are mapped to `A`..`Z`; every
-// other byte (including the upper half of any multi-byte UTF-8
-// sequence) is copied unchanged. Non ASCII case is out of scope.
-fun to_upper(s: String) -> String {
-    let n = __str_len(s)
-    let out = ""
-    let i = 0
-    while i < n {
-        let b = __str_byte_at(s, i)
-        if b >= 97 {
-            if b <= 122 {
-                out = __str_concat(out, __str_from_byte(b - 32))
+    fun to_upper(self) -> String {
+        let n = __str_len(self)
+        let out = ""
+        let i = 0
+        while i < n {
+            let b = __str_byte_at(self, i)
+            if b >= 97 {
+                if b <= 122 {
+                    out = __str_concat(out, __str_from_byte(b - 32))
+                } else {
+                    out = __str_concat(out, __str_from_byte(b))
+                }
             } else {
                 out = __str_concat(out, __str_from_byte(b))
             }
-        } else {
-            out = __str_concat(out, __str_from_byte(b))
+            i = i + 1
         }
-        i = i + 1
+        return out
     }
-    return out
-}
 
-// ASCII lower case. Bytes in `A`..`Z` are mapped to `a`..`z`; every
-// other byte is copied unchanged. Non ASCII case is out of scope.
-fun to_lower(s: String) -> String {
-    let n = __str_len(s)
-    let out = ""
-    let i = 0
-    while i < n {
-        let b = __str_byte_at(s, i)
-        if b >= 65 {
-            if b <= 90 {
-                out = __str_concat(out, __str_from_byte(b + 32))
+    fun to_lower(self) -> String {
+        let n = __str_len(self)
+        let out = ""
+        let i = 0
+        while i < n {
+            let b = __str_byte_at(self, i)
+            if b >= 65 {
+                if b <= 90 {
+                    out = __str_concat(out, __str_from_byte(b + 32))
+                } else {
+                    out = __str_concat(out, __str_from_byte(b))
+                }
             } else {
                 out = __str_concat(out, __str_from_byte(b))
             }
-        } else {
-            out = __str_concat(out, __str_from_byte(b))
+            i = i + 1
         }
-        i = i + 1
+        return out
     }
-    return out
+
+    // Remove leading and trailing ASCII whitespace; interior whitespace is
+    // kept.
+    fun trim(self) -> String {
+        let n = __str_len(self)
+        let start = 0
+        let scanning = true
+        while scanning {
+            if start >= n {
+                scanning = false
+            } else {
+                if is_space_byte(__str_byte_at(self, start)) {
+                    start = start + 1
+                } else {
+                    scanning = false
+                }
+            }
+        }
+        let end = n
+        scanning = true
+        while scanning {
+            if end <= start {
+                scanning = false
+            } else {
+                if is_space_byte(__str_byte_at(self, end - 1)) {
+                    end = end - 1
+                } else {
+                    scanning = false
+                }
+            }
+        }
+        return __str_substring(self, start, end)
+    }
+
+    fun is_blank(self) -> Bool {
+        let n = __str_len(self)
+        let i = 0
+        while i < n {
+            if is_space_byte(__str_byte_at(self, i)) {
+                i = i + 1
+            } else {
+                return false
+            }
+        }
+        return true
+    }
+
+    // A non-positive count yields the empty string.
+    fun repeat(self, n: Int) -> String {
+        let out = ""
+        let i = 0
+        while i < n {
+            out = __str_concat(out, self)
+            i = i + 1
+        }
+        return out
+    }
+
+    // True when the bytes of `needle` occur starting at byte index `at`.
+    fun matches_at(self, needle: String, at: Int) -> Bool {
+        let m = __str_len(needle)
+        let n = __str_len(self)
+        if at + m > n {
+            return false
+        }
+        let j = 0
+        while j < m {
+            if __str_byte_at(self, at + j) == __str_byte_at(needle, j) {
+                j = j + 1
+            } else {
+                return false
+            }
+        }
+        return true
+    }
+
+    // Byte index of the first occurrence of `needle`, or -1 when absent.
+    // An empty needle matches at 0.
+    fun index_of(self, needle: String) -> Int {
+        let n = __str_len(self)
+        let m = __str_len(needle)
+        if m == 0 {
+            return 0
+        }
+        let i = 0
+        while i + m <= n {
+            if self.matches_at(needle, i) {
+                return i
+            }
+            i = i + 1
+        }
+        return -1
+    }
+
+    fun contains(self, needle: String) -> Bool {
+        return self.index_of(needle) >= 0
+    }
+
+    fun starts_with(self, prefix: String) -> Bool {
+        return self.matches_at(prefix, 0)
+    }
+
+    fun ends_with(self, suffix: String) -> Bool {
+        let n = __str_len(self)
+        let m = __str_len(suffix)
+        if m > n {
+            return false
+        }
+        return self.matches_at(suffix, n - m)
+    }
+
+    // Replace every non-overlapping occurrence of `from`, left to right.
+    // An empty `from` returns the input unchanged.
+    fun replace(self, from: String, to: String) -> String {
+        let m = __str_len(from)
+        if m == 0 {
+            return self
+        }
+        let n = __str_len(self)
+        let out = ""
+        let i = 0
+        while i < n {
+            if self.matches_at(from, i) {
+                out = __str_concat(out, to)
+                i = i + m
+            } else {
+                out = __str_concat(out, __str_substring(self, i, i + 1))
+                i = i + 1
+            }
+        }
+        return out
+    }
 }
 
-// True when the byte at index `i` of `s` is ASCII whitespace: space,
-// tab, newline, carriage return, vertical tab, or form feed.
+// ASCII whitespace: space, tab, newline, carriage return, vertical tab,
+// form feed.
 fun is_space_byte(b: Int) -> Bool {
     if b == 32 {
         return true
@@ -114,161 +221,4 @@ fun is_space_byte(b: Int) -> Bool {
         return true
     }
     return false
-}
-
-// Remove leading and trailing ASCII whitespace. Interior whitespace is
-// preserved. Whitespace is the ASCII set listed in `is_space_byte`;
-// Unicode whitespace is out of scope. A string that is empty or all
-// whitespace trims to the empty string.
-fun trim(s: String) -> String {
-    let n = __str_len(s)
-    // Advance `start` past leading whitespace.
-    let start = 0
-    let scanning = true
-    while scanning {
-        if start >= n {
-            scanning = false
-        } else {
-            if is_space_byte(__str_byte_at(s, start)) {
-                start = start + 1
-            } else {
-                scanning = false
-            }
-        }
-    }
-    // Retreat `end` past trailing whitespace.
-    let end = n
-    scanning = true
-    while scanning {
-        if end <= start {
-            scanning = false
-        } else {
-            if is_space_byte(__str_byte_at(s, end - 1)) {
-                end = end - 1
-            } else {
-                scanning = false
-            }
-        }
-    }
-    return __str_substring(s, start, end)
-}
-
-// True when `s` is empty or contains only ASCII whitespace.
-fun is_blank(s: String) -> Bool {
-    let n = __str_len(s)
-    let i = 0
-    while i < n {
-        if is_space_byte(__str_byte_at(s, i)) {
-            i = i + 1
-        } else {
-            return false
-        }
-    }
-    return true
-}
-
-// Repeat `s` `n` times. A non positive `n` yields the empty string.
-fun repeat(s: String, n: Int) -> String {
-    let out = ""
-    let i = 0
-    while i < n {
-        out = __str_concat(out, s)
-        i = i + 1
-    }
-    return out
-}
-
-// A method on the built in `String` type, declared in a bundled stdlib
-// module. It exercises method resolution for a built in receiver and a
-// sibling free function call from inside an `impl` body. The body calls
-// the module's own `to_upper`, which the stdlib expander rewrites to its
-// namespaced name. A user writes `"hi".shout()` after importing this
-// module and gets the upper cased string back.
-impl String {
-    fun shout(self) -> String {
-        return to_upper(self)
-    }
-}
-
-// True when the bytes of `needle` occur in `s` starting exactly at byte
-// index `at`. A `needle` that runs past the end of `s` is not a match.
-fun matches_at(s: String, needle: String, at: Int) -> Bool {
-    let m = __str_len(needle)
-    let n = __str_len(s)
-    if at + m > n {
-        return false
-    }
-    let j = 0
-    while j < m {
-        if __str_byte_at(s, at + j) == __str_byte_at(needle, j) {
-            j = j + 1
-        } else {
-            return false
-        }
-    }
-    return true
-}
-
-// Byte index of the first occurrence of `needle` in `s`, or -1 when
-// `needle` does not occur. An empty `needle` matches at index 0.
-fun index_of(s: String, needle: String) -> Int {
-    let n = __str_len(s)
-    let m = __str_len(needle)
-    if m == 0 {
-        return 0
-    }
-    let i = 0
-    while i + m <= n {
-        if matches_at(s, needle, i) {
-            return i
-        }
-        i = i + 1
-    }
-    return -1
-}
-
-// True when `needle` occurs anywhere in `s`. An empty `needle` is
-// always contained.
-fun contains(s: String, needle: String) -> Bool {
-    return index_of(s, needle) >= 0
-}
-
-// True when `s` begins with the bytes of `prefix`. An empty prefix
-// always matches.
-fun starts_with(s: String, prefix: String) -> Bool {
-    return matches_at(s, prefix, 0)
-}
-
-// True when `s` ends with the bytes of `suffix`. An empty suffix always
-// matches.
-fun ends_with(s: String, suffix: String) -> Bool {
-    let n = __str_len(s)
-    let m = __str_len(suffix)
-    if m > n {
-        return false
-    }
-    return matches_at(s, suffix, n - m)
-}
-
-// Replace every non overlapping occurrence of `from` in `s` with `to`,
-// scanning left to right. When `from` is empty the input is returned
-// unchanged so the scan cannot loop forever.
-fun replace(s: String, from: String, to: String) -> String {
-    let m = __str_len(from)
-    if m == 0 {
-        return s
-    }
-    let n = __str_len(s)
-    let out = ""
-    let i = 0
-    while i < n {
-        if matches_at(s, from, i) {
-            out = __str_concat(out, to)
-            i = i + m
-        } else {
-            out = __str_concat(out, __str_substring(s, i, i + 1))
-            i = i + 1
-        }
-    }
-    return out
 }


### PR DESCRIPTION
Converts `std/string` to a method-first API: every operation is now a method on `String` rather than a free function, so user code reads `s.trim().to_upper()` and `"hi".contains("h")`. Part of #120 (the `std/io` print cleanup follows separately).

## What changed

- `stdlib/std/string.rv`: free functions become an `impl String` block. A bare `import std/string` merges the impl; methods resolve by receiver type. Methods call siblings via `self`; the ASCII-whitespace helper stays a free function and is namespaced into method bodies by the stdlib expander.
- `examples/v2/use_string.rv` and `examples/v2/stdlib_string_method.rv`: rewritten to the method API, output preserved.
- `docs/v2/specs/std-string.md`: documents the method surface and the bare-import form.
- Verbose AI-style comments trimmed from `stdlib/std/string.rv` and `stdlib/std/io.rv`.
- The intra-module-namespacing unit test now checks a method body calling the free helper.

## Verification (built and run on windows-msvc)

`use_string.rv`:
```
HELLO
world
spaced
ababab
a+b+c
ave
contains: yes
2
-1
```
`stdlib_string_method.rv` prints `HI`. Both smoke-test assertions are unchanged.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` (287 lib + 25 codegen smoke + golden suites) pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] both string examples run with output preserved
