### PR TITLE
feat(stdlib): std/env args, environment, exit, platform

### DIFF
--- a/docs/v2/specs/std-env.md
+++ b/docs/v2/specs/std-env.md
@@ -1,0 +1,84 @@
+# std/env Spec
+
+Access to the process environment: command-line arguments, environment
+variables, process exit, and platform info. The primitives bind the
+raven-runtime C ABI; the convenience functions are pure Raven on top of
+them.
+
+## Import
+
+```raven
+import std/env { get_env, has_env, get_env_or, args, arg_count, arg_at, exit, os_name, arch }
+```
+
+## Surface
+
+### Environment variables
+
+```raven
+fun get_env(name: String) -> String
+fun has_env(name: String) -> Bool
+fun get_env_or(name: String, default: String) -> String
+```
+
+`get_env` returns the value of `name`, or `""` when the variable is unset.
+A variable set to the empty string and a variable that is not set both
+yield `""`, so `get_env` alone cannot tell them apart. `has_env` reports
+whether the variable is set, regardless of value, which is how a caller
+distinguishes unset from empty.
+
+This is why the surface uses `has_env` rather than returning an
+`Option<String>`: constructing an enum across the FFI boundary is avoided,
+and the empty-or-unset distinction is recovered with a separate boolean
+query. `get_env_or` is pure Raven: it returns `default` when `has_env`
+is false and `get_env(name)` otherwise.
+
+A value that is not valid UTF-8 is reported as `""`.
+
+### Command-line arguments
+
+```raven
+fun arg_count() -> Int
+fun arg_at(i: Int) -> String
+fun args() -> List<String>
+```
+
+`arg_count` is the number of process arguments, always at least 1.
+Index 0 is the program path; the user-supplied arguments start at index 1.
+`arg_at(i)` returns the argument at `i`, or `""` when `i` is out of range
+(or the argument is not valid UTF-8). `args` is pure Raven: it loops
+`arg_at` over `0..arg_count()` into a `List<String>`.
+
+### Process exit
+
+```raven
+fun exit(code: Int)
+```
+
+`exit` terminates the process with status `code`. It does not return;
+any code after a call to `exit` is unreachable. The Raven return type is
+declared `Unit` because the surface language has no never type, but the
+runtime call (`std::process::exit`) never comes back.
+
+### Platform info
+
+```raven
+fun os_name() -> String
+fun arch() -> String
+```
+
+`os_name` returns one of `"windows"`, `"linux"`, or `"macos"` (and
+`"unknown"` on any other target). `arch` returns the CPU architecture,
+for example `"x86_64"` or `"aarch64"` (and `"unknown"` when unrecognized).
+Both are resolved at compile time in the runtime through `cfg!`.
+
+## FFI path
+
+This module uses `extern "C"` blocks binding raven-runtime symbols
+directly, not compiler builtin intrinsics. A Raven `String` is a single
+GC pointer (`*mut object::String`) at the ABI, so it crosses the boundary
+unchanged in both directions, which lets `extern "C"` carry `String`
+arguments and returns without any codegen change. The runtime symbols
+(`raven_env_get`, `raven_env_has`, `raven_env_arg_count`,
+`raven_env_arg_at`, `raven_env_exit`, `raven_env_os_name`,
+`raven_env_arch`) live in `raven-runtime/src/lib.rs`.

