### PR TITLE
feat(tycheck): construct enum variants with EnumName.Variant

### DIFF
--- a/docs/v2/specs/hir.md
+++ b/docs/v2/specs/hir.md
@@ -179,6 +179,28 @@ iterable never produces a `RangeNew`: the for-loop lowering reads the
 range endpoints straight off the AST and emits the counter loop above,
 so `RangeNew` carries no iteration responsibility.
 
+### Enum variant construction
+
+A user enum variant is built in expression position with a qualified
+name:
+
+```
+EnumName.Variant          unit variant
+EnumName.Variant(args)    payload variant
+```
+
+Both forms lower to `EnumCreate { variant, args }`, where `variant` is
+the variant's index in declaration order (the same index patterns and
+codegen use) and the node's `ty` is the enum type with its concrete type
+arguments. The built-in `Some`, `Ok`, `Err`, and `None` keep their own
+constructor nodes (`SomeCtor`, `OkCtor`, `ErrCtor`, `NoneCtor`), which
+MIR lowers to the same `EnumCreate` rvalue.
+
+Bare-name construction (`Red`, `Circle(2.0)`) is not supported yet; it
+needs expected-type disambiguation and is a follow-up. Match patterns
+are unchanged and continue to use bare variant names (`match c { Red ->
+... }`).
+
 ### Compound assignment
 
 ```

--- a/docs/v2/specs/tycheck.md
+++ b/docs/v2/specs/tycheck.md
@@ -132,6 +132,12 @@ Method dispatch is statically resolved. When the user writes `r.m(...)` and `r: 
 
 A method call on a value of `Self` type inside an `impl` block resolves through the implementing type. Each impl's generic parameters get fresh inference variables and the substituted `self_ty` is unified against the receiver, so a generic impl such as `impl<T> List<T>` matches a concrete `List<Int>` receiver and the method's `T` binds to `Int`.
 
+### Enum variant construction
+
+A user enum variant is constructed with a qualified name: `EnumName.Variant` for a unit variant and `EnumName.Variant(args)` for a payload variant. When the receiver of a field access or call is an `Ident` bound to an enum and the name is one of its variants, the checker treats it as construction rather than a field access or an associated function call. A unit variant types as the enum directly; a payload variant types as a constructor function whose parameters are the payload types and whose result is the enum, so the surrounding call applies and checks the arguments. For a generic enum the declared generic parameters become fresh inference variables, solved from the argument types and the surrounding expected type, the same way generic struct fields are substituted.
+
+Bare-name construction (`Red`, `Circle(2.0)`) is not supported yet and is a follow-up; it needs expected-type disambiguation. Match patterns are unchanged and keep using bare variant names. Struct-shaped variants (`Variant { field: ... }`) are not yet constructible.
+
 ### Associated functions
 
 When the receiver of `r.m(...)` is a bare type reference (a struct or enum binding, or a built-in type name) rather than a value, the call is an associated function call `Type.func(args)`. The named function on that type must have no `self`. The implementing type fixes the impl's generic parameters: explicit arguments (`Set<Int>.new()`) bind them directly, otherwise they are inference variables solved from later use. Arguments are checked against the function's parameters (there is no `self` to drop), and the result is its declared return type with the impl's parameters substituted. See `docs/v2/specs/associated-functions.md`.

