### PR TITLE
feat(stdlib): std/fs filesystem operations

### DIFF
--- a/docs/v2/specs/std-fs.md
+++ b/docs/v2/specs/std-fs.md
@@ -1,0 +1,98 @@
+# std/fs Spec
+
+Filesystem operations: reading and writing files, directory creation and
+removal, listing, size, and existence queries, plus pure path string
+manipulation. The primitives bind the raven-runtime C ABI; the wrappers
+add the Result/Error model in pure Raven on top.
+
+## Import
+
+```raven
+import std/fs { read, write, append, remove_file, create_dir, remove_dir, list_dir, size, exists, is_file, is_dir, join, dirname, basename, split }
+```
+
+## Error model
+
+Fallible operations return `Result<T, Error>`. The error is an std/error
+`Error` tagged with kind `"io"`. Raven has no type alias, so the `IoError`
+of the issue is realized as `Error` with kind `"io"`; std/fs builds it as
+an `Error` struct literal directly. The message is a short context prefix
+(the operation name) joined to the operating system error text.
+
+There are no sentinel return values. The runtime keeps a thread-local
+last-error string that each fallible op clears on success and sets to the
+OS message on failure; `raven_fs_last_error()` returns it, and the Raven
+wrapper turns a non-empty last error into an `Err`.
+
+## Fallible surface
+
+```raven
+fun read(path: String) -> Result<String, Error>
+fun write(path: String, contents: String) -> Result<Bool, Error>
+fun append(path: String, contents: String) -> Result<Bool, Error>
+fun remove_file(path: String) -> Result<Bool, Error>
+fun create_dir(path: String) -> Result<Bool, Error>
+fun remove_dir(path: String) -> Result<Bool, Error>
+fun list_dir(path: String) -> Result<List<String>, Error>
+fun size(path: String) -> Result<Int, Error>
+```
+
+`read` returns the whole file as a String. `write` creates or truncates
+`path` then writes `contents`. `append` writes to the end of `path`,
+creating it when absent.
+
+The ops with no natural payload (`write`, `append`, `remove_file`,
+`create_dir`, `remove_dir`) return `Result<Bool, Error>` with `Ok(true)`
+on success rather than `Result<Unit, Error>`. The Bool is always `true`;
+it exists only so the success arm carries a value.
+
+`create_dir` creates intermediate directories (it uses create_dir_all), so
+creating a nested path in one call succeeds. `remove_dir` removes the
+directory and all of its contents recursively.
+
+`list_dir` returns the entry names (not full paths). Across the FFI
+boundary the runtime joins the names with `\n` into a single String, and
+the Raven wrapper splits it into a `List<String>`. An empty directory
+yields an empty list, not a one-element list containing `""`.
+
+`size` is the file size in bytes.
+
+## Non-fallible queries
+
+```raven
+fun exists(path: String) -> Bool
+fun is_file(path: String) -> Bool
+fun is_dir(path: String) -> Bool
+```
+
+These return a plain `Bool` and never an error: a missing path is a normal
+`false`, not an `Err`. A path that exists but is not a regular file is
+`false` from `is_file`, and likewise for `is_dir`.
+
+## Path manipulation
+
+```raven
+fun join(a: String, b: String) -> String
+fun dirname(path: String) -> String
+fun basename(path: String) -> String
+fun split(path: String) -> List<String>
+```
+
+These are pure Raven string operations with no runtime call and no Result.
+They use `/` as the separator. Forward slash works on Windows for these
+std ops, so the OS separator is not detected. `split` drops empty
+components from leading, trailing, or repeated separators. This overlaps
+with std/path (which offers the same join/dirname/basename on `/`); std/fs
+duplicates them so the module is usable without a second import.
+
+## FFI path
+
+This module uses `extern "C"` blocks binding raven-runtime symbols
+directly, not compiler builtin intrinsics. A Raven `String` is a single GC
+pointer at the ABI, so it crosses the boundary unchanged in both
+directions; `Bool` maps to Rust `bool` and `Int` to `i64`. The runtime
+symbols (`raven_fs_read`, `raven_fs_write`, `raven_fs_append`,
+`raven_fs_remove_file`, `raven_fs_create_dir`, `raven_fs_remove_dir`,
+`raven_fs_list`, `raven_fs_size`, `raven_fs_exists`, `raven_fs_is_file`,
+`raven_fs_is_dir`, `raven_fs_last_error`) live in
+`raven-runtime/src/lib.rs`.

