### PR TITLE
feat: associated functions (Type.new())

### DIFF
--- a/docs/v2/specs/associated-functions.md
+++ b/docs/v2/specs/associated-functions.md
@@ -1,0 +1,106 @@
+# Associated Functions Spec
+
+An associated function is a function declared in an `impl` block that does
+not take a `self` receiver. It is called on the type, not on a value:
+`Type.func(args)`. This is the idiomatic constructor mechanism, so a type
+exposes `Type.new()` rather than a free `empty_type()` function.
+
+## Declaration
+
+An associated function is a `fun` inside an `impl` block whose first
+parameter is not `self`. The same `impl` block may mix associated
+functions and instance methods:
+
+```raven
+struct Counter { n: Int }
+
+impl Counter {
+    fun new() -> Counter { return Counter { n: 0 } }
+    fun with(start: Int) -> Counter { return Counter { n: start } }
+    fun bump(self) -> Int { return self.n + 1 }
+}
+```
+
+`new` and `with` are associated functions; `bump` is an instance method.
+
+A generic implementing type's associated function may return the generic
+type:
+
+```raven
+impl<T: Eq> Set<T> {
+    fun new() -> Set<T> {
+        let items: List<T> = []
+        return Set { items: items }
+    }
+}
+```
+
+## Call syntax
+
+```
+Type.func(args)
+Type<Args>.func(args)
+```
+
+The leading `Type` is a type name: a user struct or enum, or a built-in
+type (`Int`, `String`, `Array`, ...). Type arguments may be written on the
+type for a generic associated function (`Set<Int>.new()`).
+
+```raven
+let a = Counter.new()
+let b = Counter.with(41)
+let s = Set<Int>.new()
+```
+
+## Disambiguation
+
+`Type.func(...)` is parsed as a method call whose receiver expression is
+the leading name. The resolver and type checker classify it by what the
+receiver names:
+
+* The receiver is a bare reference to a type (a struct or enum binding, or
+  a built-in type identifier): the call is an associated function call. The
+  named function on that type must have no `self`.
+* The receiver is a value (a local, parameter, field, or any other
+  expression): the call is an ordinary instance method call.
+
+`Color.Red` (an enum variant) is field syntax (`receiver.name` with no
+call parens), not a call, so it is unaffected. An imported free function
+called as `f(...)` is a plain call, also unaffected.
+
+## Generic instantiation
+
+The implementing type's generic parameters are instantiated for the call.
+With explicit type arguments (`Set<Int>.new()`) the parameters are fixed
+directly. Without them (`Set.new()`), the element type is left as an
+inference variable and solved from later use within the same body:
+
+```raven
+let s = Set.new()   // T is an inference variable
+s.add(7)            // unifies T = Int
+```
+
+When no later use pins the parameters, the type arguments must be written
+on the call (`Set<Int>.new()`); an unresolved parameter is a
+`cannot infer type` error.
+
+## Codegen
+
+An associated function lowers to a direct static call to the per-type
+symbol `<TypeMangle>$<func>`, with no receiver argument (the only
+difference from an instance method call, which passes the receiver as the
+leading argument). A non-generic associated function is a monomorphization
+root, like any concrete-receiver method. A generic one is specialized at
+the call site the same way a generic method is: the named implementing type
+fixes the impl's type arguments, and the instantiation is queued for the
+monomorphizer, which emits the body under the matching per-instantiation
+symbol.
+
+## Deferrals
+
+* An associated function that introduces its own generic parameters beyond
+  the implementing type's (`fun parse<U>(...)` on `impl<T> Wrap<T>`) is out
+  of scope. The supported cases are `impl Counter { fun new() }` and
+  `impl<T> Set<T> { fun new() -> Set<T> }`.
+* Element inference for `Set.new()` works when a later use pins the type
+  parameters. With no such use, write the type arguments on the call.

--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -139,6 +139,7 @@ Calling `emit_statement` appends to the current block; calling
 | `Ident`       | `Assign { tmp, Use(Copy(local)) }` |
 | `Call`        | Lower callee and args to operands, emit `Assign { tmp, Call { callee, args } }` |
 | `MethodCall`  | Receiver becomes the first arg, otherwise identical to `Call` |
