### PR TITLE
feat: interpolate any ToString value, including generics

### DIFF
--- a/docs/v2/specs/interpolation.md
+++ b/docs/v2/specs/interpolation.md
@@ -91,7 +91,8 @@ An unterminated `${` or an empty `${}` is a parse error.
 ## Type rules
 
 An interpolated string has type `String`. Each embedded expression must
-have a type with a known text rendering. The supported set is:
+have a type with a text rendering. The built-in scalars render through a
+dedicated per-type conversion:
 
 | Embedded type | Conversion |
 |---------------|------------|
@@ -101,19 +102,29 @@ have a type with a known text rendering. The supported set is:
 | `Float`       | default `{}` rendering (so `7.0` renders `7`) |
 | `Char`        | the single Unicode scalar value |
 
-Any other embedded type is a type error with a hint that points the user
-at converting to a `String` first, for example a struct value cannot be
-interpolated until it has a string conversion. The type checker records
-each fragment expression's resolved type so the lowering pass can pick
-the right conversion.
+Any other embedded type renders through its `ToString` impl. This covers
+a user type that implements `ToString` (`${point}`) and a generic
+parameter bounded by `ToString` (`fun show<T: ToString>(x: T) = "${x}"`),
+where the bound supplies `to_string` and each monomorphization picks the
+concrete impl. A type that is neither a built-in scalar nor a `ToString`
+implementor is a type error with a hint to implement `ToString` or
+convert to a `String` first. The type checker records each fragment
+expression's resolved type so the lowering pass can pick the right
+conversion.
 
 ## HIR desugaring
 
 HIR lowering walks the AST fragments and produces a structured
 `Interpolate { parts: Vec<InterpolPart> }` node. A `Literal` fragment
 becomes `Text(String)`; an `Expr` fragment is lowered like any other
-expression into `Expr(HirExpr)`, carrying its static type. HIR keeps the
-structured form so the concat strategy stays a lowering concern.
+expression into `Expr(HirExpr)`, carrying its static type. A part whose
+static type is a built-in scalar (or `String`) is kept as-is for the
+per-type fast path. A part of any other type (a generic `T: ToString` or
+a user type with a `ToString` impl) is rewritten into a `to_string()`
+method call during HIR lowering, so it arrives at MIR already typed
+`String`; that call routes through the ordinary bound/method dispatch and
+monomorphizes per call site. HIR keeps the structured form so the concat
+strategy stays a lowering concern.
 
 MIR lowering performs the desugaring. It turns each part into a heap
 `String` operand and folds them left to right:
@@ -125,8 +136,10 @@ concat(concat("sum is ", int_to_string(a + b)), "!")
 ```
 
 A `String` part needs no conversion. An `Int`, `Bool`, `Float`, or
-`Char` part is routed through its per-type to-string intrinsic. Literal
-text parts are string constants the back-end promotes to heap Strings.
+`Char` part is routed through its per-type to-string intrinsic. A part of
+any other type is already a `to_string()` call result (a `String`) from
+HIR lowering, so it too needs no conversion here. Literal text parts are
+string constants the back-end promotes to heap Strings.
 An empty interpolation yields an empty `String`; a single part binds
 straight to a result temporary.
 
@@ -171,9 +184,9 @@ work.
 
 ## Out of scope
 
-* Interpolating struct, enum, list, map, or function values. These need
-  a user-facing string conversion (a future `Display`-style trait) and
-  raise a type error today.
+* Interpolating an enum, list, map, or function value that does not
+  implement `ToString`. A type with a `ToString` impl interpolates; one
+  without still raises a type error.
 * Format specifiers or alignment (`${x:04}` style). The `${...}` body is
   a plain expression with no formatting mini-language.
 * Reusing one parsed snippet across passes by source byte offset. The

--- a/examples/v2/generic_interp.rv
+++ b/examples/v2/generic_interp.rv
@@ -1,0 +1,12 @@
+struct Point { x: Int, y: Int }
+impl ToString for Point {
+    fun to_string(self) -> String = "(${self.x}, ${self.y})"
+}
+fun show<T: ToString>(label: String, x: T) -> String {
+    return "${label}=${x}"
+}
+fun main() {
+    print(show("n", 42))                  // n=42
+    print(show("ok", true))               // ok=true
+    print(show("p", Point { x: 3, y: 4 })) // p=(3, 4)
+}

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -545,9 +545,11 @@ fn lower_interpolate(cx: &mut LowerCx<'_>, parts: &[InterpolPart], ty: MirType) 
 /// Lower an embedded interpolation expression and convert it to a heap
 /// `String`. A `String`-typed expression is used as-is; the other
 /// interpolatable scalars (`Int`, `Bool`, `Float`, `Char`) are routed
-/// through their `to_string` runtime intrinsic. The type checker has
-/// already rejected any other type, so an unexpected type here is a
-/// lowering bug; we fall back to using the value directly.
+/// through their `to_string` runtime intrinsic. Any non-scalar part
+/// (a generic `T: ToString` or a user type with a `ToString` impl) was
+/// already rewritten into a `to_string()` method call during HIR
+/// lowering, so it arrives here typed `String` and takes the as-is path;
+/// the catch-all is unreachable in practice and uses the value directly.
 fn stringify_part(cx: &mut LowerCx<'_>, e: &HirExpr) -> MirOperand {
     let value = lower_expr(cx, e);
     let part_ty = mir_ty(&e.ty, cx.subst);

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -117,6 +117,19 @@ fn interpolation_program_compiles_and_runs() {
 }
 
 #[test]
+fn generic_interpolation_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Interpolating a part whose static type is not a built-in scalar. A
+    // generic `${x}` for `T: ToString` and a `${Point}` (user `ToString`
+    // impl) are rendered through `to_string`, while the surrounding scalar
+    // parts keep the per-type fast path. `show` is monomorphized at Int,
+    // Bool, and Point. Prints `n=42`, `ok=true`, then `p=(3, 4)`.
+    compile_link_run_and_check("generic_interp.rv", "n=42\nok=true\np=(3, 4)\n", &runtime);
+}
+
+#[test]
 fn defer_order_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Interpolation now renders any value whose type implements `ToString`, including a generic `T: ToString` part and a user type with a `ToString` impl, while built-in scalars keep their per-type fast path.

Closes #167

## Approach

Non-scalar interpolation parts are routed through `ToString`. HIR lowering already rewrites a part whose static type is not a built-in scalar (a generic `T: ToString` or a user type with a `ToString` impl) into a `to_string()` method call, so it reaches MIR already typed `String`. That call goes through the ordinary bound/method dispatch and monomorphizes per call site, so each instantiation picks the concrete impl. The MIR `stringify_part` scalar fast paths (`Int`, `Bool`, `Float`, `Char`, `String`) are unchanged, so scalar interpolation is not affected.

This change refreshes the now-stale MIR lowering comment and the interpolation spec, and adds an end-to-end example plus a smoke test that exercises the new behavior.

## Verified output

`examples/v2/generic_interp.rv` interpolates a generic `${x}` at Int and Bool and a `Point` (user `ToString` impl), built and run:

```
n=42
ok=true
p=(3, 4)
```

Scalar interpolation is unchanged: `examples/v2/interpolation.rv` still prints `Hello, Raven!` then `sum is 7`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (new `generic_interpolation_program_compiles_and_runs`, existing interpolation and scalar tests pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Built and ran `generic_interp.rv`, observed `n=42` / `ok=true` / `p=(3, 4)`
