### PR TITLE
ci: run the compile-link-run smoke tests on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --workspace --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --workspace --verbose

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,4 @@
 //! Compiler errors with colored source pointers.
-//!
-//! `RavenError` is the top level error enum for every compiler stage. Lex
-//! and parse errors are populated; resolve, type, and runtime errors land
-//! as new variants when the corresponding stages are built.
-//!
-//! `RavenError::display(source)` renders a multi line message: a red header,
-//! the offending source line, a row of red carets under the bad span, and an
-//! optional dim hint line.
 
 use std::fmt;
 
@@ -28,7 +20,6 @@ pub enum LexError {
     /// A malformed `\u{...}` or `\x..` escape.
     InvalidUnicodeEscape,
     /// A numeric literal could not be parsed (overflow, empty digits, etc.).
-    /// The string carries the failing lexeme for diagnostics.
     InvalidNumber(String),
     /// A `'...'` char literal was empty, multi character, or unterminated.
     InvalidCharLit(String),
@@ -50,33 +41,23 @@ impl fmt::Display for LexError {
 }
 
 /// Parsing errors raised by the recursive descent parser.
-///
-/// Most errors render as "expected X, found Y" with the span pointing at
-/// the offending token. Specific variants exist for common shapes so that
-/// downstream tooling can match on them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseError {
-    /// The next token did not match what the parser expected. `expected`
-    /// describes the syntactic category (e.g. "`{`", "type", "identifier")
-    /// and `found` quotes the actual token kind.
-    UnexpectedToken { expected: String, found: String },
-    /// End of file reached while expecting more input.
-    UnexpectedEof { expected: String },
-    /// The left hand side of an assignment is not a valid place
-    /// expression.
+    UnexpectedToken {
+        expected: String,
+        found: String,
+    },
+    UnexpectedEof {
+        expected: String,
+    },
     InvalidAssignmentTarget,
     /// Comparison operators are not chainable: `a < b < c` is rejected.
     ChainedComparison,
-    /// A struct or enum literal repeats a field name.
     DuplicateField(String),
-    /// An `import` directive that the parser could not interpret.
     InvalidImportPath,
     /// Tuple syntax is parsed but not yet supported in v2.0.
     UnsupportedTuple,
-    /// A pattern fragment that cannot be parsed.
     InvalidPattern(String),
-    /// A bespoke error message for situations that do not fit the
-    /// dedicated variants above.
     Custom(String),
 }
 
@@ -112,26 +93,22 @@ impl fmt::Display for ParseError {
     }
 }
 
-/// Name resolution errors raised by the resolver.
-///
-/// All variants carry the offending span on the outer `RavenError::Resolve`
-/// wrapper; payload data here is just enough to format a human readable
-/// message. See `docs/v2/specs/resolver.md` for the full catalog.
+/// Name resolution errors. See `docs/v2/specs/resolver.md` for the full catalog.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolveError {
-    /// An identifier could not be found in any enclosing scope.
     UnresolvedName(String),
-    /// Two declarations with the same name appear in the same scope.
     /// `first_span` points at the original declaration so the renderer can
-    /// surface both locations if it chooses.
-    DuplicateDeclaration { name: String, first_span: Span },
-    /// An import path could not be resolved to a target.
+    /// surface both locations.
+    DuplicateDeclaration {
+        name: String,
+        first_span: Span,
+    },
     UnresolvedImport(String),
-    /// The import graph contains a cycle that reaches the given path.
     CyclicImport(String),
-    /// A name is visible from multiple import sources at the same scope.
-    AmbiguousName { name: String, candidates: Vec<Span> },
-    /// `self` or `Self` used outside an `impl` block.
+    AmbiguousName {
+        name: String,
+        candidates: Vec<Span>,
+    },
     SelfOutsideImpl,
 }
 
@@ -160,65 +137,58 @@ impl fmt::Display for ResolveError {
     }
 }
 
-/// Type checking errors raised by the type checker.
-///
-/// Wrapped in `RavenError::Type(error, span, hint)` and rendered by the
-/// shared error formatter. See `docs/v2/specs/tycheck.md` for the full
-/// catalog and which language constructs raise each variant.
+/// Type checking errors. See `docs/v2/specs/tycheck.md` for the full catalog.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeError {
-    /// The actual type does not match the expected type at this position.
-    TypeMismatch { expected: String, actual: String },
-    /// A struct does not declare the field named here.
-    UndefinedField { struct_name: String, field: String },
-    /// The receiver type does not expose a method with this name.
-    UndefinedMethod { receiver_ty: String, method: String },
-    /// More than one impl provides a method with this name on the
-    /// receiver type. `candidates` lists the source spellings of the
-    /// providing impls so the diagnostic can quote them back.
+    TypeMismatch {
+        expected: String,
+        actual: String,
+    },
+    UndefinedField {
+        struct_name: String,
+        field: String,
+    },
+    UndefinedMethod {
+        receiver_ty: String,
+        method: String,
+    },
     AmbiguousMethod {
         receiver_ty: String,
         method: String,
         candidates: Vec<String>,
     },
