### PR TITLE
feat(stdlib): std/fmt formatting helpers and Debug trait

### DIFF
--- a/docs/v2/specs/std-fmt.md
+++ b/docs/v2/specs/std-fmt.md
@@ -1,0 +1,89 @@
+# std/fmt Spec
+
+String formatting helpers and a `Debug` trait. Free functions that build
+padded fields, repeat and join strings, and render integers in a base, plus
+a `Debug` trait with impls for the built-in scalar types.
+
+## No printf
+
+The v2 surface language has no varargs, no derive macros, and no
+format-placeholder runtime, so there is no `format("{}", a, b)` function.
+String interpolation `"${expr}"` is the placeholder mechanism: any non-scalar
+expression interpolated in a string routes through `ToString` (see
+`docs/v2/specs/core-traits.md`). std/fmt provides the building blocks that
+compose with interpolation, not a printf replacement.
+
+## Byte model
+
+A Raven `String` is a byte buffer. The padding widths and `to_radix` digit
+counts are measured in UTF-8 bytes through `__str_len`, not code points. For
+ASCII text a byte equals a displayed character; for multi-byte text the width
+is the encoded byte length. The `fill` argument to the padding functions is
+assumed to be a single-byte string; a multi-byte `fill` can overshoot the
+target width by up to its length minus one.
+
+## Import
+
+All formatting helpers are free functions, bound with a selective import. The
+`Debug` trait's `debug` method dispatches by the receiver's type and needs no
+explicit selector.
+
+```raven
+import std/fmt { repeat, pad_left, pad_right, center, join, to_radix, to_binary, to_octal, to_hex, pad_int }
+import std/io { println }
+
+fun main() {
+    println(pad_left("7", 3, "0"))   // 007
+    println(to_hex(255))             // ff
+    println(to_radix(-42, 16))       // -2a
+    println("hi".debug())            // "hi"
+}
+```
+
+## Surface
+
+| Function | Result | Notes |
+|---|---|---|
+| `repeat(s, n)` | `String` | `s` concatenated `n` times; `n <= 0` yields `""`. |
+| `pad_left(s, width, fill)` | `String` | left-pad to byte width with `fill`. |
+| `pad_right(s, width, fill)` | `String` | right-pad to byte width with `fill`. |
+| `center(s, width, fill)` | `String` | center in byte width; an odd pad puts the extra byte on the right. |
+| `join(parts, sep)` | `String` | join a `List<String>` with `sep` between elements. |
+| `to_radix(n, base)` | `String` | `n` in `base`, lowercase digits, leading `-` for negatives. |
+| `to_binary(n)` / `to_octal(n)` / `to_hex(n)` | `String` | thin wrappers for base 2, 8, 16. |
+| `pad_int(n, width)` | `String` | decimal zero-padded to byte width; sign kept leftmost. |
+
+| Trait | Method | Notes |
+|---|---|---|
+| `Debug` | `debug(self) -> String` | impls for Int, Float, Bool, Char, String. |
+
+## Radix
+
+`base` must be in `2..=16`. A `base` outside that range returns the empty
+string. Digits are `0-9` then lowercase `a-f`. Zero renders as `"0"`. A
+negative `n` gets a single leading `-`. The conversion accumulates the
+negative magnitude (working in the negative domain) so the most negative i64
+has no overflowing negation.
+
+## pad_int sign handling
+
+`pad_int` zero-pads the decimal form to `width` bytes. For a negative `n` the
+`-` stays leftmost and the zero fill goes between the sign and the digits, so
+`pad_int(-7, 4)` is `"-007"`. A `width` that does not exceed the rendered
+length returns the value unchanged.
+
+## Debug
+
+`Debug` is a separate trait from `ToString`. Int, Float, and Bool delegate to
+their `to_string`. Char is wrapped in single quotes and String in double
+quotes (so `"hi".debug()` is the 4-character string `"hi"`). Inner quotes are
+not escaped: a String containing a `"` reproduces it literally inside the
+surrounding quotes.
+
+## Deferred
+
+`format_float(x, places)` (fixed decimal places) is deferred: it needs a
+Float-to-Int truncation runtime hook the surface language does not expose, and
+is not required for the rest of the module. It can land later as a small
+`extern "C"` addition (a `raven_float_trunc` symbol) without changing the
+existing surface.

