### PR TITLE
feat(stdlib): std/collections Set and Map

### DIFF
--- a/docs/v2/specs/std-collections.md
+++ b/docs/v2/specs/std-collections.md
@@ -1,0 +1,69 @@
+# std/collections Spec
+
+Generic `Set<T>` and `Map<K, V>` over keys that implement the prelude `Eq`
+trait. `List<T>` is built into the language (literals, indexing, `len`,
+`push`, `pop`, `get`) and needs no import.
+
+## Import
+
+The collection types are used by method, but their constructors are free
+functions, so a selective import binds them:
+
+```raven
+import std/collections { empty_set, empty_map }
+
+fun main() {
+    let s = empty_set()
+    s.add(1)
+    let m = empty_map()
+    m.set("a", 10)
+}
+```
+
+Importing the module also merges the `Set` and `Map` `impl` blocks, so the
+methods resolve by receiver type. Element and key/value types are inferred
+from the first use (`s.add(1)` fixes `Set<Int>`).
+
+## Set<T: Eq>
+
+| Method | Result | Notes |
+|---|---|---|
+| `len()` | `Int` | element count |
+| `is_empty()` | `Bool` | |
+| `contains(x)` | `Bool` | linear scan via `Eq` |
+| `add(x)` | | adds only if absent |
+| `remove(x)` | `Bool` | whether it was present; order not preserved |
+
+Construct with `empty_set()`.
+
+## Map<K: Eq, V>
+
+| Method | Result | Notes |
+|---|---|---|
+| `len()` | `Int` | entry count |
+| `is_empty()` | `Bool` | |
+| `has(k)` | `Bool` | |
+| `get(k)` | `Option<V>` | `None` when absent |
+| `set(k, v)` | | inserts or overwrites |
+| `remove(k)` | `Bool` | whether it was present; order not preserved |
+
+Construct with `empty_map()`. Keys and values are stored in parallel
+`List`s.
+
+## Complexity
+
+Lookup, insert, and remove are O(n): each scans the keys comparing through
+`Eq`. This keeps the module small and dependency-free while exercising
+generics, trait bounds, and `List`. Backing `Map`/`Set` with the runtime
+hash-bucket layout (which already exists with FNV hashing) for O(1)
+average operations is a planned optimization that will not change this
+surface; it depends on the `Hash` trait being wired through the bucket
+intrinsics.
+
+## Out of scope
+
+- Hash-backed storage (the optimization noted above).
+- Ordered variants and `Deque<T>`.
+- Iteration over a `Set`/`Map` (waits on returning a `List` of entries or
+  an iterator adapter).
+- Set algebra (union, intersection, difference).

--- a/examples/v2/use_collections.rv
+++ b/examples/v2/use_collections.rv
@@ -1,0 +1,25 @@
+// golden:skip
+import std/collections { empty_set, empty_map }
+import std/io { println }
+
+fun main() {
+    let s = empty_set()
+    s.add(1)
+    s.add(2)
+    s.add(2)
+    print(s.len())
+    print(s.contains(2))
+    s.remove(2)
+    print(s.contains(2))
+
+    let m = empty_map()
+    m.set("a", 10)
+    m.set("b", 20)
+    m.set("a", 99)
+    print(m.len())
+    match m.get("a") {
+        Some(v) -> print(v)
+        None -> print(0)
+    }
+    print(m.has("z"))
+}

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -37,6 +37,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("io", include_str!("../../stdlib/std/io.rv")),
     ("string", include_str!("../../stdlib/std/string.rv")),
     ("iter", include_str!("../../stdlib/std/iter.rv")),
+    ("collections", include_str!("../../stdlib/std/collections.rv")),
 ];
 
 /// The prelude module that is implicitly imported into every program.

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -37,7 +37,10 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("io", include_str!("../../stdlib/std/io.rv")),
     ("string", include_str!("../../stdlib/std/string.rv")),
     ("iter", include_str!("../../stdlib/std/iter.rv")),
