### PR TITLE
feat(stdlib): std/test assertions

### DIFF
--- a/docs/v2/specs/std-test.md
+++ b/docs/v2/specs/std-test.md
@@ -1,0 +1,65 @@
+# std/test Spec
+
+A small assertion surface for writing test programs in Raven. A failed
+assertion aborts the process with a message and a nonzero exit code; a
+program whose assertions all hold runs to completion and exits zero.
+
+## Test model
+
+Raven has no attributes or reflection yet, so there is no test discovery
+or registration framework. A test is an ordinary Raven program whose
+`main` calls these assertions:
+
+```raven
+import std/test { assert, assert_eq_int }
+import std/io { println }
+
+fun main() {
+    assert(1 + 1 == 2)
+    assert_eq_int(6 * 7, 42)
+    println("all passed")
+}
+```
+
+Build and run the program. Exit zero means every assertion held; a
+nonzero exit means an assertion failed, and the panic message names the
+failure. A test runner is just whatever invokes the compiled program and
+checks its exit code (for example a shell loop or CI step).
+
+## Import
+
+The assertions are free functions, so a selective import binds them:
+
+```raven
+import std/test { assert, assert_msg, assert_true, assert_false, assert_eq_int, assert_eq_str }
+```
+
+## Surface
+
+| Function | Fails when | Panic message |
+|---|---|---|
+| `assert(cond: Bool)` | `cond` is false | `assertion failed` |
+| `assert_msg(cond: Bool, msg: String)` | `cond` is false | `msg` |
+| `assert_true(cond: Bool)` | `cond` is false | `assertion failed: expected true` |
+| `assert_false(cond: Bool)` | `cond` is true | `assertion failed: expected false` |
+| `assert_eq_int(a: Int, b: Int)` | `a != b` | `assertion failed: ${a} != ${b}` |
+| `assert_eq_str(a: String, b: String)` | `a != b` | `assertion failed: ${a} != ${b}` |
+
+`assert_eq_str` relies on `String` `==` comparing contents (equivalent to
+the prelude `Eq` `equals`). The integer and string equality messages
+interpolate both operands so a failure shows the mismatched values.
+
+A failure lowers to the runtime panic (`raven_panic`), which writes the
+message to stderr and exits nonzero. The compiler exposes this through an
+internal `__panic(msg: String)` intrinsic that `std/test` calls; users
+call the assertions, not `__panic` directly.
+
+## Out of scope
+
+- Test discovery, registration, or attributes.
+- A generic `assert_eq<T: Eq + ToString>`: interpolating a value of a
+  generic `T` in the panic message is not yet supported by code
+  generation, so the concrete `assert_eq_int` and `assert_eq_str` ship
+  instead. The generic form is deferred until generic interpolation lands.
+- Fixtures, setup/teardown, and parametrized cases.
+- Floating point tolerance comparisons.

--- a/examples/v2/use_test.rv
+++ b/examples/v2/use_test.rv
@@ -1,0 +1,17 @@
+// golden:skip
+// std/test assertions in a passing test program: every assertion holds,
+// so the program reaches the final line and exits zero. A failing
+// assertion would call the runtime panic and abort with a nonzero exit.
+import std/test { assert, assert_msg, assert_true, assert_false, assert_eq_int, assert_eq_str }
+import std/string
+import std/io { println }
+
+fun main() {
+    assert(1 + 1 == 2)
+    assert_msg(2 * 2 == 4, "math broke")
+    assert_true(10 > 3)
+    assert_false(3 > 10)
+    assert_eq_int(6 * 7, 42)
+    assert_eq_str("ab".concat("c"), "abc")
+    println("all passed")
+}

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -1576,6 +1576,24 @@ fn lower_intrinsic(
             builder.ins().call(local_ref, &[ptr_val, len_val]);
             Ok(None)
         }
