### PR TITLE
feat(stdlib): std/cmp ordering and sorting

### DIFF
--- a/docs/v2/specs/std-cmp.md
+++ b/docs/v2/specs/std-cmp.md
@@ -1,0 +1,60 @@
+# std/cmp Spec
+
+Free generic functions for ordering and sorting, built on the prelude
+`Ord` trait (`fun compare(self, other: Self) -> Int`, negative when
+`self < other`, zero when equal, positive when `self > other`). `List<T>`
+is built into the language and needs no import.
+
+## Import
+
+These functions have no natural single receiver, so they are free
+functions bound by a selective import:
+
+```raven
+import std/cmp { sort, max, min, max_of }
+
+fun main() {
+    let xs = [5, 2, 8, 1]
+    let s = sort(xs)
+    print(min(3, 7))
+    print(max_of(xs))
+}
+```
+
+## Surface
+
+| Function | Result | Notes |
+|---|---|---|
+| `min<T: Ord>(a, b)` | `T` | the lesser; returns `a` on a tie |
+| `max<T: Ord>(a, b)` | `T` | the greater; returns `a` on a tie |
+| `clamp<T: Ord>(x, lo, hi)` | `T` | `lo` if `x < lo`, `hi` if `x > hi`, else `x` |
+| `sort<T: Ord>(xs)` | `List<T>` | a new ascending list; the input is not mutated |
+| `sorted_by<T>(xs, cmp)` | `List<T>` | sort by an explicit comparator `fun(T, T) -> Int`; no `Ord` bound |
+| `max_of<T: Ord>(xs)` | `Option<T>` | largest element, `None` when empty |
+| `min_of<T: Ord>(xs)` | `Option<T>` | smallest element, `None` when empty |
+
+`sort` delegates to `sorted_by` with the comparator
+`fun(a, b) -> Int = a.compare(b)`. Use `sorted_by` directly to sort by a
+custom key or in descending order (for example `fun(a, b) -> Int = b - a`).
+
+## Ordering vs comparator
+
+`min`, `max`, `clamp`, `sort`, `max_of`, and `min_of` use the `Ord` bound
+so any type that implements `compare` is usable, including user structs.
+`sorted_by` takes the comparator as a value, so it needs no bound and can
+order types that have no single natural ordering.
+
+## Complexity
+
+`sort` and `sorted_by` use selection sort: O(n^2) comparisons. This keeps
+the module small and dependency-free while exercising generics, trait
+bounds, closures, and `List`. A faster sort is a planned optimization that
+will not change this surface.
+
+## Out of scope
+
+- Binary search and `contains_sorted`.
+- Partial orders (`PartialOrd`) and NaN-aware float ordering.
+- A stable-sort guarantee: selection sort here is not stable, so the
+  relative order of elements that compare equal is unspecified.
+- In-place sorting that mutates the input list.

--- a/examples/v2/use_cmp.rv
+++ b/examples/v2/use_cmp.rv
@@ -1,0 +1,21 @@
+// golden:skip
+import std/cmp { sort, max, min, max_of, min_of, clamp }
+import std/io { println }
+
+fun main() {
+    print(min(3, 7))
+    print(max(3, 7))
+    print(clamp(12, 0, 10))
+    let xs = [5, 2, 8, 1, 9, 3]
+    let s = sort(xs)
+    print(s[0])
+    print(s[5])
+    match max_of(xs) {
+        Some(v) -> print(v)
+        None -> print(0)
+    }
+    match min_of(xs) {
+        Some(v) -> print(v)
+        None -> print(0)
+    }
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -75,6 +75,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "io",
     "iter",
     "collections",
+    "cmp",
     "string",
     "math",
     "fs",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -41,6 +41,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
         "collections",
         include_str!("../../stdlib/std/collections.rv"),
     ),
+    ("cmp", include_str!("../../stdlib/std/cmp.rv")),
 ];
 
 /// The prelude module that is implicitly imported into every program.

