### PR TITLE
refactor(stdlib): drop redundant int helpers from std/io

### DIFF
--- a/docs/v2/specs/stdlib.md
+++ b/docs/v2/specs/stdlib.md
@@ -81,11 +81,11 @@ for a `println(...)` call that bound to the bundled function.
 The working import form for a bundled module is the selective import:
 
 ```raven
-import std/io { println, println_int }
+import std/io { println }
 ```
 
-The resolver binds each selector (`println`, `println_int`) directly to
-the namespaced function (`std.io.println`, `std.io.println_int`). The call
+The resolver binds each selector (`println`) directly to the namespaced
+function (`std.io.println`). The call
 site `println("hi")` is then an ordinary call to a known function, which
 the type checker, HIR, MIR, and codegen handle with no member access
 machinery. An explicit selector binding wins over a builtin of the same
@@ -141,29 +141,24 @@ primitive adds one intrinsic and one runtime symbol the same way.
 
 * `print(s: String)`: write `s` with no trailing newline.
 * `println(s: String)`: write `s` followed by a newline.
-* `print_int(n: Int)`: write the base ten rendering of `n`, no newline.
-* `println_int(n: Int)`: write the base ten rendering of `n`, plus a newline.
-* `int_to_string(n: Int) -> String`: render an `Int` as a `String`.
-* `bool_to_string(b: Bool) -> String`: render a `Bool` as `"true"` / `"false"`.
 * `input(prompt: String) -> String`: print `prompt` (no newline), read one
   line from stdin, and return it without the trailing newline.
 * `read_line() -> String`: read one line from stdin, newline stripped.
 
-The integer and conversion functions are built on string interpolation
-(`"${n}"`), which the compiler already lowers to the runtime integer to
-string and bool to string conversions. The module thus needs no separate
-integer intrinsics.
+To print a non-string value, interpolate it (`println("${n}")`) or use the
+builtin `print`, which accepts any `ToString` value. The module keeps no
+type-specific print variants.
 
 ## Relationship to the print builtins
 
-The compiler keeps `print` and `print_int` as global builtins for
-convenience (used by examples and quick programs without an import). For
-historical reasons those builtins append a newline. `std/io` is the
-blessed user facing surface: its `print` writes with no newline and its
-`println` adds one, which is the conventional split. Because an explicit
-import binds over a builtin, a program that imports `std/io`'s `print`
-gets the module's no newline behavior; a program that does not import it
-keeps the builtin.
+The compiler keeps a global `print` builtin for convenience (used by
+examples and quick programs without an import). It accepts any `ToString`
+value and appends a newline. `std/io` is the explicit surface: its `print`
+writes with no newline and its `println` adds one, the conventional split.
+Because an explicit import binds over a builtin, a program that imports
+`std/io`'s `print` gets the module's no newline behavior; a program that
+does not import it keeps the builtin. (A separate `print_int` builtin also
+still exists and is slated for removal now that `print` covers integers.)
 
 ## How later modules plug in
 

--- a/examples/v2/use_io.rv
+++ b/examples/v2/use_io.rv
@@ -1,10 +1,7 @@
 // golden:skip
-// Import the bundled std/io module and use its functions. The selective
-// import binds `println` and `println_int` to the namespaced stdlib
-// functions the compiler merges into the program. Prints two lines.
-import std/io { println, println_int }
+import std/io { println }
 
 fun main() {
     println("Hello from std/io!")
-    println_int(40 + 2)
+    println("${40 + 2}")
 }

--- a/stdlib/std/io.rv
+++ b/stdlib/std/io.rv
@@ -9,22 +9,6 @@ fun println(s: String) {
     __io_println_str(s)
 }
 
-fun print_int(n: Int) {
-    __io_print_str("${n}")
-}
-
-fun println_int(n: Int) {
-    __io_println_str("${n}")
-}
-
-fun int_to_string(n: Int) -> String {
-    "${n}"
-}
-
-fun bool_to_string(b: Bool) -> String {
-    "${b}"
-}
-
 // Print `prompt` with no trailing newline, then read one line from stdin
 // without its newline. Empty at end of input.
 fun input(prompt: String) -> String {


### PR DESCRIPTION
Removes the redundant integer-specific functions from `std/io`. The builtin `print` already accepts any `ToString` value and string interpolation renders integers, so `print_int`, `println_int`, `int_to_string`, and `bool_to_string` in `std/io` duplicated existing capability. The module now exposes `print`, `println`, `input`, and `read_line`.

Completes the `std/io` half of #120 (the `std/string` method-first half merged in #149).

## What changed

- `stdlib/std/io.rv`: drop the four int/bool helpers.
- `examples/v2/use_io.rv`: print the integer via interpolation (`println("${40 + 2}")`); output unchanged.
- `docs/v2/specs/stdlib.md`: updated io surface and import examples.

## Deferred (tracked follow-up)

The separate global `print_int` builtin still exists and is used by ~20 examples plus the two C FFI examples (`ffi_strlen`, `ffi_abs`), where it prints `CSize`/`CInt` results. Removing it cleanly needs a `ToString` path for the C integer FFI types so `print(cValue)` works, plus migrating those call sites. That is a focused follow-up, not bundled here.

## Verification (built and run on windows-msvc)

`use_io.rv`:
```
Hello from std/io!
42
```

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` (287 lib + 25 codegen smoke + golden) pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] use_io output preserved
