### PR TITLE
feat(stdlib): std/net TCP listener and stream

### DIFF
--- a/docs/v2/specs/std-net.md
+++ b/docs/v2/specs/std-net.md
@@ -1,0 +1,109 @@
+# std/net Spec
+
+TCP networking: connecting a client stream, binding a listener and
+accepting connections, reading and writing bytes, DNS resolution, and a
+reachability probe. The primitives bind the raven-runtime C ABI; the
+wrappers add the Result/Error model and the handle types in pure Raven.
+
+## Import
+
+```raven
+import std/net { connect, listen, dns_lookup, reachable }
+```
+
+The methods on `TcpStream` and `TcpListener` come in with the types and need
+no separate selector.
+
+## Handle registry model
+
+A `TcpStream` or `TcpListener` cannot cross the FFI boundary, so the runtime
+keeps the real socket in a process-wide registry keyed by an incrementing
+`i64` id and hands Raven only that id. The Raven `TcpStream { id: Int }` and
+`TcpListener { id: Int }` structs wrap the id. Every operation looks the
+socket up by id, acts on it, and returns scalars or a String. Ids start at
+1; an id of 0 (or any non-positive value) is the failure sentinel paired
+with a set last-error. `close` removes the id from the registry, and
+dropping the socket closes it.
+
+## Error model
+
+Fallible operations return `Result<T, Error>`. The error is an std/error
+`Error` tagged with kind `"net"`, built directly as a struct literal (a
+bundled module cannot call another bundled module's free functions, but its
+types resolve). The message is a short context prefix (the operation name)
+joined to the runtime error text.
+
+There are no error structs across the FFI. The runtime keeps a thread-local
+last-error string that a fallible op clears on success and sets to the OS
+message on failure; `raven_net_last_error()` returns it, and the Raven
+wrapper turns a non-empty last error (or, for the id-returning ops, an id of
+0) into an `Err`.
+
+## Surface
+
+```raven
+struct TcpStream { id: Int }
+struct TcpListener { id: Int }
+
+fun connect(addr: String) -> Result<TcpStream, Error>
+fun listen(addr: String) -> Result<TcpListener, Error>
+
+impl TcpListener {
+    fun accept(self) -> Result<TcpStream, Error>
+}
+
+impl TcpStream {
+    fun read(self, max: Int) -> Result<String, Error>
+    fun write(self, data: String) -> Result<Int, Error>
+    fun set_read_timeout_ms(self, ms: Int)
+    fun close(self)
+}
+
+fun dns_lookup(host: String) -> Result<List<String>, Error>
+fun reachable(addr: String) -> Bool
+```
+
+`connect` opens a stream to `addr` in "host:port" form. `listen` binds a
+listener to `addr`. `accept` blocks until a connection arrives and returns
+the accepted stream (blocking accept is intentional).
+
+`read` reads up to `max` bytes and returns them as a `String`. The payload
+is treated as a byte buffer carried in a String (lossy UTF-8 at the FFI
+boundary), not as guaranteed text. A clean EOF returns `Ok("")`: the runtime
+clears the last error on a successful read of zero bytes so the caller can
+tell EOF from an error. `write` writes all bytes of `data` and returns the
+count written.
+
+`set_read_timeout_ms` sets the stream read timeout. A value of 0 means no
+timeout (blocking reads); a positive value makes a stalled read fail rather
+than hang. `close` releases the runtime-side socket.
+
+`dns_lookup` resolves `host` to its IP addresses. The runtime joins them
+with `\n` into one String and the wrapper splits that into a
+`List<String>`; an empty result is an empty list, not a one-element list of
+`""`.
+
+`reachable` is a non-failing boolean probe: it attempts a short
+connect_timeout to `addr` and returns whether it succeeded. It never sets an
+error and never returns a Result.
+
+## Client or server, not both
+
+Raven v2 has no concurrency, so a single Raven program cannot be both a
+server (blocking on `accept`) and a client at the same time. A program is
+one or the other. The end-to-end test reflects this: a loopback echo server
+runs on a background thread on the test side and the compiled Raven program
+is the client.
+
+## FFI path
+
+This module uses `extern "C"` blocks binding raven-runtime symbols
+directly, not compiler builtin intrinsics. A Raven `String` is a single GC
+pointer at the ABI, so it crosses the boundary unchanged in both
+directions; `Bool` maps to Rust `bool` and `Int` to `i64`. The runtime
+symbols (`raven_net_connect`, `raven_net_listen`, `raven_net_accept`,
+`raven_net_read`, `raven_net_write`, `raven_net_close`,
+`raven_net_set_read_timeout_ms`, `raven_dns_lookup`, `raven_net_reachable`,
+`raven_net_last_error`) live in `raven-runtime/src/lib.rs`. The socket
+registry there is an `OnceLock<Mutex<HashMap<i64, Socket>>>` with an
+`AtomicI64` issuing ids.

