### PR TITLE
feat(stdlib): std/encoding hex and base64

### DIFF
--- a/docs/v2/specs/std-encoding.md
+++ b/docs/v2/specs/std-encoding.md
@@ -1,0 +1,64 @@
+# std/encoding Spec
+
+Hex and standard base64 over the bytes of a `String`. Free functions that
+encode a `String`'s raw bytes to text and decode the inverse.
+
+## Byte model
+
+A Raven `String` is a byte buffer. These functions treat the input as raw
+bytes (`__str_byte_at` reads byte values 0..255), so they work on arbitrary
+binary data carried in a `String`, not only valid UTF-8 text. A decoder
+likewise returns the decoded bytes as a `String`.
+
+## Import
+
+All entries are free functions, bound with a selective import:
+
+```raven
+import std/encoding { hex_encode, hex_decode, base64_encode, base64_decode }
+
+fun main() {
+    let h = hex_encode("abc")          // "616263"
+    let b = base64_encode("abc")       // "YWJj"
+    let back = base64_decode(b)        // "abc"
+}
+```
+
+## Surface
+
+| Function | Result | Notes |
+|---|---|---|
+| `hex_encode(s: String)` | `String` | each input byte to two lowercase hex digits |
+| `hex_decode(s: String)` | `String` | inverse; accepts lowercase, uppercase, or mixed |
+| `base64_encode(s: String)` | `String` | standard alphabet (`A-Z a-z 0-9 + /`), `=` padding |
+| `base64_decode(s: String)` | `String` | inverse; honors `=` padding |
+
+## Known vectors
+
+`hex_encode("abc")` is `616263`. `base64_encode` of `"abc"`, `"Man"`,
+`"Ma"`, and `"M"` is `YWJj`, `TWFu`, `TWE=`, and `TQ==` (the last two show
+one and two bytes of trailing input producing `=` padding). Encode then
+decode round-trips: `base64_decode(base64_encode(s)) == s`.
+
+## Invalid input
+
+The decoders favor a simple, total mapping over rejecting input:
+
+- `hex_decode`: digits outside `0-9 a-f A-F` map to nibble `0`. An odd final
+  digit is read as the high nibble of a zero-padded byte.
+- `base64_decode`: bytes outside the alphabet (other than `=` padding) map to
+  sextet `0`. Trailing `=` padding sets how many bytes the final group
+  yields. Input whose length is not a multiple of four decodes the leading
+  whole groups and drops a trailing partial group.
+
+## Out of scope
+
+URL-safe base64 (the `-_` alphabet) and base64 line wrapping. Both can be
+added later without changing the existing functions.
+
+## Deferred
+
+`utf8` and `csv` (named in the tracking issue) are deferred. A Raven `String`
+is already a UTF-8 byte buffer, so a dedicated `utf8` codec adds little here,
+and `csv` needs more surface (quoting, delimiters, record streaming) than
+this module covers. They can land as separate work.

--- a/examples/v2/use_encoding.rv
+++ b/examples/v2/use_encoding.rv
@@ -1,0 +1,14 @@
+// golden:skip
+import std/encoding { hex_encode, hex_decode, base64_encode, base64_decode }
+import std/io { println }
+
+fun main() {
+    println(hex_encode("abc"))
+    println(base64_encode("abc"))
+    println(base64_encode("Man"))
+    println(base64_encode("Ma"))
+    println(base64_encode("M"))
+    print(hex_decode("616263") == "abc")
+    print(base64_decode("YWJj") == "abc")
+    print(base64_decode(base64_encode("hello, world")) == "hello, world")
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -77,6 +77,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "collections",
     "cmp",
     "hash",
+    "encoding",
     "string",
     "math",
     "path",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -43,6 +43,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ),
     ("cmp", include_str!("../../stdlib/std/cmp.rv")),
     ("hash", include_str!("../../stdlib/std/hash.rv")),
+    ("encoding", include_str!("../../stdlib/std/encoding.rv")),
     ("math", include_str!("../../stdlib/std/math.rv")),
     ("path", include_str!("../../stdlib/std/path.rv")),
     ("error", include_str!("../../stdlib/std/error.rv")),
