### PR TITLE
feat(stdlib): std/regex regular expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +513,7 @@ name = "raven-runtime"
 version = "2.0.0-dev"
 dependencies = [
  "chrono",
+ "regex",
  "ureq",
 ]
 
@@ -519,6 +529,35 @@ dependencies = [
  "slice-group-by",
  "smallvec",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"

--- a/docs/v2/specs/std-regex.md
+++ b/docs/v2/specs/std-regex.md
@@ -1,0 +1,107 @@
+# std/regex Spec
+
+Regular expressions: compiling a pattern once into a reusable handle, then
+testing for a match, finding the first match or all matches, extracting
+capture groups, replacing matches, and splitting on a pattern. The
+primitives bind the raven-runtime C ABI; the wrappers add the Result/Error
+model, the `Option`/`List` return shapes, and the `Regex` handle type in
+pure Raven.
+
+## Import
+
+```raven
+import std/regex { compile }
+```
+
+The methods on `Regex` come in with the type and need no separate selector.
+
+## Backing and syntax flavor
+
+The runtime is backed by the Rust `regex` crate. Its syntax is RE2-style:
+linear-time matching with no backreferences and no lookaround (no `\1`
+within the pattern, no `(?=...)`/`(?<=...)`). Standard constructs are
+supported: character classes, anchors, quantifiers, alternation, groups,
+named groups, and Unicode classes. See the regex crate documentation for
+the full grammar.
+
+## Handle registry model
+
+A compiled pattern (`regex::Regex`) cannot cross the FFI boundary, so the
+runtime keeps it in a process-wide registry keyed by an incrementing `i64`
+id and hands Raven only that id. The Raven `Regex { id: Int }` struct wraps
+the id. Every match operation looks the pattern up by id and acts on it.
+Ids start at 1; an id of 0 is the failure sentinel paired with a set
+last-error.
+
+Compiling once and reusing the handle avoids recompiling the pattern per
+call and lets a syntax error be reported cleanly at compile time rather
+than at each match.
+
+There is no destructor. A caller should call `free(self)` when done with a
+pattern to drop its registry entry. Not freeing leaks the entry for the
+life of the process; for a short program with a fixed set of patterns the
+leak is bounded and harmless, but a long-running program that compiles
+patterns dynamically should free them.
+
+## Error model
+
+`compile` returns `Result<Regex, Error>`. The error is an std/error `Error`
+tagged with kind `"regex"`, built directly as a struct literal, its message
+the underlying regex syntax error. The runtime keeps a thread-local
+last-error string set on a failed compile; `raven_regex_compile` returns id
+0 on failure, and the wrapper turns an id of 0 into an `Err` carrying
+`raven_regex_last_error()`. The match operations are infallible on a valid
+handle and do not use the Result model.
+
+## List representation across the FFI
+
+No collections cross the FFI. `find_all`, `captures`, and `split` return
+their results as a single String with the pieces joined by `\n`, which the
+Raven wrapper splits back into a `List<String>`. An empty runtime result
+maps to an empty list (not a one-element list of `""`).
+
+This `\n`-join is ambiguous when a matched substring or a split piece itself
+contains a literal newline: such a piece would be read as two list
+elements. This is an accepted limitation for v2.0. A pattern that does not
+match newline content is unaffected.
+
+## No-match vs matched empty string
+
+`raven_regex_find` returns the first match substring, or `""` when there is
+no match. Because a pattern can also match the empty string, the empty
+return is ambiguous on its own. The runtime additionally exposes
+`raven_regex_has_match(id, text) -> bool`, and `find` uses it to decide:
+`Some(s)` when there is a match (`s` may be `""`), `None` when there is no
+match. `captures` uses the same flag to return an empty list on no match.
+
+## Capture-group conventions
+
+`captures` returns the groups of the first match, group 0 (the whole match)
+first, then groups 1, 2, and so on, joined by `\n`. An unmatched optional
+group becomes an empty line (an empty string in the resulting list). When
+there is no match the result is an empty list.
+
+## Replacement references
+
+`replace_all(text, repl)` replaces every non-overlapping match with `repl`.
+The regex crate honors group references in `repl`: `$1` and `${1}` for
+numbered groups and `$name` for named groups. To insert a literal `$`,
+escape it per the regex crate's replacement rules.
+
+## Runtime symbols
+
+| Symbol | Returns | Role |
+|--------|---------|------|
+| `raven_regex_last_error()` | String | Last compile error, empty on success |
+| `raven_regex_compile(pattern)` | Int | Compile, return id or 0 on failure |
+| `raven_regex_is_match(id, text)` | Bool | Whether the pattern matches anywhere |
+| `raven_regex_has_match(id, text)` | Bool | Match flag distinguishing no-match from empty match |
+| `raven_regex_find(id, text)` | String | First match, `""` when none |
+| `raven_regex_find_all(id, text)` | String | All matches, `\n`-joined |
+| `raven_regex_captures(id, text)` | String | Groups of the first match, `\n`-joined |
+| `raven_regex_replace_all(id, text, repl)` | String | Replace all matches (honors `$1`/`$name`) |
+| `raven_regex_split(id, text)` | String | Split on the pattern, `\n`-joined |
+| `raven_regex_free(id)` | Unit | Drop the compiled pattern |
+
+The `regex` crate is added to `raven-runtime`. It is pure Rust with no
+system library dependency and builds on Linux, macOS, and Windows.

--- a/examples/v2/use_regex.rv
+++ b/examples/v2/use_regex.rv
@@ -1,0 +1,44 @@
+import std/regex { compile }
+
+fun main() {
+    match compile("a+") {
+        Ok(re) -> {
+            print(re.is_match("xaaay"))
+            match re.find("xaaay") {
+                Some(m) -> print(m),
+                None -> print("none"),
+            }
+            match re.find("zzz") {
+                Some(m) -> print(m),
+                None -> print("none"),
+            }
+            let parts = re.split("xaaayaz")
+            print_int(parts.len())
+            print(parts[0])
+            print(parts[1])
+            print(parts[2])
+            re.free()
+        },
+        Err(e) -> print("compile failed"),
+    }
+    match compile("(\\d+)-(\\d+)") {
+        Ok(re) -> {
+            let all = re.find_all("12-345 and 67-8")
+            print_int(all.len())
+            print(all[0])
+            print(all[1])
+            let caps = re.captures("12-345")
+            print_int(caps.len())
+            print(caps[0])
+            print(caps[1])
+            print(caps[2])
+            print(re.replace_all("a 12-345 b", "$2-$1"))
+            re.free()
+        },
+        Err(e) -> print("compile failed"),
+    }
+    match compile("(") {
+        Ok(re) -> print("ok"),
+        Err(e) -> print("compile failed"),
+    }
+}

--- a/raven-runtime/Cargo.toml
+++ b/raven-runtime/Cargo.toml
@@ -13,4 +13,5 @@ name = "raven_runtime"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+regex = "1"
 ureq = "2.12"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -123,6 +123,35 @@ fn http_clear_error() {
     HTTP_LAST_ERROR.with(|e| e.borrow_mut().clear());
 }
 
+thread_local! {
+    // Message of the most recent failed regex compile: empty on success,
+    // the syntax error text on failure. The std/regex wrapper reads it
+    // through `raven_regex_last_error` to decide Ok vs Err.
+    static REGEX_LAST_ERROR: RefCell<std::string::String> = const { RefCell::new(std::string::String::new()) };
+}
+
+fn regex_set_error(msg: std::string::String) {
+    REGEX_LAST_ERROR.with(|e| *e.borrow_mut() = msg);
+}
+
+fn regex_clear_error() {
+    REGEX_LAST_ERROR.with(|e| e.borrow_mut().clear());
+}
+
+/// The process-wide compiled-regex registry keyed by an incrementing id.
+/// Ids start at 1; 0 is the failure sentinel that pairs with a set
+/// last-error.
+fn regex_registry() -> &'static Mutex<HashMap<i64, regex::Regex>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<i64, regex::Regex>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Issue the next compiled-regex id.
+fn regex_next_id() -> i64 {
+    static NEXT_ID: AtomicI64 = AtomicI64::new(1);
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
 /// A response captured eagerly into owned data. ureq consumes the
 /// response when its body is read, so the whole request runs in one call
 /// and the status, headers, and body are stored here keyed by an id.
@@ -1225,6 +1254,203 @@ pub extern "C" fn raven_http_headers(id: i64) -> *mut object::String {
 #[no_mangle]
 pub extern "C" fn raven_http_free(id: i64) {
     http_registry().lock().unwrap().remove(&id);
+}
+
+/// The message of the most recent failed regex compile, empty when it
+/// succeeded. The std/regex wrapper reads this to build an `Err` only
+/// when the compile id is 0.
+#[no_mangle]
+pub extern "C" fn raven_regex_last_error() -> *mut object::String {
+    REGEX_LAST_ERROR.with(|e| {
+        let msg = e.borrow();
+        object::raven_string_from_bytes(msg.as_ptr(), msg.len())
+    })
+}
+
+/// Compile `pattern` (Rust regex, RE2-style: no backreferences or
+/// lookaround) and register it. Returns the pattern id, or 0 on a syntax
+/// error with the last-error slot set.
+///
+/// # Safety
+///
+/// `pattern` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_regex_compile(pattern: *const object::String) -> i64 {
+    let Some(pattern) = env_name(pattern) else {
+        regex_set_error("pattern is not valid UTF-8".to_string());
+        return 0;
+    };
+    match regex::Regex::new(pattern) {
+        Ok(re) => {
+            let id = regex_next_id();
+            regex_registry().lock().unwrap().insert(id, re);
+            regex_clear_error();
+            id
+        }
+        Err(e) => {
+            regex_set_error(e.to_string());
+            0
+        }
+    }
+}
+
+/// Whether the compiled pattern `id` matches anywhere in `text`. An
+/// unknown id yields false.
+///
+/// # Safety
+///
+/// `text` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_regex_is_match(id: i64, text: *const object::String) -> bool {
+    let Some(text) = env_name(text) else {
+        return false;
+    };
+    let registry = regex_registry().lock().unwrap();
+    registry.get(&id).is_some_and(|re| re.is_match(text))
+}
+
+/// Whether the compiled pattern `id` has a match in `text`. Lets the
+/// wrapper tell "no match" apart from "matched the empty string", which
+/// `raven_regex_find` cannot signal by its return value alone.
+///
+/// # Safety
+///
+/// `text` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_regex_has_match(id: i64, text: *const object::String) -> bool {
+    raven_regex_is_match(id, text)
+}
+
+/// The first match of the compiled pattern `id` in `text`, or an empty
+/// `String` when there is no match (pair with `raven_regex_has_match` to
+/// tell a matched empty string apart from no match).
+///
+/// # Safety
+///
+/// `text` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_regex_find(id: i64, text: *const object::String) -> *mut object::String {
+    let value = env_name(text)
+        .and_then(|text| {
+            let registry = regex_registry().lock().unwrap();
+            registry
+                .get(&id)
+                .and_then(|re| re.find(text).map(|m| m.as_str().to_string()))
+        })
+        .unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// All non-overlapping matches of the compiled pattern `id` in `text`,
+/// joined by `\n`. An empty result means no matches. A match that itself
+/// contains a literal newline is ambiguous under this scheme.
+///
+/// # Safety
+///
+/// `text` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_regex_find_all(
+    id: i64,
+    text: *const object::String,
+) -> *mut object::String {
+    let value = env_name(text)
+        .map(|text| {
+            let registry = regex_registry().lock().unwrap();
+            match registry.get(&id) {
+                Some(re) => re
+                    .find_iter(text)
+                    .map(|m| m.as_str())
+                    .collect::<Vec<&str>>()
+                    .join("\n"),
+                None => std::string::String::new(),
+            }
+        })
+        .unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// The capture groups of the first match of the compiled pattern `id` in
+/// `text`, joined by `\n`: group 0 (the whole match) first, then groups
+/// 1, 2, and so on. An unmatched optional group becomes an empty line. An
+/// empty result means no match (pair with `raven_regex_has_match`).
+///
+/// # Safety
+///
+/// `text` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_regex_captures(
+    id: i64,
+    text: *const object::String,
+) -> *mut object::String {
+    let value = env_name(text)
+        .and_then(|text| {
+            let registry = regex_registry().lock().unwrap();
+            registry.get(&id).and_then(|re| {
+                re.captures(text).map(|caps| {
+                    caps.iter()
+                        .map(|g| g.map(|m| m.as_str()).unwrap_or(""))
+                        .collect::<Vec<&str>>()
+                        .join("\n")
+                })
+            })
+        })
+        .unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// Replace every match of the compiled pattern `id` in `text` with
+/// `repl`. The regex crate honors `$name`, `$1`, and `${1}` group
+/// references in `repl`. An unknown id returns `text` unchanged.
+///
+/// # Safety
+///
+/// `text` and `repl` must be valid `raven_string_from_bytes`-built
+/// `String`s.
+#[no_mangle]
+pub extern "C" fn raven_regex_replace_all(
+    id: i64,
+    text: *const object::String,
+    repl: *const object::String,
+) -> *mut object::String {
+    let value = match (env_name(text), env_name(repl)) {
+        (Some(text), Some(repl)) => {
+            let registry = regex_registry().lock().unwrap();
+            match registry.get(&id) {
+                Some(re) => re.replace_all(text, repl).into_owned(),
+                None => text.to_string(),
+            }
+        }
+        (Some(text), None) => text.to_string(),
+        _ => std::string::String::new(),
+    };
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// Split `text` on the compiled pattern `id`, joining the pieces by `\n`.
+/// An unknown id returns `text` unchanged.
+///
+/// # Safety
+///
+/// `text` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_regex_split(id: i64, text: *const object::String) -> *mut object::String {
+    let value = env_name(text)
+        .map(|text| {
+            let registry = regex_registry().lock().unwrap();
+            match registry.get(&id) {
+                Some(re) => re.split(text).collect::<Vec<&str>>().join("\n"),
+                None => text.to_string(),
+            }
+        })
+        .unwrap_or_default();
+    object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// Drop the compiled pattern `id` from the registry. An unknown id is a
+/// no-op.
+#[no_mangle]
+pub extern "C" fn raven_regex_free(id: i64) {
+    regex_registry().lock().unwrap().remove(&id);
 }
 
 /// A stack buffer large enough for any base-ten `i64` plus a sign.

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -91,6 +91,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "http",
     "time",
     "json",
+    "regex",
     "ffi",
 ];
 

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -55,6 +55,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("net", include_str!("../../stdlib/std/net.rv")),
     ("http", include_str!("../../stdlib/std/http.rv")),
     ("json", include_str!("../../stdlib/std/json.rv")),
+    ("regex", include_str!("../../stdlib/std/regex.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -482,6 +483,11 @@ mod tests {
     #[test]
     fn json_module_is_bundled() {
         assert!(bundled_source("json").is_some());
+    }
+
+    #[test]
+    fn regex_module_is_bundled() {
+        assert!(bundled_source("regex").is_some());
     }
 
     #[test]

--- a/stdlib/std/regex.rv
+++ b/stdlib/std/regex.rv
@@ -1,0 +1,112 @@
+// std/regex: regular expressions over the raven-runtime C ABI, backed by
+// the Rust `regex` crate (RE2-style, no backreferences or lookaround). A
+// compiled pattern cannot cross the FFI, so the runtime keeps it in a
+// registry keyed by an opaque integer id and hands Raven that id; the
+// Regex struct wraps the id. compile is fallible and returns
+// Result<Regex, Error> tagged with kind "regex" via the runtime's
+// thread-local last-error slot. List results cross the FFI as `\n`-joined
+// Strings split back into a List in Raven. There is no destructor, so a
+// caller should `free` a pattern when done; not freeing leaks the
+// registry entry for the life of the process. See
+// docs/v2/specs/std-regex.md.
+
+import std/error
+
+struct Regex {
+    id: Int,
+}
+
+extern "C" {
+    fun raven_regex_last_error() -> String
+    fun raven_regex_compile(pattern: String) -> Int
+    fun raven_regex_is_match(id: Int, text: String) -> Bool
+    fun raven_regex_has_match(id: Int, text: String) -> Bool
+    fun raven_regex_find(id: Int, text: String) -> String
+    fun raven_regex_find_all(id: Int, text: String) -> String
+    fun raven_regex_captures(id: Int, text: String) -> String
+    fun raven_regex_replace_all(id: Int, text: String, repl: String) -> String
+    fun raven_regex_split(id: Int, text: String) -> String
+    fun raven_regex_free(id: Int)
+}
+
+// Compile `pattern` into a reusable Regex. An invalid pattern is an Err
+// tagged with kind "regex" carrying the underlying syntax error.
+fun compile(pattern: String) -> Result<Regex, Error> {
+    let id = raven_regex_compile(pattern)
+    if id == 0 {
+        return Err(Error { kind: "regex", message: raven_regex_last_error() })
+    }
+    return Ok(Regex { id: id })
+}
+
+impl Regex {
+    // Whether the pattern matches anywhere in `text`.
+    fun is_match(self, text: String) -> Bool {
+        return raven_regex_is_match(self.id, text)
+    }
+
+    // The first match in `text`, or None when there is no match. A
+    // matched empty string is Some("").
+    fun find(self, text: String) -> Option<String> {
+        if raven_regex_has_match(self.id, text) {
+            return Some(raven_regex_find(self.id, text))
+        }
+        return None
+    }
+
+    // Every non-overlapping match in `text`. No matches yields an empty
+    // list.
+    fun find_all(self, text: String) -> List<String> {
+        return split_lines(raven_regex_find_all(self.id, text))
+    }
+
+    // The capture groups of the first match: group 0 (the whole match)
+    // first, then groups 1, 2, and so on. An unmatched optional group is
+    // an empty string. No match yields an empty list.
+    fun captures(self, text: String) -> List<String> {
+        if raven_regex_has_match(self.id, text) {
+            return split_lines(raven_regex_captures(self.id, text))
+        }
+        let empty: List<String> = []
+        return empty
+    }
+
+    // Replace every match in `text` with `repl`. `$1`, `${1}`, and
+    // `$name` group references in `repl` are honored.
+    fun replace_all(self, text: String, repl: String) -> String {
+        return raven_regex_replace_all(self.id, text, repl)
+    }
+
+    // Split `text` on the pattern.
+    fun split(self, text: String) -> List<String> {
+        return split_lines(raven_regex_split(self.id, text))
+    }
+
+    // Release the compiled pattern. There is no destructor, so call this
+    // when done; not freeing leaks the registry entry.
+    fun free(self) {
+        raven_regex_free(self.id)
+    }
+}
+
+// Split `s` on `\n` into a list. An empty string yields an empty list (not
+// a one-element list of ""), so an empty runtime result maps to an empty
+// list.
+fun split_lines(s: String) -> List<String> {
+    let out: List<String> = []
+    if s.length() == 0 {
+        return out
+    }
+    let n = s.length()
+    let start = 0
+    let i = 0
+    while i < n {
+        if s.char_at(i).starts_with("\n") {
+            out.push(s.substring(start, i))
+            start = i + 1
+        }
+        i = i + 1
+    }
+    out.push(s.substring(start, n))
+    return out
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -969,6 +969,38 @@ fn json_program_compiles_and_runs() {
     compile_link_run_and_check("use_json.rv", expected, &runtime);
 }
 
+#[test]
+fn regex_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/regex end to end, backed by the Rust regex crate through the
+    // runtime handle registry. Every line is deterministic: `a+` matches
+    // "xaaay" (true) and finds "aaa", a non-match returns None (none),
+    // and splitting "xaaayaz" yields 3 pieces x/y/z. The `(\d+)-(\d+)`
+    // pattern finds 2 matches (12-345, 67-8), captures 3 groups of the
+    // first match (12-345, 12, 345), and replace_all with "$2-$1" swaps
+    // the groups to "a 345-12 b". An invalid pattern "(" takes the Err
+    // path, printing "compile failed".
+    let expected = "true\n\
+                    aaa\n\
+                    none\n\
+                    3\n\
+                    x\n\
+                    y\n\
+                    z\n\
+                    2\n\
+                    12-345\n\
+                    67-8\n\
+                    3\n\
+                    12-345\n\
+                    12\n\
+                    345\n\
+                    a 345-12 b\n\
+                    compile failed\n";
+    compile_link_run_and_check("use_regex.rv", expected, &runtime);
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Add the `std/regex` standard-library module: regular expressions with a method-first API, backed at runtime by the Rust `regex` crate.

Closes #132

## Surface

```raven
import std/regex { compile }

struct Regex { id: Int }

fun compile(pattern: String) -> Result<Regex, Error>

impl Regex {
    fun is_match(self, text: String) -> Bool
    fun find(self, text: String) -> Option<String>
    fun find_all(self, text: String) -> List<String>
    fun captures(self, text: String) -> List<String>
    fun replace_all(self, text: String, repl: String) -> String
    fun split(self, text: String) -> List<String>
    fun free(self)
}
```

## Backing and syntax

Runtime-backed by the Rust `regex` crate (added to `raven-runtime`). Its syntax is RE2-style: linear-time matching with no backreferences and no lookaround. `replace_all` honors `$1`, `${1}`, and `$name` group references in the replacement.

## Handle registry

A compiled pattern cannot cross the FFI, so the runtime stores `regex::Regex` in a process-wide registry keyed by an `i64` id (the same shape `std/net` uses for sockets). `compile` returns the id, or 0 on a syntax error with the thread-local last-error slot set, which the wrapper turns into an `Err(Error { kind: "regex", ... })`. There is no destructor, so `free(self)` drops the registry entry; not freeing leaks it for the life of the process. `find` distinguishes no match from a matched empty string through a `has_match` flag rather than the empty-string return alone. `find_all`, `captures`, and `split` cross the FFI as `\n`-joined Strings split back into a `List<String>` in Raven (with the documented limitation that a piece containing a literal newline is ambiguous).

## Verified output

`examples/v2/use_regex.rv`, compiled and run:

```
true
aaa
none
3
x
y
z
2
12-345
67-8
3
12-345
12
345
a 345-12 b
compile failed
```

This covers a match, a no-match (`find` returns `None`, printed `none`), `split` (3 pieces), `find_all` (2 matches), `captures` (3 groups), `replace_all` with `$2-$1`, and an invalid-pattern compile error.

## Test plan

- [x] `cargo build --workspace` (regex crate builds, `Cargo.lock` updated)
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `regex_program_compiles_and_runs` smoke test (gated on `supported_runtime()`) covering match, no-match, captures, replace_all, split, invalid pattern
- [x] `regex_module_is_bundled` unit test
