### PR TITLE
feat(stdlib): std/error type and Result helpers

### DIFF
--- a/docs/v2/specs/std-error.md
+++ b/docs/v2/specs/std-error.md
@@ -1,0 +1,81 @@
+# std/error Spec
+
+An `Error` value type plus ergonomic helpers over the built-in
+`Result<T, E>`. The language already provides `Result`, `Option`, and the
+`?` operator (see `docs/v2/specs/core-traits.md`); this module adds a
+carryable error with a message and optional kind, context chaining, and a
+small set of free functions over `Result`.
+
+## Import
+
+```raven
+import std/error { error, unwrap_or, is_ok }
+import std/io { println }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    print(unwrap_or(divide(10, 2), -1))   // 5
+    print(is_ok(divide(1, 0)))            // false
+}
+```
+
+Importing the module also merges the `Error` `impl` blocks (including its
+`ToString` impl), so `print(e)` renders the message and `e.message()`
+resolves by receiver type. `std/error` itself imports `std/string` for
+`concat`; that dependency is merged transitively.
+
+## Error
+
+A struct holding a `kind` and a `message`, both `String`.
+
+| Item | Result | Notes |
+|---|---|---|
+| `error(msg)` | `Error` | constructor with an empty kind |
+| `error_kind(kind, msg)` | `Error` | constructor with a kind tag |
+| `message()` | `String` | the message text |
+| `kind()` | `String` | the kind tag, `""` when unset |
+| `with_context(ctx)` | `Error` | new error with message `ctx + ": " + message`, kind preserved |
+| `to_string()` | `String` | `message` when the kind is empty, else `kind + ": " + message` |
+
+`with_context` adds a higher-level explanation as an error propagates,
+for example `read_file(p).with_context("load config")`. It returns a new
+`Error` and does not mutate the receiver.
+
+## Result helpers
+
+Free functions generic over `Result<T, E>`. Each matches the Result with
+`match r { Ok(v) -> ..., Err(e) -> ... }`.
+
+| Function | Result | Notes |
+|---|---|---|
+| `is_ok(r)` | `Bool` | true when `Ok` |
+| `is_err(r)` | `Bool` | true when `Err` |
+| `unwrap_or(r, default)` | `T` | the Ok value, or `default` on Err |
+| `ok(r)` | `Option<T>` | Ok to Some, Err to None |
+| `err(r)` | `Option<E>` | Err to Some, Ok to None |
+
+These work with any error type, not just this module's `Error`.
+
+## Relationship to built-in Result, ?, and panic
+
+`Result<T, E>`, `Option<T>`, `Ok`, `Err`, `Some`, and `None` are built in.
+The `?` operator unwraps an `Ok`/`Some` or returns the `Err`/`None` early;
+it needs no import and is the primary propagation mechanism. This module
+adds an error payload to carry in the `E` slot and helpers for the cases
+where matching by hand is verbose. `panic(msg)` aborts the process and is
+the runtime's facility, not part of this module: errors here are values,
+never control flow.
+
+## Out of scope
+
+- Backtraces and source locations.
+- Numeric error codes and `errno` mapping.
+- Downcasting or a dynamic error trait object.
+- `map`/`map_err`/`and_then` combinators (deferred; `match` and `?` cover
+  the common cases for now).

--- a/examples/v2/use_error.rv
+++ b/examples/v2/use_error.rv
@@ -1,0 +1,31 @@
+// golden:skip
+import std/error { error, unwrap_or, is_ok, is_err, ok }
+import std/io { println }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    match divide(10, 2) {
+        Ok(v) -> print(v)
+        Err(e) -> print(e)
+    }
+    let r = divide(1, 0)
+    print(is_ok(r))
+    print(is_err(r))
+    print(unwrap_or(divide(1, 0), -1))
+    match divide(1, 0) {
+        Ok(v) -> print(v)
+        Err(e) -> print(e.message())
+    }
+    let wrapped = error("disk full").with_context("save config")
+    print(wrapped.to_string())
+    match ok(divide(8, 4)) {
+        Some(v) -> print(v)
+        None -> print(0)
+    }
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -79,6 +79,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "string",
     "math",
     "path",
+    "error",
     "fs",
     "net",
     "http",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -44,6 +44,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("cmp", include_str!("../../stdlib/std/cmp.rv")),
     ("math", include_str!("../../stdlib/std/math.rv")),
     ("path", include_str!("../../stdlib/std/path.rv")),
+    ("error", include_str!("../../stdlib/std/error.rv")),
 ];
 
 /// The prelude module that is implicitly imported into every program.