-    /// A function or method is called with the wrong number of
-    /// arguments.
     WrongArity {
         func: String,
         expected: usize,
         actual: usize,
     },
-    /// A `match` expression does not cover every variant of the
-    /// scrutinee, and lacks a wildcard arm.
-    NonExhaustiveMatch { missing: Vec<String> },
-    /// A `match` arm is fully shadowed by an earlier arm.
+    NonExhaustiveMatch {
+        missing: Vec<String>,
+    },
     RedundantPattern,
-    /// A type path could not be resolved to a known type.
     UnknownType(String),
-    /// Inference reached a binding or expression whose type could not
-    /// be determined from context. The user should annotate.
     CannotInferType,
-    /// The occurs check rejected unifying a variable with a type that
-    /// transitively contains it (`?T` with `List<?T>`).
-    OccursCheck { var: String, ty: String },
-    /// A type does not satisfy a required trait bound.
-    BoundNotSatisfied { ty: String, trait_name: String },
-    /// A generic declaration was instantiated with the wrong number of
-    /// type arguments.
+    /// Occurs check: a variable cannot unify with a type that contains it
+    /// (`?T` with `List<?T>`).
+    OccursCheck {
+        var: String,
+        ty: String,
+    },
+    BoundNotSatisfied {
+        ty: String,
+        trait_name: String,
+    },
     GenericArityMismatch {
         decl: String,
         expected: usize,
         actual: usize,
     },
-    /// Two or more impl blocks claim the same `(type, trait)` pair.
     OverlappingImpls {
         ty: String,
         trait_name: String,
         candidates: Vec<String>,
     },
-    /// A call expression's callee is not a callable type.
     NotCallable(String),
-    /// A bespoke message for shapes without a dedicated variant.
     Custom(String),
 }
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,18 +1,11 @@
 //! Source spans for the v2 compiler.
-//!
-//! A `Span` is a half open byte range into a single source file, paired with
-//! the 1 indexed line and column of its start position for human readable
-//! error display. The `file` field is an `Arc<PathBuf>` so spans can be
-//! cloned cheaply and passed through the pipeline without lifetime knots.
 
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-/// A half open byte range `[start, end)` inside a source file.
-///
-/// `line` and `col` refer to the first character of the span and use 1
-/// indexed counting (line 1, column 1 is the very first character).
+/// A half open byte range `[start, end)` inside a source file. `line`/`col` are
+/// 1 indexed and refer to the span's start.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Span {
     pub file: Arc<PathBuf>,
