### PR TITLE
feat(stdlib): std/http HTTP 1.1 client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +46,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bumpalo"
@@ -224,6 +236,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +276,17 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -307,6 +349,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279259b0ac81c89d11c290495fdcfa96ea3643b7df311c138b6fe8ca5237f0f8"
+dependencies = [
+ "idna_mapping",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna_mapping"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c13906586a4b339310541a274dd927aff6fcbb5b8e3af90634c4b31681c792"
+dependencies = [
+ "unicode-joining-type",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +420,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +455,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -415,6 +504,7 @@ name = "raven-runtime"
 version = "2.0.0-dev"
 dependencies = [
  "chrono",
+ "ureq",
 ]
 
 [[package]]
@@ -431,10 +521,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -443,10 +582,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -473,6 +647,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,16 +670,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-joining-type"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d00a78170970967fdb83f9d49b92f959ab2bb829186b113e4f4604ad98e180"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -544,6 +806,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -606,6 +886,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,3 +977,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/docs/v2/specs/std-http.md
+++ b/docs/v2/specs/std-http.md
@@ -1,0 +1,122 @@
+# std/http Spec
+
+An HTTP/1.1 client: GET, POST, PUT, and DELETE returning a captured
+response. The primitives bind the raven-runtime C ABI (backed by ureq);
+the wrappers add the Result/Error model and the `HttpResponse` type in
+pure Raven.
+
+## Import
+
+```raven
+import std/http { get, post, put, delete, request }
+```
+
+The `HttpResponse` type comes in with the module and needs no separate
+selector.
+
+## Surface
+
+```raven
+struct HttpResponse {
+    status_code: Int,
+    status_text: String,
+    headers: String,
+    body: String,
+}
+
+fun get(url: String) -> Result<HttpResponse, Error>
+fun post(url: String, body: String) -> Result<HttpResponse, Error>
+fun put(url: String, body: String) -> Result<HttpResponse, Error>
+fun delete(url: String) -> Result<HttpResponse, Error>
+fun request(method: String, url: String, body: String, headers: String) -> Result<HttpResponse, Error>
+```
+
+`get` and `delete` send no request body. `post` and `put` send their
+`body` argument. `request` is the general form the others delegate to: its
+`headers` argument is a String of `Key: Value` lines separated by `\n`
+(empty for none), and `get`/`post`/`put`/`delete` pass `""` for it. The
+response `headers` field is likewise the response headers as `Key: Value`
+lines joined by `\n`.
+
+## Response handle registry model
+
+A `ureq::Response` is consumed when its body is read, so it cannot be
+handed back across calls. The whole request runs in one runtime call
+(`raven_http_request`) that eagerly reads the status code, reason phrase,
+all response headers, and the body into an owned struct, stores that in a
+process-wide registry keyed by an incrementing `i64` id, and returns the
+id. The extractors (`raven_http_status`, `raven_http_status_text`,
+`raven_http_body`, `raven_http_header`, `raven_http_headers`) read the
+stored struct by id, and `raven_http_free` drops the entry. The Raven
+`request` wrapper pulls the four fields, frees the id, and returns
+`Ok(HttpResponse { ... })`. Ids start at 1; an id of 0 is the failure
+sentinel paired with a set last-error. The registry is an
+`OnceLock<Mutex<HashMap<i64, HttpResp>>>` with an `AtomicI64` issuing ids.
+
+## Non-2xx is a successful response, not an Err
+
+A non-2xx HTTP status (for example 404 or 500) is a successful request
+that yielded a response, not a transport failure. ureq surfaces a 4xx/5xx
+as `Err(ureq::Error::Status(code, resp))`; the runtime treats that as a
+normal response, captures its status and body, and stores a normal
+registry entry. The Raven caller therefore gets `Ok(HttpResponse)` with
+`status_code` set to 404 (or whatever the server returned) and inspects
+the code itself. Only transport errors (DNS, connect, timeout, malformed
+response) become id 0 plus a last-error, and only those take the `Err`
+path.
+
+## Error model
+
+Fallible requests return `Result<HttpResponse, Error>`. On a transport
+failure the error is an std/error `Error` tagged with kind `"http"`, built
+directly as a struct literal (a bundled module cannot call another bundled
+module's free functions, but its types resolve). The message is a short
+context prefix (the HTTP method) joined to the runtime error text.
+
+There are no error structs across the FFI. The runtime keeps a
+thread-local last-error string that `raven_http_request` clears on success
+and sets to the transport error text on failure; `raven_http_last_error()`
+returns it, and the Raven wrapper turns a non-empty last error (or an id of
+0) into an `Err`. A non-2xx status never sets this slot.
+
+## TLS backend
+
+TLS is provided by ureq's default `tls` feature: rustls with the
+`webpki-roots` bundled Mozilla root certificate set. This needs no OpenSSL
+or system-TLS `-sys` package, so the build is portable across the Linux CI
+host and Windows without extra system libraries. The v1 carryover note
+about "TLS via system roots" is intentionally not followed here: build
+portability across CI takes precedence, so the roots are bundled rather
+than read from the OS trust store. On windows-msvc, rustls pulls in
+`bcrypt.lib` (BCryptGenRandom), which the linker adds to the native system
+library list.
+
+## Timeouts
+
+The runtime builds the ureq agent with fixed timeouts so a hung server
+cannot wedge a program or a test: 5 seconds to connect, 10 seconds to read,
+and 10 seconds to write.
+
+## FFI path
+
+This module uses `extern "C"` blocks binding raven-runtime symbols
+directly, not compiler builtin intrinsics. A Raven `String` is a single GC
+pointer at the ABI, so it crosses the boundary unchanged in both
+directions, and `Int` maps to `i64`. The runtime symbols
+(`raven_http_request`, `raven_http_status`, `raven_http_status_text`,
+`raven_http_body`, `raven_http_header`, `raven_http_headers`,
+`raven_http_free`, `raven_http_last_error`) live in
+`raven-runtime/src/lib.rs`.
+
+## Testing without external network
+
+CI has no external network and Raven v2 has no threads, so a single program
+cannot be both server and client. The end-to-end smoke test binds a
+`std::net::TcpListener` on `127.0.0.1:0`, spawns a background thread that
+accepts one connection, reads the request headers, and writes a fixed
+minimal HTTP/1.1 response (`HTTP/1.1 200 OK` with `Content-Length` and
+`Connection: close`). The compiled Raven program is the client: it GETs the
+loopback URL (passed through the `RAVEN_HTTP_URL` env var) and prints the
+status code then the body, asserted to be exactly `200` then `hello`. Read
+timeouts on both ends keep a failure from hanging CI. No test hits a real
+external URL.

--- a/examples/v2/use_http.rv
+++ b/examples/v2/use_http.rv
@@ -1,0 +1,15 @@
+// golden:skip
+import std/http { get }
+import std/env { get_env }
+import std/io { println }
+
+fun main() {
+    let url = get_env("RAVEN_HTTP_URL")
+    match get(url) {
+        Ok(resp) -> {
+            println("${resp.status_code}")
+            println(resp.body)
+        },
+        Err(e) -> println("request failed"),
+    }
+}

--- a/raven-runtime/Cargo.toml
+++ b/raven-runtime/Cargo.toml
@@ -13,3 +13,4 @@ name = "raven_runtime"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+ureq = "2.12"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -106,6 +106,48 @@ fn net_clear_error() {
     NET_LAST_ERROR.with(|e| e.borrow_mut().clear());
 }
 
+thread_local! {
+    // Message of the most recent fallible http op: empty on success, the
+    // transport error text on failure. The std/http wrapper reads it
+    // through `raven_http_last_error` to decide Ok vs Err. A non-2xx HTTP
+    // status is NOT a failure here; only transport, DNS, connect, or
+    // timeout errors set this slot.
+    static HTTP_LAST_ERROR: RefCell<std::string::String> = const { RefCell::new(std::string::String::new()) };
+}
+
+fn http_set_error(msg: std::string::String) {
+    HTTP_LAST_ERROR.with(|e| *e.borrow_mut() = msg);
+}
+
+fn http_clear_error() {
+    HTTP_LAST_ERROR.with(|e| e.borrow_mut().clear());
+}
+
+/// A response captured eagerly into owned data. ureq consumes the
+/// response when its body is read, so the whole request runs in one call
+/// and the status, headers, and body are stored here keyed by an id.
+struct HttpResp {
+    status: i64,
+    status_text: std::string::String,
+    // Response headers as `Key: Value` lines joined by `\n`.
+    headers: std::string::String,
+    body: std::string::String,
+}
+
+/// The process-wide HTTP response registry keyed by an incrementing id.
+/// Ids start at 1; 0 is the failure sentinel that pairs with a set
+/// last-error.
+fn http_registry() -> &'static Mutex<HashMap<i64, HttpResp>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<i64, HttpResp>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Issue the next HTTP response id.
+fn http_next_id() -> i64 {
+    static NEXT_ID: AtomicI64 = AtomicI64::new(1);
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
 /// An entry in the socket registry. A listener or a stream is kept
 /// runtime-side so only an opaque integer id crosses the FFI.
 enum Socket {
@@ -962,6 +1004,227 @@ pub extern "C" fn raven_net_reachable(addr: *const object::String) -> bool {
         return false;
     };
     targets.any(|sa| TcpStream::connect_timeout(&sa, Duration::from_millis(500)).is_ok())
+}
+
+/// The message of the most recent fallible http op, empty when it
+/// succeeded. The std/http wrapper reads this to build an `Err` only when
+/// it is non-empty. A non-2xx HTTP status never sets it.
+#[no_mangle]
+pub extern "C" fn raven_http_last_error() -> *mut object::String {
+    HTTP_LAST_ERROR.with(|e| {
+        let msg = e.borrow();
+        object::raven_string_from_bytes(msg.as_ptr(), msg.len())
+    })
+}
+
+/// The standard reason phrase for an HTTP status code, for callers when
+/// the server omits one.
+fn http_reason(code: u16) -> &'static str {
+    match code {
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        204 => "No Content",
+        301 => "Moved Permanently",
+        302 => "Found",
+        304 => "Not Modified",
+        307 => "Temporary Redirect",
+        308 => "Permanent Redirect",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        408 => "Request Timeout",
+        409 => "Conflict",
+        410 => "Gone",
+        422 => "Unprocessable Entity",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        _ => "",
+    }
+}
+
+/// Capture a ureq response into an owned `HttpResp`, reading the status,
+/// reason, headers, and body eagerly (reading the body consumes the
+/// response).
+fn http_capture(resp: ureq::Response) -> HttpResp {
+    let status = resp.status();
+    let reason = resp.status_text();
+    let status_text = if reason.is_empty() {
+        http_reason(status).to_string()
+    } else {
+        reason.to_string()
+    };
+    let mut header_lines: Vec<std::string::String> = Vec::new();
+    for name in resp.headers_names() {
+        if let Some(value) = resp.header(&name) {
+            header_lines.push(format!("{name}: {value}"));
+        }
+    }
+    let headers = header_lines.join("\n");
+    let body = resp.into_string().unwrap_or_default();
+    HttpResp {
+        status: status as i64,
+        status_text,
+        headers,
+        body,
+    }
+}
+
+/// Store a captured response and return its id, clearing the last error.
+fn http_store(resp: HttpResp) -> i64 {
+    let id = http_next_id();
+    http_registry().lock().unwrap().insert(id, resp);
+    http_clear_error();
+    id
+}
+
+/// Perform an HTTP/1.1 request and store the response.
+///
+/// `method` is "GET"/"POST"/"PUT"/"DELETE", `url` the target, `body` the
+/// request body (empty for GET/DELETE), and `headers` a String of
+/// `Key: Value` lines separated by `\n` (empty for none). Returns a
+/// response id, or 0 on a transport failure (DNS, connect, timeout) with
+/// the last-error slot set.
+///
+/// A non-2xx HTTP status (for example 404 or 500) is a SUCCESSFUL request
+/// that yielded a response: ureq surfaces it as `Error::Status`, and this
+/// stores a normal response entry from it. Only `Error::Transport`
+/// becomes id 0 plus a last-error.
+///
+/// # Safety
+///
+/// `method`, `url`, `body`, and `headers` must be valid
+/// `raven_string_from_bytes`-built `String`s.
+#[no_mangle]
+pub extern "C" fn raven_http_request(
+    method: *const object::String,
+    url: *const object::String,
+    body: *const object::String,
+    headers: *const object::String,
+) -> i64 {
+    let (Some(method), Some(url), Some(body), Some(headers)) = (
+        env_name(method),
+        env_name(url),
+        env_name(body),
+        env_name(headers),
+    ) else {
+        http_set_error("method, url, body, or headers is not valid UTF-8".to_string());
+        return 0;
+    };
+
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(5))
+        .timeout_read(Duration::from_secs(10))
+        .timeout_write(Duration::from_secs(10))
+        .build();
+
+    let mut req = agent.request(method, url);
+    for line in headers.split('\n') {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            req = req.set(name.trim(), value.trim());
+        }
+    }
+
+    // GET and DELETE send no body; POST and PUT send `body`.
+    let result = if body.is_empty() {
+        req.call()
+    } else {
+        req.send_string(body)
+    };
+
+    match result {
+        Ok(resp) => http_store(http_capture(resp)),
+        // A non-2xx status is a response, not a transport failure.
+        Err(ureq::Error::Status(_, resp)) => http_store(http_capture(resp)),
+        Err(ureq::Error::Transport(t)) => {
+            http_set_error(t.to_string());
+            0
+        }
+    }
+}
+
+/// Status code of the stored response `id`, for example 200 or 404. An
+/// unknown id yields 0.
+#[no_mangle]
+pub extern "C" fn raven_http_status(id: i64) -> i64 {
+    http_registry()
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|r| r.status)
+        .unwrap_or(0)
+}
+
+/// Reason phrase of the stored response `id`, for example "OK". An
+/// unknown id yields an empty `String`.
+#[no_mangle]
+pub extern "C" fn raven_http_status_text(id: i64) -> *mut object::String {
+    let registry = http_registry().lock().unwrap();
+    let text = registry
+        .get(&id)
+        .map(|r| r.status_text.as_str())
+        .unwrap_or("");
+    object::raven_string_from_bytes(text.as_ptr(), text.len())
+}
+
+/// Body of the stored response `id`. An unknown id yields an empty
+/// `String`.
+#[no_mangle]
+pub extern "C" fn raven_http_body(id: i64) -> *mut object::String {
+    let registry = http_registry().lock().unwrap();
+    let body = registry.get(&id).map(|r| r.body.as_str()).unwrap_or("");
+    object::raven_string_from_bytes(body.as_ptr(), body.len())
+}
+
+/// A single response header value of `id` by `name` (case-insensitive),
+/// or an empty `String` when absent or the id is unknown.
+///
+/// # Safety
+///
+/// `name` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_http_header(id: i64, name: *const object::String) -> *mut object::String {
+    let wanted = env_name(name).unwrap_or("");
+    let registry = http_registry().lock().unwrap();
+    let value = registry
+        .get(&id)
+        .and_then(|r| {
+            r.headers.lines().find_map(|line| {
+                let (k, v) = line.split_once(':')?;
+                if k.trim().eq_ignore_ascii_case(wanted) {
+                    Some(v.trim().to_string())
+                } else {
+                    None
+                }
+            })
+        })
+        .unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// All response headers of `id` as `Key: Value` lines joined by `\n`. An
+/// unknown id yields an empty `String`.
+#[no_mangle]
+pub extern "C" fn raven_http_headers(id: i64) -> *mut object::String {
+    let registry = http_registry().lock().unwrap();
+    let headers = registry.get(&id).map(|r| r.headers.as_str()).unwrap_or("");
+    object::raven_string_from_bytes(headers.as_ptr(), headers.len())
+}
+
+/// Drop the stored response `id`, releasing its captured data. An unknown
+/// id is a no-op.
+#[no_mangle]
+pub extern "C" fn raven_http_free(id: i64) {
+    http_registry().lock().unwrap().remove(&id);
 }
 
 /// A stack buffer large enough for any base-ten `i64` plus a sign.

