### PR TITLE
feat(stdlib): std/hash non-cryptographic hashing

### DIFF
--- a/docs/v2/specs/std-hash.md
+++ b/docs/v2/specs/std-hash.md
@@ -1,0 +1,73 @@
+# std/hash Spec
+
+Non-cryptographic hashing building blocks: free functions over the bytes of
+a `String` and over `Int`. These are fast, well-known mixing functions for
+hash tables, checksums, and composite-value hashing.
+
+Not cryptographic. Do not use these for passwords, signatures, integrity
+against an adversary, or any security purpose. Cryptographic hashes (SHA-2,
+BLAKE3, and similar) are out of scope for the standard library and belong in
+a package, per the stdlib charter.
+
+## Import
+
+All entries are free functions, bound with a selective import:
+
+```raven
+import std/hash { fnv1a, djb2, hash_int, combine }
+
+fun main() {
+    let h = fnv1a("abc")
+    let g = combine(h, hash_int(42))
+}
+```
+
+## Surface
+
+| Function | Result | Notes |
+|---|---|---|
+| `fnv1a(s: String)` | `Int` | FNV-1a over the bytes of `s`, 64-bit variant |
+| `djb2(s: String)` | `Int` | classic djb2 string hash (`hash * 33 + byte`, seed 5381) |
+| `hash_int(n: Int)` | `Int` | splitmix64-style bit-mix so sequential ints scatter |
+| `combine(seed, value)` | `Int` | combine two hashes into one (boost `hash_combine`) |
+| `checksum(s: String)` | `Int` | additive byte checksum; cheap and weak, change detection only |
+
+## Integers wrap
+
+Raven `Int` is i64 and arithmetic wraps in two's complement. That wrapping is
+the intended behavior here: the FNV multiply, the djb2 multiply, and the
+integer mixes all rely on it. `fnv1a` uses the standard FNV-64 offset basis
+(`14695981039346656037`, written as its i64 two's-complement value) and prime
+(`1099511628211`); it reproduces the canonical FNV-1a 64 vectors (for example
+`fnv1a("abc")` is `0xe71fa2190541574b`). Returned hashes are full-width i64
+and may be negative.
+
+`>>` is an arithmetic (sign-propagating) shift. The integer mixes stay
+deterministic under it; the values differ from an unsigned-shift reference but
+that does not matter for a non-cryptographic hash.
+
+## Relationship to the Hash trait
+
+The prelude defines `trait Hash { fun hash(self) -> Int }` with built-in impls
+for `Int`, `Bool`, and `String`. These functions are building blocks a user's
+own `Hash` impl can call. A struct can hash its fields and fold them with
+`combine`:
+
+```raven
+import std/hash { fnv1a, hash_int, combine }
+
+struct Point { x: Int, y: Int }
+
+impl Hash for Point {
+    fun hash(self) -> Int {
+        let h = hash_int(self.x)
+        combine(h, hash_int(self.y))
+    }
+}
+```
+
+## Out of scope
+
+Cryptographic hashing and keyed/seeded MACs. Streaming/incremental hasher
+objects. These functions take a whole `String` or `Int` and return a final
+hash.

--- a/examples/v2/use_hash.rv
+++ b/examples/v2/use_hash.rv
@@ -1,0 +1,13 @@
+// golden:skip
+import std/hash { fnv1a, djb2, hash_int, combine }
+
+fun main() {
+    print(fnv1a("") == fnv1a(""))
+    print(fnv1a("abc") == fnv1a("abc"))
+    print(fnv1a("abc") == fnv1a("abd"))
+    print(djb2("hello") == djb2("hello"))
+    print(hash_int(1) == hash_int(1))
+    print(hash_int(1) == hash_int(2))
+    print(combine(1, 2) == combine(1, 2))
+    print(combine(1, 2) == combine(2, 1))
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -76,6 +76,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "iter",
     "collections",
     "cmp",
+    "hash",
     "string",
     "math",
     "path",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -42,6 +42,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
         include_str!("../../stdlib/std/collections.rv"),
     ),
     ("cmp", include_str!("../../stdlib/std/cmp.rv")),
+    ("hash", include_str!("../../stdlib/std/hash.rv")),
     ("math", include_str!("../../stdlib/std/math.rv")),
     ("path", include_str!("../../stdlib/std/path.rv")),
     ("error", include_str!("../../stdlib/std/error.rv")),
@@ -417,6 +418,11 @@ mod tests {
     #[test]
     fn error_module_is_bundled() {
         assert!(bundled_source("error").is_some());
+    }
+
+    #[test]
+    fn hash_module_is_bundled() {
+        assert!(bundled_source("hash").is_some());
     }
 
     #[test]

--- a/stdlib/std/hash.rv
+++ b/stdlib/std/hash.rv
@@ -1,0 +1,58 @@
+// std/hash: non-cryptographic hashing building blocks. NOT for security.
+// `Int` is i64 and arithmetic wraps in two's complement, which is the
+// intended behavior for these hashes. See docs/v2/specs/std-hash.md.
+
+// FNV-1a over the bytes of `s`, 64-bit variant. The offset basis
+// 14695981039346656037 and prime 1099511628211 are the standard FNV-64
+// constants; the basis is written as its i64 two's-complement value.
+fun fnv1a(s: String) -> Int {
+    let n = __str_len(s)
+    let h = -3750763034362895579
+    let i = 0
+    while i < n {
+        h = h ^ __str_byte_at(s, i)
+        h = h * 1099511628211
+        i = i + 1
+    }
+    h
+}
+
+// Classic djb2 string hash: hash = hash * 33 + byte, seeded at 5381.
+fun djb2(s: String) -> Int {
+    let n = __str_len(s)
+    let h = 5381
+    let i = 0
+    while i < n {
+        h = h * 33 + __str_byte_at(s, i)
+        i = i + 1
+    }
+    h
+}
+
+// splitmix64-style integer bit-mix so sequential ints scatter.
+fun hash_int(n: Int) -> Int {
+    let x = n + -7046029254386353131
+    x = (x ^ (x >> 30)) * -4658895280553007687
+    x = (x ^ (x >> 27)) * -7723592293110705685
+    x = x ^ (x >> 31)
+    x
+}
+
+// Combine two hashes into one (boost hash_combine). The constant
+// 2654435769 is the 32-bit golden ratio.
+fun combine(seed: Int, value: Int) -> Int {
+    seed ^ (value + 2654435769 + (seed << 6) + (seed >> 2))
+}
+
+// Simple additive checksum over the bytes of `s`. Cheaper than the hashes
+// above and weaker; for quick change detection only.
+fun checksum(s: String) -> Int {
+    let n = __str_len(s)
+    let sum = 0
+    let i = 0
+    while i < n {
+        sum = sum + __str_byte_at(s, i)
+        i = i + 1
+    }
+    sum
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -257,6 +257,22 @@ fn test_program_compiles_and_runs() {
 }
 
 #[test]
+fn hash_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/hash non-cryptographic hashes: fnv1a, djb2, hash_int, and combine
+    // are deterministic (equal inputs hash equal) and input-sensitive
+    // (different inputs differ; combine is order-sensitive). The booleans
+    // print true, true, false, true, true, false, true, false.
+    compile_link_run_and_check(
+        "use_hash.rv",
+        "true\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\nfalse\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn string_eq_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Add `std/hash`, a small non-cryptographic hashing surface in pure Raven over String bytes and Int.

Closes #131

Spec: `docs/v2/specs/std-hash.md`

## Surface

- `fnv1a(s: String) -> Int`: FNV-1a, 64-bit variant. Reproduces the canonical vectors (`fnv1a("abc") == 0xe71fa2190541574b`).
- `djb2(s: String) -> Int`: classic djb2 (`hash * 33 + byte`, seed 5381).
- `hash_int(n: Int) -> Int`: splitmix64-style bit-mix.
- `combine(seed: Int, value: Int) -> Int`: boost-style `hash_combine` for composite values.
- `checksum(s: String) -> Int`: additive byte checksum, change detection only.

`Int` is i64 and arithmetic wraps in two's complement, which is the intended behavior for these hashes. The functions are building blocks a user's `Hash` impl can call.

Not cryptographic. Do not use for security. Cryptographic hashes are out of scope for the stdlib and belong in a package.

## Verification

`examples/v2/use_hash.rv` compiled and run on x86_64-pc-windows-msvc:

```
true
true
false
true
true
false
true
false
```

(determinism, input sensitivity, and order sensitivity of `combine`). The FNV-1a output was separately checked against a reference vector.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (includes `hash_program_compiles_and_runs`, which links and runs the example for real)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