-    ("collections", include_str!("../../stdlib/std/collections.rv")),
+    (
+        "collections",
+        include_str!("../../stdlib/std/collections.rv"),
+    ),
 ];
 
 /// The prelude module that is implicitly imported into every program.

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -623,8 +623,6 @@ fn is_builtin_type_name(name: &str) -> bool {
             | "Array"
             | "Option"
             | "Result"
-            | "Map"
-            | "Set"
             | "Vec"
             | "List"
             | "CString"

--- a/stdlib/std/collections.rv
+++ b/stdlib/std/collections.rv
@@ -1,0 +1,132 @@
+// std/collections: Set and Map over keys that implement Eq.
+//
+// Lookup is a linear scan using the Eq bound, so operations are O(n). A
+// hash-backed implementation using the runtime bucket layout is a planned
+// optimization that will not change this surface. `List<T>` is built into
+// the language and needs no import.
+
+struct Set<T: Eq> {
+    items: List<T>,
+}
+
+fun empty_set<T: Eq>() -> Set<T> {
+    let items: List<T> = []
+    return Set { items: items }
+}
+
+impl<T: Eq> Set<T> {
+    fun len(self) -> Int {
+        return self.items.len()
+    }
+
+    fun is_empty(self) -> Bool {
+        return self.items.len() == 0
+    }
+
+    fun index_of(self, x: T) -> Int {
+        let i = 0
+        let n = self.items.len()
+        while i < n {
+            if self.items[i].equals(x) {
+                return i
+            }
+            i = i + 1
+        }
+        return -1
+    }
+
+    fun contains(self, x: T) -> Bool {
+        return self.index_of(x) >= 0
+    }
+
+    // Add `x` if it is not already present.
+    fun add(self, x: T) {
+        if self.index_of(x) < 0 {
+            self.items.push(x)
+        }
+    }
+
+    // Remove `x` if present, returning whether it was. Order is not
+    // preserved: the last element fills the removed slot.
+    fun remove(self, x: T) -> Bool {
+        let idx = self.index_of(x)
+        if idx < 0 {
+            return false
+        }
+        let last = self.items.len() - 1
+        self.items[idx] = self.items[last]
+        self.items.pop()
+        return true
+    }
+}
+
+struct Map<K: Eq, V> {
+    keys: List<K>,
+    values: List<V>,
+}
+
+fun empty_map<K: Eq, V>() -> Map<K, V> {
+    let keys: List<K> = []
+    let values: List<V> = []
+    return Map { keys: keys, values: values }
+}
+
+impl<K: Eq, V> Map<K, V> {
+    fun len(self) -> Int {
+        return self.keys.len()
+    }
+
+    fun is_empty(self) -> Bool {
+        return self.keys.len() == 0
+    }
+
+    fun index_of(self, k: K) -> Int {
+        let i = 0
+        let n = self.keys.len()
+        while i < n {
+            if self.keys[i].equals(k) {
+                return i
+            }
+            i = i + 1
+        }
+        return -1
+    }
+
+    fun has(self, k: K) -> Bool {
+        return self.index_of(k) >= 0
+    }
+
+    fun get(self, k: K) -> Option<V> {
+        let idx = self.index_of(k)
+        if idx < 0 {
+            return None
+        }
+        return Some(self.values[idx])
+    }
+
+    // Insert `k` with `v`, or overwrite the value if `k` is present.
+    fun set(self, k: K, v: V) {
+        let idx = self.index_of(k)
+        if idx < 0 {
+            self.keys.push(k)
+            self.values.push(v)
+        } else {
+            self.values[idx] = v
+        }
+    }
+
+    // Remove `k` if present, returning whether it was. Order is not
+    // preserved.
+    fun remove(self, k: K) -> Bool {
+        let idx = self.index_of(k)
+        if idx < 0 {
+            return false
+        }
+        let last = self.keys.len() - 1
+        self.keys[idx] = self.keys[last]
+        self.values[idx] = self.values[last]
+        self.keys.pop()
+        self.values.pop()
+        return true
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -210,6 +210,21 @@ fn builtin_method_program_compiles_and_runs() {
 }
 
 #[test]
+fn collections_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/collections Set<T: Eq> and Map<K: Eq, V>: dedup add, contains,
+    // remove on the set; insert, overwrite, get, has on the map. Prints
+    // 2, true, false, 2, 99, false.
+    compile_link_run_and_check(
+        "use_collections.rv",
+        "2\ntrue\nfalse\n2\n99\nfalse\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn stdlib_string_method_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Adds the `std/collections` module: generic `Set<T: Eq>` and `Map<K: Eq, V>`. Closes #72.

## Surface

- `Set<T: Eq>`: `add` (dedup), `contains`, `remove`, `len`, `is_empty`; constructed with `empty_set()`.
- `Map<K: Eq, V>`: `set` (insert or overwrite), `get -> Option<V>`, `has`, `remove`, `len`, `is_empty`; constructed with `empty_map()`.

Methods resolve by receiver type once the module is imported; the `empty_set`/`empty_map` constructors are free functions bound via a selective import (`import std/collections { empty_set, empty_map }`). Lookup is built on `List` and the prelude `Eq` trait.

## Compiler change

`Map` and `Set` were reserved as built-in type names in the resolver but never implemented as built-in types (only runtime layouts exist). They are stdlib structs in our design, so the reservation is removed, letting the structs claim those names. `List`/`Array`/`Vec` stay built-in.

## Complexity note

Lookup/insert/remove are O(n) linear scans. Backing with the runtime hash-bucket layout (already present with FNV hashing) for O(1) average is a planned optimization that keeps this surface; it depends on wiring the `Hash` trait through the bucket intrinsics.

## Verification (built and run on windows-msvc)

`use_collections.rv`:
```
2
true
false
2
99
false
```
(Set: add dedups to len 2, contains 2 is true, after remove false. Map: two entries after an overwrite, get("a") is 99, has("z") false.)

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` (288 lib + 26 codegen smoke including collections + golden) pass
- [x] `cargo fmt --check` clean (changed files)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] collections example runs with expected output
