### PR TITLE
feat(stdlib): std/path manipulation

### DIFF
--- a/docs/v2/specs/std-path.md
+++ b/docs/v2/specs/std-path.md
@@ -1,0 +1,61 @@
+# std/path Spec
+
+Path string manipulation on the POSIX `/` separator. Every function is
+pure string work: no filesystem access, no allocation beyond the returned
+`String`. The functions are built in Raven on the `__str_*` byte
+intrinsics, so the module has no dependency on `std/string`.
+
+## Model
+
+A path is a `String` whose components are separated by `/`. This is the
+only separator the module understands. Windows backslash (`\`) paths and
+drive letters are out of scope for v2.0; a `\` is treated as an ordinary
+path byte.
+
+## Import
+
+The functions have no natural single receiver, so they are free functions
+bound by a selective import:
+
+```raven
+import std/path { join, basename, dirname, extension, stem, is_absolute }
+
+fun main() {
+    let p = join("a/b", "c.txt")   // a/b/c.txt
+    let d = dirname(p)             // a/b
+    let f = basename(p)            // c.txt
+    let e = extension(p)           // txt
+    let s = stem(p)                // c
+}
+```
+
+## Surface
+
+| Function | Result | Notes |
+|---|---|---|
+| `join(a, b)` | `String` | join with a single `/`; never doubles when `a` ends with `/` or `b` starts with `/`. An empty operand returns the other unchanged. |
+| `basename(p)` | `String` | final component after the last `/`, or the whole string when there is no `/`. |
+| `dirname(p)` | `String` | everything up to the last `/`; `"."` when there is no `/`; `"/"` when the only `/` is at index 0. |
+| `extension(p)` | `String` | substring after the last `.` in the basename, or `""` when none. A leading dot (a dotfile such as `.gitignore`) is not an extension. |
+| `stem(p)` | `String` | basename without its extension. |
+| `is_absolute(p)` | `Bool` | whether `p` starts with `/`. The empty string is relative. |
+
+Indices are byte offsets, consistent with `std/string`. Paths are assumed
+to be valid UTF-8 with the separator and dot appearing only as their own
+single-byte ASCII forms.
+
+## normalize
+
+`normalize` (resolving `.` and `..` segments and collapsing repeated
+separators) is deferred. It is fiddly to specify (root escapes, trailing
+slashes, empty results) and not required by the current consumers. It can
+be added later without changing the existing surface.
+
+## Out of scope
+
+- Windows `\` separators, drive letters, and UNC paths.
+- `normalize` and any `..`/`.` resolution.
+- Filesystem queries (existence, canonicalization); those belong to
+  `std/fs`.
+- Splitting a path into a `List` of components (waits on a stable list
+  return convention in the stdlib).

--- a/examples/v2/use_path.rv
+++ b/examples/v2/use_path.rv
@@ -1,0 +1,19 @@
+// golden:skip
+import std/path { join, basename, dirname, extension, stem, is_absolute }
+import std/io { println }
+
+fun main() {
+    println(join("a/b", "c.txt"))
+    println(join("a/b/", "c.txt"))
+    println(basename("a/b/c.txt"))
+    println(dirname("a/b/c.txt"))
+    println(dirname("file.txt"))
+    println(extension("a/b/c.txt"))
+    println(stem("a/b/c.txt"))
+    println(extension("README"))
+    if is_absolute("/etc/hosts") {
+        println("absolute")
+    } else {
+        println("relative")
+    }
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -78,6 +78,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "cmp",
     "string",
     "math",
+    "path",
     "fs",
     "net",
     "http",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -43,6 +43,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ),
     ("cmp", include_str!("../../stdlib/std/cmp.rv")),
     ("math", include_str!("../../stdlib/std/math.rv")),
+    ("path", include_str!("../../stdlib/std/path.rv")),
 ];
 
 /// The prelude module that is implicitly imported into every program.
@@ -362,6 +363,11 @@ mod tests {
     #[test]
     fn math_module_is_bundled() {
         assert!(bundled_source("math").is_some());
+    }
+
+    #[test]
+    fn path_module_is_bundled() {
+        assert!(bundled_source("path").is_some());
     }
 
     #[test]

--- a/stdlib/std/path.rv
+++ b/stdlib/std/path.rv
@@ -1,0 +1,92 @@
+// std/path: POSIX-style path manipulation on `/` separators. Pure string
+// work over the `__str_*` byte intrinsics; Windows `\` handling is out of
+// scope. Separator `/` is byte 47, `.` is byte 46.
+
+// Byte index of the last `/`, or -1 when none.
+fun last_slash(p: String) -> Int {
+    let i = __str_len(p) - 1
+    while i >= 0 {
+        if __str_byte_at(p, i) == 47 {
+            return i
+        }
+        i = i - 1
+    }
+    return -1
+}
+
+fun join(a: String, b: String) -> String {
+    let na = __str_len(a)
+    let nb = __str_len(b)
+    if na == 0 {
+        return b
+    }
+    if nb == 0 {
+        return a
+    }
+    let a_slash = __str_byte_at(a, na - 1) == 47
+    let b_slash = __str_byte_at(b, 0) == 47
+    if a_slash {
+        if b_slash {
+            return __str_concat(a, __str_substring(b, 1, nb))
+        }
+        return __str_concat(a, b)
+    }
+    if b_slash {
+        return __str_concat(a, b)
+    }
+    return __str_concat(__str_concat(a, "/"), b)
+}
+
+fun basename(p: String) -> String {
+    let i = last_slash(p)
+    if i < 0 {
+        return p
+    }
+    return __str_substring(p, i + 1, __str_len(p))
+}
+
+fun dirname(p: String) -> String {
+    let i = last_slash(p)
+    if i < 0 {
+        return "."
+    }
+    if i == 0 {
+        return "/"
+    }
+    return __str_substring(p, 0, i)
+}
+
+// Substring after the last `.` in the basename, or "" when none. A leading
+// dot (a dotfile such as ".gitignore") is not an extension.
+fun extension(p: String) -> String {
+    let base = basename(p)
+    let n = __str_len(base)
+    let i = n - 1
+    while i > 0 {
+        if __str_byte_at(base, i) == 46 {
+            return __str_substring(base, i + 1, n)
+        }
+        i = i - 1
+    }
+    return ""
+}
+
+fun stem(p: String) -> String {
+    let base = basename(p)
+    let n = __str_len(base)
+    let i = n - 1
+    while i > 0 {
+        if __str_byte_at(base, i) == 46 {
+            return __str_substring(base, 0, i)
+        }
+        i = i - 1
+    }
+    return base
+}
+
+fun is_absolute(p: String) -> Bool {
+    if __str_len(p) == 0 {
+        return false
+    }
+    return __str_byte_at(p, 0) == 47
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -225,6 +225,24 @@ fn collections_program_compiles_and_runs() {
 }
 
 #[test]
+fn path_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/path POSIX `/` manipulation in pure Raven over the `__str_*` byte
+    // intrinsics: join collapses a trailing separator, basename/dirname split
+    // on the last `/` (dirname of a bare name is "."), extension/stem split on
+    // the last `.` of the basename (a name with no dot has an empty
+    // extension), and is_absolute tests a leading `/`. Prints a/b/c.txt twice,
+    // c.txt, a/b, ".", txt, c, an empty line, then absolute.
+    compile_link_run_and_check(
+        "use_path.rv",
+        "a/b/c.txt\na/b/c.txt\nc.txt\na/b\n.\ntxt\nc\n\nabsolute\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn cmp_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Add `std/path`, POSIX `/` path string manipulation written in pure Raven over the `__str_*` byte intrinsics.

Closes #126

Spec: `docs/v2/specs/std-path.md`.

## Surface

| Function | Result | Notes |
|---|---|---|
| `join(a, b)` | `String` | single `/`, never doubled; empty operand returns the other |
| `basename(p)` | `String` | last component, or the whole string when no `/` |
| `dirname(p)` | `String` | up to the last `/`; `"."` when none; `"/"` at root |
| `extension(p)` | `String` | after the last `.` in the basename, `""` when none; a leading dot is not an extension |
| `stem(p)` | `String` | basename without its extension |
| `is_absolute(p)` | `Bool` | starts with `/` |

Deferred: `normalize` (`.`/`..` resolution), Windows `\` paths and drive letters, filesystem queries, component splitting.

## Verified output

`examples/v2/use_path.rv` compiled and run on x86_64-pc-windows-msvc:

```
a/b/c.txt
a/b/c.txt
c.txt
a/b
.
txt
c

absolute
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (includes `path_program_compiles_and_runs` end-to-end smoke test and `path_module_is_bundled`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
