### PR TITLE
fix(codegen): match on self reads enum payload correctly

### DIFF
--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -147,7 +147,7 @@ Calling `emit_statement` appends to the current block; calling
 | `Array`       | Lower elements, then `ArrayLit` |
 | `Block`       | Lower stmts in order; the optional tail expression's local is the block's result |
 | `If`          | Cond into a local, `SwitchInt` to two arm blocks, each writes to a join local, both `Goto` the continuation block |
-| `Match`       | Discriminant into a local, then `SwitchEnum` for enum scrutinees or chained `SwitchInt` for integer literals; arm blocks bind patterns and `Goto` the continuation |
+| `Match`       | Discriminant into a local, then `SwitchEnum` for enum scrutinees or chained `SwitchInt` for integer literals; arm blocks bind patterns and `Goto` the continuation. The scrutinee type is taken after stripping a method receiver's `SelfTy` wrapper, so matching on `self` dispatches and projects payloads identically to the same enum value passed as a parameter |
 | `Loop`        | Header block contains the body; `break` desugars to `Goto continuation`, `continue` to `Goto header` |
 | `While`       | Header block tests cond with `SwitchInt`; true branch is the body and tail-jumps to header; false branch is the continuation |
 | `Return(v)`   | Lower `v`, then close the current block with `Return(local)` |

--- a/examples/v2/enum_self_method.rv
+++ b/examples/v2/enum_self_method.rv
@@ -1,0 +1,48 @@
+// Match on the `self` receiver of an enum method and read its payload.
+// Regression for issue #186: the receiver carries a `SelfTy` wrapper, so
+// the match scrutinee must resolve to the underlying enum before payload
+// projection. Covers a scalar payload and heap payloads (String, List).
+
+enum Bag {
+    Num(Int),
+    Text(String),
+    Items(List<Int>),
+}
+
+impl Bag {
+    fun num(self) -> Int {
+        return match self {
+            Num(n) -> n,
+            Text(s) -> -1,
+            Items(xs) -> -1,
+        }
+    }
+
+    fun text(self) -> String {
+        return match self {
+            Text(s) -> s,
+            Num(n) -> "none",
+            Items(xs) -> "none",
+        }
+    }
+
+    fun count(self) -> Int {
+        return match self {
+            Items(xs) -> xs.len(),
+            Num(n) -> 0,
+            Text(s) -> 0,
+        }
+    }
+}
+
+fun main() {
+    let a = Bag.Num(42)
+    print(a.num())
+
+    let b = Bag.Text("hello")
+    print(b.text())
+
+    let xs: List<Int> = [1, 2, 3]
+    let c = Bag.Items(xs)
+    print(c.count())
+}

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -36,8 +36,13 @@ pub fn lower_match(
     // mentions a generic parameter (for example `Option<T>` returned by a
     // bound iterator's `next`) yields concrete payload-binding types. Using
     // the raw HIR type would leave `T` abstract, which lowers to a unit
-    // slot and produces a type mismatch in the generated code.
-    let scrut_ty = super::substitute(&scrutinee.ty, cx.subst);
+    // slot and produces a type mismatch in the generated code. Strip the
+    // `SelfTy(T)` wrapper a method receiver carries so the match dispatches
+    // on the underlying enum and projects payloads the same way a plain
+    // value scrutinee does.
+    let scrut_ty = super::substitute(&scrutinee.ty, cx.subst)
+        .strip_self()
+        .clone();
     let result_local = cx.builder.fresh_temp("match", result_ty);
     let cont = cx.builder.new_block();
 

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -61,6 +61,18 @@ fn enum_construction_compiles_and_runs() {
 }
 
 #[test]
+fn enum_self_method_match_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Regression for issue #186: matching on the `self` receiver of an
+    // enum method must read the payload through the underlying enum, not
+    // the `SelfTy` wrapper. Scalar prints 42, String prints hello, List
+    // payload `.len()` prints 3.
+    compile_link_run_and_check("enum_self_method.rv", "42\nhello\n3\n", &runtime);
+}
+
+#[test]
 fn closure_value_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Matching on the `self` receiver of an enum method now reads its payload correctly instead of returning pointer-shaped garbage.

Closes #186

## Root cause

A method receiver is typed as `Ty::SelfTy(T)`, wrapping the implementing type. MIR match lowering (`src/mir/lower/pattern.rs`) used the raw scrutinee type to choose the lowering strategy, and `is_enum_like` does not see through `SelfTy`. So `match self { ... }` fell into `lower_fallback_match` instead of `lower_enum_match`.

The MIR made the defect concrete. For a value parameter (`get_free`) the match lowered correctly:

```
(bb0 (switch-enum _0 cases=(0:bb2)))
(bb2 (assign _2 (field _0 #1)) (assign _1 (use _2)) (goto bb1))
```

For the `self` receiver (`Box$get_method`) no `SwitchEnum` was emitted and the payload binding produced a Unit:

```
(bb0 (goto bb2))
(bb2 (assign _1 (use ())) (goto bb1))
```

The fallback path treats a constructor pattern as "always matches" and binds nothing, so the payload local stayed Unit. Reading it back as `Int` yielded garbage; reading it as a `List`/`Map` hit the runtime "list receiver used a Unit value" error.

## Fix

Strip the `SelfTy` wrapper from the scrutinee type in `lower_match` before the dispatch decision. `MirType::from_ty` already unwraps `SelfTy`, so once the dispatch picks `lower_enum_match`, variant resolution and payload projection run exactly as they do for a value parameter. This is not a syntactic special-case of `match self`; it normalizes the scrutinee type so a method receiver and a plain parameter behave identically.

## Verification

Repro from the issue now prints:

```
42
42
```

A method matching on `self` and reading each payload kind:

- scalar `Int` payload -> `42`
- `String` payload -> `hello`
- `List<Int>` payload via `.len()` -> `3`
- `Map<String, Int>` payload via `.len()` -> `2` (no "list receiver used a Unit value")

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (303 lib + 47 codegen_smoke, 0 failures)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] New regression `examples/v2/enum_self_method.rv` plus `enum_self_method_match_compiles_and_runs` in `tests/codegen_smoke.rs` asserting `42\nhello\n3\n`
- [x] Existing `enum_construction_compiles_and_runs` and `json_program_compiles_and_runs` still pass

## Follow-up

`std/json`'s accessors were written as free functions to dodge this bug. They work as-is and are left unchanged here; with this fix they can be simplified to methods matching on `self` in a follow-up.