--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -36,6 +36,7 @@ use super::CodegenError;
 /// if the runtime crate gains native dependencies. The trailing
 /// `/defaultlib:msvcrt` selects the C runtime and is passed verbatim.
 const MSVC_NATIVE_STATIC_LIBS: &[&str] = &[
+    "bcrypt.lib",
     "kernel32.lib",
     "advapi32.lib",
     "ntdll.lib",

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -53,6 +53,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("fs", include_str!("../../stdlib/std/fs.rv")),
     ("time", include_str!("../../stdlib/std/time.rv")),
     ("net", include_str!("../../stdlib/std/net.rv")),
+    ("http", include_str!("../../stdlib/std/http.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -470,6 +471,11 @@ mod tests {
     #[test]
     fn net_module_is_bundled() {
         assert!(bundled_source("net").is_some());
+    }
+
+    #[test]
+    fn http_module_is_bundled() {
+        assert!(bundled_source("http").is_some());
     }
 
     #[test]

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -1,0 +1,78 @@
+// std/http: an HTTP/1.1 client over the raven-runtime C ABI, backed by
+// ureq. A ureq Response is consumed when its body is read, so the whole
+// request runs in one runtime call that eagerly captures the status,
+// reason, headers, and body into a registry entry keyed by an opaque
+// integer id; the extractors then read that entry by id. A non-2xx HTTP
+// status (404, 500) is a successful request that yielded a response, not
+// a transport error: only DNS, connect, and timeout failures take the Err
+// path through the runtime's thread-local last-error slot, tagged with
+// kind "http". See docs/v2/specs/std-http.md.
+
+import std/error
+
+struct HttpResponse {
+    status_code: Int,
+    status_text: String,
+    // Response headers as `Key: Value` lines joined by `\n`.
+    headers: String,
+    body: String,
+}
+
+extern "C" {
+    fun raven_http_last_error() -> String
+    fun raven_http_request(method: String, url: String, body: String, headers: String) -> Int
+    fun raven_http_status(id: Int) -> Int
+    fun raven_http_status_text(id: Int) -> String
+    fun raven_http_body(id: Int) -> String
+    fun raven_http_header(id: Int, name: String) -> String
+    fun raven_http_headers(id: Int) -> String
+    fun raven_http_free(id: Int)
+}
+
+// An Error tagged with kind "http", its message a context prefix joined to
+// the runtime's last-error text.
+fun http_error(ctx: String) -> Error {
+    return Error { kind: "http", message: ctx.concat(": ").concat(raven_http_last_error()) }
+}
+
+// Run a request and assemble an HttpResponse, or an Err on transport
+// failure. The headers argument is `Key: Value` lines joined by `\n`, or
+// "" for none. A non-2xx HTTP status is still Ok: the runtime reports it
+// as a normal response.
+fun request(method: String, url: String, body: String, headers: String) -> Result<HttpResponse, Error> {
+    let id = raven_http_request(method, url, body, headers)
+    if id == 0 {
+        return Err(http_error(method))
+    }
+    if raven_http_last_error().length() > 0 {
+        return Err(http_error(method))
+    }
+    let resp = HttpResponse {
+        status_code: raven_http_status(id),
+        status_text: raven_http_status_text(id),
+        headers: raven_http_headers(id),
+        body: raven_http_body(id),
+    }
+    raven_http_free(id)
+    return Ok(resp)
+}
+
+// GET `url`.
+fun get(url: String) -> Result<HttpResponse, Error> {
+    return request("GET", url, "", "")
+}
+
+// POST `body` to `url`.
+fun post(url: String, body: String) -> Result<HttpResponse, Error> {
+    return request("POST", url, body, "")
+}
+
+// PUT `body` to `url`.
+fun put(url: String, body: String) -> Result<HttpResponse, Error> {
+    return request("PUT", url, body, "")
+}
+
+// DELETE `url`.
+fun delete(url: String) -> Result<HttpResponse, Error> {
+    return request("DELETE", url, "", "")
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -786,6 +786,96 @@ fn net_program_compiles_and_runs() {
 }
 
 #[test]
+fn http_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/http client end to end against a loopback mock server. CI has no
+    // external network and Raven v2 has no threads, so the test runs a tiny
+    // HTTP/1.1 server on a std::thread that accepts one connection, reads the
+    // request headers, and writes a fixed 200 response. The compiled Raven
+    // program GETs that URL (passed through RAVEN_HTTP_URL) and prints the
+    // status code then the body. Read timeouts on both ends keep a failure
+    // from hanging CI.
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let addr = listener
+        .local_addr()
+        .expect("listener local addr")
+        .to_string();
+    let url = format!("http://{addr}/");
+
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+            // Read until the end of the request headers; the GET has no body.
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 256];
+            loop {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        buf.extend_from_slice(&chunk[..n]);
+                        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            let resp = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello";
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    let name = "use_http.rv";
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("v2")
+        .join(name);
+    let source =
+        std::fs::read_to_string(&source_path).unwrap_or_else(|e| panic!("read {}: {}", name, e));
+    let object_bytes = match build_object(&source, &source_path) {
+        Ok(b) => b,
+        Err(e) => panic!("frontend or codegen failed for {}: {}", name, e),
+    };
+    let tmp = workdir();
+    let object_path = tmp.join("use_http.o");
+    std::fs::write(&object_path, &object_bytes).expect("write object");
+    let binary = tmp.join(if cfg!(windows) {
+        "use_http.exe"
+    } else {
+        "use_http"
+    });
+    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+        cleanup(&tmp);
+        panic!("linker failed to produce an executable for {}: {}", name, e);
+    }
+    let output = Command::new(&binary)
+        .env("RAVEN_HTTP_URL", &url)
+        .output()
+        .unwrap_or_else(|e| panic!("run {} binary: {}", name, e));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = server.join();
+    cleanup(&tmp);
+    assert!(
+        output.status.success(),
+        "use_http binary exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "200\nhello\n",
+        "unexpected stdout for use_http: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn time_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Add a `std/http` standard-library module: an HTTP/1.1 client backed by ureq that performs requests and returns a captured response.

Closes #77

## Surface

```raven
import std/http { get, post, put, delete, request }

struct HttpResponse { status_code: Int, status_text: String, headers: String, body: String }

fun get(url: String) -> Result<HttpResponse, Error>
fun post(url: String, body: String) -> Result<HttpResponse, Error>
fun put(url: String, body: String) -> Result<HttpResponse, Error>
fun delete(url: String) -> Result<HttpResponse, Error>
fun request(method: String, url: String, body: String, headers: String) -> Result<HttpResponse, Error>
```

`request` is the general form the others delegate to; `headers` is `Key: Value` lines joined by `\n`, and the response `headers` field uses the same representation. `get`/`post`/`put`/`delete` pass empty headers.

## Response handle registry and the non-2xx rule

A `ureq::Response` is consumed when its body is read, so the whole request runs in one runtime call (`raven_http_request`) that eagerly captures status, reason, headers, and body into an owned struct, stores it in a process-wide registry (`OnceLock<Mutex<HashMap<i64, HttpResp>>>` with an `AtomicI64`), and returns the id. The extractors read the entry by id and `raven_http_free` drops it.

A non-2xx HTTP status (404, 500) is a successful request that yielded a response, not an `Err`: ureq reports a 4xx/5xx as `Error::Status(code, resp)`, and the runtime stores a normal response from it. Only transport failures (DNS, connect, timeout) become id 0 plus a last-error and take the `Err` path, with the error tagged kind `"http"` via the thread-local last-error slot.

## TLS backend

ureq is added to `raven-runtime` with its default `tls` feature: rustls with the bundled `webpki-roots` Mozilla root set. This needs no OpenSSL or system-TLS `-sys` package, so the build is portable across the Linux CI host and Windows. On windows-msvc, rustls pulls in `bcrypt.lib` (BCryptGenRandom), now added to the linker native system library list. A default timeout (5s connect, 10s read, 10s write) keeps a hung server from wedging a program.

## Mock-server test design

CI has no external network and Raven v2 has no threads, so the smoke test binds a `std::net::TcpListener` on `127.0.0.1:0`, spawns a background thread that accepts one connection, reads the request headers, and writes a fixed minimal HTTP/1.1 response (`HTTP/1.1 200 OK` with `Content-Length` and `Connection: close`). The compiled Raven program is the client: it GETs the loopback URL (passed via `RAVEN_HTTP_URL`) and prints the status code then the body. Read timeouts on both ends prevent a hang. No test hits a real external URL.

Smoke-test stdout:

```
200
hello
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (302 lib tests, 44 smoke tests)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo test --test codegen_smoke http_program_compiles_and_runs` passes (real loopback HTTP round trip, prints 200 then hello)
- [x] `http_module_is_bundled` unit test
