### PR TITLE
feat(stdlib): std/random seeded PRNG

### DIFF
--- a/docs/v2/specs/std-random.md
+++ b/docs/v2/specs/std-random.md
@@ -1,0 +1,78 @@
+# std/random Spec
+
+A small, reproducible pseudo-random generator. `Rng` is a value type
+holding the generator state; its methods draw the next value and mutate
+the state in place.
+
+## Algorithm
+
+The generator is splitmix64. Each draw advances a 64-bit state by the
+constant `0x9E3779B97F4A7C15` and runs the result through two
+xor-shift-multiply rounds and a final xor-shift. splitmix64 is fast, has
+a full 2^64 period, and passes the usual statistical batteries, which
+makes it a good default for seeding and general non-cryptographic use.
+
+Raven `Int` is i64 and its arithmetic wraps two's-complement, so
+splitmix64's unsigned add and multiply map directly onto `+` and `*` (the
+multiplier constants are written as their signed i64 forms). The `>>`
+operator is arithmetic (sign-propagating), so the finalizer's logical
+right shifts go through a small `ushr` helper that masks off the bits the
+sign would otherwise fill.
+
+This generator is not cryptographically secure. Do not use it for keys,
+tokens, or anything where predictability is a risk.
+
+## Reproducibility
+
+`Rng.new(seed)` is deterministic: two generators created with the same
+seed produce the identical sequence of draws. This is the reproducibility
+guarantee and the reason the seeded constructor exists separately from
+entropy seeding.
+
+`Rng.from_entropy()` seeds from a runtime source (a high-resolution
+timestamp mixed with the process id), so its stream is not reproducible
+across runs. Use it when you want a fresh, unpredictable sequence.
+
+## Import
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(42)
+    let n = rng.next_int()
+    let d = rng.gen_range(0, 6)        // a value in [0, 6)
+    let f = rng.next_float()           // a value in [0.0, 1.0)
+}
+```
+
+## Surface
+
+| Method | Result | Notes |
+|---|---|---|
+| `Rng.new(seed: Int)` | `Rng` | Deterministic seeding; same seed, same sequence. |
+| `Rng.from_entropy()` | `Rng` | Non-reproducible seed from a time/pid source. |
+| `next_int(self)` | `Int` | The next raw 64-bit draw. |
+| `gen_range(self, lo, hi)` | `Int` | Uniform-ish in `[lo, hi)`. |
+| `next_float(self)` | `Float` | In `[0.0, 1.0)`, 53-bit precision. |
+| `next_bool(self)` | `Bool` | Low bit of a draw. |
+| `choice<T>(self, xs)` | `Option<T>` | A random element, `None` if empty. |
+| `shuffle<T>(self, xs)` | (unit) | In-place Fisher-Yates. |
+
+## Notes
+
+`gen_range(lo, hi)` reduces a non-negative draw modulo `(hi - lo)`. A
+modulo introduces a small bias when the range does not evenly divide the
+draw space (2^63 after the sign bit is masked off), but for typical small
+ranges the bias is negligible. The interval is half-open: `lo` is
+possible, `hi` is not. If `lo >= hi` the function returns `lo`.
+
+`next_float` takes the top 53 bits of a draw and scales by 2^-53, the
+full f64 mantissa width, so every representable multiple of 2^-53 in
+`[0.0, 1.0)` is reachable.
+
+The Int-to-Float construction and the entropy seed are provided by two
+`extern "C"` runtime symbols (`raven_int_to_float`, `raven_random_entropy`)
+because the v2 surface language has no Int-to-Float cast and no clock
+primitive. They are resolved at link time against the runtime staticlib,
+the same way `std/math` binds libm.

--- a/examples/v2/use_random.rv
+++ b/examples/v2/use_random.rv
@@ -1,0 +1,54 @@
+// golden:skip
+import std/random
+
+fun main() {
+    let a = Rng.new(42)
+    let b = Rng.new(42)
+    print(a.next_int() == b.next_int())
+    print(a.next_int() == b.next_int())
+
+    let r = Rng.new(7)
+    let in_range = true
+    let k = 0
+    while k < 100 {
+        let v = r.gen_range(0, 10)
+        if v < 0 {
+            in_range = false
+        }
+        if v >= 10 {
+            in_range = false
+        }
+        k = k + 1
+    }
+    print(in_range)
+
+    let bg = Rng.new(1)
+    let f = bg.next_float()
+    print(f >= 0.0)
+    print(f < 1.0)
+
+    let cg = Rng.new(3)
+    let picks: List<Int> = [10, 20, 30]
+    match cg.choice(picks) {
+        Some(v) -> print(v >= 10),
+        None -> print(false),
+    }
+
+    let empty: List<Int> = []
+    match cg.choice(empty) {
+        Some(v) -> print(false),
+        None -> print(true),
+    }
+
+    let sg = Rng.new(99)
+    let xs: List<Int> = [1, 2, 3, 4, 5]
+    sg.shuffle(xs)
+    print(xs.len() == 5)
+    let sum = 0
+    let i = 0
+    while i < xs.len() {
+        sum = sum + xs[i]
+        i = i + 1
+    }
+    print(sum == 15)
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -196,6 +196,35 @@ pub extern "C" fn raven_println_int(value: i64) {
     let _ = handle.write_all(b"\n");
 }
 
+/// Reinterpret a signed 64-bit integer as an `f64` by value conversion.
+///
+/// The v2 surface language has no Int-to-Float cast, so `std/random`
+/// binds this symbol through `extern "C"` to build a `Float` in
+/// `[0.0, 1.0)` from generated bits.
+#[no_mangle]
+pub extern "C" fn raven_int_to_float(value: i64) -> f64 {
+    value as f64
+}
+
+/// Return a non-deterministic 64-bit seed for entropy seeding.
+///
+/// Mixes a high-resolution timestamp with the process id through a
+/// splitmix64 finalizer so distinct calls differ. This is a seed source,
+/// not a cryptographic random generator.
+#[no_mangle]
+pub extern "C" fn raven_random_entropy() -> i64 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let mut z = nanos ^ (u64::from(process::id()) << 32);
+    z = z.wrapping_add(0x9E3779B97F4A7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z = z ^ (z >> 31);
+    z as i64
+}
+
 /// A stack buffer large enough for any base-ten `i64` plus a sign.
 fn itoa_buf() -> [u8; 20] {
     [0u8; 20]

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -78,6 +78,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "cmp",
     "hash",
     "encoding",
+    "random",
     "string",
     "math",
     "path",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -44,6 +44,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("cmp", include_str!("../../stdlib/std/cmp.rv")),
     ("hash", include_str!("../../stdlib/std/hash.rv")),
     ("encoding", include_str!("../../stdlib/std/encoding.rv")),
+    ("random", include_str!("../../stdlib/std/random.rv")),
     ("math", include_str!("../../stdlib/std/math.rv")),
     ("path", include_str!("../../stdlib/std/path.rv")),
     ("error", include_str!("../../stdlib/std/error.rv")),
@@ -434,6 +435,11 @@ mod tests {
     #[test]
     fn encoding_module_is_bundled() {
         assert!(bundled_source("encoding").is_some());
+    }
+
+    #[test]
+    fn random_module_is_bundled() {
+        assert!(bundled_source("random").is_some());
     }
 
     #[test]

--- a/stdlib/std/random.rv
+++ b/stdlib/std/random.rv
@@ -1,0 +1,92 @@
+// std/random: a seeded pseudo-random generator using splitmix64.
+//
+// `Rng.new(seed)` is deterministic: the same seed yields the same
+// sequence, which is the reproducibility guarantee. `Rng.from_entropy()`
+// seeds from a runtime time/pid source for a non-reproducible stream.
+// See docs/v2/specs/std-random.md.
+//
+// Raven Int is i64 and arithmetic wraps two's-complement, so splitmix64's
+// unsigned add and multiply map directly onto `+` and `*`. The `>>`
+// operator is arithmetic (sign-propagating), so the finalizer's logical
+// right shifts go through `ushr` below.
+
+extern "C" {
+    fun raven_int_to_float(x: Int) -> Float
+    fun raven_random_entropy() -> Int
+}
+
+// Logical (zero-filling) right shift of a 64-bit value by `n` in 1..63.
+// Masks off the high `n` bits the arithmetic `>>` would sign-fill.
+fun ushr(x: Int, n: Int) -> Int {
+    let mask = (1 << (64 - n)) - 1
+    return (x >> n) & mask
+}
+
+struct Rng {
+    state: Int,
+}
+
+impl Rng {
+    fun new(seed: Int) -> Rng {
+        return Rng { state: seed }
+    }
+
+    fun from_entropy() -> Rng {
+        return Rng { state: raven_random_entropy() }
+    }
+
+    // splitmix64: advance the state, then finalize the old sum.
+    fun next_int(self) -> Int {
+        self.state = self.state + -7046029254386353131
+        let z = self.state
+        let a = (z ^ ushr(z, 30)) * -4658895280553007687
+        let b = (a ^ ushr(a, 27)) * -7723592293110705685
+        return b ^ ushr(b, 31)
+    }
+
+    // Uniform-ish in the half-open interval [lo, hi). Uses a modulo,
+    // which carries a small bias when (hi - lo) does not divide the 2^63
+    // value range; for typical small ranges the bias is negligible.
+    // Assumes lo < hi; if lo >= hi the result is lo.
+    fun gen_range(self, lo: Int, hi: Int) -> Int {
+        if lo >= hi {
+            return lo
+        }
+        let span = hi - lo
+        // Force a non-negative magnitude before the modulo.
+        let r = ushr(self.next_int(), 1)
+        return lo + (r % span)
+    }
+
+    // In [0.0, 1.0): the top 53 bits of a draw scaled by 2^-53, which is
+    // the full f64 mantissa precision.
+    fun next_float(self) -> Float {
+        let bits = ushr(self.next_int(), 11)
+        return raven_int_to_float(bits) / raven_int_to_float(9007199254740992)
+    }
+
+    fun next_bool(self) -> Bool {
+        return (self.next_int() & 1) == 1
+    }
+
+    fun choice<T>(self, xs: List<T>) -> Option<T> {
+        let n = xs.len()
+        if n == 0 {
+            return None
+        }
+        let i = self.gen_range(0, n)
+        return Some(xs.get(i))
+    }
+
+    // In-place Fisher-Yates shuffle.
+    fun shuffle<T>(self, xs: List<T>) {
+        let i = xs.len() - 1
+        while i > 0 {
+            let j = self.gen_range(0, i + 1)
+            let tmp = xs[i]
+            xs[i] = xs[j]
+            xs[j] = tmp
+            i = i - 1
+        }
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -544,6 +544,24 @@ fn encoding_program_compiles_and_runs() {
     );
 }
 
+#[test]
+fn random_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/random seeded splitmix64 PRNG. Every printed line is a
+    // structural check that is deterministic given the fixed seeds: two
+    // Rng.new(42) agree on their first two draws, gen_range(0, 10) stays
+    // in range across 100 draws, next_float lands in [0.0, 1.0), choice
+    // returns an element of a small list and None on an empty list, and
+    // shuffle preserves the length and element sum. Prints nine `true`.
+    compile_link_run_and_check(
+        "use_random.rv",
+        "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n",
+        &runtime,
+    );
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Adds `std/random`, a seeded splitmix64 pseudo-random generator in the method-first style.

Closes #129

## Algorithm

splitmix64. Raven `Int` is i64 and arithmetic wraps two's-complement (verified by probe), so the unsigned add and multiply map directly onto `+` and `*`. The `>>` operator is arithmetic (sign-propagating), so the finalizer's logical right shifts go through a small `ushr` masking helper.

## Surface

- `Rng.new(seed: Int)`: deterministic seeding, same seed yields the same sequence.
- `Rng.from_entropy()`: non-reproducible seed from a time/pid runtime source.
- `next_int`, `gen_range(lo, hi)` (half-open `[lo, hi)`, modulo with a small documented bias), `next_float` (`[0.0, 1.0)`, 53-bit), `next_bool`.
- `choice<T>(xs)` returning `Option<T>`, `shuffle<T>(xs)` in-place Fisher-Yates.

Int-to-Float construction and the entropy seed are two `extern "C"` runtime symbols (`raven_int_to_float`, `raven_random_entropy`), resolved at link time against the runtime staticlib the same way `std/math` binds libm. No new compiler intrinsic wiring was needed.

## Deterministic output

`examples/v2/use_random.rv` prints nine structural checks, all `true`:

```
true
true
true
true
true
true
true
true
true
```

The first two lines confirm two `Rng.new(42)` agree on their first draws; the rest check gen_range stays in `[0, 10)` over 100 draws, next_float lands in `[0.0, 1.0)`, choice returns an element and None on empty, and shuffle preserves length and element sum.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (adds `random_program_compiles_and_runs` smoke test and `random_module_is_bundled` unit test)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