--- a/stdlib/std/cmp.rv
+++ b/stdlib/std/cmp.rv
@@ -1,0 +1,89 @@
+// std/cmp: ordering and sorting over the prelude `Ord` trait.
+
+fun min<T: Ord>(a: T, b: T) -> T {
+    if a.compare(b) <= 0 {
+        return a
+    }
+    return b
+}
+
+fun max<T: Ord>(a: T, b: T) -> T {
+    if a.compare(b) >= 0 {
+        return a
+    }
+    return b
+}
+
+fun clamp<T: Ord>(x: T, lo: T, hi: T) -> T {
+    if x.compare(lo) < 0 {
+        return lo
+    }
+    if x.compare(hi) > 0 {
+        return hi
+    }
+    return x
+}
+
+// Selection sort by an explicit comparator, building a new list. O(n^2).
+fun sorted_by<T>(xs: List<T>, cmp: fun(T, T) -> Int) -> List<T> {
+    let out: List<T> = []
+    let i = 0
+    let n = xs.len()
+    while i < n {
+        out.push(xs[i])
+        i = i + 1
+    }
+    let a = 0
+    while a < n {
+        let lo = a
+        let b = a + 1
+        while b < n {
+            if cmp(out[b], out[lo]) < 0 {
+                lo = b
+            }
+            b = b + 1
+        }
+        let tmp = out[a]
+        out[a] = out[lo]
+        out[lo] = tmp
+        a = a + 1
+    }
+    return out
+}
+
+fun sort<T: Ord>(xs: List<T>) -> List<T> {
+    let by = fun(a: T, b: T) -> Int = a.compare(b)
+    return sorted_by(xs, by)
+}
+
+fun max_of<T: Ord>(xs: List<T>) -> Option<T> {
+    let n = xs.len()
+    if n == 0 {
+        return None
+    }
+    let best = xs[0]
+    let i = 1
+    while i < n {
+        if xs[i].compare(best) > 0 {
+            best = xs[i]
+        }
+        i = i + 1
+    }
+    return Some(best)
+}
+
+fun min_of<T: Ord>(xs: List<T>) -> Option<T> {
+    let n = xs.len()
+    if n == 0 {
+        return None
+    }
+    let best = xs[0]
+    let i = 1
+    while i < n {
+        if xs[i].compare(best) < 0 {
+            best = xs[i]
+        }
+        i = i + 1
+    }
+    return Some(best)
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -225,6 +225,18 @@ fn collections_program_compiles_and_runs() {
 }
 
 #[test]
+fn cmp_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/cmp ordering and sorting over the prelude `Ord` trait: min, max,
+    // clamp, a selection sort that returns a new ascending list, and the
+    // max_of/min_of reductions returning Option. Prints 3, 7, 10, then the
+    // sorted first 1 and last 9, then max_of 9 and min_of 1.
+    compile_link_run_and_check("use_cmp.rv", "3\n7\n10\n1\n9\n9\n1\n", &runtime);
+}
+
+#[test]
 fn stdlib_string_method_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Adds the `std/cmp` standard-library module: free generic ordering and sorting functions built on the prelude `Ord` trait.

Closes #122. Spec: `docs/v2/specs/std-cmp.md`.

## Verified program output

`examples/v2/use_cmp.rv` compiled and run on windows-msvc:

```
3
7
10
1
9
9
1
```

(min 3, max 7, clamp 10, sorted first 1, sorted last 9, max_of 9, min_of 1.)

## Surface

- `min<T: Ord>(a, b) -> T`, `max<T: Ord>(a, b) -> T`
- `clamp<T: Ord>(x, lo, hi) -> T`
- `sort<T: Ord>(xs) -> List<T>`: new ascending list, input not mutated (selection sort, O(n^2))
- `sorted_by<T>(xs, cmp: fun(T, T) -> Int) -> List<T>`: sort by an explicit comparator, no `Ord` bound
- `max_of<T: Ord>(xs) -> Option<T>`, `min_of<T: Ord>(xs) -> Option<T>`

## Deferred

- Binary search / `contains_sorted`
- Partial orders and NaN-aware float ordering
- A stable-sort guarantee (selection sort is not stable)
- In-place sorting

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (new `cmp_program_compiles_and_runs` smoke test passes)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Compiled and ran `examples/v2/use_cmp.rv`, output matches expected