+        intrinsics::PANIC_FN => {
+            if args.len() != 1 {
+                return Err(CodegenError::Unsupported(format!(
+                    "__panic intrinsic expects 1 arg, got {}",
+                    args.len()
+                )));
+            }
+            let (ptr_val, len_val) = lower_string_arg(cx, builder, &args[0], slots)?;
+            let func_id = cx
+                .runtime_id(intrinsics::RUNTIME_PANIC)
+                .expect("panic declared at module init");
+            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
+            // raven_panic terminates the process; the call is treated as a
+            // normal returning void call so lowering of any trailing code in
+            // the block stays well formed (that code is dead at runtime).
+            builder.ins().call(local_ref, &[ptr_val, len_val]);
+            Ok(None)
+        }
         intrinsics::IO_READ_LINE => {
             if !args.is_empty() {
                 return Err(CodegenError::Unsupported(format!(

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -23,6 +23,12 @@ pub const IO_PRINTLN_STR: &str = "__io_println_str";
 /// `__io_read_line() -> String` reads one line from stdin (no newline).
 pub const IO_READ_LINE: &str = "__io_read_line";
 
+/// Internal panic intrinsic. The bundled `std/test` source calls
+/// `__panic(msg: String)` to abort the process with a message on a failed
+/// assertion; it lowers to the runtime's `raven_panic` symbol. The
+/// leading `__` marks it internal (a user calls `std/test`'s assertions).
+pub const PANIC_FN: &str = "__panic";
+
 /// Internal stdlib string intrinsics. The bundled `std/string` source
 /// calls these byte-level primitives to build the higher-level utilities
 /// (case mapping, search, trim, ...) in pure Raven. The leading `__str_`
@@ -169,6 +175,7 @@ pub fn is_intrinsic(mangled: &str) -> bool {
             | IO_PRINT_STR
             | IO_PRINTLN_STR
             | IO_READ_LINE
+            | PANIC_FN
             | STR_LEN
             | STR_BYTE_AT
             | STR_SUBSTRING

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -80,6 +80,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "math",
     "path",
     "error",
+    "test",
     "fs",
     "net",
     "http",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -45,6 +45,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("math", include_str!("../../stdlib/std/math.rv")),
     ("path", include_str!("../../stdlib/std/path.rv")),
     ("error", include_str!("../../stdlib/std/error.rv")),
+    ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
 /// The prelude module that is implicitly imported into every program.
@@ -416,6 +417,11 @@ mod tests {
     #[test]
     fn error_module_is_bundled() {
         assert!(bundled_source("error").is_some());
+    }
+
+    #[test]
+    fn test_module_is_bundled() {
+        assert!(bundled_source("test").is_some());
     }
 
     #[test]

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -660,6 +660,7 @@ fn is_builtin_ctor_name(name: &str) -> bool {
             | "__io_print_str"
             | "__io_println_str"
             | "__io_read_line"
+            | "__panic"
             | "__str_len"
             | "__str_byte_at"
             | "__str_substring"

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1265,6 +1265,17 @@ impl<'a, 'b> Checker<'a, 'b> {
                 self.unify(&Ty::Str, &arg_ty, &args[0].span)?;
                 Ok(Ty::Unit)
             }
+            "__panic" => {
+                // Internal `__panic(msg: String)` intrinsic. The bundled
+                // `std/test` source calls it to abort on a failed assertion;
+                // the back end lowers it to the runtime `raven_panic`. It
+                // never returns at runtime, but is typed as `Unit` so a call
+                // is a valid statement.
+                self.check_intrinsic_arity(name, args, 1, span)?;
+                let arg_ty = self.check_expr(&args[0])?;
+                self.unify(&Ty::Str, &arg_ty, &args[0].span)?;
+                Ok(Ty::Unit)
+            }
             "__io_read_line" => {
                 if !args.is_empty() {
                     return Err(RavenError::ty(

--- a/stdlib/std/test.rv
+++ b/stdlib/std/test.rv
@@ -1,0 +1,41 @@
+// std/test: assertions for writing test programs in Raven. A test is a
+// Raven program whose `main` calls these assertions; a failed assertion
+// calls the runtime panic, aborting with a message and a nonzero exit.
+// There is no discovery or registration framework. See
+// docs/v2/specs/std-test.md.
+
+fun assert(cond: Bool) {
+    if !cond {
+        __panic("assertion failed")
+    }
+}
+
+fun assert_msg(cond: Bool, msg: String) {
+    if !cond {
+        __panic(msg)
+    }
+}
+
+fun assert_true(cond: Bool) {
+    if !cond {
+        __panic("assertion failed: expected true")
+    }
+}
+
+fun assert_false(cond: Bool) {
+    if cond {
+        __panic("assertion failed: expected false")
+    }
+}
+
+fun assert_eq_int(a: Int, b: Int) {
+    if a != b {
+        __panic("assertion failed: ${a} != ${b}")
+    }
+}
+
+fun assert_eq_str(a: String, b: String) {
+    if a != b {
+        __panic("assertion failed: ${a} != ${b}")
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -245,6 +245,18 @@ fn error_program_compiles_and_runs() {
 }
 
 #[test]
+fn test_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/test assertions in a passing program: assert, assert_msg,
+    // assert_true, assert_false, assert_eq_int, and assert_eq_str all hold,
+    // so no assertion calls the runtime panic. The program reaches the
+    // final line and exits zero, printing `all passed`.
+    compile_link_run_and_check("use_test.rv", "all passed\n", &runtime);
+}
+
+#[test]
 fn string_eq_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Adds the `std/test` standard-library module: a minimal assertion surface for writing test programs in Raven.

Closes #125

## Model

Raven has no attributes or reflection, so there is no discovery or registration framework. A test is an ordinary Raven program whose `main` calls these assertions: a failed assertion aborts the process with a message and a nonzero exit, and an all-passing program runs to completion and exits zero. See `docs/v2/specs/std-test.md`.

## Surface

- `assert(cond)`, `assert_msg(cond, msg)`
- `assert_true(cond)`, `assert_false(cond)`
- `assert_eq_int(a, b)`, `assert_eq_str(a, b)` (panic message interpolates both operands)

A failed assertion lowers through a new internal `__panic(msg: String)` intrinsic (wired across the type checker, resolver, and Cranelift back end) that calls the runtime `raven_panic`. Users call the assertions, not `__panic`.

### Deferred

A generic `assert_eq<T: Eq + ToString>`: interpolating a value of a generic `T` in the panic message is not yet supported by code generation, so the concrete `assert_eq_int` and `assert_eq_str` ship instead. Documented in the spec under out of scope.

## Verification

Passing program (`examples/v2/use_test.rv`), compiled and run on windows-msvc:

```
all passed
exit=0
```

A failing assertion (`assert_eq_int(1, 2)` in a throwaway program) aborts nonzero:

```
raven panic: assertion failed: 1 != 2
exit=101
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (adds `test_program_compiles_and_runs` smoke test and `test_module_is_bundled`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Compiled program prints `all passed` and exits 0
- [x] Failing assertion aborts with a message and nonzero exit
