### PR TITLE
feat(resolve): bundled stdlib modules can import other stdlib modules

### DIFF
--- a/docs/v2/specs/std-path.md
+++ b/docs/v2/specs/std-path.md
@@ -2,8 +2,10 @@
 
 Path string manipulation on the POSIX `/` separator. Every function is
 pure string work: no filesystem access, no allocation beyond the returned
-`String`. The functions are built in Raven on the `__str_*` byte
-intrinsics, so the module has no dependency on `std/string`.
+`String`. The functions are built in Raven on `std/string`'s `String`
+methods (`length`, `substring`, `concat`, `char_at`, `starts_with`,
+`ends_with`); the module `import std/string` and lets stdlib expansion
+merge it transitively.
 
 ## Model
 

--- a/docs/v2/specs/stdlib.md
+++ b/docs/v2/specs/stdlib.md
@@ -55,6 +55,33 @@ When the program imports a bundled module, the compiler:
 A module is loaded once. Duplicate imports of the same `std/<module>` (in
 the same program, or selecting different names) merge a single copy.
 
+## Transitive bundled imports
+
+A bundled module may itself `import std/<other>` to build on another
+bundled module (for example `std/path` builds on `std/string`'s `String`
+methods). Stdlib expansion follows these imports transitively:
+
+1. The set of modules to merge is seeded from the prelude and the user
+   file's `std/...` imports.
+2. Each bundled module's source is scanned for its own `import std/...`
+   lines, and any bundled module named there is added to the set. The
+   scan repeats to a fixed point.
+3. The set deduplicates by module name, so every module (including the
+   prelude) merges exactly once even when reached through several import
+   paths. An import cycle (A imports B, B imports A) simply resolves to
+   both being present once: the fixed-point loop terminates because a
+   module is added to the set at most once and only newly added modules
+   are queued for scanning.
+
+A bundled module's own `import std/...` declarations are consumed by the
+expander, not emitted: they are stripped from the combined file so the
+resolver never sees a stdlib module's internal import as an import item.
+A method that one bundled module calls on a built-in type (for example
+`p.length()` in `std/path`) resolves by the receiver's type once the
+defining module's `impl` is merged, so no selector is needed. Cross-module
+free-function calls would still need the namespaced name; the present
+modules use type-dispatched methods across module boundaries.
+
 ## Multi module compilation and namespacing
 
 The driver builds one combined `ast::File` whose `items` are the bundled

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -83,20 +83,34 @@ pub fn bundled_source(module_path: &str) -> Option<&'static str> {
 /// the import pass to report as `UnresolvedImport`; this function only
 /// merges the modules it can load.
 pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
+    // Modules to merge, collected to a fixed point. A module enters the
+    // set from the user file's `std/...` imports or from a bundled
+    // module's own `import std/...` line. The set deduplicates, so each
+    // module merges exactly once and an import cycle (A imports B imports
+    // A) just resolves to both being present once with no infinite loop.
     let mut wanted: BTreeSet<String> = BTreeSet::new();
     // The prelude (`std/core`) is implicitly imported into every program,
     // so its traits and built-in impls are always in scope without an
-    // `import std/core` line. It is merged first; a `BTreeSet` keeps the
-    // module order stable and deduplicates against any later explicit
-    // import of the same module.
+    // `import std/core` line. It seeds the set; a `BTreeSet` keeps the
+    // module order stable and deduplicates against any later import of the
+    // same module (so the prelude never merges twice).
     wanted.insert(PRELUDE_MODULE.to_string());