--- a/examples/v2/use_fs.rv
+++ b/examples/v2/use_fs.rv
@@ -1,0 +1,40 @@
+// golden:skip
+import std/fs { write, read, append, size, exists, is_file, is_dir, remove_file }
+import std/io { println }
+
+fun main() {
+    let path = "raven_fs_smoke_7Q.txt"
+
+    match write(path, "hello") {
+        Ok(_) -> println("wrote"),
+        Err(e) -> println("write failed"),
+    }
+    println("${exists(path)}")
+    println("${is_file(path)}")
+    println("${is_dir(path)}")
+    match read(path) {
+        Ok(s) -> println(s),
+        Err(e) -> println("read failed"),
+    }
+    match append(path, " world") {
+        Ok(_) -> println("appended"),
+        Err(e) -> println("append failed"),
+    }
+    match read(path) {
+        Ok(s) -> println(s),
+        Err(e) -> println("read failed"),
+    }
+    match size(path) {
+        Ok(n) -> println("${n}"),
+        Err(e) -> println("size failed"),
+    }
+    match remove_file(path) {
+        Ok(_) -> println("removed"),
+        Err(e) -> println("remove failed"),
+    }
+    println("${exists(path)}")
+    match read("raven_fs_definitely_missing_7Q.txt") {
+        Ok(s) -> println(s),
+        Err(e) -> println("read failed"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -36,9 +36,40 @@ pub use object::{
 };
 
 use std::alloc::{self, Layout};
+use std::cell::RefCell;
 use std::io::{self, BufRead, Write};
 use std::process;
 use std::slice;
+
+thread_local! {
+    // Message of the most recent fallible fs op: empty on success, the OS
+    // error text on failure. The Raven wrapper reads it through
+    // `raven_fs_last_error` after each call to decide Ok vs Err.
+    static FS_LAST_ERROR: RefCell<std::string::String> = const { RefCell::new(std::string::String::new()) };
+}
+
+fn fs_set_error(msg: std::string::String) {
+    FS_LAST_ERROR.with(|e| *e.borrow_mut() = msg);
+}
+
+fn fs_clear_error() {
+    FS_LAST_ERROR.with(|e| e.borrow_mut().clear());
+}
+
+/// Record the result of a fallible fs op: clear the last error on success,
+/// store the OS message on failure.
+fn fs_record<T>(r: io::Result<T>) -> Option<T> {
+    match r {
+        Ok(v) => {
+            fs_clear_error();
+            Some(v)
+        }
+        Err(e) => {
+            fs_set_error(e.to_string());
+            None
+        }
+    }
+}
 
 /// Allocate `size` bytes aligned to `align`.
 ///
@@ -328,6 +359,184 @@ pub extern "C" fn raven_random_entropy() -> i64 {
     z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
     z = z ^ (z >> 31);
     z as i64
+}
+
+/// The message of the most recent fallible fs op, empty when it
+/// succeeded. The Raven wrapper reads this to build an `Err` only when it
+/// is non-empty.
+#[no_mangle]
+pub extern "C" fn raven_fs_last_error() -> *mut object::String {
+    FS_LAST_ERROR.with(|e| {
+        let msg = e.borrow();
+        object::raven_string_from_bytes(msg.as_ptr(), msg.len())
+    })
+}
+
+/// Read the whole file at `path` as a `String`. On failure stores the OS
+/// message in the last-error slot and returns an empty `String`.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_read(path: *const object::String) -> *mut object::String {
+    let contents = env_name(path)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path is not valid UTF-8"))
+        .and_then(std::fs::read_to_string);
+    let value = fs_record(contents).unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// Create or truncate `path` and write `contents` to it.
+///
+/// # Safety
+///
+/// Both arguments must be valid `raven_string_from_bytes`-built `String`s.
+#[no_mangle]
+pub extern "C" fn raven_fs_write(
+    path: *const object::String,
+    contents: *const object::String,
+) -> bool {
+    let result = match (env_name(path), env_name(contents)) {
+        (Some(p), Some(c)) => std::fs::write(p, c),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path or contents is not valid UTF-8",
+        )),
+    };
+    fs_record(result).is_some()
+}
+
+/// Append `contents` to `path`, creating it when absent.
+///
+/// # Safety
+///
+/// Both arguments must be valid `raven_string_from_bytes`-built `String`s.
+#[no_mangle]
+pub extern "C" fn raven_fs_append(
+    path: *const object::String,
+    contents: *const object::String,
+) -> bool {
+    let result = match (env_name(path), env_name(contents)) {
+        (Some(p), Some(c)) => std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)
+            .and_then(|mut f| f.write_all(c.as_bytes())),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path or contents is not valid UTF-8",
+        )),
+    };
+    fs_record(result).is_some()
+}
+
+/// Remove the file at `path`.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_remove_file(path: *const object::String) -> bool {
+    let result = env_name(path)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path is not valid UTF-8"))
+        .and_then(std::fs::remove_file);
+    fs_record(result).is_some()
+}
+
+/// Create the directory at `path`, including any missing parents.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_create_dir(path: *const object::String) -> bool {
+    let result = env_name(path)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path is not valid UTF-8"))
+        .and_then(std::fs::create_dir_all);
+    fs_record(result).is_some()
+}
+
+/// Remove the directory at `path` and all of its contents.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_remove_dir(path: *const object::String) -> bool {
+    let result = env_name(path)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path is not valid UTF-8"))
+        .and_then(std::fs::remove_dir_all);
+    fs_record(result).is_some()
+}
+
+/// List the entry names of the directory at `path`, joined by `\n`. An
+/// empty directory yields an empty `String`. On failure stores the OS
+/// message and returns an empty `String`.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_list(path: *const object::String) -> *mut object::String {
+    let result = env_name(path)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path is not valid UTF-8"))
+        .and_then(|p| {
+            let mut names: Vec<std::string::String> = Vec::new();
+            for entry in std::fs::read_dir(p)? {
+                let entry = entry?;
+                names.push(entry.file_name().to_string_lossy().into_owned());
+            }
+            Ok(names.join("\n"))
+        });
+    let value = fs_record(result).unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// File size at `path` in bytes. On failure stores the OS message and
+/// returns 0.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_size(path: *const object::String) -> i64 {
+    let result = env_name(path)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path is not valid UTF-8"))
+        .and_then(std::fs::metadata)
+        .map(|m| m.len() as i64);
+    fs_record(result).unwrap_or(0)
+}
+
+/// Whether anything exists at `path`. Not fallible: a missing path is a
+/// normal `false`.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_exists(path: *const object::String) -> bool {
+    env_name(path).is_some_and(|p| std::path::Path::new(p).exists())
+}
+
+/// Whether `path` is a regular file. A missing path is `false`.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_is_file(path: *const object::String) -> bool {
+    env_name(path).is_some_and(|p| std::path::Path::new(p).is_file())
+}
+
+/// Whether `path` is a directory. A missing path is `false`.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_is_dir(path: *const object::String) -> bool {
+    env_name(path).is_some_and(|p| std::path::Path::new(p).is_dir())
 }
 
 /// A stack buffer large enough for any base-ten `i64` plus a sign.

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -50,6 +50,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("path", include_str!("../../stdlib/std/path.rv")),
     ("error", include_str!("../../stdlib/std/error.rv")),
     ("env", include_str!("../../stdlib/std/env.rv")),