--- a/examples/v2/use_fmt.rv
+++ b/examples/v2/use_fmt.rv
@@ -1,0 +1,21 @@
+// golden:skip
+import std/fmt { repeat, pad_left, pad_right, center, join, to_radix, to_binary, to_octal, to_hex, pad_int }
+import std/io { println }
+
+fun main() {
+    println(repeat("ab", 3))
+    println(pad_left("7", 3, "0"))
+    println(pad_right("7", 3, "-"))
+    println(center("hi", 6, "*"))
+    println(to_binary(10))
+    println(to_octal(64))
+    println(to_hex(255))
+    println(to_radix(-42, 16))
+    println(pad_int(42, 5))
+    println(pad_int(-7, 4))
+    println(join(["a", "b", "c"], ", "))
+    println((42).debug())
+    println(true.debug())
+    println('x'.debug())
+    println("hi".debug())
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -79,6 +79,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "hash",
     "encoding",
     "random",
+    "fmt",
     "string",
     "math",
     "path",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -45,6 +45,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("hash", include_str!("../../stdlib/std/hash.rv")),
     ("encoding", include_str!("../../stdlib/std/encoding.rv")),
     ("random", include_str!("../../stdlib/std/random.rv")),
+    ("fmt", include_str!("../../stdlib/std/fmt.rv")),
     ("math", include_str!("../../stdlib/std/math.rv")),
     ("path", include_str!("../../stdlib/std/path.rv")),
     ("error", include_str!("../../stdlib/std/error.rv")),
@@ -440,6 +441,11 @@ mod tests {
     #[test]
     fn random_module_is_bundled() {
         assert!(bundled_source("random").is_some());
+    }
+
+    #[test]
+    fn fmt_module_is_bundled() {
+        assert!(bundled_source("fmt").is_some());
     }
 
     #[test]

--- a/stdlib/std/fmt.rv
+++ b/stdlib/std/fmt.rv
@@ -1,0 +1,158 @@
+// std/fmt: string formatting helpers and a Debug trait. Padding widths
+// count UTF-8 bytes, matching the byte-oriented String model. There is no
+// printf-style format function: string interpolation "${expr}" is the
+// placeholder mechanism, and these are the building blocks. See
+// docs/v2/specs/std-fmt.md.
+
+import std/string
+
+// `s` repeated `n` times. A non-positive `n` yields the empty string.
+fun repeat(s: String, n: Int) -> String {
+    let out = ""
+    let i = 0
+    while i < n {
+        out = __str_concat(out, s)
+        i = i + 1
+    }
+    return out
+}
+
+// Left-pad `s` with `fill` until its byte length is at least `width`.
+// `fill` is assumed to be a single-byte string; a multi-byte `fill` may
+// overshoot the target width by up to its length minus one.
+fun pad_left(s: String, width: Int, fill: String) -> String {
+    let pad = width - __str_len(s)
+    if pad <= 0 {
+        return s
+    }
+    return __str_concat(repeat(fill, pad), s)
+}
+
+// Right-pad `s` with `fill` until its byte length is at least `width`.
+fun pad_right(s: String, width: Int, fill: String) -> String {
+    let pad = width - __str_len(s)
+    if pad <= 0 {
+        return s
+    }
+    return __str_concat(s, repeat(fill, pad))
+}
+
+// Center `s` in a field of byte width `width`, padding with `fill`. An
+// odd amount of padding puts the extra byte on the right.
+fun center(s: String, width: Int, fill: String) -> String {
+    let pad = width - __str_len(s)
+    if pad <= 0 {
+        return s
+    }
+    let left = pad / 2
+    let right = pad - left
+    return __str_concat(__str_concat(repeat(fill, left), s), repeat(fill, right))
+}
+
+// Join `parts` with `sep` between adjacent elements.
+fun join(parts: List<String>, sep: String) -> String {
+    let n = parts.len()
+    let out = ""
+    let i = 0
+    while i < n {
+        if i > 0 {
+            out = __str_concat(out, sep)
+        }
+        out = __str_concat(out, parts[i])
+        i = i + 1
+    }
+    return out
+}
+
+// Map a 0..15 digit value to its lowercase digit byte (0-9, a-f).
+fun radix_digit(v: Int) -> Int {
+    if v < 10 {
+        return 48 + v
+    }
+    return 87 + v
+}
+
+// `n` written in `base`, with a leading '-' for negatives. `base` must be
+// in 2..=16; out of range returns the empty string. Zero is "0". The most
+// negative i64 is handled by accumulating the negative magnitude so no
+// overflow occurs on negation.
+fun to_radix(n: Int, base: Int) -> String {
+    if base < 2 {
+        return ""
+    }
+    if base > 16 {
+        return ""
+    }
+    if n == 0 {
+        return "0"
+    }
+    let neg = n < 0
+    // Work in the negative domain so INT_MIN has no overflowing negation.
+    let m = n
+    if m > 0 {
+        m = 0 - m
+    }
+    let out = ""
+    while m < 0 {
+        let d = 0 - (m % base)
+        out = __str_concat(__str_from_byte(radix_digit(d)), out)
+        m = m / base
+    }
+    if neg {
+        out = __str_concat("-", out)
+    }
+    return out
+}
+
+fun to_binary(n: Int) -> String {
+    return to_radix(n, 2)
+}
+
+fun to_octal(n: Int) -> String {
+    return to_radix(n, 8)
+}
+
+fun to_hex(n: Int) -> String {
+    return to_radix(n, 16)
+}
+
+// Decimal `n` zero-padded to byte width `width`. For a negative `n` the
+// '-' stays leftmost and the zero fill goes between the sign and the
+// digits, so pad_int(-7, 4) is "-007".
+fun pad_int(n: Int, width: Int) -> String {
+    if n < 0 {
+        let digits = (0 - n).to_string()
+        return __str_concat("-", pad_left(digits, width - 1, "0"))
+    }
+    return pad_left(n.to_string(), width, "0")
+}
+
+trait Debug {
+    fun debug(self) -> String
+}
+
+impl Debug for Int {
+    fun debug(self) -> String = self.to_string()
+}
+
+impl Debug for Float {
+    fun debug(self) -> String = self.to_string()
+}
+
+impl Debug for Bool {
+    fun debug(self) -> String = self.to_string()
+}
+
+// Quoted with single quotes. Inner quotes are not escaped.
+impl Debug for Char {
+    fun debug(self) -> String {
+        return __str_concat(__str_concat("'", self.to_string()), "'")
+    }
+}
+
+// Quoted with double quotes. Inner quotes are not escaped.
+impl Debug for String {
+    fun debug(self) -> String {
+        return __str_concat(__str_concat("\"", self), "\"")
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -562,6 +562,37 @@ fn random_program_compiles_and_runs() {
     );
 }
 
+#[test]
+fn fmt_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/fmt string and integer formatting plus the Debug trait. repeat,
+    // pad_left, pad_right, and center build fixed-width fields (widths count
+    // bytes); to_binary/to_octal/to_hex/to_radix render integers in a base,
+    // with to_radix(-42, 16) showing the leading '-'; pad_int zero-pads with
+    // the sign kept leftmost; join inserts the separator between elements;
+    // and .debug() delegates to ToString for Int/Bool and wraps Char and
+    // String in quotes. Prints ababab, 007, 7--, **hi**, 1010, 100, ff, -2a,
+    // 00042, -007, "a, b, c", 42, true, 'x', and "hi".
+    let expected = "ababab\n\
+                    007\n\
+                    7--\n\
+                    **hi**\n\
+                    1010\n\
+                    100\n\
+                    ff\n\
+                    -2a\n\
+                    00042\n\
+                    -007\n\
+                    a, b, c\n\
+                    42\n\
+                    true\n\
+                    'x'\n\
+                    \"hi\"\n";
+    compile_link_run_and_check("use_fmt.rv", expected, &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Add the `std/fmt` standard-library module: pure-Raven string and integer formatting helpers plus a `Debug` trait, built on the byte-oriented `String` intrinsics and the prelude `ToString`.

Closes #123

## Surface

Free functions (bound with `import std/fmt { ... }`):

- `repeat(s, n)`, `pad_left(s, width, fill)`, `pad_right(s, width, fill)`, `center(s, width, fill)`: build fixed-width fields; widths count UTF-8 bytes.
- `join(parts, sep)`: join a `List<String>` with a separator.
- `to_radix(n, base)` (base in 2..=16, lowercase digits, leading `-` for negatives, INT_MIN safe), with `to_binary`/`to_octal`/`to_hex` wrappers.
- `pad_int(n, width)`: decimal zero-padded to byte width, sign kept leftmost (`pad_int(-7, 4)` is `-007`).

Trait `Debug { fun debug(self) -> String }` with impls for Int, Float, Bool, Char, String. Int/Float/Bool delegate to `to_string`; Char is single-quoted and String double-quoted, with no escaping of inner quotes.

There is no printf-style `format`: string interpolation `"${expr}"` is the placeholder mechanism, and these are the building blocks.

## Literal output

`examples/v2/use_fmt.rv` compiled and run prints:

```
ababab
007
7--
**hi**
1010
100
ff
-2a
00042
-007
a, b, c
42
true
'x'
"hi"
```

## Deferred

`format_float(x, places)` is deferred: it needs a Float-to-Int truncation runtime hook the surface language does not expose, and is not required for the rest of the module. It can land later as a small `extern "C"` addition without changing this surface.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (adds `fmt_program_compiles_and_runs` smoke test and the `fmt_module_is_bundled` unit test)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Compiled and ran `examples/v2/use_fmt.rv`, output matches the smoke-test expectation byte for byte.

Spec: `docs/v2/specs/std-fmt.md`.