-    for decl in &user.items {
-        if let DeclKind::Import(import) = &decl.kind {
-            if let ImportSource::Std(segments) = &import.source {
-                if let Some(head) = segments.first() {
-                    if bundled_source(head).is_some() {
-                        wanted.insert(head.clone());
-                    }
+    collect_std_module_imports(user, &mut wanted);
+
+    // Follow each bundled module's own `std/...` imports to a fixed point.
+    // A worklist over the not-yet-scanned modules terminates because every
+    // discovered module is added to `wanted` (a set) at most once and only
+    // unscanned modules are pushed.
+    let mut to_scan: Vec<String> = wanted.iter().cloned().collect();
+    while let Some(module) = to_scan.pop() {
+        let module_file = parse_bundled_module(&module)?;
+        let before = wanted.len();
+        collect_std_module_imports(&module_file, &mut wanted);
+        if wanted.len() != before {
+            // New modules appeared; queue only the freshly added ones.
+            for m in &wanted {
+                if !to_scan.contains(m) {
+                    to_scan.push(m.clone());
                 }
             }
         }
@@ -104,13 +118,7 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
 
     let mut combined_items = Vec::new();
     for module in &wanted {
-        let source = bundled_source(module).expect("module presence checked above");
-        let virtual_path = PathBuf::from(format!("<bundled>/std/{module}.rv"));
-        let tokens = Lexer::new(source.to_string(), virtual_path.clone())
-            .tokenize()
-            .map_err(|e| bundled_error(module, format!("lex: {e}")))?;
-        let module_file =
-            parse(&tokens).map_err(|e| bundled_error(module, format!("parse: {e}")))?;
+        let module_file = parse_bundled_module(module)?;
 
         // Collect the module's own top level function names so a call to
         // a sibling function (for example `trim` calling `is_space_byte`)
@@ -127,6 +135,13 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
             .collect();
 
         for mut decl in module_file.items {
+            // A bundled module's own `import std/...` declarations are
+            // consumed by this expander (the imported module is merged
+            // separately); they must not leak into the combined file as
+            // import items, which is why they are dropped here.
+            if matches!(&decl.kind, DeclKind::Import(_)) {
+                continue;
+            }
             match &mut decl.kind {
                 DeclKind::Function(f) => {
                     rewrite_fn_body_calls(&mut f.body, module, &siblings);
@@ -162,6 +177,33 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
         items: combined_items,
         span: user.span.clone(),
     })
+}
+
+/// Add every bundled `std/<module>` imported by `file` to `wanted`. Only
+/// imports that name a known bundled module are added; an unknown module
+/// is left for the import pass to report.
+fn collect_std_module_imports(file: &File, wanted: &mut BTreeSet<String>) {
+    for decl in &file.items {
+        if let DeclKind::Import(import) = &decl.kind {
+            if let ImportSource::Std(segments) = &import.source {
+                if let Some(head) = segments.first() {
+                    if bundled_source(head).is_some() {
+                        wanted.insert(head.clone());
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Lex and parse one bundled module's embedded source.
+fn parse_bundled_module(module: &str) -> Result<File, RavenError> {
+    let source = bundled_source(module).expect("module presence checked by caller");
+    let virtual_path = PathBuf::from(format!("<bundled>/std/{module}.rv"));
+    let tokens = Lexer::new(source.to_string(), virtual_path)
+        .tokenize()
+        .map_err(|e| bundled_error(module, format!("lex: {e}")))?;
+    parse(&tokens).map_err(|e| bundled_error(module, format!("parse: {e}")))
 }
 
 /// Rewrite every reference to a sibling stdlib function inside a bundled
@@ -506,6 +548,50 @@ mod tests {
             .items
             .iter()
             .any(|d| matches!(&d.kind, DeclKind::Trait(t) if t.name == "ToString")));
+    }
+
+    #[test]
+    fn transitive_std_import_merges_dependency_once() {
+        // `std/path` imports `std/string`. A user importing only `std/path`
+        // must still get `std/string`'s items merged (so path's `String`
+        // method calls resolve), and exactly once.
+        let user = parse_src("import std/path { basename }\nfun main() {}\n");
+        let combined = expand_with_stdlib(&user).expect("expand");
+
+        // `std/string` declares the free helper `is_space_byte`; it must be
+        // present under its namespaced name exactly once.
+        let string_helper = mangle_stdlib_fn("string", "is_space_byte");
+        let count = combined
+            .items
+            .iter()
+            .filter(|d| matches!(&d.kind, DeclKind::Function(f) if f.name == string_helper))
+            .count();
+        assert_eq!(count, 1, "std/string must merge exactly once");
+
+        // `std/string`'s `impl String` methods (resolved by type) must be
+        // present so path's `p.length()` etc. resolve.
+        let has_length = combined.items.iter().any(|d| {
+            matches!(
+                &d.kind,
+                DeclKind::Impl(imp) if imp.items.iter().any(|m| m.name == "length")
+            )
+        });
+        assert!(has_length, "std/string impl methods must be merged");
+
+        // The bundled module's own `import std/string` line must not leak
+        // into the combined file as an import item. The only std import
+        // present should be the user's own `import std/path`.
+        let leaked_string_import = combined.items.iter().any(|d| match &d.kind {
+            DeclKind::Import(i) => matches!(
+                &i.source,
+                ImportSource::Std(s) if s.first().map(|x| x.as_str()) == Some("string")
+            ),
+            _ => false,
+        });
+        assert!(
+            !leaked_string_import,
+            "a bundled module's std import must be stripped from the merged file"
+        );
     }
 
     #[test]

--- a/stdlib/std/path.rv
+++ b/stdlib/std/path.rv
@@ -1,12 +1,13 @@
-// std/path: POSIX-style path manipulation on `/` separators. Pure string
-// work over the `__str_*` byte intrinsics; Windows `\` handling is out of
-// scope. Separator `/` is byte 47, `.` is byte 46.
+// std/path: POSIX-style path manipulation on `/` separators. Built on the
+// `String` methods from std/string. Windows `\` handling is out of scope.
+
+import std/string
 
 // Byte index of the last `/`, or -1 when none.
 fun last_slash(p: String) -> Int {
-    let i = __str_len(p) - 1
+    let i = p.length() - 1
     while i >= 0 {
-        if __str_byte_at(p, i) == 47 {
+        if p.char_at(i).starts_with("/") {
             return i
         }
         i = i - 1
@@ -15,26 +16,24 @@ fun last_slash(p: String) -> Int {
 }
 
 fun join(a: String, b: String) -> String {
-    let na = __str_len(a)
-    let nb = __str_len(b)
-    if na == 0 {
+    if a.length() == 0 {
         return b
     }
-    if nb == 0 {
+    if b.length() == 0 {
         return a
     }
-    let a_slash = __str_byte_at(a, na - 1) == 47
-    let b_slash = __str_byte_at(b, 0) == 47
+    let a_slash = a.ends_with("/")
+    let b_slash = b.starts_with("/")
     if a_slash {
         if b_slash {
-            return __str_concat(a, __str_substring(b, 1, nb))
+            return a.concat(b.substring(1, b.length()))
         }
-        return __str_concat(a, b)
+        return a.concat(b)
     }
     if b_slash {
-        return __str_concat(a, b)
+        return a.concat(b)
     }
-    return __str_concat(__str_concat(a, "/"), b)
+    return a.concat("/").concat(b)
 }
 
 fun basename(p: String) -> String {
@@ -42,7 +41,7 @@ fun basename(p: String) -> String {
     if i < 0 {
         return p
     }
-    return __str_substring(p, i + 1, __str_len(p))
+    return p.substring(i + 1, p.length())
 }
 
 fun dirname(p: String) -> String {
@@ -53,18 +52,18 @@ fun dirname(p: String) -> String {
     if i == 0 {
         return "/"
     }
-    return __str_substring(p, 0, i)
+    return p.substring(0, i)
 }
 
 // Substring after the last `.` in the basename, or "" when none. A leading
 // dot (a dotfile such as ".gitignore") is not an extension.
 fun extension(p: String) -> String {
     let base = basename(p)
-    let n = __str_len(base)
+    let n = base.length()
     let i = n - 1
     while i > 0 {
-        if __str_byte_at(base, i) == 46 {
-            return __str_substring(base, i + 1, n)
+        if base.char_at(i).starts_with(".") {
+            return base.substring(i + 1, n)
         }
         i = i - 1
     }
@@ -73,11 +72,11 @@ fun extension(p: String) -> String {
 
 fun stem(p: String) -> String {
     let base = basename(p)
-    let n = __str_len(base)
+    let n = base.length()
     let i = n - 1
     while i > 0 {
-        if __str_byte_at(base, i) == 46 {
-            return __str_substring(base, 0, i)
+        if base.char_at(i).starts_with(".") {
+            return base.substring(0, i)
         }
         i = i - 1
     }
@@ -85,8 +84,5 @@ fun stem(p: String) -> String {
 }
 
 fun is_absolute(p: String) -> Bool {
-    if __str_len(p) == 0 {
-        return false
-    }
-    return __str_byte_at(p, 0) == 47
+    return p.starts_with("/")
 }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -229,8 +229,8 @@ fn path_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;
     };
-    // std/path POSIX `/` manipulation in pure Raven over the `__str_*` byte
-    // intrinsics: join collapses a trailing separator, basename/dirname split
+    // std/path POSIX `/` manipulation built on std/string's `String` methods
+    // (a bundled module importing another): join collapses a trailing separator, basename/dirname split
     // on the last `/` (dirname of a bare name is "."), extension/stem split on
     // the last `.` of the basename (a name with no dot has an empty
     // extension), and is_absolute tests a leading `/`. Prints a/b/c.txt twice,


### PR DESCRIPTION
Bundled stdlib modules can now import other bundled stdlib modules, so a module like `std/path` can build on `std/string` instead of hand-rolling byte loops.

Closes #161

## How it works

- **Transitive merge.** `expand_with_stdlib` seeds the merge set from the prelude and the user file's `std/...` imports, then scans each bundled module's source for its own `import std/...` lines and adds any bundled module named there. The scan repeats to a fixed point.
- **Dedup.** The set is a `BTreeSet<String>` keyed by module name, so every module (including the prelude) merges exactly once even when reached through several import paths.
- **Cycle handling.** A cycle (A imports B, B imports A) resolves to both modules present once. The worklist loop terminates because a module is added to the set at most once and only newly added modules are queued for scanning.
- **Stripped imports.** A bundled module's own `import std/...` declarations are consumed by the expander and dropped from the combined file, so the resolver never sees a stdlib module's internal import as an import item.
- Cross-module `String` methods (for example `p.length()` in `std/path`) resolve by the receiver's type once the defining module's `impl` is merged, so no selector is needed.

## Proof

`stdlib/std/path.rv` now does `import std/string` and uses `String` methods (`length`, `substring`, `concat`, `char_at`, `starts_with`, `ends_with`). Building and running `examples/v2/use_path.rv` produces the same output as before:

```
a/b/c.txt
a/b/c.txt
c.txt
a/b
.
txt
c

absolute
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (resolver tests including `intra_module_sibling_calls_are_namespaced` and the codegen smoke suite)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] New resolver test `transitive_std_import_merges_dependency_once`: a user importing only `std/path` gets `std/string` merged exactly once, its `impl String` methods present, and path's own `import std/string` stripped.
- [x] `path_program_compiles_and_runs` smoke test passes with unchanged expected output.