--- a/examples/v2/use_net.rv
+++ b/examples/v2/use_net.rv
@@ -1,0 +1,23 @@
+// golden:skip
+import std/net { connect }
+import std/env { get_env }
+import std/io { println }
+
+fun main() {
+    let addr = get_env("RAVEN_NET_ADDR")
+    match connect(addr) {
+        Ok(s) -> {
+            s.set_read_timeout_ms(2000)
+            match s.write("ping") {
+                Ok(n) -> {},
+                Err(e) -> println("write failed"),
+            }
+            match s.read(64) {
+                Ok(data) -> println(data),
+                Err(e) -> println("read failed"),
+            }
+            s.close()
+        },
+        Err(e) -> println("connect failed"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -37,9 +37,14 @@ pub use object::{
 
 use std::alloc::{self, Layout};
 use std::cell::RefCell;
-use std::io::{self, BufRead, Write};
+use std::collections::HashMap;
+use std::io::{self, BufRead, Read, Write};
+use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::process;
 use std::slice;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 thread_local! {
     // Message of the most recent fallible fs op: empty on success, the OS
@@ -84,6 +89,50 @@ fn time_set_error(msg: std::string::String) {
 
 fn time_clear_error() {
     TIME_LAST_ERROR.with(|e| e.borrow_mut().clear());
+}
+
+thread_local! {
+    // Message of the most recent fallible net op: empty on success, the OS
+    // error text on failure. The std/net wrapper reads it through
+    // `raven_net_last_error` to decide Ok vs Err.
+    static NET_LAST_ERROR: RefCell<std::string::String> = const { RefCell::new(std::string::String::new()) };
+}
+
+fn net_set_error(msg: std::string::String) {
+    NET_LAST_ERROR.with(|e| *e.borrow_mut() = msg);
+}
+
+fn net_clear_error() {
+    NET_LAST_ERROR.with(|e| e.borrow_mut().clear());
+}
+
+/// An entry in the socket registry. A listener or a stream is kept
+/// runtime-side so only an opaque integer id crosses the FFI.
+enum Socket {
+    Listener(TcpListener),
+    Stream(TcpStream),
+}
+
+/// The process-wide socket registry keyed by an incrementing id. Ids start
+/// at 1; 0 (or any non-positive value) is the failure sentinel that pairs
+/// with a set last-error.
+fn net_registry() -> &'static Mutex<HashMap<i64, Socket>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<i64, Socket>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Issue the next socket id.
+fn net_next_id() -> i64 {
+    static NEXT_ID: AtomicI64 = AtomicI64::new(1);
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Insert a socket and return its id, clearing the last error.
+fn net_insert(sock: Socket) -> i64 {
+    let id = net_next_id();
+    net_registry().lock().unwrap().insert(id, sock);
+    net_clear_error();
+    id
 }
 
 /// Allocate `size` bytes aligned to `align`.
@@ -690,6 +739,229 @@ pub extern "C" fn raven_time_parse(
 pub extern "C" fn raven_time_sleep_millis(ms: i64) {
     let ms = ms.max(0) as u64;
     std::thread::sleep(std::time::Duration::from_millis(ms));
+}
+
+/// The message of the most recent fallible net op, empty when it
+/// succeeded. The std/net wrapper reads this to build an `Err` only when it
+/// is non-empty.
+#[no_mangle]
+pub extern "C" fn raven_net_last_error() -> *mut object::String {
+    NET_LAST_ERROR.with(|e| {
+        let msg = e.borrow();
+        object::raven_string_from_bytes(msg.as_ptr(), msg.len())
+    })
+}
+
+/// Connect a TCP stream to `addr` ("host:port") and register it. Returns
+/// the stream id, or 0 on failure with the last-error slot set.
+///
+/// # Safety
+///
+/// `addr` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_net_connect(addr: *const object::String) -> i64 {
+    let result = env_name(addr)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "addr is not valid UTF-8"))
+        .and_then(TcpStream::connect);
+    match result {
+        Ok(stream) => net_insert(Socket::Stream(stream)),
+        Err(e) => {
+            net_set_error(e.to_string());
+            0
+        }
+    }
+}
+
+/// Bind a TCP listener to `addr` ("host:port") and register it. Returns the
+/// listener id, or 0 on failure with the last-error slot set.
+///
+/// # Safety
+///
+/// `addr` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_net_listen(addr: *const object::String) -> i64 {
+    let result = env_name(addr)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "addr is not valid UTF-8"))
+        .and_then(TcpListener::bind);
+    match result {
+        Ok(listener) => net_insert(Socket::Listener(listener)),
+        Err(e) => {
+            net_set_error(e.to_string());
+            0
+        }
+    }
+}
+
+/// Block until a connection arrives on the listener `listener_id`, register
+/// the accepted stream, and return its id. Returns 0 on failure (unknown
+/// id, the id is not a listener, or an accept error) with the last-error
+/// slot set.
+#[no_mangle]
+pub extern "C" fn raven_net_accept(listener_id: i64) -> i64 {
+    let accepted = {
+        let registry = net_registry().lock().unwrap();
+        match registry.get(&listener_id) {
+            Some(Socket::Listener(l)) => l.accept().map(|(stream, _)| stream),
+            Some(Socket::Stream(_)) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "id is not a listener",
+            )),
+            None => Err(io::Error::new(io::ErrorKind::NotFound, "unknown socket id")),
+        }
+    };
+    match accepted {
+        Ok(stream) => net_insert(Socket::Stream(stream)),
+        Err(e) => {
+            net_set_error(e.to_string());
+            0
+        }
+    }
+}
+
+/// Read up to `max` bytes from the stream `stream_id` and return them as a
+/// `String` (treated as a byte buffer). A clean EOF returns an empty
+/// `String` with the last error cleared, so the wrapper can return Ok("").
+/// On error sets the last error and returns an empty `String`.
+#[no_mangle]
+pub extern "C" fn raven_net_read(stream_id: i64, max: i64) -> *mut object::String {
+    let cap = max.max(0) as usize;
+    let result = {
+        let mut registry = net_registry().lock().unwrap();
+        match registry.get_mut(&stream_id) {
+            Some(Socket::Stream(s)) => {
+                let mut buf = vec![0u8; cap];
+                s.read(&mut buf).map(|n| {
+                    buf.truncate(n);
+                    buf
+                })
+            }
+            Some(Socket::Listener(_)) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "id is not a stream",
+            )),
+            None => Err(io::Error::new(io::ErrorKind::NotFound, "unknown socket id")),
+        }
+    };
+    match result {
+        Ok(bytes) => {
+            net_clear_error();
+            object::raven_string_from_bytes(bytes.as_ptr(), bytes.len())
+        }
+        Err(e) => {
+            net_set_error(e.to_string());
+            object::raven_string_from_bytes(std::ptr::null(), 0)
+        }
+    }
+}
+
+/// Write all bytes of `data` to the stream `stream_id`. Returns the number
+/// of bytes written, or -1 on failure with the last error set.
+///
+/// # Safety
+///
+/// `data` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_net_write(stream_id: i64, data: *const object::String) -> i64 {
+    let ptr = object::raven_string_bytes(data);
+    let len = object::raven_string_len(data) as usize;
+    let bytes: &[u8] = if ptr.is_null() || len == 0 {
+        &[]
+    } else {
+        // SAFETY: a Raven String holds `len` initialized bytes.
+        unsafe { slice::from_raw_parts(ptr, len) }
+    };
+    let result = {
+        let mut registry = net_registry().lock().unwrap();
+        match registry.get_mut(&stream_id) {
+            Some(Socket::Stream(s)) => s.write_all(bytes).map(|()| bytes.len() as i64),
+            Some(Socket::Listener(_)) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "id is not a stream",
+            )),
+            None => Err(io::Error::new(io::ErrorKind::NotFound, "unknown socket id")),
+        }
+    };
+    match result {
+        Ok(n) => {
+            net_clear_error();
+            n
+        }
+        Err(e) => {
+            net_set_error(e.to_string());
+            -1
+        }
+    }
+}
+
+/// Remove `stream_id` from the registry; dropping the socket closes it. An
+/// unknown id is a no-op.
+#[no_mangle]
+pub extern "C" fn raven_net_close(stream_id: i64) {
+    net_registry().lock().unwrap().remove(&stream_id);
+}
+
+/// Set the read timeout of the stream `stream_id` to `ms` milliseconds. A
+/// value of 0 clears the timeout (blocking reads). Errors are stored in the
+/// last-error slot.
+#[no_mangle]
+pub extern "C" fn raven_net_set_read_timeout_ms(stream_id: i64, ms: i64) {
+    let timeout = if ms <= 0 {
+        None
+    } else {
+        Some(Duration::from_millis(ms as u64))
+    };
+    let registry = net_registry().lock().unwrap();
+    match registry.get(&stream_id) {
+        Some(Socket::Stream(s)) => match s.set_read_timeout(timeout) {
+            Ok(()) => net_clear_error(),
+            Err(e) => net_set_error(e.to_string()),
+        },
+        _ => net_set_error("unknown socket id".to_string()),
+    }
+}
+
+/// Resolve `host` to its IP addresses, newline-joined. On failure stores
+/// the error and returns an empty `String`.
+///
+/// # Safety
+///
+/// `host` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_dns_lookup(host: *const object::String) -> *mut object::String {
+    let result = env_name(host)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "host is not valid UTF-8"))
+        .and_then(|h| {
+            let addrs = (h, 0u16).to_socket_addrs()?;
+            let ips: Vec<std::string::String> = addrs.map(|sa| sa.ip().to_string()).collect();
+            Ok(ips.join("\n"))
+        });
+    match result {
+        Ok(joined) => {
+            net_clear_error();
+            object::raven_string_from_bytes(joined.as_ptr(), joined.len())
+        }
+        Err(e) => {
+            net_set_error(e.to_string());
+            object::raven_string_from_bytes(std::ptr::null(), 0)
+        }
+    }
+}
+
+/// Probe whether `addr` ("host:port") accepts a TCP connection within a
+/// short timeout. A pure boolean probe: never sets the last error.
+///
+/// # Safety
+///
+/// `addr` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_net_reachable(addr: *const object::String) -> bool {
+    let Some(text) = env_name(addr) else {
+        return false;
+    };
+    let Ok(mut targets) = text.to_socket_addrs() else {
+        return false;
+    };
+    targets.any(|sa| TcpStream::connect_timeout(&sa, Duration::from_millis(500)).is_ok())
 }
 
 /// A stack buffer large enough for any base-ten `i64` plus a sign.

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -52,6 +52,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("env", include_str!("../../stdlib/std/env.rv")),
     ("fs", include_str!("../../stdlib/std/fs.rv")),
     ("time", include_str!("../../stdlib/std/time.rv")),