@@ -410,6 +411,11 @@ mod tests {
     #[test]
     fn path_module_is_bundled() {
         assert!(bundled_source("path").is_some());
+    }
+
+    #[test]
+    fn error_module_is_bundled() {
+        assert!(bundled_source("error").is_some());
     }
 
     #[test]

--- a/stdlib/std/error.rv
+++ b/stdlib/std/error.rv
@@ -1,0 +1,85 @@
+// std/error: an `Error` value type plus ergonomic helpers over the
+// built-in `Result<T, E>`. Raven already has `Result`, `Option`, and the
+// `?` operator; this module adds a carryable error with a message and
+// optional kind, context chaining, and a few free functions over Result.
+
+import std/string
+
+struct Error {
+    kind: String,
+    message: String,
+}
+
+// Construct an error with an empty kind.
+fun error(msg: String) -> Error {
+    return Error { kind: "", message: msg }
+}
+
+// Construct an error tagged with a kind (for example "io" or "parse").
+fun error_kind(kind: String, msg: String) -> Error {
+    return Error { kind: kind, message: msg }
+}
+
+impl Error {
+    fun message(self) -> String {
+        return self.message
+    }
+
+    fun kind(self) -> String {
+        return self.kind
+    }
+
+    // A new error whose message is `ctx + ": " + message`, preserving the
+    // kind. Use it to add a higher-level explanation to a lower-level
+    // failure as it propagates.
+    fun with_context(self, ctx: String) -> Error {
+        return Error { kind: self.kind, message: ctx.concat(": ").concat(self.message) }
+    }
+}
+
+impl ToString for Error {
+    fun to_string(self) -> String {
+        if self.kind.length() == 0 {
+            return self.message
+        }
+        return self.kind.concat(": ").concat(self.message)
+    }
+}
+
+fun is_ok<T, E>(r: Result<T, E>) -> Bool {
+    return match r {
+        Ok(v) -> true,
+        Err(e) -> false,
+    }
+}
+
+fun is_err<T, E>(r: Result<T, E>) -> Bool {
+    return match r {
+        Ok(v) -> false,
+        Err(e) -> true,
+    }
+}
+
+// The Ok value, or `default` when the Result is an Err.
+fun unwrap_or<T, E>(r: Result<T, E>, default: T) -> T {
+    return match r {
+        Ok(v) -> v,
+        Err(e) -> default,
+    }
+}
+
+// Discard the error, mapping Ok to Some and Err to None.
+fun ok<T, E>(r: Result<T, E>) -> Option<T> {
+    return match r {
+        Ok(v) -> Some(v),
+        Err(e) -> None,
+    }
+}
+
+// Keep the error, mapping Err to Some and Ok to None.
+fun err<T, E>(r: Result<T, E>) -> Option<E> {
+    return match r {
+        Ok(v) -> None,
+        Err(e) -> Some(e),
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -225,6 +225,26 @@ fn collections_program_compiles_and_runs() {
 }
 
 #[test]
+fn error_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/error end to end: the `Error` value type, its `ToString` impl
+    // (so `print(e)` renders the message), `with_context` chaining, and the
+    // generic free helpers over the built-in `Result<T, E>` (`is_ok`,
+    // `is_err`, `unwrap_or`, `ok`) matched through `match r { Ok(v) ->
+    // ..., Err(e) -> ... }`. divide(10, 2) prints 5; is_ok and is_err on
+    // an Err print false and true; unwrap_or of an Err returns the default
+    // -1; the Err's message is "divide by zero"; with_context prefixes
+    // "save config: disk full"; and ok(divide(8, 4)) is Some(2).
+    compile_link_run_and_check(
+        "use_error.rv",
+        "5\nfalse\ntrue\n-1\ndivide by zero\nsave config: disk full\n2\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn string_eq_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Adds the `std/error` module: an `Error` value type with context chaining plus ergonomic free helpers over the built-in `Result<T, E>`.

Closes #124

Spec: `docs/v2/specs/std-error.md`.

## Surface

- `Error` struct (`kind`, `message`), constructors `error(msg)` and `error_kind(kind, msg)`.
- `impl Error`: `message()`, `kind()`, `with_context(ctx)` (returns a new error with message `ctx + ": " + message`, kind preserved).
- `impl ToString for Error` so `print(e)` renders the message.
- Generic Result helpers, each matching `match r { Ok(v) -> ..., Err(e) -> ... }`: `is_ok`, `is_err`, `unwrap_or`, `ok`, `err`.

Verified that generic `Result<T, E>` helper functions and `match` on `Result` both work end to end in the v2 compiler.

## Verified output

`examples/v2/use_error.rv`, compiled and run on windows-msvc:

```
5
false
true
-1
divide by zero
save config: disk full
2
```

The smoke test asserts this exact output.

## Deferred

- `map`/`map_err`/`and_then` combinators (`match` and `?` cover the common cases for now).
- Backtraces, numeric error codes, downcasting (out of scope, documented in the spec).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (includes `error_program_compiles_and_runs` smoke test and `error_module_is_bundled` unit test, both observed running not skipped)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