--- a/examples/v2/enum_construct.rv
+++ b/examples/v2/enum_construct.rv
@@ -1,0 +1,36 @@
+// Construct user enum variants in expression position and match them.
+// Unit variants build with `EnumName.Variant`, payload variants with
+// `EnumName.Variant(args)`.
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+enum Shape {
+    Circle(Float),
+    Square(Float),
+}
+
+fun name(c: Color) -> String {
+    return match c {
+        Red -> "red",
+        Green -> "green",
+        Blue -> "blue",
+    }
+}
+
+fun area(s: Shape) -> Float {
+    return match s {
+        Circle(r) -> r * r * 3.0,
+        Square(w) -> w * w,
+    }
+}
+
+fun main() {
+    let c = Color.Green
+    print(name(c))
+    print(area(Shape.Circle(2.0)))
+    print(area(Shape.Square(3.0)))
+}

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -210,6 +210,14 @@ pub enum HirExprKind {
     SomeCtor(Box<HirExpr>),
     /// `None` constructor literal.
     NoneCtor,
+    /// A user enum variant construction `EnumName.Variant(args)`. The
+    /// result type (the enum, with concrete type arguments) lives on the
+    /// `HirExpr.ty`. `variant` is the variant's index in declaration
+    /// order, matching what patterns and codegen use.
+    EnumCreate {
+        variant: usize,
+        args: Vec<HirExpr>,
+    },
 
     // ----- lambda -----
     Lambda {

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -158,6 +158,24 @@ pub(crate) fn lower_expr(
             }
         }
         ExprKind::Call { callee, args } => {
+            // `EnumName.Variant(args)` lowers to an `EnumCreate`. The
+            // callee is a `Field` whose receiver is the enum name.
+            if let ExprKind::Field { receiver, name } = &callee.kind {
+                if let Some(variant) = enum_variant_index(receiver, name, cx) {
+                    let mut lowered = Vec::with_capacity(args.len());
+                    for a in args {
+                        lowered.push(lower_expr(a, &Ty::Error, cx)?);
+                    }
+                    return Ok(make_expr(
+                        HirExprKind::EnumCreate {
+                            variant,
+                            args: lowered,
+                        },
+                        ty,
+                        span,
+                    ));
+                }
+            }
             // Recognize the built in enum constructors `Some(x)`, `Ok(x)`,
             // and `Err(x)` so they lower to typed constructor nodes (and
             // then to `EnumCreate` in MIR) rather than ordinary calls.
@@ -226,6 +244,23 @@ pub(crate) fn lower_expr(
             args,
             ..
         } => {
+            // `EnumName.Variant(args)` constructs a payload variant. The
+            // parser shapes it as a method call, so it is recognized here
+            // before associated-call routing.
+            if let Some(variant) = enum_variant_index(receiver, name, cx) {
+                let mut lowered = Vec::with_capacity(args.len());
+                for a in args {
+                    lowered.push(lower_expr(a, &Ty::Error, cx)?);
+                }
+                return Ok(make_expr(
+                    HirExprKind::EnumCreate {
+                        variant,
+                        args: lowered,
+                    },
+                    ty,
+                    span,
+                ));
+            }
             // `Type.func(args)` lowers to a receiverless associated call.
             // The type checker recorded the implementing type at the
             // receiver span; its presence as a type reference (not a value)
@@ -256,10 +291,19 @@ pub(crate) fn lower_expr(
             }
         }
         ExprKind::Field { receiver, name } => {
-            let r = lower_expr(receiver, &Ty::Error, cx)?;
-            HirExprKind::Field {
-                receiver: Box::new(r),
-                name: name.clone(),
+            // `EnumName.Variant` with no payload is a unit-variant
+            // construction, not a field access.
+            if let Some(variant) = enum_variant_index(receiver, name, cx) {
+                HirExprKind::EnumCreate {
+                    variant,
+                    args: Vec::new(),
+                }
+            } else {
+                let r = lower_expr(receiver, &Ty::Error, cx)?;
+                HirExprKind::Field {
+                    receiver: Box::new(r),
+                    name: name.clone(),
+                }
             }
         }
         ExprKind::Index { receiver, index } => {
@@ -294,9 +338,11 @@ pub(crate) fn lower_expr(
         }
         ExprKind::Match { scrutinee, arms } => {
             let s = lower_expr(scrutinee, &Ty::Error, cx)?;
+            let scrut_ty = s.ty.clone();
             let mut lowered = Vec::with_capacity(arms.len());
             for arm in arms {
-                let pattern = lower_pattern(&arm.pattern, cx)?;
+                let mut pattern = lower_pattern(&arm.pattern, cx)?;
+                reclassify_unit_variant(&mut pattern, &scrut_ty, cx);
                 let guard = match &arm.guard {
                     Some(g) => Some(lower_expr(g, &Ty::Bool, cx)?),
                     None => None,
@@ -1163,6 +1209,49 @@ fn is_type_ref_receiver(receiver: &Expr, cx: &LowerCtx<'_>) -> bool {
             "Int" | "Float" | "Bool" | "String" | "Char" | "Unit" | "Array" | "List" | "Vec"
         ),
     }
+}
+
+/// Rewrite a bare-identifier match pattern into a unit-variant
+/// constructor when the scrutinee is a user enum that declares a unit
+/// variant by that name. The resolver binds every bare pattern ident as
+/// a fresh binding; only the scrutinee type (known here) disambiguates a
+/// nullary variant from a binding. The type checker performs the same
+/// reconciliation, so this keeps HIR and tycheck in step.
+fn reclassify_unit_variant(pat: &mut HirPattern, scrut_ty: &Ty, cx: &LowerCtx<'_>) {
+    let HirPatternKind::Binding(name) = &pat.kind else {
+        return;
+    };
+    let Ty::Enum { name: ename, .. } = scrut_ty.strip_self() else {
+        return;
+    };
+    let Some(decl) = cx.env.enums.values().find(|e| &e.name == ename) else {
+        return;
+    };
+    let is_unit_variant = decl.variants.iter().any(|v| {
+        v.name == *name && matches!(v.payload, crate::tycheck::env::VariantPayloadSig::Unit)
+    });
+    if is_unit_variant {
+        pat.kind = HirPatternKind::Constructor {
+            name: Some(name.clone()),
+            elements: Vec::new(),
+        };
+    }
+}
+
+/// If `receiver` is a bare enum name and `name` is one of its variants,
+/// return that variant's index in declaration order. Returns `None` for
+/// any other receiver (an ordinary struct field access, for example), so
+/// the caller leaves that path untouched.
+fn enum_variant_index(receiver: &Expr, name: &str, cx: &LowerCtx<'_>) -> Option<usize> {
+    use crate::resolve::Binding;
+    let ExprKind::Ident { .. } = &receiver.kind else {
+        return None;
+    };
+    let Some(Binding::Enum(id)) = cx.resolved.map.lookup(&receiver.span) else {
+        return None;
+    };
+    let sig = cx.env.enums.get(id)?;
+    sig.variant(name).map(|(idx, _)| idx)
 }
 
 /// Wrap an interpolation part in a `to_string()` method call when its

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -470,6 +470,14 @@ fn pretty_expr(buf: &mut String, expr: &HirExpr, depth: usize) {
             buf.push_str(")\n");
         }
         HirExprKind::NoneCtor => writeln!(buf, "(none ty={})", expr.ty).unwrap(),
+        HirExprKind::EnumCreate { variant, args } => {
+            writeln!(buf, "(enum-create variant={} ty={}", variant, expr.ty).unwrap();
+            for a in args {
+                pretty_expr(buf, a, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
         HirExprKind::Lambda { params, ret, body } => {
             write!(buf, "(lambda ret={} params=(", ret).unwrap();
             for (i, (name, ty, _)) in params.iter().enumerate() {

--- a/src/mir/lower/closure.rs
+++ b/src/mir/lower/closure.rs
@@ -342,6 +342,11 @@ fn collect_free_expr(
                 collect_free_expr(a, bound, seen, out);
             }
         }
+        HirExprKind::EnumCreate { args, .. } => {
+            for a in args {
+                collect_free_expr(a, bound, seen, out);
+            }
+        }
         HirExprKind::MethodCall { receiver, args, .. } => {
             collect_free_expr(receiver, bound, seen, out);
             for a in args {

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -270,6 +270,26 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
         HirExprKind::OkCtor(inner) => enum_ctor_unary(cx, inner, "Ok", 0, ty),
         HirExprKind::ErrCtor(inner) => enum_ctor_unary(cx, inner, "Err", 1, ty),
         HirExprKind::SomeCtor(inner) => enum_ctor_unary(cx, inner, "Some", 0, ty),
+        HirExprKind::EnumCreate { variant, args } => {
+            let mut payload = Vec::with_capacity(args.len());
+            let mut payload_tys = Vec::with_capacity(args.len());
+            for a in args {
+                payload_tys.push(mir_ty(&a.ty, cx.subst));
+                payload.push(lower_expr(cx, a));
+            }
+            let dst = cx.builder.fresh_temp("enum", ty.clone());
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::EnumCreate {
+                    ty,
+                    variant: *variant,
+                    payload,
+                    payload_tys,
+                },
+            );
+            MirOperand::Copy(dst)
+        }
         HirExprKind::NoneCtor => {
             let dst = cx.builder.fresh_temp("none", ty.clone());
             cx.builder.assign(

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -78,7 +78,7 @@ fn lower_enum_match(
     }
 
     for (i, arm) in arms.iter().enumerate() {
-        match variant_index_of(&arm.pattern, scrut_ty) {
+        match variant_index_of(&arm.pattern, scrut_ty, cx) {
             Some(idx) => targets.push((idx, arm_blocks[i])),
             None => otherwise = Some(arm_blocks[i]),
         }
@@ -233,7 +233,7 @@ fn lower_fallback_match(
 /// Variant index of a constructor pattern against an enum-like type.
 /// Returns `None` for wildcard, binding, or unrecognized cases (the
 /// caller treats those as the `otherwise` arm).
-fn variant_index_of(pat: &HirPattern, scrut_ty: &Ty) -> Option<usize> {
+fn variant_index_of(pat: &HirPattern, scrut_ty: &Ty, cx: &LowerCx<'_>) -> Option<usize> {
     let name = match &pat.kind {
         HirPatternKind::Constructor { name: Some(n), .. } => n,
         HirPatternKind::Struct { name, .. } => name,
@@ -250,7 +250,10 @@ fn variant_index_of(pat: &HirPattern, scrut_ty: &Ty) -> Option<usize> {
             "Err" => Some(1),
             _ => None,
         },
-        Ty::Enum { .. } => None,
+        Ty::Enum { name: ename, .. } => {
+            let decl = cx.decls.enums.get(ename)?;
+            decl.variants.iter().position(|v| v.name == *name)
+        }
         _ => None,
     }
 }
@@ -268,14 +271,17 @@ fn bind_pattern(cx: &mut LowerCx<'_>, pat: &HirPattern, scrut_ty: &Ty, scrut: &M
                 .assign(cx.current, local, MirRvalue::Use(scrut.clone()));
             cx.bind(name.clone(), local);
         }
-        HirPatternKind::Constructor { elements, .. } => {
+        HirPatternKind::Constructor {
+            elements,
+            name: variant,
+        } => {
             // Each element binds the payload at its positional index. The
             // enum value stores its discriminant in slot 0, so payload
             // field `i` lives in slot `i + 1`.
             for (i, element) in elements.iter().enumerate() {
                 match &element.kind {
                     HirPatternKind::Binding(name) => {
-                        let payload_ty = payload_type_at(scrut_ty, i);
+                        let payload_ty = payload_type_at(scrut_ty, variant.as_deref(), i, cx);
                         let mty = MirType::from_ty(&payload_ty);
                         let local = cx.builder.named_local(name.clone(), mty);
                         cx.builder.assign(
@@ -297,13 +303,13 @@ fn bind_pattern(cx: &mut LowerCx<'_>, pat: &HirPattern, scrut_ty: &Ty, scrut: &M
                 }
             }
         }
-        HirPatternKind::Struct { fields, .. } => {
+        HirPatternKind::Struct { fields, name } => {
             for (i, field) in fields.iter().enumerate() {
+                let payload_ty = payload_type_at(scrut_ty, Some(name), i, cx);
+                let mty = MirType::from_ty(&payload_ty);
                 if let Some(p) = &field.pattern {
-                    if let HirPatternKind::Binding(name) = &p.kind {
-                        let payload_ty = payload_type_at(scrut_ty, i);
-                        let mty = MirType::from_ty(&payload_ty);
-                        let local = cx.builder.named_local(name.clone(), mty);
+                    if let HirPatternKind::Binding(bname) = &p.kind {
+                        let local = cx.builder.named_local(bname.clone(), mty);
                         cx.builder.assign(
                             cx.current,
                             local,
@@ -312,13 +318,11 @@ fn bind_pattern(cx: &mut LowerCx<'_>, pat: &HirPattern, scrut_ty: &Ty, scrut: &M
                                 index: i + 1,
                             },
                         );
-                        cx.bind(name.clone(), local);
+                        cx.bind(bname.clone(), local);
                     }
                 } else {
                     // Shorthand `{ name }` binds the field name to a
                     // local of the same name.
-                    let payload_ty = payload_type_at(scrut_ty, i);
-                    let mty = MirType::from_ty(&payload_ty);
                     let local = cx.builder.named_local(field.name.clone(), mty);
                     cx.builder.assign(
                         cx.current,
@@ -335,11 +339,25 @@ fn bind_pattern(cx: &mut LowerCx<'_>, pat: &HirPattern, scrut_ty: &Ty, scrut: &M
     }
 }
 
-fn payload_type_at(scrut_ty: &Ty, index: usize) -> Ty {
+fn payload_type_at(scrut_ty: &Ty, variant: Option<&str>, index: usize, cx: &LowerCx<'_>) -> Ty {
     match scrut_ty {
         Ty::Option(inner) if index == 0 => (**inner).clone(),
         Ty::Result(t, _) if index == 0 => (**t).clone(),
         Ty::Result(_, e) if index == 1 => (**e).clone(),
+        Ty::Enum { name, .. } => {
+            let Some(vname) = variant else {
+                return Ty::Error;
+            };
+            let Some(decl) = cx.decls.enums.get(name) else {
+                return Ty::Error;
+            };
+            decl.variants
+                .iter()
+                .find(|v| v.name == vname)
+                .and_then(|v| v.fields.get(index))
+                .map(|(_, ty, _)| ty.clone())
+                .unwrap_or(Ty::Error)
+        }
         _ => Ty::Error,
     }
 }

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -21,7 +21,7 @@ use crate::span::Span;
 
 use super::builtin;
 use super::collect::{resolve_ty, scope_from_params, GenericScope};
-use super::env::{FnSig, GenericParamSig, TypeEnv};
+use super::env::{FnSig, GenericParamSig, TypeEnv, VariantPayloadSig};
 use super::infer::{substitute, InferCtx};
 use super::pattern;
 use super::ty::InferVarId;
@@ -1368,6 +1368,33 @@ impl<'a, 'b> Checker<'a, 'b> {
         args: &[Expr],
         span: &Span,
     ) -> Result<Ty, RavenError> {
+        // `EnumName.Variant(args)` constructs a payload variant. The
+        // parser shapes this as a method call, so it is recognized here
+        // (before associated-function routing) when the receiver is an
+        // enum name and the called name is one of its variants.
+        if let Some(ctor_ty) = self.try_enum_variant_ctor(receiver, name, &receiver.span)? {
+            let (params, ret) = match ctor_ty {
+                Ty::Function { params, ret } => (params, *ret),
+                // A unit variant called with arguments: report the arity.
+                other => (Vec::new(), other),
+            };
+            if params.len() != args.len() {
+                return Err(RavenError::ty(
+                    TypeError::WrongArity {
+                        func: format!("{}", ret),
+                        expected: params.len(),
+                        actual: args.len(),
+                    },
+                    span.clone(),
+                ));
+            }
+            for (param_ty, arg) in params.iter().zip(args.iter()) {
+                let a = self.check_expr(arg)?;
+                self.unify(param_ty, &a, &arg.span)?;
+            }
+            return Ok(ret);
+        }
+
         // `Type.func(args)`: when the receiver is a type name (a struct or
         // enum, or a built-in type), this is an associated function call,
         // not an instance method call. The named function on that type has
@@ -1898,6 +1925,12 @@ impl<'a, 'b> Checker<'a, 'b> {
     }
 
     fn check_field(&mut self, receiver: &Expr, name: &str, span: &Span) -> Result<Ty, RavenError> {
+        // `EnumName.Variant` constructs a variant. Intercept before
+        // checking the receiver as a value: a bare enum name is a type,
+        // not a value, so `check_expr(receiver)` cannot type it.
+        if let Some(ty) = self.try_enum_variant_ctor(receiver, name, span)? {
+            return Ok(ty);
+        }
         let recv = self.check_expr(receiver)?;
         let recv_resolved = self.infer.resolve(&recv);
         let stripped = recv_resolved.strip_self().clone();
@@ -1939,6 +1972,72 @@ impl<'a, 'b> Checker<'a, 'b> {
             Ty::Error => Ok(Ty::Error),
             other => Err(RavenError::ty(
                 TypeError::Custom(format!("type `{}` has no field `{}`", other, name)),
+                span.clone(),
+            )),
+        }
+    }
+
+    /// If `receiver` is a bare enum name and `name` is one of its
+    /// variants, return the type produced by constructing it.
+    ///
+    /// A unit variant yields the enum type directly. A payload variant
+    /// yields a function type whose parameters are the payload types and
+    /// whose result is the enum type, so the surrounding `check_call`
+    /// applies the arguments. For a generic enum the declared generic
+    /// parameters become fresh inference variables, solved by unification
+    /// against the argument types and the surrounding expected type.
+    ///
+    /// Returns `None` when the receiver is not an enum name, so ordinary
+    /// struct field access is left untouched.
+    fn try_enum_variant_ctor(
+        &mut self,
+        receiver: &Expr,
+        name: &str,
+        span: &Span,
+    ) -> Result<Option<Ty>, RavenError> {
+        let ExprKind::Ident { .. } = &receiver.kind else {
+            return Ok(None);
+        };
+        let Some(Binding::Enum(id)) = self.resolved.map.lookup(&receiver.span).cloned() else {
+            return Ok(None);
+        };
+        let sig = self
+            .env
+            .enums
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| ty_custom("enum signature missing", span))?;
+        let Some((_, variant)) = sig.variant(name) else {
+            return Err(RavenError::ty(
+                TypeError::Custom(format!("enum `{}` has no variant `{}`", sig.name, name)),
+                span.clone(),
+            ));
+        };
+        // Fresh inference variables for the enum's generic parameters.
+        let args = self.instantiate_type_args(&sig.generics, &[], span, &sig.name)?;
+        let mut subst: HashMap<ParamId, Ty> = HashMap::new();
+        for (p, a) in sig.generics.iter().zip(args.iter()) {
+            subst.insert(p.id.clone(), a.clone());
+        }
+        let enum_ty = Ty::Enum {
+            id,
+            name: sig.name.clone(),
+            args,
+        };
+        match &variant.payload {
+            VariantPayloadSig::Unit => Ok(Some(enum_ty)),
+            VariantPayloadSig::Tuple(tys) => {
+                let params = tys.iter().map(|t| substitute(t, &subst)).collect();
+                Ok(Some(Ty::Function {
+                    params,
+                    ret: Box::new(enum_ty),
+                }))
+            }
+            VariantPayloadSig::Struct(_) => Err(RavenError::ty(
+                TypeError::Custom(format!(
+                    "variant `{}` has named fields; struct-variant construction is not yet supported",
+                    name
+                )),
                 span.clone(),
             )),
         }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -50,6 +50,17 @@ fn enum_program_compiles_and_runs() {
 }
 
 #[test]
+fn enum_construction_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // User enum variants constructed in expression position and matched.
+    // `Color.Green` (unit) prints `green`; `Shape.Circle(2.0)` and
+    // `Shape.Square(3.0)` (payload) print 12 and 9.
+    compile_link_run_and_check("enum_construct.rv", "green\n12\n9\n", &runtime);
+}
+
+#[test]
 fn closure_value_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Construct user-defined enum variants in expression position using the qualified syntax `EnumName.Variant` and `EnumName.Variant(args)`.

Closes #182

## Syntax shipped

* `EnumName.Variant` builds a unit variant.
* `EnumName.Variant(args)` builds a payload variant.
* Match patterns are unchanged and keep using bare variant names.
* Bare-name construction (`Red`, `Circle(2.0)`) is a documented follow-up; it needs expected-type disambiguation.
* Struct-shaped variants are not yet constructible.

Generic enums are supported: a payload variant of a generic enum introduces fresh inference variables for the enum's parameters, solved through the call arguments and the surrounding expected type. Recursive enums carrying generic collections (for example `JArr(List<JsonV>)`) compile and run.

## Verification programs

Unit variant (prints `red`):

```
enum Color { Red, Green, Blue }
fun name(c: Color) -> String { return match c { Red -> "red", Green -> "green", Blue -> "blue" } }
fun main() { let c = Color.Red; print(name(c)) }
```

Payload variant (prints `12`):

```
enum Shape { Circle(Float), Square(Float) }
fun area(s: Shape) -> Float { return match s { Circle(r) -> r * r * 3.0, Square(w) -> w * w } }
fun main() { print(area(Shape.Circle(2.0))) }
```

Recursive and generic-collection-bearing enum (prints `2`):

```
import std/collections
enum JsonV { JNull, JBool(Bool), JArr(List<JsonV>), JObj(Map<String, JsonV>) }
fun main() {
    let a: List<JsonV> = [JsonV.JBool(true), JsonV.JNull]
    let v = JsonV.JArr(a)
    let n = match v { JArr(items) -> items.len(), _ -> 0 }
    print(n)
}
```

All three compile and print the expected values.

## Test plan

* [x] `cargo build --workspace`
* [x] `cargo test --workspace`
* [x] `cargo fmt --check`
* [x] `cargo clippy --workspace --all-targets`
* [x] New `examples/v2/enum_construct.rv` (unit + payload) and a `tests/codegen_smoke.rs` case `enum_construction_compiles_and_runs` asserting stdout `green\n12\n9\n`.
* [x] All three verification programs run with the expected output.

## Notes

The selective stdlib import form `import std/collections { Map }` currently fails resolution with "the name `Map` is declared multiple times". This is a pre-existing bug on the base branch, unrelated to enum construction, and affects any selective stdlib import. The whole-module form `import std/collections` works and was used for the recursive verification program. A consumer such as `std/json` can use the whole-module import as a workaround until the selective-import bug is fixed.
