### PR TITLE
feat(stdlib): std/time date and time with chrono backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +34,12 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bumpalo"
@@ -47,6 +62,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranelift-bforest"
@@ -192,6 +224,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +283,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +314,18 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -255,6 +347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +372,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -306,6 +413,9 @@ dependencies = [
 [[package]]
 name = "raven-runtime"
 version = "2.0.0-dev"
+dependencies = [
+ "chrono",
+]
 
 [[package]]
 name = "regalloc2"
@@ -327,10 +437,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slice-group-by"
@@ -378,6 +500,110 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zerocopy"

--- a/docs/v2/specs/std-time.md
+++ b/docs/v2/specs/std-time.md
@@ -1,0 +1,106 @@
+# std/time Spec
+
+Date and time over the raven-runtime C ABI, backed by `chrono`. Every
+value is UTC. Timestamps are Unix time in seconds (or milliseconds for
+`now_millis`); there is no local-timezone handling. The primitives bind
+runtime symbols through `extern "C"`; the structs and the convenience
+helpers are pure Raven on top of them.
+
+## Import
+
+```raven
+import std/time { now, now_millis, from_timestamp, weekday, format_timestamp, parse_timestamp, sleep_millis }
+```
+
+## Structs
+
+```raven
+struct Date { year: Int, month: Int, day: Int }
+struct Time { hour: Int, minute: Int, second: Int }
+struct DateTime { date: Date, time: Time }
+```
+
+`month` is 1 through 12, `day` is 1 through 31, `hour` is 0 through 23,
+`minute` and `second` are 0 through 59. `Date`, `Time`, and `DateTime`
+each have a `ToString` impl producing ISO-like text: a `Date` renders as
+`1970-01-01` (year zero-padded to four digits, month and day to two), a
+`Time` as `00:00:00`, and a `DateTime` as the two joined by a space,
+`1970-01-01 00:00:00`.
+
+## Surface
+
+### Current time
+
+```raven
+fun now() -> Int
+fun now_millis() -> Int
+```
+
+`now` is the current Unix timestamp in whole seconds (UTC). `now_millis`
+is the current Unix time in milliseconds (UTC). Both are
+non-deterministic; tests assert only structural facts about them (for
+example `now() > 1700000000`).
+
+### Decomposition
+
+```raven
+fun from_timestamp(ts: Int) -> DateTime
+fun weekday(ts: Int) -> Int
+```
+
+`from_timestamp` decomposes a Unix timestamp (seconds, UTC) into a
+`DateTime`. A struct cannot cross the FFI boundary, so the runtime exposes
+one scalar extractor per field (`raven_time_year`, `_month`, `_day`,
+`_hour`, `_minute`, `_second`), and the `DateTime` is assembled in Raven.
+A timestamp outside chrono's representable range falls back to the epoch.
+
+`weekday` returns the weekday of `ts` as 0 for Sunday through 6 for
+Saturday (chrono's `num_days_from_sunday`).
+
+### Formatting and parsing
+
+```raven
+fun format_timestamp(ts: Int, pattern: String) -> String
+fun parse_timestamp(text: String, pattern: String) -> Result<Int, Error>
+```
+
+`pattern` is a chrono strftime pattern, for example `%Y-%m-%d %H:%M:%S`.
+`format_timestamp` renders the UTC datetime of `ts` with that pattern.
+`parse_timestamp` parses `text` as a UTC datetime by the pattern and
+returns the Unix timestamp in seconds.
+
+Parsing is fallible. The runtime keeps a thread-local last-error string:
+the parse wrapper runs `raven_time_parse`, then reads
+`raven_time_last_error` and turns a non-empty value into an `Err`. The
+error is an std/error `Error` tagged with kind `"time"`. The `Error` type
+resolves across the bundled-module boundary, but a sibling module's free
+functions do not (issue #178), so the wrapper builds the `Error` struct
+literal directly rather than calling `error_kind`.
+
+### Sleep
+
+```raven
+fun sleep_millis(ms: Int)
+```
+
+`sleep_millis` sleeps the current thread for `ms` milliseconds
+(`std::thread::sleep`). A negative value is treated as zero. The Raven
+return type is `Unit`.
+
+## FFI path
+
+This module uses `extern "C"` blocks binding raven-runtime symbols
+directly, not compiler builtin intrinsics. A Raven `String` is a single GC
+pointer at the ABI, so it crosses the boundary unchanged in both
+directions, which lets `extern "C"` carry `String` arguments and returns
+with no codegen change. Returning a struct across the FFI is not
+supported, so the runtime returns scalar `i64` components and the `.rv`
+wrapper assembles the `Date`, `Time`, and `DateTime` structs. The runtime
+symbols (`raven_time_now`, `raven_time_now_millis`, `raven_time_year`,
+`raven_time_month`, `raven_time_day`, `raven_time_hour`,
+`raven_time_minute`, `raven_time_second`, `raven_time_weekday`,
+`raven_time_format`, `raven_time_parse`, `raven_time_last_error`,
+`raven_time_sleep_millis`) live in `raven-runtime/src/lib.rs` and are
+backed by `chrono` in UTC. The runtime depends on `chrono` with
+`default-features = false` and the `clock` and `std` features.
+```

--- a/docs/v2/specs/stdlib-modules.md
+++ b/docs/v2/specs/stdlib-modules.md
@@ -50,7 +50,7 @@ Every module implicitly imports the prelude.
 
 | Module | Contents | Primary inspiration |
 |---|---|---|
-| `std/time` | `Instant`, `Duration`, `DateTime`, formatting, sleep | Java java.time, Go time |
+| `std/time` | UTC timestamps, `Date`, `Time`, `DateTime`, strftime format and parse, sleep | Java java.time, Go time |
 | `std/fs` | files, directories, metadata, read and write, all `Result` | Go os, Rust fs |
 | `std/path` | join, split, normalize, extension | Go path/filepath, Python pathlib |
 | `std/env` | args, environment variables, exit, platform info | Go os, Rust env |

--- a/examples/v2/use_time.rv
+++ b/examples/v2/use_time.rv
@@ -1,0 +1,19 @@
+// golden:skip
+import std/time { from_timestamp, format_timestamp, parse_timestamp, now }
+import std/io { println }
+
+fun main() {
+    println(format_timestamp(0, "%Y-%m-%d %H:%M:%S"))
+    let dt = from_timestamp(86400)
+    println("${dt.date.year}-${dt.date.month}-${dt.date.day}")
+    println(format_timestamp(1700000000, "%Y-%m-%d"))
+    match parse_timestamp("2000-01-01 00:00:00", "%Y-%m-%d %H:%M:%S") {
+        Ok(ts) -> println("${ts}"),
+        Err(e) -> println("parse failed"),
+    }
+    match parse_timestamp("not a date", "%Y-%m-%d %H:%M:%S") {
+        Ok(ts) -> println("ok"),
+        Err(e) -> println("parse failed"),
+    }
+    println("${now() > 1700000000}")
+}

--- a/raven-runtime/Cargo.toml
+++ b/raven-runtime/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["rlib", "staticlib"]
 name = "raven_runtime"
 
 [dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -71,6 +71,21 @@ fn fs_record<T>(r: io::Result<T>) -> Option<T> {
     }
 }
 
+thread_local! {
+    // Message of the most recent fallible time op (parsing): empty on
+    // success, the parse error text on failure. The std/time wrapper reads
+    // it through `raven_time_last_error` to decide Ok vs Err.
+    static TIME_LAST_ERROR: RefCell<std::string::String> = const { RefCell::new(std::string::String::new()) };
+}
+
+fn time_set_error(msg: std::string::String) {
+    TIME_LAST_ERROR.with(|e| *e.borrow_mut() = msg);
+}
+
+fn time_clear_error() {
+    TIME_LAST_ERROR.with(|e| e.borrow_mut().clear());
+}
+
 /// Allocate `size` bytes aligned to `align`.
 ///
 /// Returns null on allocation failure or invalid layout. The current
@@ -537,6 +552,144 @@ pub extern "C" fn raven_fs_is_file(path: *const object::String) -> bool {
 #[no_mangle]
 pub extern "C" fn raven_fs_is_dir(path: *const object::String) -> bool {
     env_name(path).is_some_and(|p| std::path::Path::new(p).is_dir())
+}
+
+/// The message of the most recent fallible time op (parsing), empty when
+/// it succeeded. The std/time wrapper reads this to build an `Err` only
+/// when it is non-empty.
+#[no_mangle]
+pub extern "C" fn raven_time_last_error() -> *mut object::String {
+    TIME_LAST_ERROR.with(|e| {
+        let msg = e.borrow();
+        object::raven_string_from_bytes(msg.as_ptr(), msg.len())
+    })
+}
+
+/// Current Unix timestamp in whole seconds (UTC).
+#[no_mangle]
+pub extern "C" fn raven_time_now() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+/// Current Unix time in milliseconds (UTC).
+#[no_mangle]
+pub extern "C" fn raven_time_now_millis() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+/// The UTC datetime for a Unix timestamp in seconds, or the epoch when the
+/// timestamp is out of chrono's representable range.
+fn time_from_ts(ts: i64) -> chrono::DateTime<chrono::Utc> {
+    use chrono::TimeZone;
+    match chrono::Utc.timestamp_opt(ts, 0) {
+        chrono::LocalResult::Single(dt) => dt,
+        _ => chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
+    }
+}
+
+/// Calendar year of `ts` (UTC).
+#[no_mangle]
+pub extern "C" fn raven_time_year(ts: i64) -> i64 {
+    use chrono::Datelike;
+    time_from_ts(ts).year() as i64
+}
+
+/// Month of `ts` (UTC), 1 through 12.
+#[no_mangle]
+pub extern "C" fn raven_time_month(ts: i64) -> i64 {
+    use chrono::Datelike;
+    time_from_ts(ts).month() as i64
+}
+
+/// Day of month of `ts` (UTC), 1 through 31.
+#[no_mangle]
+pub extern "C" fn raven_time_day(ts: i64) -> i64 {
+    use chrono::Datelike;
+    time_from_ts(ts).day() as i64
+}
+
+/// Hour of `ts` (UTC), 0 through 23.
+#[no_mangle]
+pub extern "C" fn raven_time_hour(ts: i64) -> i64 {
+    use chrono::Timelike;
+    time_from_ts(ts).hour() as i64
+}
+
+/// Minute of `ts` (UTC), 0 through 59.
+#[no_mangle]
+pub extern "C" fn raven_time_minute(ts: i64) -> i64 {
+    use chrono::Timelike;
+    time_from_ts(ts).minute() as i64
+}
+
+/// Second of `ts` (UTC), 0 through 59 (60 on a leap second).
+#[no_mangle]
+pub extern "C" fn raven_time_second(ts: i64) -> i64 {
+    use chrono::Timelike;
+    time_from_ts(ts).second() as i64
+}
+
+/// Weekday of `ts` (UTC) as 0 for Sunday through 6 for Saturday.
+#[no_mangle]
+pub extern "C" fn raven_time_weekday(ts: i64) -> i64 {
+    use chrono::Datelike;
+    time_from_ts(ts).weekday().num_days_from_sunday() as i64
+}
+
+/// Format the UTC datetime of `ts` with a chrono strftime `pattern`.
+///
+/// # Safety
+///
+/// `pattern` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_time_format(
+    ts: i64,
+    pattern: *const object::String,
+) -> *mut object::String {
+    let dt = time_from_ts(ts);
+    let value = match env_name(pattern) {
+        Some(p) => dt.format(p).to_string(),
+        None => std::string::String::new(),
+    };
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// Parse `text` as a UTC datetime by the chrono strftime `pattern`,
+/// returning the Unix timestamp in seconds. On failure stores the parse
+/// error in the last-error slot and returns 0.
+///
+/// # Safety
+///
+/// Both arguments must be valid `raven_string_from_bytes`-built `String`s.
+#[no_mangle]
+pub extern "C" fn raven_time_parse(
+    text: *const object::String,
+    pattern: *const object::String,
+) -> i64 {
+    let parsed = match (env_name(text), env_name(pattern)) {
+        (Some(t), Some(p)) => chrono::NaiveDateTime::parse_from_str(t, p)
+            .map_err(|e| e.to_string())
+            .map(|dt| dt.and_utc().timestamp()),
+        _ => Err("text or pattern is not valid UTF-8".to_string()),
+    };
+    match parsed {
+        Ok(ts) => {
+            time_clear_error();
+            ts
+        }
+        Err(msg) => {
+            time_set_error(msg);
+            0
+        }
+    }
+}
+
+/// Sleep the current thread for `ms` milliseconds. A negative value is
+/// treated as zero.
+#[no_mangle]
+pub extern "C" fn raven_time_sleep_millis(ms: i64) {
+    let ms = ms.max(0) as u64;
+    std::thread::sleep(std::time::Duration::from_millis(ms));
 }
 
 /// A stack buffer large enough for any base-ten `i64` plus a sign.

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -51,6 +51,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("error", include_str!("../../stdlib/std/error.rv")),
     ("env", include_str!("../../stdlib/std/env.rv")),
     ("fs", include_str!("../../stdlib/std/fs.rv")),
+    ("time", include_str!("../../stdlib/std/time.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -458,6 +459,11 @@ mod tests {
     #[test]
     fn fmt_module_is_bundled() {
         assert!(bundled_source("fmt").is_some());
+    }
+
+    #[test]
+    fn time_module_is_bundled() {
+        assert!(bundled_source("time").is_some());
     }
 
     #[test]

--- a/stdlib/std/time.rv
+++ b/stdlib/std/time.rv
@@ -1,0 +1,136 @@
+// std/time: date and time over the raven-runtime C ABI, backed by chrono
+// in UTC. All timestamps are Unix seconds (or milliseconds) in UTC; there
+// is no local-timezone handling. The primitives bind `raven_time_*`
+// symbols through `extern "C"`; the structs are assembled in pure Raven
+// from scalar component extractors because a struct cannot cross the FFI
+// boundary. Parsing is fallible and returns Result<Int, Error> through the
+// runtime's thread-local last-error slot. See docs/v2/specs/std-time.md.
+
+import std/error
+
+struct Date {
+    year: Int,
+    month: Int,
+    day: Int,
+}
+
+struct Time {
+    hour: Int,
+    minute: Int,
+    second: Int,
+}
+
+struct DateTime {
+    date: Date,
+    time: Time,
+}
+
+extern "C" {
+    fun raven_time_last_error() -> String
+    fun raven_time_now() -> Int
+    fun raven_time_now_millis() -> Int
+    fun raven_time_year(ts: Int) -> Int
+    fun raven_time_month(ts: Int) -> Int
+    fun raven_time_day(ts: Int) -> Int
+    fun raven_time_hour(ts: Int) -> Int
+    fun raven_time_minute(ts: Int) -> Int
+    fun raven_time_second(ts: Int) -> Int
+    fun raven_time_weekday(ts: Int) -> Int
+    fun raven_time_format(ts: Int, pattern: String) -> String
+    fun raven_time_parse(text: String, pattern: String) -> Int
+    fun raven_time_sleep_millis(ms: Int)
+}
+
+// Current Unix timestamp in whole seconds (UTC).
+fun now() -> Int {
+    return raven_time_now()
+}
+
+// Current Unix time in milliseconds (UTC).
+fun now_millis() -> Int {
+    return raven_time_now_millis()
+}
+
+// Decompose a Unix timestamp (seconds, UTC) into a DateTime, assembled in
+// Raven from the per-component runtime extractors.
+fun from_timestamp(ts: Int) -> DateTime {
+    let d = Date {
+        year: raven_time_year(ts),
+        month: raven_time_month(ts),
+        day: raven_time_day(ts),
+    }
+    let t = Time {
+        hour: raven_time_hour(ts),
+        minute: raven_time_minute(ts),
+        second: raven_time_second(ts),
+    }
+    return DateTime { date: d, time: t }
+}
+
+// Weekday of `ts` (UTC) as 0 for Sunday through 6 for Saturday.
+fun weekday(ts: Int) -> Int {
+    return raven_time_weekday(ts)
+}
+
+// Format the UTC datetime of `ts` with a chrono strftime `pattern`, for
+// example "%Y-%m-%d %H:%M:%S".
+fun format_timestamp(ts: Int, pattern: String) -> String {
+    return raven_time_format(ts, pattern)
+}
+
+// Parse a UTC datetime `text` by a chrono strftime `pattern`, returning
+// the Unix timestamp in seconds. On a parse failure returns an Error
+// tagged with kind "time".
+fun parse_timestamp(text: String, pattern: String) -> Result<Int, Error> {
+    let ts = raven_time_parse(text, pattern)
+    if raven_time_last_error().length() > 0 {
+        return Err(Error { kind: "time", message: "parse: ".concat(raven_time_last_error()) })
+    }
+    return Ok(ts)
+}
+
+// Sleep the current thread for `ms` milliseconds.
+fun sleep_millis(ms: Int) {
+    raven_time_sleep_millis(ms)
+}
+
+// Left-pad the base-ten text of `n` with zeros to at least `width` digits.
+// Negative values are not expected for the calendar fields used here, so
+// the sign is not handled specially.
+fun pad2(n: Int) -> String {
+    if n < 10 {
+        return "0".concat("${n}")
+    }
+    return "${n}"
+}
+
+fun pad4(n: Int) -> String {
+    if n < 10 {
+        return "000".concat("${n}")
+    }
+    if n < 100 {
+        return "00".concat("${n}")
+    }
+    if n < 1000 {
+        return "0".concat("${n}")
+    }
+    return "${n}"
+}
+
+impl ToString for Date {
+    fun to_string(self) -> String {
+        return pad4(self.year).concat("-").concat(pad2(self.month)).concat("-").concat(pad2(self.day))
+    }
+}
+
+impl ToString for Time {
+    fun to_string(self) -> String {
+        return pad2(self.hour).concat(":").concat(pad2(self.minute)).concat(":").concat(pad2(self.second))
+    }
+}
+
+impl ToString for DateTime {
+    fun to_string(self) -> String {
+        return self.date.to_string().concat(" ").concat(self.time.to_string())
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -705,6 +705,59 @@ fn fs_program_compiles_and_runs() {
     );
 }
 
+#[test]
+fn time_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/time date and time end to end, driven by fixed UTC timestamps so
+    // every printed line is identical on every host: the epoch formats to
+    // 1970-01-01 00:00:00, 86400 seconds decomposes to 1970-1-2, 1700000000
+    // formats to 2023-11-14, parsing "2000-01-01 00:00:00" yields the Unix
+    // timestamp 946684800, an unparseable string takes the Err path printing
+    // "parse failed", and now() is past Nov 2023 so the final line is true.
+    let name = "use_time.rv";
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("v2")
+        .join(name);
+    let source =
+        std::fs::read_to_string(&source_path).unwrap_or_else(|e| panic!("read {}: {}", name, e));
+    let object_bytes = match build_object(&source, &source_path) {
+        Ok(b) => b,
+        Err(e) => panic!("frontend or codegen failed for {}: {}", name, e),
+    };
+    let tmp = workdir();
+    let object_path = tmp.join("use_time.o");
+    std::fs::write(&object_path, &object_bytes).expect("write object");
+    let binary = tmp.join(if cfg!(windows) {
+        "use_time.exe"
+    } else {
+        "use_time"
+    });
+    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+        cleanup(&tmp);
+        panic!("linker failed to produce an executable for {}: {}", name, e);
+    }
+    let output = Command::new(&binary)
+        .output()
+        .unwrap_or_else(|e| panic!("run {} binary: {}", name, e));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&tmp);
+    assert!(
+        output.status.success(),
+        "use_time binary exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "1970-01-01 00:00:00\n1970-1-2\n2023-11-14\n946684800\nparse failed\ntrue\n",
+        "unexpected stdout for use_time: {:?}",
+        stdout
+    );
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Add the `std/time` standard-library module: UTC date and time backed by chrono in the runtime.

Closes #78

## Surface

```raven
import std/time { now, now_millis, from_timestamp, weekday, format_timestamp, parse_timestamp, sleep_millis }
```

- `struct Date { year, month, day }`, `struct Time { hour, minute, second }`, `struct DateTime { date, time }`, each with a `ToString` impl rendering ISO-like text.
- `now() -> Int` and `now_millis() -> Int`: current Unix time in seconds and milliseconds (UTC).
- `from_timestamp(ts: Int) -> DateTime`: decompose a Unix timestamp into a DateTime.
- `weekday(ts: Int) -> Int`: 0 for Sunday through 6 for Saturday.
- `format_timestamp(ts: Int, pattern: String) -> String`: chrono strftime formatting.
- `parse_timestamp(text: String, pattern: String) -> Result<Int, Error>`: parse a UTC datetime, Err tagged with kind "time" on failure.
- `sleep_millis(ms: Int)`: sleep the current thread.

## Backing

Everything is UTC. The runtime binds `raven_time_*` symbols backed by chrono. A struct cannot cross the FFI boundary, so the runtime returns scalar i64 components and the `.rv` wrapper assembles the structs. Parsing uses the thread-local last-error pattern. chrono was added to raven-runtime with `default-features = false` plus the `clock` and `std` features.

## Output

`examples/v2/use_time.rv` produces (identical on every host, fixed UTC timestamps):

```
1970-01-01 00:00:00
1970-1-2
2023-11-14
946684800
parse failed
true
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `time_program_compiles_and_runs` smoke test (Ok and Err parse paths)
- [x] `time_module_is_bundled` unit test
