### PR TITLE
feat(stdlib): std/process subprocesses

### DIFF
--- a/docs/v2/specs/std-process.md
+++ b/docs/v2/specs/std-process.md
@@ -1,0 +1,86 @@
+# std/process Spec
+
+Spawn a subprocess, run it to completion, and read its exit code plus
+captured stdout and stderr. Optionally feed data to the child's stdin. The
+primitives bind the raven-runtime C ABI (backed by `std::process::Command`);
+the wrappers add the Result/Error model and the `Output` value type in pure
+Raven.
+
+## Import
+
+```raven
+import std/process { run, run_with_input }
+```
+
+The `success` method on `Output` comes in with the type and needs no
+separate selector.
+
+## Surface
+
+```raven
+struct Output { code: Int, stdout: String, stderr: String }
+
+fun run(program: String, args: List<String>) -> Result<Output, Error>
+fun run_with_input(program: String, args: List<String>, input: String) -> Result<Output, Error>
+
+impl Output {
+    fun success(self) -> Bool   // code == 0
+}
+```
+
+`run` spawns `program` with `args`, feeds it no stdin, waits for it to
+finish, and returns its captured output. `run_with_input` is the same but
+writes `input` to the child's stdin (which is then closed).
+
+## Run-to-completion model
+
+There is no streaming in v2.0. A run executes the child to completion in a
+single runtime call that captures the whole of stdout and stderr into an
+owned result before returning. A caller that needs incremental output is
+not served by this surface.
+
+## Argument encoding (NUL-joined)
+
+A Raven `List` cannot cross the C ABI, so `run` joins the args into one
+String with a single NUL byte (`\0`) between elements and the runtime splits
+that String back into the child's argument vector. An empty list is the
+empty String (zero args). Program arguments effectively never contain a NUL
+byte, so the encoding is unambiguous; an argument that itself contains a NUL
+byte is not supported.
+
+## Handle registry model
+
+A finished child's output cannot cross the FFI as a struct, so the runtime
+captures the exit code, stdout, and stderr into an entry in a process-wide
+registry keyed by an incrementing `i64` id and hands Raven only that id. The
+wrappers read the three fields by id through the extractors, then free the
+entry, so a caller never sees the id. Ids start at 1; an id of 0 is the
+spawn-failure sentinel paired with a set last-error.
+
+## Non-zero exit is not an error
+
+A child that spawns and runs but exits with a non-zero code is a normal,
+successful run: its code and output are captured and `run` returns
+`Ok(Output)`. The caller inspects `code` (or `success()`) to decide what a
+non-zero exit means. Only a spawn failure (for example the program is not
+found, or it cannot be executed) takes the `Err` path.
+
+## Error model
+
+A spawn failure returns `Err(Error { kind: "process", message })`, the
+message being the OS error text the runtime captured in its thread-local
+last-error slot. The `Error` value type comes from `std/error`.
+
+## Signal termination
+
+A child terminated by a signal with no exit code (a Unix concern; Windows
+processes always carry a code) reports a code of `-1`. This sentinel also
+covers an unknown id.
+
+## Stdin
+
+`run` writes nothing to the child's stdin and closes it immediately, so a
+child that reads stdin sees end of input at once. `run_with_input` writes
+the given `input` and then closes stdin. A broken pipe (the child exits
+without reading) is ignored: the run still yields the child's captured
+output.

--- a/examples/v2/proc_child.rv
+++ b/examples/v2/proc_child.rv
@@ -1,0 +1,7 @@
+// golden:skip
+// A deterministic child process for the std/process smoke test: prints 7
+// then a newline (the builtin `print` adds the newline). The parent runs
+// this compiled binary and inspects its exit code and stdout.
+fun main() {
+    print(7)
+}