@@ -428,6 +429,11 @@ mod tests {
     #[test]
     fn test_module_is_bundled() {
         assert!(bundled_source("test").is_some());
+    }
+
+    #[test]
+    fn encoding_module_is_bundled() {
+        assert!(bundled_source("encoding").is_some());
     }
 
     #[test]

--- a/stdlib/std/encoding.rv
+++ b/stdlib/std/encoding.rv
@@ -1,0 +1,174 @@
+// std/encoding: hex and standard base64 over the bytes of a String.
+// Raven String is a byte buffer; input is treated as raw bytes. See
+// docs/v2/specs/std-encoding.md.
+
+// Map a 0..15 nibble to its lowercase hex digit byte.
+fun hex_digit(v: Int) -> Int {
+    if v < 10 {
+        return 48 + v
+    }
+    return 87 + v
+}
+
+// Map a hex digit byte (0-9, a-f, A-F) to its 0..15 value. Any other
+// byte maps to 0.
+fun hex_value(b: Int) -> Int {
+    if b >= 48 {
+        if b <= 57 {
+            return b - 48
+        }
+    }
+    if b >= 97 {
+        if b <= 102 {
+            return b - 87
+        }
+    }
+    if b >= 65 {
+        if b <= 70 {
+            return b - 55
+        }
+    }
+    return 0
+}
+
+fun hex_encode(s: String) -> String {
+    let n = __str_len(s)
+    let out = ""
+    let i = 0
+    while i < n {
+        let b = __str_byte_at(s, i)
+        out = __str_concat(out, __str_from_byte(hex_digit(b >> 4)))
+        out = __str_concat(out, __str_from_byte(hex_digit(b & 15)))
+        i = i + 1
+    }
+    return out
+}
+
+// Inverse of hex_encode. Assumes even length; a trailing odd byte is
+// ignored. Non-hex bytes decode as 0.
+fun hex_decode(s: String) -> String {
+    let n = __str_len(s)
+    let out = ""
+    let i = 0
+    while i + 1 < n {
+        let hi = hex_value(__str_byte_at(s, i))
+        let lo = hex_value(__str_byte_at(s, i + 1))
+        out = __str_concat(out, __str_from_byte((hi << 4) | lo))
+        i = i + 2
+    }
+    if i < n {
+        // Lone final digit: treat as the high nibble of a zero-padded byte.
+        out = __str_concat(out, __str_from_byte(hex_value(__str_byte_at(s, i)) << 4))
+    }
+    return out
+}
+
+// Map a 0..63 sextet to its standard base64 alphabet byte (A-Z, a-z,
+// 0-9, +, /).
+fun b64_digit(v: Int) -> Int {
+    if v < 26 {
+        return 65 + v
+    }
+    if v < 52 {
+        return 71 + v
+    }
+    if v < 62 {
+        return v - 4
+    }
+    if v == 62 {
+        return 43
+    }
+    return 47
+}
+
+// Map a base64 alphabet byte to its 0..63 value. Any other byte
+// (including padding) maps to 0; callers track padding separately.
+fun b64_value(b: Int) -> Int {
+    if b >= 65 {
+        if b <= 90 {
+            return b - 65
+        }
+    }
+    if b >= 97 {
+        if b <= 122 {
+            return b - 71
+        }
+    }
+    if b >= 48 {
+        if b <= 57 {
+            return b + 4
+        }
+    }
+    if b == 43 {
+        return 62
+    }
+    if b == 47 {
+        return 63
+    }
+    return 0
+}
+
+fun base64_encode(s: String) -> String {
+    let n = __str_len(s)
+    let out = ""
+    let i = 0
+    while i + 3 <= n {
+        let b0 = __str_byte_at(s, i)
+        let b1 = __str_byte_at(s, i + 1)
+        let b2 = __str_byte_at(s, i + 2)
+        out = __str_concat(out, __str_from_byte(b64_digit(b0 >> 2)))
+        out = __str_concat(out, __str_from_byte(b64_digit(((b0 & 3) << 4) | (b1 >> 4))))
+        out = __str_concat(out, __str_from_byte(b64_digit(((b1 & 15) << 2) | (b2 >> 6))))
+        out = __str_concat(out, __str_from_byte(b64_digit(b2 & 63)))
+        i = i + 3
+    }
+    let rem = n - i
+    if rem == 1 {
+        let b0 = __str_byte_at(s, i)
+        out = __str_concat(out, __str_from_byte(b64_digit(b0 >> 2)))
+        out = __str_concat(out, __str_from_byte(b64_digit((b0 & 3) << 4)))
+        out = __str_concat(out, "==")
+    }
+    if rem == 2 {
+        let b0 = __str_byte_at(s, i)
+        let b1 = __str_byte_at(s, i + 1)
+        out = __str_concat(out, __str_from_byte(b64_digit(b0 >> 2)))
+        out = __str_concat(out, __str_from_byte(b64_digit(((b0 & 3) << 4) | (b1 >> 4))))
+        out = __str_concat(out, __str_from_byte(b64_digit((b1 & 15) << 2)))
+        out = __str_concat(out, "=")
+    }
+    return out
+}
+
+// Inverse of base64_encode. Trailing `=` padding sets how many bytes the
+// final group yields. Input length not a multiple of 4 decodes what it
+// can; stray non-alphabet bytes contribute 0.
+fun base64_decode(s: String) -> String {
+    let n = __str_len(s)
+    let out = ""
+    let i = 0
+    while i + 4 <= n {
+        let c0 = __str_byte_at(s, i)
+        let c1 = __str_byte_at(s, i + 1)
+        let c2 = __str_byte_at(s, i + 2)
+        let c3 = __str_byte_at(s, i + 3)
+        let v0 = b64_value(c0)
+        let v1 = b64_value(c1)
+        let v2 = b64_value(c2)
+        let v3 = b64_value(c3)
+        let o0 = ((v0 << 2) | (v1 >> 4)) & 255
+        out = __str_concat(out, __str_from_byte(o0))
+        if c2 != 61 {
+            let o1 = (((v1 & 15) << 4) | (v2 >> 2)) & 255
+            out = __str_concat(out, __str_from_byte(o1))
+        }
+        if c2 != 61 {
+            if c3 != 61 {
+                let o2 = (((v2 & 3) << 6) | v3) & 255
+                out = __str_concat(out, __str_from_byte(o2))
+            }
+        }
+        i = i + 4
+    }
+    return out
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -485,6 +485,22 @@ fn mutation_program_compiles_and_runs() {
     compile_link_run_and_check("mutation.rv", "7\n99\n", &runtime);
 }
 
+#[test]
+fn encoding_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/encoding hex and base64 over String bytes. The known vectors:
+    // hex("abc")=616263, base64 of "abc"/"Man"/"Ma"/"M" =
+    // YWJj/TWFu/TWE=/TQ== (the last two show one and two `=` padding).
+    // Then three round-trip equalities print true.
+    compile_link_run_and_check(
+        "use_encoding.rv",
+        "616263\nYWJj\nTWFu\nTWE=\nTQ==\ntrue\ntrue\ntrue\n",
+        &runtime,
+    );
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Adds `std/encoding` with hex and standard base64 codecs over the bytes of a `String`.

Closes #130

## Surface
- `hex_encode(s: String) -> String`, `hex_decode(s: String) -> String`
- `base64_encode(s: String) -> String`, `base64_decode(s: String) -> String`

All four are free functions, bound with `import std/encoding { hex_encode, hex_decode, base64_encode, base64_decode }`. They treat the `String` as a raw byte buffer and build the digit/alphabet maps arithmetically from byte values. Spec: `docs/v2/specs/std-encoding.md`.

## Observed output
`examples/v2/use_encoding.rv`, compiled and run:

```
616263
YWJj
TWFu
TWE=
TQ==
true
true
true
```

These match the known vectors (hex("abc")=616263; base64 of "abc"/"Man"/"Ma"/"M" = YWJj/TWFu/TWE=/TQ==) and the three round-trip equalities print true.

## Deferred
`utf8` and `csv` from the issue title are deferred. A Raven `String` is already a UTF-8 byte buffer, and `csv` needs more surface (quoting, delimiters, record streaming). Out of scope for now: URL-safe base64 (`-_`) and base64 line wrapping.

## Compiler bug found (worked around)
While implementing `base64_decode` the compiler stack-overflowed at compile time on a function combining a `while` loop, a doubly-nested `if`, and a deep masked bitwise expression in both inner branches. Minimal repro:

```raven
fun g(a: Int, b: Int, c: Int) -> Int {
    let out = 0
    while a < b {
        if a != 1 {
            out = out + ((((a & 15) << 4) | (b >> 2)) & 255)
            if c != 1 {
                out = out + ((((c & 3) << 6) | a) & 255)
            }
        }
        a = a + 1
    }
    return out
}
```

Removing the `while`, or hoisting the deep exprs into `let` bindings, avoids it. The shipped `base64_decode` hoists each output byte into a `let` and flattens the nested ifs as the workaround. This compiler bug is independent of std/encoding and should be tracked separately.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (adds `encoding_module_is_bundled` and `encoding_program_compiles_and_runs`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Built and ran `examples/v2/use_encoding.rv`; output matches the known vectors above