--- a/examples/v2/use_env.rv
+++ b/examples/v2/use_env.rv
@@ -1,0 +1,16 @@
+import std/env { get_env_or, has_env, arg_count, os_name }
+import std/io { println }
+
+fun main() {
+    let os = os_name()
+    let known = os == "linux" || os == "windows" || os == "macos"
+    let set = has_env("RAVEN_ENV_TEST")
+    let unset = has_env("RAVEN_DEFINITELY_UNSET_XYZ")
+    let has_arg = arg_count() >= 1
+    println(get_env_or("RAVEN_ENV_TEST", "missing"))
+    println("${set}")
+    println("${unset}")
+    println(get_env_or("RAVEN_DEFINITELY_UNSET_XYZ", "fallback"))
+    println("${has_arg}")
+    println("${known}")
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -196,6 +196,111 @@ pub extern "C" fn raven_println_int(value: i64) {
     let _ = handle.write_all(b"\n");
 }
 
+/// Look up an environment variable and return its value as a heap
+/// `String`. Returns an empty `String` when the variable is unset or its
+/// value is not valid UTF-8, so the caller always gets a usable pointer.
+/// Pair with `raven_env_has` to tell unset apart from an empty value.
+///
+/// # Safety
+///
+/// `name` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_env_get(name: *const object::String) -> *mut object::String {
+    let value = env_name(name)
+        .and_then(std::env::var_os)
+        .and_then(|v| v.into_string().ok())
+        .unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// Report whether an environment variable is set, regardless of value.
+///
+/// # Safety
+///
+/// `name` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_env_has(name: *const object::String) -> bool {
+    env_name(name).is_some_and(|n| std::env::var_os(n).is_some())
+}
+
+/// Number of process arguments, including the program path at index 0.
+#[no_mangle]
+pub extern "C" fn raven_env_arg_count() -> i64 {
+    std::env::args_os().count() as i64
+}
+
+/// The process argument at `index` as a heap `String`. Index 0 is the
+/// program path. Returns an empty `String` when `index` is out of range
+/// or the argument is not valid UTF-8.
+#[no_mangle]
+pub extern "C" fn raven_env_arg_at(index: i64) -> *mut object::String {
+    let value = usize::try_from(index)
+        .ok()
+        .and_then(|i| std::env::args_os().nth(i))
+        .and_then(|a| a.into_string().ok())
+        .unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// Terminate the process with `code`. Does not return.
+#[no_mangle]
+pub extern "C" fn raven_env_exit(code: i64) -> ! {
+    process::exit(code as i32);
+}
+
+/// The target operating system name: "windows", "linux", or "macos".
+/// Falls back to "unknown" on other targets.
+#[no_mangle]
+pub extern "C" fn raven_env_os_name() -> *mut object::String {
+    let name = if cfg!(target_os = "windows") {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else {
+        "unknown"
+    };
+    object::raven_string_from_bytes(name.as_ptr(), name.len())
+}
+
+/// The target CPU architecture name, for example "x86_64" or "aarch64".
+#[no_mangle]
+pub extern "C" fn raven_env_arch() -> *mut object::String {
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else if cfg!(target_arch = "x86") {
+        "x86"
+    } else if cfg!(target_arch = "arm") {
+        "arm"
+    } else {
+        "unknown"
+    };
+    object::raven_string_from_bytes(arch.as_ptr(), arch.len())
+}
+
+/// Borrow a Raven `String` argument as a `&str` for an env lookup.
+///
+/// # Safety
+///
+/// `name` must be a valid `raven_string_from_bytes`-built `String` or
+/// null.
+fn env_name<'a>(name: *const object::String) -> Option<&'a str> {
+    if name.is_null() {
+        return None;
+    }
+    let ptr = object::raven_string_bytes(name);
+    let len = object::raven_string_len(name) as usize;
+    if ptr.is_null() {
+        return Some("");
+    }
+    // SAFETY: a Raven String holds `len` initialized UTF-8 bytes.
+    let bytes = unsafe { slice::from_raw_parts(ptr, len) };
+    std::str::from_utf8(bytes).ok()
+}
+
 /// Reinterpret a signed 64-bit integer as an `f64` by value conversion.
 ///
 /// The v2 surface language has no Int-to-Float cast, so `std/random`

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -84,6 +84,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "math",
     "path",
     "error",
+    "env",
     "test",
     "fs",
     "net",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -49,6 +49,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("math", include_str!("../../stdlib/std/math.rv")),
     ("path", include_str!("../../stdlib/std/path.rv")),
     ("error", include_str!("../../stdlib/std/error.rv")),
+    ("env", include_str!("../../stdlib/std/env.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -441,6 +442,11 @@ mod tests {
     #[test]
     fn random_module_is_bundled() {
         assert!(bundled_source("random").is_some());
+    }
+
+    #[test]
+    fn env_module_is_bundled() {
+        assert!(bundled_source("env").is_some());
     }
 
     #[test]

--- a/stdlib/std/env.rv
+++ b/stdlib/std/env.rv
@@ -1,0 +1,71 @@
+// std/env: command-line arguments, environment variables, process exit,
+// and platform info. The primitives bind the raven-runtime C ABI through
+// `extern "C"`; the rest is pure Raven. See docs/v2/specs/std-env.md.
+
+extern "C" {
+    fun raven_env_get(name: String) -> String
+    fun raven_env_has(name: String) -> Bool
+    fun raven_env_arg_count() -> Int
+    fun raven_env_arg_at(index: Int) -> String
+    fun raven_env_exit(code: Int)
+    fun raven_env_os_name() -> String
+    fun raven_env_arch() -> String
+}
+
+// Value of the environment variable `name`, or "" when it is unset.
+// An unset variable and one set to "" both return ""; use `has_env` to
+// tell them apart.
+fun get_env(name: String) -> String {
+    return raven_env_get(name)
+}
+
+// Whether `name` is set in the environment, regardless of its value.
+fun has_env(name: String) -> Bool {
+    return raven_env_has(name)
+}
+
+// Value of `name`, or `default` when `name` is unset.
+fun get_env_or(name: String, default: String) -> String {
+    if has_env(name) {
+        return get_env(name)
+    }
+    return default
+}
+
+// Number of process arguments, including the program path at index 0.
+fun arg_count() -> Int {
+    return raven_env_arg_count()
+}
+
+// Process argument at `i` (index 0 is the program path), or "" when `i`
+// is out of range.
+fun arg_at(i: Int) -> String {
+    return raven_env_arg_at(i)
+}
+
+// All process arguments, index 0 being the program path.
+fun args() -> List<String> {
+    let out: List<String> = []
+    let i = 0
+    let n = arg_count()
+    while i < n {
+        out.push(arg_at(i))
+        i = i + 1
+    }
+    return out
+}
+
+// Terminate the process with status `code`. Does not return.
+fun exit(code: Int) {
+    raven_env_exit(code)
+}
+
+// Target operating system: "windows", "linux", or "macos".
+fun os_name() -> String {
+    return raven_env_os_name()
+}
+
+// Target CPU architecture, for example "x86_64" or "aarch64".
+fun arch() -> String {
+    return raven_env_arch()
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -593,6 +593,60 @@ fn fmt_program_compiles_and_runs() {
     compile_link_run_and_check("use_fmt.rv", expected, &runtime);
 }
 
+#[test]
+fn env_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/env environment, args, and platform info. The asserted output is
+    // driven only by the env var this test sets plus structural booleans, so
+    // it is identical on every host: get_env_or returns the set value, a set
+    // and an unset variable report true/false, get_env_or falls back when
+    // unset, arg_count is at least one, and os_name is one of the known set.
+    let name = "use_env.rv";
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("v2")
+        .join(name);
+    let source =
+        std::fs::read_to_string(&source_path).unwrap_or_else(|e| panic!("read {}: {}", name, e));
+    let object_bytes = match build_object(&source, &source_path) {
+        Ok(b) => b,
+        Err(e) => panic!("frontend or codegen failed for {}: {}", name, e),
+    };
+    let tmp = workdir();
+    let object_path = tmp.join("use_env.o");
+    std::fs::write(&object_path, &object_bytes).expect("write object");
+    let binary = tmp.join(if cfg!(windows) {
+        "use_env.exe"
+    } else {
+        "use_env"
+    });
+    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+        cleanup(&tmp);
+        panic!("linker failed to produce an executable for {}: {}", name, e);
+    }
+    let output = Command::new(&binary)
+        .env("RAVEN_ENV_TEST", "hello-env")
+        .env_remove("RAVEN_DEFINITELY_UNSET_XYZ")
+        .output()
+        .unwrap_or_else(|e| panic!("run {} binary: {}", name, e));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&tmp);
+    assert!(
+        output.status.success(),
+        "use_env binary exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "hello-env\ntrue\nfalse\nfallback\ntrue\ntrue\n",
+        "unexpected stdout for use_env: {:?}",
+        stdout
+    );
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Adds the `std/env` standard-library module for command-line arguments, environment variables, process exit, and platform info.

Closes #127

## Surface

- `get_env(name) -> String`: value, or `""` when unset.
- `has_env(name) -> Bool`: whether the variable is set (distinguishes unset from empty).
- `get_env_or(name, default) -> String`: pure Raven fallback.
- `arg_count() -> Int`, `arg_at(i) -> String`: process args (index 0 is the program path; out of range returns `""`).
- `args() -> List<String>`: pure Raven, built from `arg_at` over `0..arg_count()`.
- `exit(code)`: terminates the process; does not return.
- `os_name() -> String`: `"windows"`, `"linux"`, or `"macos"`.
- `arch() -> String`: `"x86_64"`, `"aarch64"`, etc.

## FFI path

Uses `extern "C"` blocks binding raven-runtime symbols directly, not compiler builtin intrinsics. A probe confirmed a Raven `String` (a single GC pointer at the ABI) crosses `extern "C"` unchanged in both directions, so no codegen change was needed. The runtime symbols live in `raven-runtime/src/lib.rs`; the module wraps them in `stdlib/std/env.rv`.

## Output

`examples/v2/use_env.rv` run with `RAVEN_ENV_TEST=hello-env`:

```
hello-env
true
false
fallback
true
true
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `env_program_compiles_and_runs` smoke test (sets `RAVEN_ENV_TEST`, asserts the deterministic lines above)
- [x] `env_module_is_bundled` unit test