--- a/examples/v2/use_process.rv
+++ b/examples/v2/use_process.rv
@@ -1,0 +1,24 @@
+// golden:skip
+// std/process parent: runs a second compiled Raven program (the child,
+// path from RAVEN_PROC_CHILD) and prints its exit code and stdout, then
+// exercises the spawn-failure Err path on a program that does not exist.
+// The child prints `7\n`, so this prints `0`, then `7`, then `run failed`.
+import std/process { run }
+import std/env { get_env }
+import std/io { print, println }
+
+fun main() {
+    let child = get_env("RAVEN_PROC_CHILD")
+    let no_args: List<String> = []
+    match run(child, no_args) {
+        Ok(out) -> {
+            println("${out.code}")
+            print(out.stdout)
+        },
+        Err(e) -> println("run failed"),
+    }
+    match run("definitely_not_a_real_program_xyz", no_args) {
+        Ok(out) -> println("ran"),
+        Err(e) -> println("run failed"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -138,6 +138,45 @@ fn regex_clear_error() {
     REGEX_LAST_ERROR.with(|e| e.borrow_mut().clear());
 }
 
+thread_local! {
+    // Message of the most recent failed subprocess spawn: empty on success,
+    // the OS error text on failure. The std/process wrapper reads it through
+    // `raven_process_last_error` to decide Ok vs Err. A child that runs but
+    // exits non-zero is NOT a failure here; only a spawn error sets this.
+    static PROCESS_LAST_ERROR: RefCell<std::string::String> = const { RefCell::new(std::string::String::new()) };
+}
+
+fn process_set_error(msg: std::string::String) {
+    PROCESS_LAST_ERROR.with(|e| *e.borrow_mut() = msg);
+}
+
+fn process_clear_error() {
+    PROCESS_LAST_ERROR.with(|e| e.borrow_mut().clear());
+}
+
+/// A finished child's captured output. The child runs to completion in one
+/// call and its exit code, stdout, and stderr are stored here keyed by an
+/// id so only an opaque integer crosses the FFI.
+struct ProcResult {
+    code: i64,
+    stdout: std::string::String,
+    stderr: std::string::String,
+}
+
+/// The process-wide child-result registry keyed by an incrementing id. Ids
+/// start at 1; 0 is the spawn-failure sentinel that pairs with a set
+/// last-error.
+fn process_registry() -> &'static Mutex<HashMap<i64, ProcResult>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<i64, ProcResult>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Issue the next child-result id.
+fn process_next_id() -> i64 {
+    static NEXT_ID: AtomicI64 = AtomicI64::new(1);
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
 /// The process-wide compiled-regex registry keyed by an incrementing id.
 /// Ids start at 1; 0 is the failure sentinel that pairs with a set
 /// last-error.
@@ -1451,6 +1490,132 @@ pub extern "C" fn raven_regex_split(id: i64, text: *const object::String) -> *mu
 #[no_mangle]
 pub extern "C" fn raven_regex_free(id: i64) {
     regex_registry().lock().unwrap().remove(&id);
+}
+
+/// The message of the most recent failed subprocess spawn, empty when the
+/// spawn succeeded. The std/process wrapper reads this to build an `Err`
+/// only when the run id is 0. A non-zero child exit never sets it.
+#[no_mangle]
+pub extern "C" fn raven_process_last_error() -> *mut object::String {
+    PROCESS_LAST_ERROR.with(|e| {
+        let msg = e.borrow();
+        object::raven_string_from_bytes(msg.as_ptr(), msg.len())
+    })
+}
+
+/// Spawn `program` with `args_nul_joined` (the child's args, each joined by
+/// a single NUL byte; an empty String means no args), feed `stdin_data` to
+/// the child's stdin (an empty String writes nothing), wait for it, and
+/// capture stdout, stderr (lossy UTF-8), and the exit code into a registry
+/// entry. Returns the entry id, or 0 on a spawn failure (for example the
+/// program is not found) with the last-error slot set. A child that runs
+/// but exits non-zero is NOT a spawn failure: its code and output are
+/// captured and a normal id is returned.
+///
+/// # Safety
+///
+/// `program`, `args_nul_joined`, and `stdin_data` must be valid
+/// `raven_string_from_bytes`-built `String`s.
+#[no_mangle]
+pub extern "C" fn raven_process_run(
+    program: *const object::String,
+    args_nul_joined: *const object::String,
+    stdin_data: *const object::String,
+) -> i64 {
+    let (Some(program), Some(args_joined), Some(stdin_data)) = (
+        env_name(program),
+        env_name(args_nul_joined),
+        env_name(stdin_data),
+    ) else {
+        process_set_error("program, args, or stdin is not valid UTF-8".to_string());
+        return 0;
+    };
+
+    // The args are joined by NUL. An empty String is zero args; otherwise
+    // each NUL-separated field is one arg. Program args effectively never
+    // contain NUL, so this round-trips unambiguously.
+    let args: Vec<&str> = if args_joined.is_empty() {
+        Vec::new()
+    } else {
+        args_joined.split('\0').collect()
+    };
+
+    let mut command = process::Command::new(program);
+    command.args(&args);
+    command.stdin(process::Stdio::piped());
+    command.stdout(process::Stdio::piped());
+    command.stderr(process::Stdio::piped());
+
+    let mut child = match command.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            process_set_error(e.to_string());
+            return 0;
+        }
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        // Ignore a broken pipe: a child that exits without reading still
+        // produced a valid result. Dropping stdin closes it.
+        let _ = stdin.write_all(stdin_data.as_bytes());
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => {
+            process_set_error(e.to_string());
+            return 0;
+        }
+    };
+
+    // A child terminated by a signal with no exit code maps to -1.
+    let code = output.status.code().map(|c| c as i64).unwrap_or(-1);
+    let result = ProcResult {
+        code,
+        stdout: std::string::String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: std::string::String::from_utf8_lossy(&output.stderr).into_owned(),
+    };
+    let id = process_next_id();
+    process_registry().lock().unwrap().insert(id, result);
+    process_clear_error();
+    id
+}
+
+/// Exit code of the finished child `id`. A child terminated by a signal
+/// with no code yields -1. An unknown id yields -1.
+#[no_mangle]
+pub extern "C" fn raven_process_exit_code(id: i64) -> i64 {
+    process_registry()
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|r| r.code)
+        .unwrap_or(-1)
+}
+
+/// Captured stdout of the finished child `id`. An unknown id yields an
+/// empty `String`.
+#[no_mangle]
+pub extern "C" fn raven_process_stdout(id: i64) -> *mut object::String {
+    let registry = process_registry().lock().unwrap();
+    let out = registry.get(&id).map(|r| r.stdout.as_str()).unwrap_or("");
+    object::raven_string_from_bytes(out.as_ptr(), out.len())
+}
+
+/// Captured stderr of the finished child `id`. An unknown id yields an
+/// empty `String`.
+#[no_mangle]
+pub extern "C" fn raven_process_stderr(id: i64) -> *mut object::String {
+    let registry = process_registry().lock().unwrap();
+    let err = registry.get(&id).map(|r| r.stderr.as_str()).unwrap_or("");
+    object::raven_string_from_bytes(err.as_ptr(), err.len())
+}
+
+/// Drop the finished child `id`, releasing its captured output. An unknown
+/// id is a no-op.
+#[no_mangle]
+pub extern "C" fn raven_process_free(id: i64) {
+    process_registry().lock().unwrap().remove(&id);
 }
 
 /// A stack buffer large enough for any base-ten `i64` plus a sign.

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -92,6 +92,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "time",
     "json",
     "regex",
+    "process",
     "ffi",
 ];
 

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -56,6 +56,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("http", include_str!("../../stdlib/std/http.rv")),
     ("json", include_str!("../../stdlib/std/json.rv")),
     ("regex", include_str!("../../stdlib/std/regex.rv")),