@@ -23,7 +16,6 @@ pub struct Span {
 }
 
 impl Span {
-    /// Construct a span from explicit components.
     pub fn new(file: Arc<PathBuf>, start: usize, end: usize, line: u32, col: u32) -> Self {
         Span {
             file,
@@ -34,8 +26,7 @@ impl Span {
         }
     }
 
-    /// A zero width span at `offset` on the given line and column. Used for
-    /// EOF tokens and synthetic positions.
+    /// A zero width span, used for EOF tokens and synthetic positions.
     pub fn point(file: Arc<PathBuf>, offset: usize, line: u32, col: u32) -> Self {
         Span {
             file,
@@ -46,12 +37,10 @@ impl Span {
         }
     }
 
-    /// Length in bytes.
     pub fn len(&self) -> usize {
         self.end.saturating_sub(self.start)
     }
 
-    /// True if the span covers zero bytes (e.g., EOF).
     pub fn is_empty(&self) -> bool {
         self.end == self.start
     }

--- a/stdlib/std/core.rv
+++ b/stdlib/std/core.rv
@@ -1,55 +1,26 @@
-// std/core: the language prelude.
-//
-// This module is auto-imported into every program (the compiler merges
-// it before resolution; no `import std/core` is written by the user). It
-// declares the small set of core traits that make the standard library
-// polymorphic, and implements them for the built-in scalar types and
-// String. See `docs/v2/specs/core-traits.md`.
-//
-// The built-in `ToString` impls render through string interpolation
-// (`"${self}"`), which the compiler lowers to the per-type runtime
-// conversions (`raven_int_to_string`, and so on). That keeps a single
-// source of truth for scalar rendering: the runtime owns the digits,
-// the trait owns the dispatch. `Eq`, `Ord`, and `Hash` are written in
-// pure Raven on top of the language operators and the byte-level string
-// intrinsics, so no new runtime symbol is required.
+// std/core: the prelude, auto-imported into every program. See
+// docs/v2/specs/core-traits.md.
 
-// Convert a value to its textual form. The basis of generic printing and
-// of string interpolation for user types.
 trait ToString {
     fun to_string(self) -> String
 }
 
-// Structural equality. `equals` is reflexive, symmetric, and transitive
-// for the built-in impls below.
 trait Eq {
     fun equals(self, other: Self) -> Bool
 }
 
-// Total ordering. `compare` returns a negative `Int` when `self` sorts
-// before `other`, zero when they are equal, and a positive `Int` when
-// `self` sorts after `other`.
 trait Ord {
+    // Negative when self < other, zero when equal, positive when self > other.
     fun compare(self, other: Self) -> Int
 }
 
-// A stable hash of a value, suitable for hash maps and sets. Types that
-// implement `Hash` should also implement `Eq` so that equal values hash
-// equally.
 trait Hash {
     fun hash(self) -> Int
 }
 
-// A source of values produced one at a time. `next` returns `Some(v)`
-// while values remain and `None` once the sequence is exhausted. The
-// element type is a generic parameter on the trait (Raven does not have
-// associated types yet); the lazy adapter pipeline that builds on this
-// trait is specified separately in `std/iter`.
 trait Iterator<T> {
     fun next(self) -> Option<T>
 }
-
-// ----- ToString for the built-in scalar types -----
 
 impl ToString for Int {
     fun to_string(self) -> String = "${self}"
@@ -189,15 +160,7 @@ impl Ord for String {
     }
 }
 
-// ----- Hash for the built-in types -----
-//
-// The scalar hashes are plain value mixes. The string hash is a
-// polynomial rolling hash over the byte sequence (multiplier 31), the
-// same family of non-crypto hash the runtime uses for its maps and sets.
-// Integer multiplication wraps in two's complement, which is the wanted
-// behavior for a hash mix. `Hash for Char` is deferred until a Char to
-// Int primitive lands (see `docs/v2/specs/core-traits.md`).
-
+// Hash for Char is deferred until a Char-to-Int primitive lands.
 impl Hash for Int {
     fun hash(self) -> Int = self
 }

--- a/stdlib/std/iter.rv
+++ b/stdlib/std/iter.rv
@@ -1,33 +1,9 @@
-// std/iter: lazy, single-pass iterator adapters.
+// std/iter: lazy, single-pass iterator adapters over the Iterator trait.
+// See docs/v2/specs/std-iter.md.
 //
-// This is bundled Raven source compiled into the program when a user
-// writes `import std/iter { ... }`. It builds on the `Iterator<T>` trait
-// from std/core (auto-imported), which declares a single method:
-//
-//     fun next(self) -> Option<T>
-//
-// An adapter is a small struct that stores its source iterator (and,
-// where applicable, a captured closure) and implements `Iterator`. Its
-// `next` pulls from the source on demand, so a chain such as
-//
-//     list.iter().map(f).filter(g)
-//
-// performs no work until the result is driven by a `for` loop or a
-// consumer such as `collect`. Each adapter is monomorphized at its
-// concrete source and element types, and the stored closures are called
-// through statically known function-pointer slots, so a finished
-// pipeline runs in a single pass with no per-stage allocation. See
-// `docs/v2/specs/std-iter.md` for the full design, the chaining
-// ergonomics, and the deliberate limitations.
-//
-// Generic parameter order note: a bound that mentions a sibling
-// parameter (for example `S: Iterator<T>`) must appear after that
-// parameter in the list, so every adapter lists its element types first
-// and its bounded source type last.
+// A bound that mentions a sibling parameter (`S: Iterator<T>`) must come
+// after it, so each adapter lists element types before its source type.
 
-// ----- ListIter: the bridge from a List into the iterator world -----
-
-// Iterates a `List<T>` by index. `iter()` on a `List<T>` returns this.
 struct ListIter<T> {
     items: List<T>,
     pos: Int,


### PR DESCRIPTION
Makes CI build and test the whole workspace so the codegen smoke tests, which link and run real binaries against the `raven-runtime` staticlib, actually run on Linux. They previously skipped on CI (the runtime was never built there), so the end-to-end compile, link (the `cc` path), and run sequence had only ever executed on a maintainer's windows-msvc host. This locks in cross-platform verification ahead of the multi-target release (#92).

Also includes pending comment trims in `error.rs`/`span.rs` and the `std/core` and `std/iter` sources.

## Test plan

- [x] `cargo build --workspace` / `cargo test --workspace` green locally (288 lib + 26 codegen smoke + golden)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] trimmed stdlib still compiles and runs (iter pipeline 4/180/3, collections 2/true/false/2/99/false)
- [ ] CI green on Linux with the smoke tests now running (watching this PR)