+    ("fs", include_str!("../../stdlib/std/fs.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -447,6 +448,11 @@ mod tests {
     #[test]
     fn env_module_is_bundled() {
         assert!(bundled_source("env").is_some());
+    }
+
+    #[test]
+    fn fs_module_is_bundled() {
+        assert!(bundled_source("fs").is_some());
     }
 
     #[test]

--- a/stdlib/std/fs.rv
+++ b/stdlib/std/fs.rv
@@ -1,0 +1,226 @@
+// std/fs: filesystem operations over the raven-runtime C ABI. Fallible
+// ops return Result<T, Error> where the error is an std/error `Error`
+// tagged with kind "io" (Raven has no type alias, so IoError is realized
+// as that, built directly as an `Error` struct literal with kind "io").
+// The runtime keeps a thread-local last-error string; each
+// wrapper runs the op and turns a non-empty last error into an Err. The
+// non-fallible queries (exists, is_file, is_dir) treat a missing path as a
+// normal false. Path manipulation is pure Raven string work on `/`. See
+// docs/v2/specs/std-fs.md.
+
+import std/error
+import std/string
+
+extern "C" {
+    fun raven_fs_last_error() -> String
+    fun raven_fs_read(path: String) -> String
+    fun raven_fs_write(path: String, contents: String) -> Bool
+    fun raven_fs_append(path: String, contents: String) -> Bool
+    fun raven_fs_remove_file(path: String) -> Bool
+    fun raven_fs_create_dir(path: String) -> Bool
+    fun raven_fs_remove_dir(path: String) -> Bool
+    fun raven_fs_list(path: String) -> String
+    fun raven_fs_size(path: String) -> Int
+    fun raven_fs_exists(path: String) -> Bool
+    fun raven_fs_is_file(path: String) -> Bool
+    fun raven_fs_is_dir(path: String) -> Bool
+}
+
+// An Error tagged with kind "io" (the IoError realization), its message a
+// context prefix joined to the runtime's last-error text.
+fun io_error(ctx: String) -> Error {
+    return Error { kind: "io", message: ctx.concat(": ").concat(raven_fs_last_error()) }
+}
+
+// Whole file at `path` as a String.
+fun read(path: String) -> Result<String, Error> {
+    let out = raven_fs_read(path)
+    if raven_fs_last_error().length() > 0 {
+        return Err(io_error("read"))
+    }
+    return Ok(out)
+}
+
+// Create or truncate `path` and write `contents`. Returns Ok(true) on
+// success; the Bool payload is always true and exists only because the
+// surface uses Result<Bool, Error> rather than a Unit payload.
+fun write(path: String, contents: String) -> Result<Bool, Error> {
+    raven_fs_write(path, contents)
+    if raven_fs_last_error().length() > 0 {
+        return Err(io_error("write"))
+    }
+    return Ok(true)
+}
+
+// Append `contents` to `path`, creating it when absent. Ok(true) on success.
+fun append(path: String, contents: String) -> Result<Bool, Error> {
+    raven_fs_append(path, contents)
+    if raven_fs_last_error().length() > 0 {
+        return Err(io_error("append"))
+    }
+    return Ok(true)
+}
+
+// Remove the file at `path`. Ok(true) on success.
+fun remove_file(path: String) -> Result<Bool, Error> {
+    raven_fs_remove_file(path)
+    if raven_fs_last_error().length() > 0 {
+        return Err(io_error("remove_file"))
+    }
+    return Ok(true)
+}
+
+// Create the directory at `path`, including any missing parents. Ok(true)
+// on success.
+fun create_dir(path: String) -> Result<Bool, Error> {
+    raven_fs_create_dir(path)
+    if raven_fs_last_error().length() > 0 {
+        return Err(io_error("create_dir"))
+    }
+    return Ok(true)
+}
+
+// Remove the directory at `path` and all of its contents. Ok(true) on
+// success.
+fun remove_dir(path: String) -> Result<Bool, Error> {
+    raven_fs_remove_dir(path)
+    if raven_fs_last_error().length() > 0 {
+        return Err(io_error("remove_dir"))
+    }
+    return Ok(true)
+}
+
+// Entry names (not full paths) of the directory at `path`. An empty
+// directory yields an empty list.
+fun list_dir(path: String) -> Result<List<String>, Error> {
+    let joined = raven_fs_list(path)
+    if raven_fs_last_error().length() > 0 {
+        return Err(io_error("list_dir"))
+    }
+    return Ok(split_lines(joined))
+}
+
+// File size at `path` in bytes.
+fun size(path: String) -> Result<Int, Error> {
+    let n = raven_fs_size(path)
+    if raven_fs_last_error().length() > 0 {
+        return Err(io_error("size"))
+    }
+    return Ok(n)
+}
+
+// Whether anything exists at `path`. A missing path is a normal false.
+fun exists(path: String) -> Bool {
+    return raven_fs_exists(path)
+}
+
+// Whether `path` is a regular file. A missing path is false.
+fun is_file(path: String) -> Bool {
+    return raven_fs_is_file(path)
+}
+
+// Whether `path` is a directory. A missing path is false.
+fun is_dir(path: String) -> Bool {
+    return raven_fs_is_dir(path)
+}
+
+// Split `s` on `\n` into a list of lines. An empty string yields an empty
+// list (not a one-element list of ""), so an empty directory listing maps
+// to an empty list.
+fun split_lines(s: String) -> List<String> {
+    let out: List<String> = []
+    if s.length() == 0 {
+        return out
+    }
+    let n = s.length()
+    let start = 0
+    let i = 0
+    while i < n {
+        if s.char_at(i).starts_with("\n") {
+            out.push(s.substring(start, i))
+            start = i + 1
+        }
+        i = i + 1
+    }
+    out.push(s.substring(start, n))
+    return out
+}
+
+// Path manipulation on `/` separators. Forward slash works on Windows for
+// these std ops; the OS separator is not detected. These overlap with
+// std/path; they are duplicated here so std/fs is usable without a second
+// import.
+
+// Byte index of the last `/`, or -1 when none.
+fun last_slash(p: String) -> Int {
+    let i = p.length() - 1
+    while i >= 0 {
+        if p.char_at(i).starts_with("/") {
+            return i
+        }
+        i = i - 1
+    }
+    return -1
+}
+
+fun join(a: String, b: String) -> String {
+    if a.length() == 0 {
+        return b
+    }
+    if b.length() == 0 {
+        return a
+    }
+    let a_slash = a.ends_with("/")
+    let b_slash = b.starts_with("/")
+    if a_slash {
+        if b_slash {
+            return a.concat(b.substring(1, b.length()))
+        }
+        return a.concat(b)
+    }
+    if b_slash {
+        return a.concat(b)
+    }
+    return a.concat("/").concat(b)
+}
+
+fun basename(p: String) -> String {
+    let i = last_slash(p)
+    if i < 0 {
+        return p
+    }
+    return p.substring(i + 1, p.length())
+}
+
+fun dirname(p: String) -> String {
+    let i = last_slash(p)
+    if i < 0 {
+        return "."
+    }
+    if i == 0 {
+        return "/"
+    }
+    return p.substring(0, i)
+}
+
+// Split `p` on `/` into its components, dropping empty pieces produced by
+// leading, trailing, or repeated separators.
+fun split(p: String) -> List<String> {
+    let out: List<String> = []
+    let n = p.length()
+    let start = 0
+    let i = 0
+    while i < n {
+        if p.char_at(i).starts_with("/") {
+            if i > start {
+                out.push(p.substring(start, i))
+            }
+            start = i + 1
+        }
+        i = i + 1
+    }
+    if n > start {
+        out.push(p.substring(start, n))
+    }
+    return out
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -647,6 +647,64 @@ fn env_program_compiles_and_runs() {
     );
 }
 
+#[test]
+fn fs_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/fs filesystem ops end to end. The program writes a uniquely
+    // named file in its working directory, queries it, appends, sizes it,
+    // removes it, and finally reads a missing file to exercise the Err
+    // path. Every printed line is deterministic: wrote, then exists/is_file
+    // true and is_dir false, the contents "hello", appended, the appended
+    // contents "hello world", the size 11, removed, exists false, and the
+    // missing-file read reporting "read failed". The binary runs from a
+    // fresh temp dir so its own temp file (which it removes) leaves no
+    // residue.
+    let name = "use_fs.rv";
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("v2")
+        .join(name);
+    let source =
+        std::fs::read_to_string(&source_path).unwrap_or_else(|e| panic!("read {}: {}", name, e));
+    let object_bytes = match build_object(&source, &source_path) {
+        Ok(b) => b,
+        Err(e) => panic!("frontend or codegen failed for {}: {}", name, e),
+    };
+    let tmp = workdir();
+    let object_path = tmp.join("use_fs.o");
+    std::fs::write(&object_path, &object_bytes).expect("write object");
+    let binary = tmp.join(if cfg!(windows) {
+        "use_fs.exe"
+    } else {
+        "use_fs"
+    });
+    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+        cleanup(&tmp);
+        panic!("linker failed to produce an executable for {}: {}", name, e);
+    }
+    let output = Command::new(&binary)
+        .current_dir(&tmp)
+        .output()
+        .unwrap_or_else(|e| panic!("run {} binary: {}", name, e));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&tmp);
+    assert!(
+        output.status.success(),
+        "use_fs binary exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout,
+        "wrote\ntrue\ntrue\nfalse\nhello\nappended\nhello world\n11\nremoved\nfalse\nread failed\n",
+        "unexpected stdout for use_fs: {:?}",
+        stdout
+    );
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Add a `std/fs` standard-library module for filesystem operations backed by the raven-runtime C ABI.

