### PR TITLE
fix(codegen): == on String compares contents

### DIFF
--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -207,6 +207,20 @@ conversions `__raven_int_to_string`, `__raven_bool_to_string`,
 matching `raven_*_to_string` symbols. Each returns a heap `String`
 pointer that flows like any other string value.
 
+### String equality
+
+`==` and `!=` on `String` compare contents, not object identity. A plain
+`BinaryOp(Eq/Ne)` would emit an `icmp` on the two `String` pointers,
+which would report two distinct heap objects as unequal even when their
+bytes match. To avoid that, MIR lowering special-cases `==`/`!=` whose
+left operand is `String`: it emits a `Call` to the `__raven_str_eq`
+intrinsic, which the back-end routes to `raven_string_eq(a, b) -> i8`
+(the runtime compares lengths, then bytes). `==` uses the `i8` result
+directly; `!=` lowers an extra `UnaryOp(Not)` over it. `Int`, `Float`,
+`Bool`, and `Char` operands are unaffected and keep the `icmp`/`fcmp`
+value compare above. Comparison of user structs and enums is not
+special-cased and remains an identity (pointer) compare.
+
 ### `print_int` intrinsic
 
 `print_int(n: Int)` is the integer companion of `print`. It is a built

--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -135,7 +135,7 @@ Calling `emit_statement` appends to the current block; calling
 | HIR construct | MIR lowering |
 |---------------|--------------|
 | Literal       | `Assign { tmp, Use(Const) }` |
-| Binary / Unary | Evaluate children into locals, then `Assign { tmp, BinaryOp(...) }` |
+| Binary / Unary | Evaluate children into locals, then `Assign { tmp, BinaryOp(...) }`. Exception: `==`/`!=` on `String` lower to a `Call` to the `__raven_str_eq` intrinsic (content compare), with `!=` adding a `UnaryOp(Not)`; see `docs/v2/specs/codegen.md`. |
 | `Ident`       | `Assign { tmp, Use(Copy(local)) }` |
 | `Call`        | Lower callee and args to operands, emit `Assign { tmp, Call { callee, args } }` |
 | `MethodCall`  | Receiver becomes the first arg, otherwise identical to `Call` |

--- a/docs/v2/specs/tycheck.md
+++ b/docs/v2/specs/tycheck.md
@@ -102,6 +102,12 @@ Operators (selection):
 
 Mixed numeric operands are rejected; there is no implicit promotion.
 
+`==` and `!=` accept two operands of the same type and yield `Bool`. The comparison semantics depend on the operand type, and the back-end (not the type checker) selects them:
+
+* `Int`, `Float`, `Bool`, and `Char` compare by value.
+* `String` compares by content: two strings are equal when they hold the same bytes, regardless of whether they are the same heap object. `!=` is the negation. See `docs/v2/specs/codegen.md`.
+* User structs and enums currently compare by object identity (the two operands are equal only when they are the same heap object). Structural `==` for user types, and routing `==` through an `Eq` trait, are out of scope here; user code that wants value comparison defines and calls a method such as `equals`.
+
 Control flow:
 
 * `if c { a } else { b }` requires `c: Bool` and unifies `a` and `b`. A bare `if` without `else` has type `Unit`; both branches must therefore be `Unit`.

