### PR TITLE
feat(stdlib): std/math constants and functions

### DIFF
--- a/docs/v2/specs/std-math.md
+++ b/docs/v2/specs/std-math.md
@@ -1,0 +1,106 @@
+# std/math
+
+Numeric constants and functions, importable with `import std/math { ... }`.
+The module is bundled into the compiler as Raven source and merged into a
+program the same way the other `std/*` modules are.
+
+## Surface
+
+Functions are free functions. Constants are zero-argument functions
+returning `Float` (the language has no `Float` const items yet).
+
+Constants:
+
+| Function | Value |
+|----------|-------|
+| `pi() -> Float`  | 3.141592653589793 |
+| `e() -> Float`   | 2.718281828459045 |
+| `tau() -> Float` | 6.283185307179586 |
+
+Integer functions:
+
+| Function | Notes |
+|----------|-------|
+| `abs_int(x: Int) -> Int` | absolute value |
+| `min_int(a: Int, b: Int) -> Int` | smaller of two |
+| `max_int(a: Int, b: Int) -> Int` | larger of two |
+| `clamp_int(x: Int, lo: Int, hi: Int) -> Int` | clamp into `[lo, hi]` |
+| `pow_int(base: Int, exp: Int) -> Int` | power by squaring; a negative `exp` returns 0 |
+
+Float functions:
+
+| Function | Notes |
+|----------|-------|
+| `abs(x: Float) -> Float` | absolute value (C `fabs`) |
+| `min(a: Float, b: Float) -> Float` | smaller of two |
+| `max(a: Float, b: Float) -> Float` | larger of two |
+| `clamp(x: Float, lo: Float, hi: Float) -> Float` | clamp into `[lo, hi]` |
+| `sqrt(x: Float) -> Float` | square root |
+| `pow(base: Float, exp: Float) -> Float` | power |
+| `exp(x: Float) -> Float` | e raised to x |
+| `ln(x: Float) -> Float` | natural logarithm (C `log`) |
+| `log10(x: Float) -> Float` | base-10 logarithm |
+| `sin`, `cos`, `tan` `(x: Float) -> Float` | radians |
+| `floor`, `ceil`, `trunc`, `round` `(x: Float) -> Float` | rounding to a whole-valued Float |
+
+Free functions, not methods. The language does not yet need an `impl Float`
+surface for these, and free functions import cleanly through the existing
+stdlib selector mechanism.
+
+`min`/`max`/`clamp` overlap `std/cmp`, but those operate over the generic
+`Ord` trait while these operate on numbers directly. The integer and float
+variants are named distinctly (`min` vs `min_int`) because the language has
+no overloading.
+
+## Implementation: FFI to the C math library
+
+The transcendental and rounding functions bind directly to the C runtime
+math library through `extern "C"`:
+
+```raven
+extern "C" {
+    fun sqrt(x: Float) -> Float
+    fun pow(base: Float, exp: Float) -> Float
+    ...
+}
+```
+
+A Raven `Float` is a 64-bit IEEE double, the same as C `double`, so it is
+passed and returned across the C ABI directly. The FFI spec
+(`docs/v2/specs/ffi.md`) lists only integer and pointer FFI primitives and
+no `CDouble`, but `Float` itself is accepted in an `extern` signature and
+lowers to the f64 ABI type, which matches C `double`.
+
+This was verified before committing to the approach. A probe declaring
+`extern "C" { fun sqrt(x: Float) -> Float }` and calling `sqrt(2.0)`
+compiled, linked against the CRT on `x86_64-pc-windows-msvc`, and printed
+`1.4142135623730951`. Further probes confirmed `pow` (two doubles), `sin`,
+`cos`, `tan`, `exp`, `log`, `log10`, `floor`, `ceil`, `trunc`, `round`, and
+`fabs` all resolve and return correct values.
+
+So the FFI path is used rather than a pure-Raven series approximation:
+results are the platform libm's, with its accuracy, and there is no series
+truncation to document. On `x86_64-pc-windows-msvc` these symbols come from
+the CRT (`msvcrt`/`ucrt`), which the linker already puts on the link line;
+no extra link flags are needed.
+
+`ln` and `abs` are thin Raven wrappers over the C `log` and `fabs` symbols,
+renamed to the conventional Raven spellings. The integer functions,
+`pow_int`, and the constants are pure Raven.
+
+## Accuracy
+
+The transcendentals are the platform C library's, so accuracy matches the
+host libm (correctly rounded or near-correctly-rounded doubles on a normal
+desktop target). `pow_int` is exact for results that fit in a 64-bit signed
+integer; it does not detect overflow.
+
+## Out of scope
+
+* Complex numbers.
+* Arbitrary-precision / big integers.
+* Statistics (mean, variance, and similar).
+* Random number generation (tracked separately as `std/random`, issue #129).
+* Methods on `Float`/`Int` (`x.sqrt()`); the surface is free functions.
+* Float-to-Int and Int-to-Float conversions; the language has no numeric
+  cast yet, so the rounding functions return a whole-valued `Float`.

--- a/examples/v2/use_math.rv
+++ b/examples/v2/use_math.rv
@@ -1,0 +1,30 @@
+// golden:skip
+import std/math { sqrt, pow, exp, ln, abs, floor, ceil, round, trunc, sin, cos, abs_int, min_int, max_int, clamp_int, pow_int, pi, e }
+
+fun main() {
+    print(abs_int(-5))
+    print(min_int(3, 7))
+    print(max_int(3, 7))
+    print(clamp_int(12, 0, 10))
+    print(pow_int(2, 10))
+
+    print(sqrt(16.0))
+    print(pow(2.0, 10.0))
+    print(abs(-4.0))
+    print(floor(3.7))
+    print(ceil(3.1))
+    print(round(2.5))
+    print(trunc(3.9))
+
+    // exp(ln(x)) recovers x; check it lands within tolerance of 5.
+    let recovered = exp(ln(5.0))
+    print(abs(recovered - 5.0) < 0.0001)
+
+    // sin(0) is 0, cos(0) is 1.
+    print(sin(0.0))
+    print(cos(0.0))
+
+    // Constants are positive and ordered pi < e_times below.
+    print(pi() > 3.0)
+    print(e() > 2.0)
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -311,6 +311,17 @@ fn bind_import(
                     scope.insert(name, binding, import.span.clone())?;
                     continue;
                 }
+                // A bundled module may export an `extern "C"` function
+                // (for example `std/math` binding libm's `sqrt`). Externs
+                // keep their bare C name, so the merged declaration is
+                // already in module scope under the selector's name. The
+                // selector therefore needs no new binding.
+                if matches!(
+                    scope.lookup(name).map(|e| &e.binding),
+                    Some(Binding::Extern { .. })
+                ) {
+                    continue;
+                }
             }
             scope.insert(
                 name,

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -42,6 +42,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
         include_str!("../../stdlib/std/collections.rv"),
     ),
     ("cmp", include_str!("../../stdlib/std/cmp.rv")),
+    ("math", include_str!("../../stdlib/std/math.rv")),
 ];
 
 /// The prelude module that is implicitly imported into every program.