+    ("process", include_str!("../../stdlib/std/process.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -488,6 +489,11 @@ mod tests {
     #[test]
     fn regex_module_is_bundled() {
         assert!(bundled_source("regex").is_some());
+    }
+
+    #[test]
+    fn process_module_is_bundled() {
+        assert!(bundled_source("process").is_some());
     }
 
     #[test]

--- a/stdlib/std/process.rv
+++ b/stdlib/std/process.rv
@@ -1,0 +1,89 @@
+// std/process: spawn subprocesses over the raven-runtime C ABI, backed by
+// std::process::Command. A child runs to completion in one runtime call
+// that captures its exit code, stdout, and stderr into a registry entry
+// keyed by an opaque integer id; the wrappers pull those out and free the
+// id. A non-zero exit is NOT an Err: the caller inspects `code`. Only a
+// spawn failure (for example the program is not found) takes the Err path
+// through the runtime's thread-local last-error slot, tagged with kind
+// "process".
+//
+// A `List` cannot cross the FFI, so the args are joined into one String
+// with a single NUL byte (`\0`) between elements and split back in the
+// runtime. Program args effectively never contain NUL, so this is
+// unambiguous; an arg containing a NUL byte is not supported. An empty arg
+// list is the empty String. See docs/v2/specs/std-process.md.
+
+import std/error
+
+struct Output {
+    code: Int,
+    stdout: String,
+    stderr: String,
+}
+
+extern "C" {
+    fun raven_process_last_error() -> String
+    fun raven_process_run(program: String, args_nul_joined: String, stdin_data: String) -> Int
+    fun raven_process_exit_code(id: Int) -> Int
+    fun raven_process_stdout(id: Int) -> String
+    fun raven_process_stderr(id: Int) -> String
+    fun raven_process_free(id: Int)
+}
+
+impl Output {
+    // Whether the child exited with code 0.
+    fun success(self) -> Bool {
+        return self.code == 0
+    }
+}
+
+// Join `args` into one String with a single NUL byte between elements, the
+// encoding the runtime splits back into the child's argument list. An empty
+// list yields the empty String (zero args). An arg must not contain NUL.
+fun join_args(args: List<String>) -> String {
+    let out = ""
+    let nul = __str_from_byte(0)
+    let i = 0
+    let n = args.len()
+    while i < n {
+        if i > 0 {
+            out = out.concat(nul)
+        }
+        out = out.concat(args[i])
+        i = i + 1
+    }
+    return out
+}
+
+// Pull the finished child `id` into an Output and free the registry entry.
+fun collect(id: Int) -> Output {
+    let out = Output {
+        code: raven_process_exit_code(id),
+        stdout: raven_process_stdout(id),
+        stderr: raven_process_stderr(id),
+    }
+    raven_process_free(id)
+    return out
+}
+
+// Run `program` with `args`, no stdin, waiting for it to finish. On success
+// returns Ok(Output) with the captured code, stdout, and stderr; a non-zero
+// exit is still Ok. On a spawn failure returns Err tagged with kind
+// "process".
+fun run(program: String, args: List<String>) -> Result<Output, Error> {
+    let id = raven_process_run(program, join_args(args), "")
+    if id == 0 {
+        return Err(Error { kind: "process", message: raven_process_last_error() })
+    }
+    return Ok(collect(id))
+}
+
+// Like `run`, but feeds `input` to the child's stdin (which is then
+// closed).
+fun run_with_input(program: String, args: List<String>, input: String) -> Result<Output, Error> {
+    let id = raven_process_run(program, join_args(args), input)
+    if id == 0 {
+        return Err(Error { kind: "process", message: raven_process_last_error() })
+    }
+    return Ok(collect(id))
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1001,6 +1001,86 @@ fn regex_program_compiles_and_runs() {
     compile_link_run_and_check("use_regex.rv", expected, &runtime);
 }
 
+#[test]
+fn process_module_is_bundled() {
+    // The std/process module source is embedded in the compiler and visible
+    // to the resolver under its `std/` path.
+    assert!(raven::resolve::stdlib::bundled_source("process").is_some());
+}
+
+#[test]
+fn process_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/process subprocesses end to end. A portable subprocess test
+    // cannot rely on host commands (echo/cmd differ across platforms), so
+    // the child is a SECOND compiled Raven program with identical output
+    // everywhere: proc_child.rv prints `7\n`. The parent (use_process.rv)
+    // reads the child's path from RAVEN_PROC_CHILD, runs it with no args,
+    // and prints the exit code (0) then the captured stdout (`7\n`), then
+    // takes the spawn-failure Err path on a nonexistent program, printing
+    // `run failed`. Total stdout is `0\n7\nrun failed\n`.
+    let child = build_example_binary("proc_child.rv", &runtime);
+    let parent = build_example_binary("use_process.rv", &runtime);
+
+    let output = Command::new(&parent.binary)
+        .env("RAVEN_PROC_CHILD", &child.binary)
+        .output()
+        .expect("run use_process binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&child.tmp);
+    cleanup(&parent.tmp);
+    assert!(
+        output.status.success(),
+        "use_process binary exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "0\n7\nrun failed\n",
+        "unexpected stdout for use_process: {:?}",
+        stdout
+    );
+}
+
+/// A compiled example binary plus the temp dir holding it, so the caller
+/// can run the binary and then clean up.
+struct ExampleBinary {
+    binary: PathBuf,
+    tmp: PathBuf,
+}
+
+/// Compile `examples/v2/<name>` to a fresh temp executable and return its
+/// path. Panics on any failure on a supported host.
+fn build_example_binary(name: &str, runtime: &RuntimeStaticLib) -> ExampleBinary {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("v2")
+        .join(name);
+    let source =
+        std::fs::read_to_string(&source_path).unwrap_or_else(|e| panic!("read {}: {}", name, e));
+    let object_bytes = match build_object(&source, &source_path) {
+        Ok(b) => b,
+        Err(e) => panic!("frontend or codegen failed for {}: {}", name, e),
+    };
+    let tmp = workdir();
+    let stem = Path::new(name).file_stem().unwrap().to_string_lossy();
+    let object_path = tmp.join(format!("{}.o", stem));
+    std::fs::write(&object_path, &object_bytes).expect("write object");
+    let binary = tmp.join(if cfg!(windows) {
+        format!("{}.exe", stem)
+    } else {
+        stem.to_string()
+    });
+    if let Err(e) = linker::link(&object_path, runtime, &binary) {
+        cleanup(&tmp);
+        panic!("linker failed to produce an executable for {}: {}", name, e);
+    }
+    ExampleBinary { binary, tmp }
+}
+
 /// Return the runtime staticlib when a linker and the staticlib are both
 /// present, or skip with a diagnostic. Shared by every smoke case so the
 /// skip behavior stays identical.


### PR DESCRIPTION
Add the `std/process` standard-library module: spawn a subprocess, run it to completion, and read its exit code plus captured stdout and stderr, optionally feeding stdin.

Closes #128

## Surface

```raven
import std/process { run, run_with_input }

struct Output { code: Int, stdout: String, stderr: String }

fun run(program: String, args: List<String>) -> Result<Output, Error>
fun run_with_input(program: String, args: List<String>, input: String) -> Result<Output, Error>

impl Output {
    fun success(self) -> Bool   // code == 0
}
```

Backed by `std::process::Command` through the raven-runtime C ABI (`raven_process_*`) with a result-handle registry keyed by an `i64` id; the Result/Error model and the `Output` value type are pure Raven, mirroring `std/http` and `std/regex`.

## Argument encoding and run-to-completion model

A Raven `List` cannot cross the C ABI, so `run` joins the args into one String with a single NUL byte (`\0`) between elements and the runtime splits it back into the child's argument vector. An empty list is the empty String (zero args); an argument containing a NUL byte is not supported. There is no streaming in v2.0: the child runs to completion in one call and its whole stdout and stderr are captured before returning. A non-zero child exit is a normal `Ok`; only a spawn failure is an `Err` tagged with kind `"process"`. A child terminated by a signal with no code reports `-1`.

## Test design

A portable subprocess test cannot rely on host commands (echo/cmd differ across platforms), so the child is a SECOND compiled Raven program with identical output everywhere. `examples/v2/proc_child.rv` prints `7`. The parent `examples/v2/use_process.rv` reads the child's path from `RAVEN_PROC_CHILD`, runs it with no args, prints the exit code and captured stdout, then takes the spawn-failure `Err` path on a nonexistent program. The smoke test `process_program_compiles_and_runs` builds both binaries, runs the parent with the env var set, and asserts the exact stdout.

Observed parent stdout:

```
0
7
run failed
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (smoke test runs a real child and the spawn-failure Err path; golden suite green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Manual run of the compiled parent with `RAVEN_PROC_CHILD` set: stdout `0\n7\nrun failed\n`
