### PR TITLE
feat(stdlib): std/json parser and serializer

### DIFF
--- a/docs/v2/specs/std-json.md
+++ b/docs/v2/specs/std-json.md
@@ -1,0 +1,128 @@
+# std/json Spec
+
+A JSON parser and serializer written in pure Raven over the `__str_*` byte
+intrinsics. `parse` is a recursive descent parser; `stringify` is a compact
+serializer. The value tree is the `JsonValue` enum.
+
+## Value type
+
+```raven
+enum JsonValue {
+    Null,
+    Bool(Bool),
+    Number(Float),
+    Str(String),
+    Array(List<JsonValue>),
+    Object(Map<String, JsonValue>),
+}
+```
+
+Construct variants with the qualified form (`JsonValue.Null`,
+`JsonValue.Bool(true)`, `JsonValue.Number(1.0)`, `JsonValue.Str(s)`,
+`JsonValue.Array(list)`, `JsonValue.Object(map)`). Match with the bare
+variant names (`Null`, `Bool(b)`, `Number(n)`, ...).
+
+`Object` uses `std/collections` `Map<String, JsonValue>`. The Map stores
+parallel `keys` and `values` lists, so members keep insertion order. The
+serializer reads `map.keys` and `map.values` directly to emit members in
+that order.
+
+## Numbers are Float
+
+Every JSON number, integer or not, parses to `Float`. Raven `Float` is an
+IEEE 754 double, so integers beyond the 53-bit mantissa (roughly
+9.0e15) lose precision. There is no separate integer JSON type.
+
+## Import
+
+```raven
+import std/json { parse, stringify }
+
+fun main() {
+    match parse("{\"a\": 1, \"b\": [true, null]}") {
+        Ok(v) -> print(stringify(v)),
+        Err(e) -> print("bad json"),
+    }
+}
+```
+
+## Surface
+
+| Item | Result | Notes |
+|---|---|---|
+| `parse(text: String)` | `Result<JsonValue, Error>` | full recursive descent parse |
+| `stringify(value: JsonValue)` | `String` | compact (non-pretty) serialization |
+| `JsonValue.is_null(self)` | `Bool` | true only for `Null` |
+| `JsonValue.as_bool(self)` | `Option<Bool>` | `Some` only for `Bool` |
+| `JsonValue.as_number(self)` | `Option<Float>` | `Some` only for `Number` |
+| `JsonValue.as_string(self)` | `Option<String>` | `Some` only for `Str` |
+| `JsonValue.get(self, key: String)` | `Option<JsonValue>` | object member, else `None` |
+| `JsonValue.at(self, i: Int)` | `Option<JsonValue>` | array element, else `None` |
+
+The accessors return `Option`, so a wrong-kind or missing lookup is a normal
+`None` rather than an error.
+
+## Parsing
+
+`parse` handles nested objects and arrays (including empty `{}` and `[]`),
+strings, numbers, `true`, `false`, `null`, and inter-token whitespace
+(space, tab, newline, carriage return). It rejects any non-whitespace
+content after the top-level value.
+
+### String escapes
+
+The two-character escapes `\" \\ \/ \b \f \n \r \t` decode to their usual
+bytes. A `\uXXXX` escape decodes a BMP code point and is encoded to UTF-8
+bytes in the result.
+
+### Surrogate pairs
+
+A high surrogate (`\uD800` to `\uDBFF`) immediately followed by a low
+surrogate (`\uDC00` to `\uDFFF`) decodes to the astral code point and is
+UTF-8 encoded. A high surrogate not followed by a low surrogate, or a lone
+low surrogate, decodes to U+FFFD (the replacement character). Note that the
+Raven lexer rejects surrogate `\u` escapes inside a source string literal,
+so a surrogate input reaches `parse` only from data read at runtime.
+
+### Numbers
+
+A number is an optional minus, integer digits, an optional `.` fraction,
+and an optional `e`/`E` exponent with an optional sign. Digits accumulate
+into a `Float` (integer part built through the runtime's
+`raven_int_to_float`, fraction divided by a power of ten, exponent applied
+as a power-of-ten factor).
+
+## Errors
+
+A parse failure is an `std/error` `Error` with `kind` `"json"`. Raven has
+no type alias and a bundled module cannot call another bundled module's
+free functions, so the value is built directly as the `Error` struct
+literal (the same workaround `std/fs` and others use). The message names
+roughly what failed and, for unexpected or trailing bytes, the byte offset.
+
+## Serialization
+
+`stringify` produces compact output with no spaces between tokens. Object
+members are emitted in the Map's key order. String escaping is the reverse
+of parsing: `"` and `\` are escaped, control bytes below `0x20` use the
+`\b \f \n \r \t` shorthands where they exist and `\u00XX` otherwise, and
+every other byte (printable ASCII or a UTF-8 continuation byte) passes
+through unchanged.
+
+A whole-number `Float` renders the way the runtime's Float-to-string
+produces it: `1.0` serializes as `1`, and `0.15` serializes as `0.15`.
+
+## Accessor implementation note
+
+The payload-reading accessor methods (`as_bool`, `as_number`, `as_string`,
+`is_null`, `get`, `at`) forward to free functions that take the value as a
+plain parameter. Matching a `self` receiver and then reading the bound
+payload currently corrupts the extracted value in the back end, so every
+accessor that inspects a payload goes through a free helper. The serializer
+is already a free function for the same reason.
+
+## Out of scope
+
+Pretty printing (indentation), duplicate-key policy beyond last-wins (the
+Map overwrites on a repeated key), and streaming or incremental parsing.
+These can be added later without changing the existing surface.

--- a/examples/v2/use_json.rv
+++ b/examples/v2/use_json.rv
@@ -1,0 +1,18 @@
+// golden:skip
+import std/json { parse, stringify }
+import std/io { println }
+
+fun main() {
+    match parse("{\"a\": 1, \"b\": [true, null, \"hi\"]}") {
+        Ok(v) -> println(stringify(v)),
+        Err(e) -> println("parse failed"),
+    }
+    match parse("\"x\\ny \\u0041\"") {
+        Ok(v) -> println(stringify(v)),
+        Err(e) -> println("parse failed"),
+    }
+    match parse("{ bad ]") {
+        Ok(v) -> println("ok"),
+        Err(e) -> println("parse failed"),
+    }
+}

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -54,6 +54,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("time", include_str!("../../stdlib/std/time.rv")),
     ("net", include_str!("../../stdlib/std/net.rv")),
     ("http", include_str!("../../stdlib/std/http.rv")),
+    ("json", include_str!("../../stdlib/std/json.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -476,6 +477,11 @@ mod tests {
     #[test]
     fn http_module_is_bundled() {
         assert!(bundled_source("http").is_some());
+    }
+
+    #[test]
+    fn json_module_is_bundled() {
+        assert!(bundled_source("json").is_some());
     }
 
     #[test]

--- a/stdlib/std/json.rv
+++ b/stdlib/std/json.rv
@@ -1,0 +1,602 @@
+// std/json: a JSON parser and serializer in pure Raven over the byte
+// intrinsics. `parse` is a recursive descent parser returning
+// Result<JsonValue, Error>; `stringify` is a compact serializer. All JSON
+// numbers parse to Float, so integers beyond the 53-bit mantissa lose
+// precision. See docs/v2/specs/std-json.md.
+
+import std/collections
+import std/error
+import std/string
+
+extern "C" {
+    fun raven_int_to_float(x: Int) -> Float
+}
+
+// The JSON value tree. Construct variants with the qualified form
+// (`JsonValue.Null`, `JsonValue.Number(1.0)`, ...); match with the bare
+// variant names. Object preserves insertion order through the underlying
+// Map's parallel key and value lists.
+enum JsonValue {
+    Null,
+    Bool(Bool),
+    Number(Float),
+    Str(String),
+    Array(List<JsonValue>),
+    Object(Map<String, JsonValue>),
+}
+
+// A JsonError is an std/error `Error` tagged with kind "json". Raven has
+// no type alias and a bundled module cannot call another bundled module's
+// free functions, so the struct literal is built directly here.
+fun json_error(msg: String) -> Error {
+    return Error { kind: "json", message: msg }
+}
+
+// Parser cursor: the input bytes and the current byte offset. A shared
+// Cursor is threaded through the recursive helpers, which advance it by
+// mutating `pos`.
+struct Cursor {
+    text: String,
+    pos: Int,
+}
+
+impl Cursor {
+    fun at_end(self) -> Bool {
+        return self.pos >= __str_len(self.text)
+    }
+
+    // Current byte, or -1 at end of input.
+    fun peek(self) -> Int {
+        if self.pos >= __str_len(self.text) {
+            return -1
+        }
+        return __str_byte_at(self.text, self.pos)
+    }
+
+    fun advance(self) {
+        self.pos = self.pos + 1
+    }
+
+    fun skip_ws(self) {
+        let scanning = true
+        while scanning {
+            let b = self.peek()
+            if b == 32 {
+                self.pos = self.pos + 1
+            } else if b == 9 {
+                self.pos = self.pos + 1
+            } else if b == 10 {
+                self.pos = self.pos + 1
+            } else if b == 13 {
+                self.pos = self.pos + 1
+            } else {
+                scanning = false
+            }
+        }
+    }
+}
+
+fun is_digit(b: Int) -> Bool {
+    return b >= 48 && b <= 57
+}
+
+// Append the UTF-8 encoding of a Unicode code point to `out`.
+fun encode_utf8(out: String, cp: Int) -> String {
+    if cp < 128 {
+        return __str_concat(out, __str_from_byte(cp))
+    }
+    if cp < 2048 {
+        let b0 = 192 | (cp >> 6)
+        let b1 = 128 | (cp & 63)
+        return __str_concat(__str_concat(out, __str_from_byte(b0)), __str_from_byte(b1))
+    }
+    if cp < 65536 {
+        let b0 = 224 | (cp >> 12)
+        let b1 = 128 | ((cp >> 6) & 63)
+        let b2 = 128 | (cp & 63)
+        let r = __str_concat(out, __str_from_byte(b0))
+        r = __str_concat(r, __str_from_byte(b1))
+        return __str_concat(r, __str_from_byte(b2))
+    }
+    let b0 = 240 | (cp >> 18)
+    let b1 = 128 | ((cp >> 12) & 63)
+    let b2 = 128 | ((cp >> 6) & 63)
+    let b3 = 128 | (cp & 63)
+    let r = __str_concat(out, __str_from_byte(b0))
+    r = __str_concat(r, __str_from_byte(b1))
+    r = __str_concat(r, __str_from_byte(b2))
+    return __str_concat(r, __str_from_byte(b3))
+}
+
+// Value of one hex digit byte, or -1 when it is not a hex digit.
+fun hex_nibble(b: Int) -> Int {
+    if b >= 48 && b <= 57 {
+        return b - 48
+    }
+    if b >= 97 && b <= 102 {
+        return b - 87
+    }
+    if b >= 65 && b <= 70 {
+        return b - 55
+    }
+    return -1
+}
+
+// Read four hex digits starting at the cursor, returning the 16-bit code
+// unit or -1 on a non-hex digit or short input. Advances the cursor over
+// the digits read.
+fun read_hex4(c: Cursor) -> Int {
+    let value = 0
+    let i = 0
+    while i < 4 {
+        let n = hex_nibble(c.peek())
+        if n < 0 {
+            return -1
+        }
+        value = (value << 4) | n
+        c.advance()
+        i = i + 1
+    }
+    return value
+}
+
+// Parse the body of a string literal after the opening quote. Returns the
+// decoded String, or an Err on a bad escape or unterminated input. The
+// cursor ends just past the closing quote.
+fun parse_string(c: Cursor) -> Result<String, Error> {
+    let out = ""
+    let scanning = true
+    while scanning {
+        if c.at_end() {
+            return Err(json_error("unterminated string"))
+        }
+        let b = c.peek()
+        c.advance()
+        if b == 34 {
+            scanning = false
+        } else if b == 92 {
+            let e = c.peek()
+            c.advance()
+            if e == 34 {
+                out = __str_concat(out, __str_from_byte(34))
+            } else if e == 92 {
+                out = __str_concat(out, __str_from_byte(92))
+            } else if e == 47 {
+                out = __str_concat(out, __str_from_byte(47))
+            } else if e == 98 {
+                out = __str_concat(out, __str_from_byte(8))
+            } else if e == 102 {
+                out = __str_concat(out, __str_from_byte(12))
+            } else if e == 110 {
+                out = __str_concat(out, __str_from_byte(10))
+            } else if e == 114 {
+                out = __str_concat(out, __str_from_byte(13))
+            } else if e == 116 {
+                out = __str_concat(out, __str_from_byte(9))
+            } else if e == 117 {
+                let cp = read_hex4(c)
+                if cp < 0 {
+                    return Err(json_error("bad unicode escape"))
+                }
+                if cp >= 55296 && cp <= 56319 {
+                    // High surrogate: decode an astral code point when a
+                    // low surrogate follows, else emit U+FFFD.
+                    if c.peek() == 92 {
+                        c.advance()
+                        if c.peek() == 117 {
+                            c.advance()
+                            let low = read_hex4(c)
+                            if low >= 56320 && low <= 57343 {
+                                let astral = 65536 + ((cp - 55296) << 10) + (low - 56320)
+                                out = encode_utf8(out, astral)
+                            } else {
+                                out = encode_utf8(out, 65533)
+                            }
+                        } else {
+                            out = encode_utf8(out, 65533)
+                        }
+                    } else {
+                        out = encode_utf8(out, 65533)
+                    }
+                } else if cp >= 56320 && cp <= 57343 {
+                    out = encode_utf8(out, 65533)
+                } else {
+                    out = encode_utf8(out, cp)
+                }
+            } else {
+                return Err(json_error("bad escape"))
+            }
+        } else {
+            out = __str_concat(out, __str_from_byte(b))
+        }
+    }
+    return Ok(out)
+}
+
+// Parse a JSON number into a Float. The cursor is positioned at the first
+// byte of the number (an optional minus or a digit). Integer digits build
+// a Float through raven_int_to_float; fraction digits divide by powers of
+// ten; an exponent scales the result.
+fun parse_number(c: Cursor) -> Result<Float, Error> {
+    let negative = false
+    if c.peek() == 45 {
+        negative = true
+        c.advance()
+    }
+    if !is_digit(c.peek()) {
+        return Err(json_error("invalid number"))
+    }
+    let int_value = 0.0
+    while is_digit(c.peek()) {
+        let d = c.peek() - 48
+        int_value = int_value * 10.0 + raven_int_to_float(d)
+        c.advance()
+    }
+    let value = int_value
+    if c.peek() == 46 {
+        c.advance()
+        if !is_digit(c.peek()) {
+            return Err(json_error("invalid fraction"))
+        }
+        let scale = 1.0
+        let frac = 0.0
+        while is_digit(c.peek()) {
+            let d = c.peek() - 48
+            frac = frac * 10.0 + raven_int_to_float(d)
+            scale = scale * 10.0
+            c.advance()
+        }
+        value = value + frac / scale
+    }
+    let e = c.peek()
+    if e == 101 || e == 69 {
+        c.advance()
+        let exp_negative = false
+        if c.peek() == 43 {
+            c.advance()
+        } else if c.peek() == 45 {
+            exp_negative = true
+            c.advance()
+        }
+        if !is_digit(c.peek()) {
+            return Err(json_error("invalid exponent"))
+        }
+        let exp = 0
+        while is_digit(c.peek()) {
+            exp = exp * 10 + (c.peek() - 48)
+            c.advance()
+        }
+        let factor = 1.0
+        let i = 0
+        while i < exp {
+            factor = factor * 10.0
+            i = i + 1
+        }
+        if exp_negative {
+            value = value / factor
+        } else {
+            value = value * factor
+        }
+    }
+    if negative {
+        value = 0.0 - value
+    }
+    return Ok(value)
+}
+
+// True when the next bytes spell `word`; advances over them on a match.
+fun match_keyword(c: Cursor, word: String) -> Bool {
+    let n = __str_len(word)
+    let i = 0
+    while i < n {
+        if __str_byte_at(c.text, c.pos + i) != __str_byte_at(word, i) {
+            return false
+        }
+        i = i + 1
+    }
+    c.pos = c.pos + n
+    return true
+}
+
+fun parse_value(c: Cursor) -> Result<JsonValue, Error> {
+    c.skip_ws()
+    let b = c.peek()
+    if b == 123 {
+        return parse_object(c)
+    }
+    if b == 91 {
+        return parse_array(c)
+    }
+    if b == 34 {
+        c.advance()
+        let s = parse_string(c)?
+        return Ok(JsonValue.Str(s))
+    }
+    if b == 116 {
+        if match_keyword(c, "true") {
+            return Ok(JsonValue.Bool(true))
+        }
+        return Err(json_error("invalid token"))
+    }
+    if b == 102 {
+        if match_keyword(c, "false") {
+            return Ok(JsonValue.Bool(false))
+        }
+        return Err(json_error("invalid token"))
+    }
+    if b == 110 {
+        if match_keyword(c, "null") {
+            return Ok(JsonValue.Null)
+        }
+        return Err(json_error("invalid token"))
+    }
+    if b == 45 || is_digit(b) {
+        let n = parse_number(c)?
+        return Ok(JsonValue.Number(n))
+    }
+    return Err(json_error("unexpected byte at offset ".concat(offset_str(c.pos))))
+}
+
+fun parse_array(c: Cursor) -> Result<JsonValue, Error> {
+    c.advance()
+    let items: List<JsonValue> = []
+    c.skip_ws()
+    if c.peek() == 93 {
+        c.advance()
+        return Ok(JsonValue.Array(items))
+    }
+    let scanning = true
+    while scanning {
+        let v = parse_value(c)?
+        items.push(v)
+        c.skip_ws()
+        let b = c.peek()
+        if b == 44 {
+            c.advance()
+        } else if b == 93 {
+            c.advance()
+            scanning = false
+        } else {
+            return Err(json_error("expected , or ] in array"))
+        }
+    }
+    return Ok(JsonValue.Array(items))
+}
+
+fun parse_object(c: Cursor) -> Result<JsonValue, Error> {
+    c.advance()
+    let map: Map<String, JsonValue> = Map.new()
+    c.skip_ws()
+    if c.peek() == 125 {
+        c.advance()
+        return Ok(JsonValue.Object(map))
+    }
+    let scanning = true
+    while scanning {
+        c.skip_ws()
+        if c.peek() != 34 {
+            return Err(json_error("expected string key in object"))
+        }
+        c.advance()
+        let key = parse_string(c)?
+        c.skip_ws()
+        if c.peek() != 58 {
+            return Err(json_error("expected : in object"))
+        }
+        c.advance()
+        let v = parse_value(c)?
+        map.set(key, v)
+        c.skip_ws()
+        let b = c.peek()
+        if b == 44 {
+            c.advance()
+        } else if b == 125 {
+            c.advance()
+            scanning = false
+        } else {
+            return Err(json_error("expected , or } in object"))
+        }
+    }
+    return Ok(JsonValue.Object(map))
+}
+
+// Render a non-negative byte offset as decimal.
+fun offset_str(n: Int) -> String {
+    if n == 0 {
+        return "0"
+    }
+    let digits = ""
+    let v = n
+    while v > 0 {
+        digits = __str_concat(__str_from_byte(48 + (v - (v / 10) * 10)), digits)
+        v = v / 10
+    }
+    return digits
+}
+
+// Parse `text` as a single JSON value. Trailing content other than
+// whitespace after the top-level value is rejected.
+fun parse(text: String) -> Result<JsonValue, Error> {
+    let c = Cursor { text: text, pos: 0 }
+    let v = parse_value(c)?
+    c.skip_ws()
+    if !c.at_end() {
+        return Err(json_error("trailing content at offset ".concat(offset_str(c.pos))))
+    }
+    return Ok(v)
+}
+
+// Append the JSON string escaping of `s` (without surrounding quotes) to
+// `out`. Control bytes below 0x20 become \uXXXX; quote and backslash are
+// escaped; every other byte passes through unchanged.
+fun escape_string(out: String, s: String) -> String {
+    let n = __str_len(s)
+    let i = 0
+    let r = out
+    while i < n {
+        let b = __str_byte_at(s, i)
+        if b == 34 {
+            r = __str_concat(r, "\\\"")
+        } else if b == 92 {
+            r = __str_concat(r, "\\\\")
+        } else if b == 8 {
+            r = __str_concat(r, "\\b")
+        } else if b == 12 {
+            r = __str_concat(r, "\\f")
+        } else if b == 10 {
+            r = __str_concat(r, "\\n")
+        } else if b == 13 {
+            r = __str_concat(r, "\\r")
+        } else if b == 9 {
+            r = __str_concat(r, "\\t")
+        } else if b < 32 {
+            r = __str_concat(r, "\\u00")
+            r = __str_concat(r, __str_from_byte(hex_digit(b >> 4)))
+            r = __str_concat(r, __str_from_byte(hex_digit(b & 15)))
+        } else {
+            r = __str_concat(r, __str_from_byte(b))
+        }
+        i = i + 1
+    }
+    return r
+}
+
+fun hex_digit(v: Int) -> Int {
+    if v < 10 {
+        return 48 + v
+    }
+    return 87 + v
+}
+
+// Compact (non-pretty) serialization. A whole-number Float renders the way
+// the runtime's Float-to-string does (for example 1 prints as `1`).
+fun stringify(value: JsonValue) -> String {
+    return match value {
+        Null -> "null",
+        Bool(b) -> {
+            if b {
+                "true"
+            } else {
+                "false"
+            }
+        },
+        Number(n) -> n.to_string(),
+        Str(s) -> {
+            let q = __str_concat("\"", escape_string("", s))
+            __str_concat(q, "\"")
+        },
+        Array(items) -> {
+            let out = "["
+            let i = 0
+            let n = items.len()
+            while i < n {
+                if i > 0 {
+                    out = __str_concat(out, ",")
+                }
+                out = __str_concat(out, stringify(items[i]))
+                i = i + 1
+            }
+            __str_concat(out, "]")
+        },
+        Object(map) -> {
+            let out = "{"
+            let keys = map.keys
+            let values = map.values
+            let i = 0
+            let n = keys.len()
+            while i < n {
+                if i > 0 {
+                    out = __str_concat(out, ",")
+                }
+                let kq = __str_concat("\"", escape_string("", keys[i]))
+                out = __str_concat(out, __str_concat(kq, "\":"))
+                out = __str_concat(out, stringify(values[i]))
+                i = i + 1
+            }
+            __str_concat(out, "}")
+        },
+    }
+}
+
+// The accessor methods forward to free functions that take the value as a
+// plain parameter. Matching a `self` receiver and then reading the bound
+// payload hits a back-end limitation that corrupts the extracted value, so
+// every payload-reading accessor goes through a free helper.
+impl JsonValue {
+    fun is_null(self) -> Bool {
+        return value_is_null(self)
+    }
+
+    fun as_bool(self) -> Option<Bool> {
+        return value_as_bool(self)
+    }
+
+    fun as_number(self) -> Option<Float> {
+        return value_as_number(self)
+    }
+
+    fun as_string(self) -> Option<String> {
+        return value_as_string(self)
+    }
+
+    // Object member by key, or None when the value is not an object or the
+    // key is absent.
+    fun get(self, key: String) -> Option<JsonValue> {
+        return object_get(self, key)
+    }
+
+    // Array element by index, or None when out of range or not an array.
+    fun at(self, i: Int) -> Option<JsonValue> {
+        return array_at(self, i)
+    }
+}
+
+fun value_is_null(value: JsonValue) -> Bool {
+    return match value {
+        Null -> true,
+        _ -> false,
+    }
+}
+
+fun value_as_bool(value: JsonValue) -> Option<Bool> {
+    return match value {
+        Bool(b) -> Some(b),
+        _ -> None,
+    }
+}
+
+fun value_as_number(value: JsonValue) -> Option<Float> {
+    return match value {
+        Number(n) -> Some(n),
+        _ -> None,
+    }
+}
+
+fun value_as_string(value: JsonValue) -> Option<String> {
+    return match value {
+        Str(s) -> Some(s),
+        _ -> None,
+    }
+}
+
+fun object_get(value: JsonValue, key: String) -> Option<JsonValue> {
+    return match value {
+        Object(map) -> map.get(key),
+        _ -> None,
+    }
+}
+
+fun array_at(value: JsonValue, i: Int) -> Option<JsonValue> {
+    return match value {
+        Array(items) -> {
+            if i < 0 {
+                None
+            } else if i >= items.len() {
+                None
+            } else {
+                Some(items[i])
+            }
+        },
+        _ -> None,
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -939,6 +939,24 @@ fn time_program_compiles_and_runs() {
     );
 }
 
+#[test]
+fn json_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/json parse and stringify end to end. A nested object with an
+    // array value round trips through parse then compact stringify,
+    // preserving insertion key order and rendering the whole-number Float 1
+    // as `1`. A string with a `\n` escape and a `A` unicode escape
+    // decodes (the escape becomes the literal A) and re-serializes with the
+    // newline re-escaped. A malformed object takes the Err path. Prints the
+    // compact object, the re-escaped string, then `parse failed`.
+    let expected = "{\"a\":1,\"b\":[true,null,\"hi\"]}\n\
+                    \"x\\ny A\"\n\
+                    parse failed\n";
+    compile_link_run_and_check("use_json.rv", expected, &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Add `std/json`, a JSON parser and serializer written in pure Raven over the byte intrinsics.

Closes #79

## Surface

| Item | Result | Notes |
|---|---|---|
| `parse(text: String)` | `Result<JsonValue, Error>` | full recursive descent parse |
| `stringify(value: JsonValue)` | `String` | compact (non-pretty) serialization |
| `JsonValue.is_null(self)` | `Bool` | |
| `JsonValue.as_bool(self)` | `Option<Bool>` | |
| `JsonValue.as_number(self)` | `Option<Float>` | |
| `JsonValue.as_string(self)` | `Option<String>` | |
| `JsonValue.get(self, key: String)` | `Option<JsonValue>` | object member |
| `JsonValue.at(self, i: Int)` | `Option<JsonValue>` | array element |

`JsonValue` is `Null`, `Bool(Bool)`, `Number(Float)`, `Str(String)`, `Array(List<JsonValue>)`, `Object(Map<String, JsonValue>)`. Object uses a `std/collections` Map, so members keep insertion order. All JSON numbers parse to Float (integers beyond the 53-bit mantissa lose precision). A parse failure is an `Error` with kind `"json"`.

## Acceptance cases covered

- Nested object round trip (parse then compact stringify, key order preserved, whole-number Float renders without a decimal).
- Escaped and unicode-escaped string (`\n` plus `A`) decodes and re-serializes.
- Malformed input returns Err.
- Edge cases verified locally: empty `[]` and `{}`, negative and exponent numbers, deep nesting, leading and trailing whitespace, trailing-content rejection, accessor `Option` paths. Surrogate-pair decoding is implemented (lone surrogate falls back to U+FFFD); the Raven lexer rejects surrogate `\u` escapes in source literals, so that path is reachable only from runtime data.

## Literal output of `examples/v2/use_json.rv`

```
{"a":1,"b":[true,null,"hi"]}
"x\ny A"
parse failed
```

## Notes

The payload-reading accessors and the serializer are free functions. Matching a `self` receiver and then reading the bound payload currently corrupts the extracted value in the back end, so the impl methods forward to free helpers that take the value as a plain parameter. This is documented in the spec and worth a separate back-end fix.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (adds `json_program_compiles_and_runs` smoke test and `json_module_is_bundled` unit test)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `examples/v2/use_json.rv` compiled and run, output matches the smoke-test expectation