--- a/examples/v2/string_eq.rv
+++ b/examples/v2/string_eq.rv
@@ -1,0 +1,11 @@
+import std/string
+fun main() {
+    let c = "f".concat("oo")
+    print("foo" == c)        // true
+    print("foo" != c)        // false
+    print("foo" == "bar")    // false
+    print("abc" != "abd")    // true
+    print(1 == 1)            // true  (Int unaffected)
+    print(2 == 3)            // false
+    print(true == true)      // true
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -28,11 +28,11 @@ pub use object::{
     raven_int_to_string, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,
     raven_map_bucket_count, raven_map_buckets, raven_map_new, raven_set_bucket_count,
     raven_set_buckets, raven_set_new, raven_string_byte_at, raven_string_bytes,
-    raven_string_concat, raven_string_from_byte, raven_string_from_bytes, raven_string_len,
-    raven_string_new, raven_string_substring, raven_struct_fields, raven_struct_new,
-    Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap, MapEntry,
-    ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, GC_MARK_BIT, OBJECT_ALIGN,
-    TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING, TAG_STRUCT,
+    raven_string_concat, raven_string_eq, raven_string_from_byte, raven_string_from_bytes,
+    raven_string_len, raven_string_new, raven_string_substring, raven_struct_fields,
+    raven_struct_new, Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap,
+    MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, GC_MARK_BIT,
+    OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING, TAG_STRUCT,
 };
 
 use std::alloc::{self, Layout};

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -27,8 +27,9 @@ pub use map::{raven_map_bucket_count, raven_map_buckets, raven_map_new, Map, Map
 pub use set::{raven_set_bucket_count, raven_set_buckets, raven_set_new, Set, SetEntry};
 pub use string::{
     raven_bool_to_string, raven_char_to_string, raven_float_to_string, raven_int_to_string,
-    raven_string_byte_at, raven_string_bytes, raven_string_concat, raven_string_from_byte,
-    raven_string_from_bytes, raven_string_len, raven_string_new, raven_string_substring, String,
+    raven_string_byte_at, raven_string_bytes, raven_string_concat, raven_string_eq,
+    raven_string_from_byte, raven_string_from_bytes, raven_string_len, raven_string_new,
+    raven_string_substring, String,
 };
 pub use structval::{
     raven_struct_fields, raven_struct_new, STRUCT_FIELDS_OFFSET, STRUCT_FIELD_SLOT,

--- a/raven-runtime/src/object/string.rs
+++ b/raven-runtime/src/object/string.rs
@@ -178,6 +178,41 @@ pub extern "C" fn raven_string_byte_at(s: *const String, i: usize) -> i32 {
     byte as i32
 }
 
+/// Compare two strings by content. Returns `1` when both hold the same
+/// bytes (and same length), `0` otherwise. Either pointer may be null,
+/// in which case it is treated as the empty string, so two nulls are
+/// equal and a null equals an empty string.
+///
+/// Backs the `==`/`!=` operators on `String`, which compare contents
+/// rather than object identity.
+#[no_mangle]
+pub extern "C" fn raven_string_eq(a: *const String, b: *const String) -> i8 {
+    if a == b {
+        return 1;
+    }
+    let a_len = raven_string_len(a) as usize;
+    let b_len = raven_string_len(b) as usize;
+    if a_len != b_len {
+        return 0;
+    }
+    if a_len == 0 {
+        return 1;
+    }
+    let a_bytes = raven_string_bytes(a);
+    let b_bytes = raven_string_bytes(b);
+    if a_bytes.is_null() || b_bytes.is_null() {
+        return 0;
+    }
+    // SAFETY: both buffers hold `a_len == b_len` valid bytes.
+    let (a_slice, b_slice) = unsafe {
+        (
+            std::slice::from_raw_parts(a_bytes, a_len),
+            std::slice::from_raw_parts(b_bytes, b_len),
+        )
+    };
+    (a_slice == b_slice) as i8
+}
+
 /// Allocate a fresh `String` holding the half-open byte range
 /// `[start, end)` of `s`. The bounds are clamped to `0..=len` and a
 /// `start` past `end` yields an empty string, so the function never
@@ -523,6 +558,38 @@ mod tests {
         assert_eq!(raven_string_byte_at(s, 99), -1);
         assert_eq!(raven_string_byte_at(std::ptr::null(), 0), -1);
         unsafe { drop_string_for_test(s) };
+    }
+
+    #[test]
+    fn string_eq_compares_contents_not_identity() {
+        let a = raven_string_from_bytes(b"foo".as_ptr(), 3);
+        let b = raven_string_from_bytes(b"f".as_ptr(), 1);
+        let oo = raven_string_from_bytes(b"oo".as_ptr(), 2);
+        let c = raven_string_concat(b, oo);
+        // Distinct objects, same bytes: equal.
+        assert_eq!(raven_string_eq(a, c), 1);
+        // Same pointer: equal.
+        assert_eq!(raven_string_eq(a, a), 1);
+        // Different length and different bytes: not equal.
+        let bar = raven_string_from_bytes(b"bar".as_ptr(), 3);
+        let abcd = raven_string_from_bytes(b"abcd".as_ptr(), 4);
+        assert_eq!(raven_string_eq(a, bar), 0);
+        assert_eq!(raven_string_eq(a, abcd), 0);
+        // Null is the empty string: two nulls equal, null vs empty equal,
+        // null vs non-empty not equal.
+        let empty = raven_string_new(0);
+        assert_eq!(raven_string_eq(std::ptr::null(), std::ptr::null()), 1);
+        assert_eq!(raven_string_eq(std::ptr::null(), empty), 1);
+        assert_eq!(raven_string_eq(std::ptr::null(), a), 0);
+        unsafe {
+            drop_string_for_test(a);
+            drop_string_for_test(b);
+            drop_string_for_test(oo);
+            drop_string_for_test(c);
+            drop_string_for_test(bar);
+            drop_string_for_test(abcd);
+            drop_string_for_test(empty);
+        }
     }
 
     #[test]

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -386,6 +386,10 @@ impl ModuleCx {
         sig = self.make_sig(&[ptr, ptr], &[ptr]);
         self.declare_runtime(intrinsics::RUNTIME_STRING_CONCAT, &sig)?;
 
+        // raven_string_eq(String ptr, String ptr) -> i8 (Bool)
+        sig = self.make_sig(&[ptr, ptr], &[types::I8]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_EQ, &sig)?;
+
         // raven_int_to_string(i64) -> String ptr
         sig = self.make_sig(&[i64t], &[ptr]);
         self.declare_runtime(intrinsics::RUNTIME_INT_TO_STRING, &sig)?;

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -1462,11 +1462,11 @@ fn lower_call(
     if intrinsics::is_intrinsic(&callee.mangled) {
         return lower_intrinsic(cx, builder, &callee.mangled, args, slots);
     }
-    // Interpolation desugaring emits calls to the string concat and
-    // per-type to-string intrinsics. Route each to its runtime symbol;
+    // String runtime intrinsics (concat, per-type to-string, and the
+    // `==`/`!=` byte-equality compare). Route each to its runtime symbol;
     // every argument lowers as an ordinary operand (a String pointer or
-    // a scalar) and the call returns a heap String pointer.
-    if let Some(symbol) = intrinsics::interpolation_runtime_symbol(&callee.mangled) {
+    // a scalar) and the call returns a single result.
+    if let Some(symbol) = intrinsics::string_runtime_symbol(&callee.mangled) {
         let mut arg_vals = Vec::with_capacity(args.len());
         for a in args {
             if let Some(v) = lower_operand(cx, builder, a, slots)? {
@@ -1475,7 +1475,7 @@ fn lower_call(
         }
         let func_id = cx
             .runtime_id(symbol)
-            .expect("interpolation runtime symbol declared at module init");
+            .expect("string runtime symbol declared at module init");
         let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
         let inst = builder.ins().call(local_ref, &arg_vals);
         return Ok(builder.inst_results(inst).first().copied());

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -84,12 +84,19 @@ pub const RUNTIME_BOOL_TO_STRING: &str = "raven_bool_to_string";
 pub const RUNTIME_FLOAT_TO_STRING: &str = "raven_float_to_string";
 pub const RUNTIME_CHAR_TO_STRING: &str = "raven_char_to_string";
 
-/// Map a MIR interpolation intrinsic mangled name to the runtime C
+/// Runtime C symbol comparing two `String` values by content. Backs the
+/// `==`/`!=` operators on `String`.
+pub const RUNTIME_STRING_EQ: &str = "raven_string_eq";
+
+/// Map a MIR string-runtime intrinsic mangled name to the runtime C
 /// symbol it lowers to, or `None` when `mangled` is not one of them.
-pub fn interpolation_runtime_symbol(mangled: &str) -> Option<&'static str> {
+/// These intrinsics share one call shape: each operand lowers to an
+/// ordinary value and the call returns a single result.
+pub fn string_runtime_symbol(mangled: &str) -> Option<&'static str> {
     use crate::mir::intrinsics as mir_intr;
     Some(match mangled {
         mir_intr::STR_CONCAT => RUNTIME_STRING_CONCAT,
+        mir_intr::STR_EQ => RUNTIME_STRING_EQ,
         mir_intr::INT_TO_STRING => RUNTIME_INT_TO_STRING,
         mir_intr::BOOL_TO_STRING => RUNTIME_BOOL_TO_STRING,
         mir_intr::FLOAT_TO_STRING => RUNTIME_FLOAT_TO_STRING,

--- a/src/mir/intrinsics.rs
+++ b/src/mir/intrinsics.rs
@@ -11,6 +11,11 @@
 /// Lowers to `raven_string_concat`.
 pub const STR_CONCAT: &str = "__raven_str_concat";
 
+/// Compare two heap `String` values by content, yielding a `Bool`.
+/// Lowers to `raven_string_eq`. The `==` operator uses the result
+/// directly; `!=` negates it.
+pub const STR_EQ: &str = "__raven_str_eq";
+
 /// Render an `Int` as a heap `String`. Lowers to `raven_int_to_string`.
 pub const INT_TO_STRING: &str = "__raven_int_to_string";
 

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -52,6 +52,15 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             MirOperand::Copy(dst)
         }
         HirExprKind::Binary { op, lhs, rhs } => {
+            // `==`/`!=` on `String` compare contents, not object identity,
+            // so route them through the runtime byte-equality intrinsic.
+            // `!=` negates the equality result. Every other operand type
+            // (and every other operator) keeps the value compare below.
+            if matches!(op, HirBinaryOp::Eq | HirBinaryOp::Ne)
+                && mir_ty(&lhs.ty, cx.subst) == MirType::Str
+            {
+                return lower_string_eq(cx, *op, lhs, rhs, ty);
+            }
             let l = lower_expr(cx, lhs);
             let r = lower_expr(cx, rhs);
             let dst = cx.builder.fresh_temp("bin", ty);
@@ -429,6 +438,43 @@ fn lower_while(cx: &mut LowerCx<'_>, cond: &HirExpr, body: &HirBlock, _ty: MirTy
     cx.current = cont;
     cx.diverged = false;
     MirOperand::Const(MirConstant::Unit)
+}
+
+/// Lower a `String` `==`/`!=` into a call to the runtime byte-equality
+/// intrinsic. `==` yields the call result directly; `!=` negates it.
+fn lower_string_eq(
+    cx: &mut LowerCx<'_>,
+    op: HirBinaryOp,
+    lhs: &HirExpr,
+    rhs: &HirExpr,
+    ty: MirType,
+) -> MirOperand {
+    let l = lower_expr(cx, lhs);
+    let r = lower_expr(cx, rhs);
+    let eq = cx.builder.fresh_temp("streq", MirType::Bool);
+    cx.builder.assign(
+        cx.current,
+        eq,
+        MirRvalue::Call {
+            callee: MirFnRef {
+                mangled: super::super::intrinsics::STR_EQ.into(),
+                origin: None,
+            },
+            args: vec![l, r],
+        },
+    );
+    match op {
+        HirBinaryOp::Eq => MirOperand::Copy(eq),
+        _ => {
+            let dst = cx.builder.fresh_temp("strne", ty);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::UnaryOp(MirUnOp::Not, MirOperand::Copy(eq)),
+            );
+            MirOperand::Copy(dst)
+        }
+    }
 }
 
 /// Desugar an interpolated string into a left-folded chain of runtime

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -225,6 +225,22 @@ fn collections_program_compiles_and_runs() {
 }
 
 #[test]
+fn string_eq_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // `==`/`!=` on String compare contents, not object identity: a
+    // concatenated "foo" equals the literal "foo", and unequal literals
+    // differ. Int and Bool `==` are value compares and stay unaffected.
+    // Prints true, false, false, true, true, false, true.
+    compile_link_run_and_check(
+        "string_eq.rv",
+        "true\nfalse\nfalse\ntrue\ntrue\nfalse\ntrue\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn path_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Make `==`/`!=` on `String` compare contents instead of object identity.

Closes #163

## Problem

`==`/`!=` lowered to a `BinaryOp(Eq/Ne)`, which the back-end emits as an `icmp` on the two operand values. For `String` operands those values are GC object pointers, so two distinct heap strings with the same bytes (for example a concatenated `"foo"` versus the literal `"foo"`) compared as unequal.

## Fix

Approach: special-case `String` operands at MIR lowering and route them to a runtime byte-equality function. This is the smallest correct change and leaves scalar comparisons untouched.

Fix point:

- `src/mir/lower/expr.rs`: the `Binary` lowering detects `==`/`!=` whose left operand is `String` and emits a `Call` to the new `__raven_str_eq` intrinsic instead of a `BinaryOp`. `!=` adds a `UnaryOp(Not)` over the `i8` result.
- `raven-runtime/src/object/string.rs`: new `raven_string_eq(a, b) -> i8` compares lengths, then bytes (nulls treated as the empty string).
- `src/codegen/intrinsics.rs` and `src/codegen/context.rs`: map `__raven_str_eq` to `raven_string_eq` and declare its `(ptr, ptr) -> i8` signature.

## Before / after

For the reproduction (`"foo" == "f".concat("oo")`): before printed `false`, after prints `true`.

## Scope

- `Int`, `Float`, `Bool`, and `Char` `==`/`!=` are unchanged and still compare by value.
- User structs and enums still compare by identity. Structural `==` for user types, and routing `==` through an `Eq` trait, are out of scope. Documented in `docs/v2/specs/tycheck.md` and `docs/v2/specs/codegen.md`.

## Verification

Observed stdout of `examples/v2/string_eq.rv` (compiled and run):

```
true
false
false
true
true
false
true
```

Test plan:

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all green, including the existing Int/Float/Bool/Char and stdlib suites)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] New runtime unit test `string_eq_compares_contents_not_identity`
- [x] New smoke test `string_eq_program_compiles_and_runs` asserting the literal output above