+| `AssocCall`   | Associated function call `Type.func(args)`: a `Call` to the per-type symbol `<TypeMangle>$<func>` with no receiver argument. The named implementing type fixes a generic type's instantiation, queued like a generic method's. |
 | `Field`       | `FieldAccess { base, index }` (index resolved from struct decl) |
 | `Index`       | `IndexAccess { base, index }` |
 | `StructLit`   | Lower fields in declaration order, then `StructCreate` |

--- a/docs/v2/specs/std-collections.md
+++ b/docs/v2/specs/std-collections.md
@@ -6,23 +6,31 @@ trait. `List<T>` is built into the language (literals, indexing, `len`,
 
 ## Import
 
-The collection types are used by method, but their constructors are free
-functions, so a selective import binds them:
+The idiomatic constructor is the associated function `new()` on each type,
+called as `Type.new()`. A plain `import std/collections` is enough, since
+the call resolves the function on the named type rather than an imported
+name:
 
 ```raven
-import std/collections { empty_set, empty_map }
+import std/collections
 
 fun main() {
-    let s = empty_set()
+    let s = Set.new()
     s.add(1)
-    let m = empty_map()
+    let m = Map.new()
     m.set("a", 10)
 }
 ```
 
-Importing the module also merges the `Set` and `Map` `impl` blocks, so the
-methods resolve by receiver type. Element and key/value types are inferred
-from the first use (`s.add(1)` fixes `Set<Int>`).
+Importing the module merges the `Set` and `Map` `impl` blocks, so both the
+constructors and the instance methods resolve by type. Element and
+key/value types are inferred from the first use (`s.add(1)` fixes
+`Set<Int>`). Where no later use pins them, write the type arguments on the
+call: `Set<Int>.new()`.
+
+The free functions `empty_set()` and `empty_map()` remain available for a
+selective import (`import std/collections { empty_set, empty_map }`) and
+behave identically to `Set.new()` and `Map.new()`.
 
 ## Set<T: Eq>
 

--- a/docs/v2/specs/tycheck.md
+++ b/docs/v2/specs/tycheck.md
@@ -132,6 +132,10 @@ Method dispatch is statically resolved. When the user writes `r.m(...)` and `r: 
 
 A method call on a value of `Self` type inside an `impl` block resolves through the implementing type. Each impl's generic parameters get fresh inference variables and the substituted `self_ty` is unified against the receiver, so a generic impl such as `impl<T> List<T>` matches a concrete `List<Int>` receiver and the method's `T` binds to `Int`.
 
+### Associated functions
+
+When the receiver of `r.m(...)` is a bare type reference (a struct or enum binding, or a built-in type name) rather than a value, the call is an associated function call `Type.func(args)`. The named function on that type must have no `self`. The implementing type fixes the impl's generic parameters: explicit arguments (`Set<Int>.new()`) bind them directly, otherwise they are inference variables solved from later use. Arguments are checked against the function's parameters (there is no `self` to drop), and the result is its declared return type with the impl's parameters substituted. See `docs/v2/specs/associated-functions.md`.
+
 ### `impl` on built in types
 
 An `impl` block may target a built in type, not just a user struct or enum:

--- a/examples/v2/assoc_fn.rv
+++ b/examples/v2/assoc_fn.rv
@@ -1,0 +1,25 @@
+// Associated functions (Type.func()) as the idiomatic constructor.
+//
+// `Counter.new()` and `Counter.with(41)` call the receiverless functions
+// declared in the impl block, dispatched statically to the per-type
+// symbols `Counter$new` and `Counter$with`. Prints 0 then 41.
+struct Counter {
+    n: Int
+}
+
+impl Counter {
+    fun new() -> Counter {
+        return Counter { n: 0 }
+    }
+
+    fun with(start: Int) -> Counter {
+        return Counter { n: start }
+    }
+}
+
+fun main() {
+    let a = Counter.new()
+    let b = Counter.with(41)
+    print(a.n)
+    print(b.n)
+}

--- a/examples/v2/use_collections.rv
+++ b/examples/v2/use_collections.rv
@@ -1,9 +1,9 @@
 // golden:skip
-import std/collections { empty_set, empty_map }
+import std/collections
 import std/io { println }
 
 fun main() {
-    let s = empty_set()
+    let s = Set.new()
     s.add(1)
     s.add(2)
     s.add(2)
@@ -12,7 +12,7 @@ fun main() {
     s.remove(2)
     print(s.contains(2))
 
-    let m = empty_map()
+    let m = Map.new()
     m.set("a", 10)
     m.set("b", 20)
     m.set("a", 99)

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -143,6 +143,15 @@ pub enum HirExprKind {
         name: String,
         args: Vec<HirExpr>,
     },
+    /// `Type.func(args)`: an associated function call with no receiver.
+    /// `self_ty` is the implementing type the function is declared on,
+    /// used by MIR to build the per-type symbol and (for a generic type)
+    /// queue the right instantiation.
+    AssocCall {
+        self_ty: HirTy,
+        name: String,
+        args: Vec<HirExpr>,
+    },
     Field {
         receiver: Box<HirExpr>,
         name: String,

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -226,15 +226,33 @@ pub(crate) fn lower_expr(
             args,
             ..
         } => {
-            let r = lower_expr(receiver, &Ty::Error, cx)?;
-            let mut lowered = Vec::with_capacity(args.len());
-            for a in args {
-                lowered.push(lower_expr(a, &Ty::Error, cx)?);
-            }
-            HirExprKind::MethodCall {
-                receiver: Box::new(r),
-                name: name.clone(),
-                args: lowered,
+            // `Type.func(args)` lowers to a receiverless associated call.
+            // The type checker recorded the implementing type at the
+            // receiver span; its presence as a type reference (not a value)
+            // is what the type checker used to route this as an associated
+            // function call.
+            if is_type_ref_receiver(receiver, cx) {
+                let self_ty = cx.ty_at(&receiver.span);
+                let mut lowered = Vec::with_capacity(args.len());
+                for a in args {
+                    lowered.push(lower_expr(a, &Ty::Error, cx)?);
+                }
+                HirExprKind::AssocCall {
+                    self_ty,
+                    name: name.clone(),
+                    args: lowered,
+                }
+            } else {
+                let r = lower_expr(receiver, &Ty::Error, cx)?;
+                let mut lowered = Vec::with_capacity(args.len());
+                for a in args {
+                    lowered.push(lower_expr(a, &Ty::Error, cx)?);
+                }
+                HirExprKind::MethodCall {
+                    receiver: Box::new(r),
+                    name: name.clone(),
+                    args: lowered,
+                }
             }
         }
         ExprKind::Field { receiver, name } => {
@@ -1126,6 +1144,25 @@ fn is_builtin_print(callee: &Expr, cx: &LowerCtx<'_>) -> bool {
         return false;
     };
     name == "print" && cx.fn_name_at(&callee.span).is_none()
+}
+
+/// Whether a method call's receiver is a bare type reference, marking the
+/// call as an associated function call (`Type.func(args)`). Mirrors the
+/// type checker's `type_ref_receiver`: an `Ident` bound to a struct or
+/// enum declaration, or an unbound built-in type name.
+fn is_type_ref_receiver(receiver: &Expr, cx: &LowerCtx<'_>) -> bool {
+    use crate::resolve::Binding;
+    let ExprKind::Ident { name, .. } = &receiver.kind else {
+        return false;
+    };
+    match cx.resolved.map.lookup(&receiver.span) {
+        Some(Binding::Struct(_)) | Some(Binding::Enum(_)) => true,
+        Some(_) => false,
+        None => matches!(
+            name.as_str(),
+            "Int" | "Float" | "Bool" | "String" | "Char" | "Unit" | "Array" | "List" | "Vec"
+        ),
+    }
 }
 
 /// Wrap an interpolation part in a `to_string()` method call when its

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -323,6 +323,25 @@ fn pretty_expr(buf: &mut String, expr: &HirExpr, depth: usize) {
             indent(buf, depth);
             buf.push_str(")\n");
         }
+        HirExprKind::AssocCall {
+            self_ty,
+            name,
+            args,
+        } => {
+            writeln!(
+                buf,
+                "(assoc-call {} on={} ty={}",
+                quote(name),
+                self_ty,
+                expr.ty
+            )
+            .unwrap();
+            for a in args {
+                pretty_expr(buf, a, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
         HirExprKind::Field { receiver, name } => {
             writeln!(buf, "(field-access {} ty={}", quote(name), expr.ty).unwrap();
             pretty_expr(buf, receiver, depth + 1);

--- a/src/mir/lower/closure.rs
+++ b/src/mir/lower/closure.rs
@@ -348,6 +348,11 @@ fn collect_free_expr(
                 collect_free_expr(a, bound, seen, out);
             }
         }
+        HirExprKind::AssocCall { args, .. } => {
+            for a in args {
+                collect_free_expr(a, bound, seen, out);
+            }
+        }
         HirExprKind::Field { receiver, .. } => collect_free_expr(receiver, bound, seen, out),
         HirExprKind::Index { receiver, index } => {
             collect_free_expr(receiver, bound, seen, out);

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -101,6 +101,11 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             name,
             args,
         } => lower_method_call(cx, receiver, name, args, ty),
+        HirExprKind::AssocCall {
+            self_ty,
+            name,
+            args,
+        } => lower_assoc_call(cx, self_ty, name, args, ty),
         HirExprKind::DynCoerce {
             value,
             trait_name,
@@ -987,6 +992,36 @@ fn lower_method_call(
         arg_ops.push(lower_expr(cx, a));
     }
     let dst = cx.builder.fresh_temp("mcall", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::Call {
+            callee: MirFnRef {
+                mangled: symbol,
+                origin: None,
+            },
+            args: arg_ops,
+        },
+    );
+    MirOperand::Copy(dst)
+}
+
+/// Lower an associated function call `Type.func(args)`. Like a static
+/// method call but with no receiver argument. The per-type symbol comes
+/// from the named implementing type; a generic type's instantiation is
+/// queued the same way a generic method's is.
+fn lower_assoc_call(
+    cx: &mut LowerCx<'_>,
+    self_ty: &crate::tycheck::Ty,
+    name: &str,
+    args: &[HirExpr],
+    ty: MirType,
+) -> MirOperand {
+    let recv_ty = mir_ty(self_ty, cx.subst);
+    let symbol = queue_generic_method(cx, self_ty, name, args)
+        .unwrap_or_else(|| recv_ty.method_symbol(name));
+    let arg_ops: Vec<MirOperand> = args.iter().map(|a| lower_expr(cx, a)).collect();
+    let dst = cx.builder.fresh_temp("acall", ty);
     cx.builder.assign(
         cx.current,
         dst,

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1368,6 +1368,18 @@ impl<'a, 'b> Checker<'a, 'b> {
         args: &[Expr],
         span: &Span,
     ) -> Result<Ty, RavenError> {
+        // `Type.func(args)`: when the receiver is a type name (a struct or
+        // enum, or a built-in type), this is an associated function call,
+        // not an instance method call. The named function on that type has
+        // no `self`. Distinguished from an instance call by the receiver
+        // being a bare type reference rather than a value.
+        if let Some(type_ref) = self.type_ref_receiver(receiver)? {
+            // Record the named type at the receiver span so HIR lowering
+            // can read the concrete implementing type for the static call.
+            self.record(&receiver.span, type_ref.clone());
+            return self.check_assoc_fn_call(&type_ref, name, args, span);
+        }
+
         let recv_ty = self.check_expr(receiver)?;
         let recv_resolved = self.infer.resolve(&recv_ty);
         let recv_stripped = recv_resolved.strip_self().clone();
@@ -1507,6 +1519,131 @@ impl<'a, 'b> Checker<'a, 'b> {
             },
             span.clone(),
         ))
+    }
+
+    /// If `receiver` is a bare reference to a type name (a struct or enum
+    /// binding, or a built-in type identifier), resolve it to that type.
+    /// This marks the call as an associated function call. A value
+    /// receiver (a local, parameter, field, or any non-type expression)
+    /// returns `None` so it stays an instance method call.
+    fn type_ref_receiver(&mut self, receiver: &Expr) -> Result<Option<Ty>, RavenError> {
+        let ExprKind::Ident { name, generics } = &receiver.kind else {
+            return Ok(None);
+        };
+        // A built-in type name with no resolver binding (`Int`, `String`,
+        // `Array`, ...) resolves to its concrete type with the explicit
+        // generic arguments applied.
+        let Some(binding) = self.resolved.map.lookup(&receiver.span).cloned() else {
+            if let Some(ty) = self.builtin_type_ref(name, generics, &receiver.span)? {
+                return Ok(Some(ty));
+            }
+            return Ok(None);
+        };
+        match binding {
+            Binding::Struct(_) | Binding::Enum(_) => {
+                let mut explicit = Vec::with_capacity(generics.len());
+                for g in generics {
+                    explicit.push(self.resolve_ast_ty(g)?);
+                }
+                Ok(Some(self.type_of_binding(
+                    &binding,
+                    &receiver.span,
+                    &explicit,
+                )?))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Resolve a built-in type name to its `Ty` for an associated function
+    /// receiver. Returns `None` for a name that is not a built-in type, so
+    /// a value identifier still flows to instance dispatch.
+    fn builtin_type_ref(
+        &mut self,
+        name: &str,
+        generics: &[crate::ast::Type],
+        span: &Span,
+    ) -> Result<Option<Ty>, RavenError> {
+        let mut args = Vec::with_capacity(generics.len());
+        for g in generics {
+            args.push(self.resolve_ast_ty(g)?);
+        }
+        let ty = match name {
+            "Int" => Ty::Int,
+            "Float" => Ty::Float,
+            "Bool" => Ty::Bool,
+            "String" => Ty::Str,
+            "Char" => Ty::Char,
+            "Unit" => Ty::Unit,
+            "Array" | "List" | "Vec" => {
+                let elem = args.into_iter().next().unwrap_or(Ty::Error);
+                Ty::List(Box::new(elem))
+            }
+            _ => return Ok(None),
+        };
+        let _ = span;
+        Ok(Some(ty))
+    }
+
+    /// Check an associated function call `Type.func(args)`. Finds an impl
+    /// on the named type with a `name` function that has no `self`, checks
+    /// the arguments against its parameters, and returns its declared
+    /// return type with the impl's generic parameters instantiated.
+    fn check_assoc_fn_call(
+        &mut self,
+        type_ty: &Ty,
+        name: &str,
+        args: &[Expr],
+        span: &Span,
+    ) -> Result<Ty, RavenError> {
+        let impls_snapshot = self.env.impls.clone();
+        let mut matches: Vec<(FnSig, HashMap<ParamId, Ty>)> = Vec::new();
+        for imp in impls_snapshot.iter() {
+            let mut subst: HashMap<ParamId, Ty> = HashMap::new();
+            for p in &imp.generics {
+                let v = self.infer.fresh(span.clone());
+                for b in &p.bounds {
+                    self.infer.add_bound(v, b.clone(), span.clone());
+                }
+                subst.insert(p.id.clone(), Ty::Var(v));
+            }
+            let impl_self = substitute(&imp.self_ty, &subst);
+            if self.infer.unify(&impl_self, type_ty, span).is_err() {
+                continue;
+            }
+            let Some(msig) = imp.methods.get(name) else {
+                continue;
+            };
+            if msig.has_self {
+                continue;
+            }
+            matches.push((msig.clone(), subst));
+        }
+        match matches.len() {
+            0 => Err(RavenError::ty(
+                TypeError::UndefinedMethod {
+                    receiver_ty: format!("{}", type_ty),
+                    method: name.to_string(),
+                },
+                span.clone(),
+            )
+            .with_hint(format!(
+                "no associated function `{}` on type `{}`",
+                name, type_ty
+            ))),
+            1 => {
+                let (sig, subst) = matches.into_iter().next().unwrap();
+                self.apply_method_call(&sig, &subst, args, name, span)
+            }
+            _ => Err(RavenError::ty(
+                TypeError::AmbiguousMethod {
+                    receiver_ty: format!("{}", type_ty),
+                    method: name.to_string(),
+                    candidates: vec!["<associated>".to_string()],
+                },
+                span.clone(),
+            )),
+        }
     }
 
     fn apply_method_call(

--- a/stdlib/std/collections.rv
+++ b/stdlib/std/collections.rv
@@ -15,6 +15,11 @@ fun empty_set<T: Eq>() -> Set<T> {
 }
 
 impl<T: Eq> Set<T> {
+    fun new() -> Set<T> {
+        let items: List<T> = []
+        return Set { items: items }
+    }
+
     fun len(self) -> Int {
         return self.items.len()
     }
@@ -72,6 +77,12 @@ fun empty_map<K: Eq, V>() -> Map<K, V> {
 }
 
 impl<K: Eq, V> Map<K, V> {
+    fun new() -> Map<K, V> {
+        let keys: List<K> = []
+        let values: List<V> = []
+        return Map { keys: keys, values: values }
+    }
+
     fun len(self) -> Int {
         return self.keys.len()
     }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -210,6 +210,18 @@ fn builtin_method_program_compiles_and_runs() {
 }
 
 #[test]
+fn assoc_fn_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Associated functions (Type.func()): `Counter.new()` and
+    // `Counter.with(41)` call the receiverless functions declared in the
+    // impl block, dispatched statically to `Counter$new` and
+    // `Counter$with` with no receiver argument. Prints 0 then 41.
+    compile_link_run_and_check("assoc_fn.rv", "0\n41\n", &runtime);
+}
+
+#[test]
 fn collections_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Add associated functions: a function declared in an `impl` block without a `self` receiver, called on the type as `Type.func(args)` or `Type<Args>.func(args)`, providing the idiomatic constructor mechanism.

Closes #157

## Design

**Declaration.** An associated function is a `fun` inside an `impl` whose first parameter is not `self`. An `impl` may mix associated functions and instance methods. The parser already accepts this; no parser change was needed for the declaration or the call (the call parses as a method call whose receiver is the type name, with `Type<Args>` parsed as generics on the leading identifier).

**Disambiguation.** A method call whose receiver is a bare type reference (a struct or enum binding, or a built-in type name like `Int`, `String`, `Array`) is classified as an associated function call. A value receiver (local, parameter, field, any other expression) stays an instance method call. Enum variant access `Color.Red` is field syntax (no call parens) and is unaffected; imported free-function calls `f(...)` are unaffected.

**Type checker.** `check_method_call` detects the type-reference receiver and routes to `check_assoc_fn_call`, which finds an impl on the named type with a matching `name` function that has no `self`, instantiates the impl's generic parameters (explicit args bind them, otherwise inference variables), checks arguments against the parameters, and returns the declared return type with the impl generics substituted.

**Codegen.** HIR lowers the call to a new `AssocCall { self_ty, name, args }` node. MIR emits a direct static call to the per-type symbol `<TypeMangle>$<func>` with no receiver argument (the only difference from an instance method call). A non-generic associated function is a monomorphization root; a generic one is specialized at the call site like a generic method, with the named implementing type fixing the impl's type arguments.

## Verified outputs

`examples/v2/assoc_fn.rv` (non-generic):
```
0
41
```

`examples/v2/use_collections.rv` (generic, migrated to `Set.new()` / `Map.new()`):
```
2
true
false
2
99
false
```

## `Set.new()` inference

Element inference works: `let s = Set.new()` followed by `s.add(7)` infers `Set<Int>`. Where no later use pins the type parameters, write them on the call: `Set<Int>.new()`.

## Deferrals

- An associated function that introduces its own generic parameters beyond the implementing type's (mirroring the method-level-generics boundary) is out of scope. The supported cases are `impl Counter { fun new() }` and `impl<T> Set<T> { fun new() -> Set<T> }`.
- `empty_set`/`empty_map` remain in `std/collections` for back-compat.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (smoke tests for `assoc_fn.rv` and the migrated `use_collections.rv` pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `assoc_fn.rv` compiled, linked, and run: prints `0` then `41`
- [x] `use_collections.rv` compiled, linked, and run: matches the smoke expectation
- [x] `empty_set`/`empty_map` still compile and run
- [x] `Pair<Int>.of(3, 4)` (explicit generics) and instance methods coexist