+    ("net", include_str!("../../stdlib/std/net.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -464,6 +465,11 @@ mod tests {
     #[test]
     fn time_module_is_bundled() {
         assert!(bundled_source("time").is_some());
+    }
+
+    #[test]
+    fn net_module_is_bundled() {
+        assert!(bundled_source("net").is_some());
     }
 
     #[test]

--- a/stdlib/std/net.rv
+++ b/stdlib/std/net.rv
@@ -1,0 +1,145 @@
+// std/net: TCP client and server over the raven-runtime C ABI. Sockets
+// cannot cross the FFI, so the runtime keeps them in a registry keyed by an
+// opaque integer id and hands Raven that id; TcpStream and TcpListener wrap
+// the id. Fallible ops return Result<T, Error> tagged with kind "net" via
+// the runtime's thread-local last-error slot. A program is a client or a
+// server, not both at once, because Raven v2 has no threads. See
+// docs/v2/specs/std-net.md.
+
+import std/error
+import std/string
+
+struct TcpStream {
+    id: Int,
+}
+
+struct TcpListener {
+    id: Int,
+}
+
+extern "C" {
+    fun raven_net_last_error() -> String
+    fun raven_net_connect(addr: String) -> Int
+    fun raven_net_listen(addr: String) -> Int
+    fun raven_net_accept(listener_id: Int) -> Int
+    fun raven_net_read(stream_id: Int, max: Int) -> String
+    fun raven_net_write(stream_id: Int, data: String) -> Int
+    fun raven_net_close(stream_id: Int)
+    fun raven_net_set_read_timeout_ms(stream_id: Int, ms: Int)
+    fun raven_dns_lookup(host: String) -> String
+    fun raven_net_reachable(addr: String) -> Bool
+}
+
+// An Error tagged with kind "net", its message a context prefix joined to
+// the runtime's last-error text.
+fun net_error(ctx: String) -> Error {
+    return Error { kind: "net", message: ctx.concat(": ").concat(raven_net_last_error()) }
+}
+
+// Connect a TCP stream to `addr` ("host:port").
+fun connect(addr: String) -> Result<TcpStream, Error> {
+    let id = raven_net_connect(addr)
+    if id == 0 {
+        return Err(net_error("connect"))
+    }
+    if raven_net_last_error().length() > 0 {
+        return Err(net_error("connect"))
+    }
+    return Ok(TcpStream { id: id })
+}
+
+// Bind a TCP listener to `addr` ("host:port").
+fun listen(addr: String) -> Result<TcpListener, Error> {
+    let id = raven_net_listen(addr)
+    if id == 0 {
+        return Err(net_error("listen"))
+    }
+    if raven_net_last_error().length() > 0 {
+        return Err(net_error("listen"))
+    }
+    return Ok(TcpListener { id: id })
+}
+
+impl TcpListener {
+    // Block until a connection arrives and return the accepted stream.
+    fun accept(self) -> Result<TcpStream, Error> {
+        let id = raven_net_accept(self.id)
+        if id == 0 {
+            return Err(net_error("accept"))
+        }
+        if raven_net_last_error().length() > 0 {
+            return Err(net_error("accept"))
+        }
+        return Ok(TcpStream { id: id })
+    }
+}
+
+impl TcpStream {
+    // Read up to `max` bytes, returning them as a String byte buffer. A
+    // clean EOF yields Ok("").
+    fun read(self, max: Int) -> Result<String, Error> {
+        let data = raven_net_read(self.id, max)
+        if raven_net_last_error().length() > 0 {
+            return Err(net_error("read"))
+        }
+        return Ok(data)
+    }
+
+    // Write all bytes of `data`, returning the count written.
+    fun write(self, data: String) -> Result<Int, Error> {
+        let n = raven_net_write(self.id, data)
+        if n < 0 {
+            return Err(net_error("write"))
+        }
+        if raven_net_last_error().length() > 0 {
+            return Err(net_error("write"))
+        }
+        return Ok(n)
+    }
+
+    // Set the read timeout in milliseconds. A value of 0 means no timeout.
+    fun set_read_timeout_ms(self, ms: Int) {
+        raven_net_set_read_timeout_ms(self.id, ms)
+    }
+
+    // Close the stream, releasing the runtime-side socket.
+    fun close(self) {
+        raven_net_close(self.id)
+    }
+}
+
+// Resolve `host` to its IP addresses. An empty result yields an empty list.
+fun dns_lookup(host: String) -> Result<List<String>, Error> {
+    let joined = raven_dns_lookup(host)
+    if raven_net_last_error().length() > 0 {
+        return Err(net_error("dns_lookup"))
+    }
+    return Ok(split_lines(joined))
+}
+
+// Whether `addr` ("host:port") accepts a TCP connection within a short
+// timeout. A non-failing probe: never returns an error.
+fun reachable(addr: String) -> Bool {
+    return raven_net_reachable(addr)
+}
+
+// Split `s` on `\n` into a list. An empty string yields an empty list (not
+// a one-element list of ""), so an empty lookup maps to an empty list.
+fun split_lines(s: String) -> List<String> {
+    let out: List<String> = []
+    if s.length() == 0 {
+        return out
+    }
+    let n = s.length()
+    let start = 0
+    let i = 0
+    while i < n {
+        if s.char_at(i).starts_with("\n") {
+            out.push(s.substring(start, i))
+            start = i + 1
+        }
+        i = i + 1
+    }
+    out.push(s.substring(start, n))
+    return out
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -706,6 +706,86 @@ fn fs_program_compiles_and_runs() {
 }
 
 #[test]
+fn net_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/net TCP client end to end against a loopback echo server. Raven
+    // v2 has no threads, so a single program cannot be both server and
+    // client: the test side runs the server on a std::thread and the
+    // compiled Raven program is the client. The server binds an ephemeral
+    // loopback port, the test passes its address to the client through
+    // RAVEN_NET_ADDR, the client connects, writes "ping", reads the echo,
+    // and prints it. A read timeout on both ends keeps a failure from
+    // hanging CI.
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let addr = listener
+        .local_addr()
+        .expect("listener local addr")
+        .to_string();
+
+    let server = std::thread::spawn(move || {
+        // Accept one connection, echo back exactly what is read once, then
+        // drop. A read timeout means a misbehaving client cannot wedge the
+        // thread.
+        if let Ok((mut stream, _)) = listener.accept() {
+            let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+            let mut buf = [0u8; 256];
+            if let Ok(n) = stream.read(&mut buf) {
+                let _ = stream.write_all(&buf[..n]);
+                let _ = stream.flush();
+            }
+        }
+    });
+
+    let name = "use_net.rv";
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("v2")
+        .join(name);
+    let source =
+        std::fs::read_to_string(&source_path).unwrap_or_else(|e| panic!("read {}: {}", name, e));
+    let object_bytes = match build_object(&source, &source_path) {
+        Ok(b) => b,
+        Err(e) => panic!("frontend or codegen failed for {}: {}", name, e),
+    };
+    let tmp = workdir();
+    let object_path = tmp.join("use_net.o");
+    std::fs::write(&object_path, &object_bytes).expect("write object");
+    let binary = tmp.join(if cfg!(windows) {
+        "use_net.exe"
+    } else {
+        "use_net"
+    });
+    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+        cleanup(&tmp);
+        panic!("linker failed to produce an executable for {}: {}", name, e);
+    }
+    let output = Command::new(&binary)
+        .env("RAVEN_NET_ADDR", &addr)
+        .output()
+        .unwrap_or_else(|e| panic!("run {} binary: {}", name, e));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = server.join();
+    cleanup(&tmp);
+    assert!(
+        output.status.success(),
+        "use_net binary exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "ping\n",
+        "unexpected stdout for use_net: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn time_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Adds the runtime-backed `std/net` standard-library module for TCP client and server networking.

Closes #76

## Surface

```raven
struct TcpStream { id: Int }
struct TcpListener { id: Int }

fun connect(addr: String) -> Result<TcpStream, Error>
fun listen(addr: String) -> Result<TcpListener, Error>

impl TcpListener { fun accept(self) -> Result<TcpStream, Error> }

impl TcpStream {
    fun read(self, max: Int) -> Result<String, Error>
    fun write(self, data: String) -> Result<Int, Error>
    fun set_read_timeout_ms(self, ms: Int)
    fun close(self)
}

fun dns_lookup(host: String) -> Result<List<String>, Error>
fun reachable(addr: String) -> Bool
```

## Handle registry and error model

Sockets cannot cross the C ABI, so the runtime keeps each `TcpStream` or `TcpListener` in a process-wide registry (`OnceLock<Mutex<HashMap<i64, Socket>>>` with an `AtomicI64` issuing ids starting at 1) and hands Raven only the opaque id. The Raven structs wrap that id; an id of 0 is the failure sentinel. Fallible ops use the thread-local net last-error pattern: the wrapper runs the op, reads `raven_net_last_error()`, and returns `Err(Error { kind: "net", message: ... })` when it is non-empty (or when an id-returning op yields 0), else `Ok`. A clean EOF on `read` clears the last error and returns `Ok("")` so callers can tell EOF from an error. `read` payloads are a byte buffer carried in a String. `reachable` is a non-failing boolean probe. Blocking `accept` is intentional.

## Test design

Raven v2 has no concurrency, so a single program cannot be both server and client. The end-to-end smoke test `net_program_compiles_and_runs` binds a `std::net::TcpListener` on an ephemeral loopback port, spawns a background thread that accepts one connection and echoes back what it reads (with a read timeout so a client failure cannot hang CI), then builds and runs the compiled Raven client (`examples/v2/use_net.rv`) with the server address passed through `RAVEN_NET_ADDR`. The client connects, writes `ping`, reads the echo, and prints it. A read timeout is set on both ends.

Smoke-test stdout:

```
ping
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (codegen_smoke 43 passing, incl. `net_program_compiles_and_runs`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `net_module_is_bundled` unit test
- [x] Manual loopback sanity: `dns_lookup("localhost")` non-empty, `reachable("127.0.0.1:1")` false, `listen("127.0.0.1:0")` ok

Note: "Closes #76" will not auto-close on merge because the base is `v2.x`, not the default branch; expected.
