### PR TITLE
fix(tycheck): keep parameters of trait methods called on a generic bound

### DIFF
--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1715,13 +1715,18 @@ impl<'a, 'b> Checker<'a, 'b> {
             .with_hint(hint));
         };
 
-        // Substitute every `Self` placeholder in the trait method's
-        // signature with the receiver's parameter type, and the trait's
-        // own generic parameters with the bound's type arguments.
-        let user_params: Vec<Ty> = sig
-            .params
+        // Drop the leading `self` receiver positionally, then substitute
+        // every remaining `Self` (for example the `other: Self` of
+        // `equals`) with the receiver's parameter type and the trait's own
+        // generic parameters with the bound's type arguments. Filtering by
+        // `Self` type instead would also drop a real `Self`-typed argument.
+        let rest = if sig.has_self && !sig.params.is_empty() {
+            &sig.params[1..]
+        } else {
+            &sig.params[..]
+        };
+        let user_params: Vec<Ty> = rest
             .iter()
-            .filter(|t| !matches!(t, Ty::SelfTy(_)))
             .map(|t| substitute(&substitute_self(t, &recv_ty), &trait_subst))
             .collect();
         if user_params.len() != args.len() {

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -55,6 +55,17 @@ fn comparison_requires_compatible_operands() {
 }
 
 #[test]
+fn bound_trait_method_with_self_arg_keeps_its_parameter() {
+    // A trait method taking a `Self` argument, called on a generic value
+    // bounded by that trait, must keep the argument: only the leading
+    // `self` receiver is dropped, not every `Self`-typed parameter.
+    check(
+        "trait Combine {\n    fun combine(self, other: Self) -> Self\n}\nfun pair<T: Combine>(a: T, b: T) -> T {\n    return a.combine(b)\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
 fn struct_literal_and_field_access() {
     check(
         "struct Point { x: Int, y: Int }\nfun f() -> Int {\n    let p = Point { x: 1, y: 2 }\n    return p.x\n}\n",


### PR DESCRIPTION
Calling a trait method on a value of a generic type bounded by that trait dropped every `Self`-typed parameter, intending to drop only the `self` receiver. A real argument such as the `other: Self` of `Eq`'s `equals(self, other: Self)` was lost, so `k.equals(x)` where `K: Eq` failed with "wrong number of arguments: expected 0, found 1".

The fix drops the receiver positionally (`self` is always the first parameter), then substitutes `Self` in the remaining parameters with the receiver type. This makes any parameterized trait method usable on a generic bound, which the upcoming generic collections (`Map<K, V>` keyed by `K: Eq`) depend on.

## Verification

A generic `fun first_match<K: Eq>(xs: List<K>, target: K)` doing `xs[i].equals(target)` now compiles and runs, returning the right index. The existing `Iterator::next` bound path (no extra args) is unaffected.

## Test plan

- [x] New inline tycheck regression test (`bound_trait_method_with_self_arg_keeps_its_parameter`)
- [x] `cargo test` (288 lib + 25 codegen smoke + golden) pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] The iterator pipeline (uses the `Iterator` bound) still prints 4/180/3