@@ -356,6 +357,11 @@ mod tests {
     #[test]
     fn string_module_is_bundled() {
         assert!(bundled_source("string").is_some());
+    }
+
+    #[test]
+    fn math_module_is_bundled() {
+        assert!(bundled_source("math").is_some());
     }
 
     #[test]

--- a/stdlib/std/math.rv
+++ b/stdlib/std/math.rv
@@ -1,0 +1,115 @@
+// std/math: numeric constants and functions. The transcendental and
+// rounding functions bind directly to the C runtime math library through
+// `extern "C"`; the rest is pure Raven.
+
+extern "C" {
+    fun sqrt(x: Float) -> Float
+    fun pow(base: Float, exp: Float) -> Float
+    fun exp(x: Float) -> Float
+    fun log10(x: Float) -> Float
+    fun sin(x: Float) -> Float
+    fun cos(x: Float) -> Float
+    fun tan(x: Float) -> Float
+    fun floor(x: Float) -> Float
+    fun ceil(x: Float) -> Float
+    fun trunc(x: Float) -> Float
+    fun round(x: Float) -> Float
+    fun log(x: Float) -> Float
+    fun fabs(x: Float) -> Float
+}
+
+fun pi() -> Float {
+    return 3.141592653589793
+}
+
+fun e() -> Float {
+    return 2.718281828459045
+}
+
+fun tau() -> Float {
+    return 6.283185307179586
+}
+
+fun abs_int(x: Int) -> Int {
+    if x < 0 {
+        return 0 - x
+    }
+    return x
+}
+
+fun min_int(a: Int, b: Int) -> Int {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+fun max_int(a: Int, b: Int) -> Int {
+    if a > b {
+        return a
+    }
+    return b
+}
+
+fun clamp_int(x: Int, lo: Int, hi: Int) -> Int {
+    if x < lo {
+        return lo
+    }
+    if x > hi {
+        return hi
+    }
+    return x
+}
+
+// Natural logarithm. C names this `log`; `ln` is the conventional spelling.
+fun ln(x: Float) -> Float {
+    return log(x)
+}
+
+// Float absolute value. C names this `fabs`.
+fun abs(x: Float) -> Float {
+    return fabs(x)
+}
+
+fun min(a: Float, b: Float) -> Float {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+fun max(a: Float, b: Float) -> Float {
+    if a > b {
+        return a
+    }
+    return b
+}
+
+fun clamp(x: Float, lo: Float, hi: Float) -> Float {
+    if x < lo {
+        return lo
+    }
+    if x > hi {
+        return hi
+    }
+    return x
+}
+
+// Integer power by squaring. A negative exponent has no integer result
+// and returns 0.
+fun pow_int(base: Int, exp: Int) -> Int {
+    if exp < 0 {
+        return 0
+    }
+    let result = 1
+    let b = base
+    let n = exp
+    while n > 0 {
+        if n % 2 == 1 {
+            result = result * b
+        }
+        b = b * b
+        n = n / 2
+    }
+    return result
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -237,6 +237,27 @@ fn cmp_program_compiles_and_runs() {
 }
 
 #[test]
+fn math_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/math end to end. The transcendental and rounding functions bind
+    // to the C runtime math library through `extern "C"` (libm via the CRT),
+    // returning C `double` as Raven `Float`; the integer helpers and the
+    // `ln`/`abs` wrappers are pure Raven. Inputs are chosen so every Float
+    // result lands on a whole number, and the exp(ln(x)) round trip is
+    // asserted within a tolerance so the printed output is stable. Prints
+    // abs_int 5, min_int 3, max_int 7, clamp_int 10, pow_int 1024, then
+    // sqrt 4, pow 1024, abs 4, floor 3, ceil 4, round 3, trunc 3, the
+    // tolerance check true, sin 0, cos 1, and the two constant checks true.
+    compile_link_run_and_check(
+        "use_math.rv",
+        "5\n3\n7\n10\n1024\n4\n1024\n4\n3\n4\n3\n3\ntrue\n0\n1\ntrue\ntrue\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn stdlib_string_method_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Add the `std/math` standard-library module: numeric constants and functions importable with `import std/math { ... }`.

Closes #74. Spec: `docs/v2/specs/std-math.md`.

## FFI vs pure Raven

The transcendental and rounding functions bind directly to the C runtime math library through `extern "C"`. This was probed before committing to it: `extern "C" { fun sqrt(x: Float) -> Float }` calling `sqrt(2.0)` compiled, linked against the CRT on `x86_64-pc-windows-msvc`, and printed `1.4142135623730951`. A Raven `Float` is a 64-bit IEEE double, identical to C `double`, so it crosses the C ABI to libm directly even though the FFI layer has no `CDouble` type. Further probes confirmed `pow`, `sin`, `cos`, `tan`, `exp`, `log`, `log10`, `floor`, `ceil`, `trunc`, `round`, and `fabs` all resolve and return correct values. So the FFI path is used rather than a pure-Raven series approximation: there is no series truncation to document, and accuracy matches the host libm. `ln` and `abs` are thin Raven wrappers over C `log` and `fabs`; the integer functions, `pow_int`, and the constants are pure Raven.

## Surface

- Constants: `pi()`, `e()`, `tau()` (zero-arg functions returning `Float`).
- Int: `abs_int`, `min_int`, `max_int`, `clamp_int`, `pow_int` (by squaring; negative exponent returns 0).
- Float: `abs`, `min`, `max`, `clamp`, `sqrt`, `pow`, `exp`, `ln`, `log10`, `sin`, `cos`, `tan`, `floor`, `ceil`, `trunc`, `round`.

Free functions, not methods. Int and Float variants are named distinctly (`min` vs `min_int`) since the language has no overloading.

## Resolver

A bundled module can now export an `extern "C"` function. Externs keep their bare C name (the link symbol), so a `std/math` selector such as `sqrt` binds to the already-merged extern instead of creating a duplicate.

## Program output

`examples/v2/use_math.rv` prints (literal, asserted by the smoke test):

```
5
3
7
10
1024
4
1024
4
3
4
3
3
true
0
1
true
true
```

## Out of scope

Complex numbers, big integers, statistics, RNG (`std/random`, #129), methods on `Float`/`Int`, numeric casts.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (includes `math_program_compiles_and_runs` and `math_module_is_bundled`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Compiled `use_math.rv` runs and prints the output above