Closes #75

## Surface

Fallible ops return `Result<T, Error>` (the error tagged kind `"io"`):

```raven
fun read(path: String) -> Result<String, Error>
fun write(path: String, contents: String) -> Result<Bool, Error>
fun append(path: String, contents: String) -> Result<Bool, Error>
fun remove_file(path: String) -> Result<Bool, Error>
fun create_dir(path: String) -> Result<Bool, Error>
fun remove_dir(path: String) -> Result<Bool, Error>
fun list_dir(path: String) -> Result<List<String>, Error>
fun size(path: String) -> Result<Int, Error>
```

Non-fallible queries (a missing path is a normal `false`):

```raven
fun exists(path: String) -> Bool
fun is_file(path: String) -> Bool
fun is_dir(path: String) -> Bool
```

Pure path string work on `/`:

```raven
fun join(a: String, b: String) -> String
fun dirname(path: String) -> String
fun basename(path: String) -> String
fun split(path: String) -> List<String>
```

## Result and last-error model

There are no sentinel values. Each fallible runtime op records its result in a thread-local last-error string (cleared on success, set to the OS message on failure); `raven_fs_last_error()` returns it, and the Raven wrapper turns a non-empty last error into an `Err`. The error is an std/error `Error` with kind `"io"` (Raven has no type alias, so the issue's `IoError` is realized as `Error` kind `"io"`, built as a struct literal). The ops with no natural payload return `Result<Bool, Error>` with `Ok(true)`. `create_dir` makes intermediate dirs (create_dir_all); `remove_dir` is recursive. `list_dir` crosses the FFI as newline-joined names split in Raven, with an empty directory mapping to an empty list.

## Output

`examples/v2/use_fs.rv` writes a uniquely named file in its working directory, queries it, appends, sizes it, removes it, then reads a missing file to exercise the Err path:

```
wrote
true
true
false
hello
appended
hello world
11
removed
false
read failed
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (adds `fs_module_is_bundled` and the `fs_program_compiles_and_runs` smoke test, which runs the binary from a fresh temp dir and asserts the literal output above)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Error path verified: reading a missing file returns `Err` with a non-empty message
