### PR TITLE
feat(stdlib): std/ffi C types and String conversions

### DIFF
--- a/docs/v2/specs/ffi.md
+++ b/docs/v2/specs/ffi.md
@@ -67,11 +67,15 @@ not silently passed where the C ABI expects a foreign one.
 | `CLong`    | `long`           | `i64`                  |
 | `CSize`    | `size_t`         | pointer width (`i64`)  |
 | `CStr`     | `const char *`   | pointer width (`i64`)  |
+| `CDouble`  | `double`         | `f64`                  |
 | `CPtr<T>`  | `T *` (opaque)   | pointer width (`i64`)  |
 
 `CInt` is fixed at 32-bit, which matches the C `int` on every ABI Raven
 targets. `CLong` and `CSize` are 64-bit on the 64-bit targets Raven
-supports. `CStr`, `CSize`, and `CPtr<T>` are all pointer width.
+supports. `CStr`, `CSize`, and `CPtr<T>` are all pointer width. `CDouble`
+is C `double`, the same `f64` representation a Raven `Float` already uses,
+so a `Float` argument is accepted where a `CDouble` is expected. C `float`
+(`CFloat`) is not yet provided; see `docs/v2/specs/std-ffi.md`.
 
 `CPtr<T>` is a typed but opaque pointer in v2.0: the pointee type is kept
 for documentation and future conversions, but the back end treats the
@@ -81,8 +85,8 @@ for it yet.
 `CString` is accepted as an alias for `CStr` so that older `extern`
 signatures keep checking.
 
-The full `std/ffi` module with conversion helpers is issue #80; this
-spec provides only what is needed to call C.
+The `std/ffi` module adds runtime `String` to `CStr` conversion helpers
+on top of these primitives. See `docs/v2/specs/std-ffi.md`.
 
 ## C string literals and `CStr`
 
@@ -96,9 +100,10 @@ Passing a native Raven `String` where a `CStr` is expected is rejected.
 A heap `String` (see `docs/v2/specs/object-layout.md` and
 `raven-runtime/src/object/string.rs`) is length-prefixed and not
 guaranteed to be null-terminated, so it is not a valid `const char *`.
-String-to-CStr conversion (a null-terminated copy through a helper such
-as `raven_string_as_cstr`) is deferred to issue #80. In this release,
-only `c"..."` literals produce a `CStr`.
+To pass a runtime `String`, convert it through `std/ffi`'s `to_cstr`,
+which copies the bytes into a null-terminated buffer (see
+`docs/v2/specs/std-ffi.md`). A `c"..."` literal still produces a `CStr`
+directly with no allocation.
 
 An integer C parameter (`CInt`, `CLong`, `CSize`) accepts a native `Int`
 argument, so a literal such as `abs(-7)` checks. The back end converts
@@ -152,6 +157,5 @@ non-CRT symbol surfaces as an unresolved-symbol error at link time.
 * Variadic C functions (for example `printf` with format arguments).
 * Callbacks from C back into Raven (passing a Raven function as a C
   function pointer).
-* String-to-CStr conversion of a heap `String` (issue #80).
 * Non-CRT libraries and their link flags (issue #81).
 * Dereferencing or arithmetic on `CPtr<T>`.

--- a/docs/v2/specs/std-ffi.md
+++ b/docs/v2/specs/std-ffi.md
@@ -1,0 +1,142 @@
+# std/ffi Spec
+
+Companion module for the C foreign-function interface. The C type set is
+built into the type checker (see `docs/v2/specs/ffi.md`); this module adds
+the runtime conversions between a Raven `String` and a C `CStr`, which the
+compiler FFI layer deliberately left out. A `c"..."` literal already
+yields a `CStr` at compile time, but a `String` value computed at runtime
+needs a conversion, which is what `to_cstr` and `from_cstr` provide.
+
+## Import
+
+```raven
+import std/ffi { to_cstr, from_cstr }
+```
+
+## Surface
+
+```raven
+fun to_cstr(s: String) -> CStr
+fun from_cstr(p: CStr) -> String
+```
+
+`to_cstr` copies the bytes of `s` into a fresh, null-terminated buffer and
+returns a `CStr` pointing at the first byte. The result is a standalone
+copy, not the String's own length-prefixed buffer, so it is a valid
+`const char *`. `from_cstr` reads the null-terminated bytes at `p`,
+stopping at the first NUL, and builds a Raven `String` from them (the
+terminator is not included).
+
+Both wrappers are pure Raven over two raven-runtime symbols bound through
+`extern "C"`: `raven_string_to_cstr` and `raven_cstr_to_string`.
+
+## Lifetime and ownership
+
+`to_cstr` allocates the null-terminated buffer outside the GC heap and
+does not reclaim it: the pointer is valid for the rest of the program run.
+This copy semantics is intentional. A C callee may read the pointer after
+the call returns or retain it, and the buffer must not move or be freed by
+a later garbage collection, so it cannot be the String's own GC-managed
+bytes. The cost is that each `to_cstr` call leaks one buffer; callers that
+convert in a hot loop should hoist the conversion. There is no `free`
+helper in this release.
+
+`from_cstr` produces an ordinary GC-managed `String`, traced and reclaimed
+like any other. Embedded NUL bytes in the source `String` are preserved by
+`to_cstr` up to the first one, but a C reader stops at that first NUL, so a
+round trip through `from_cstr` truncates at an embedded NUL. Plain UTF-8
+text without interior NUL bytes round-trips exactly.
+
+## C type set
+
+The C ABI primitives recognized by the type checker, with their machine
+mappings. `CInt`/`CLong`/`CSize`/`CStr`/`CPtr<T>` are specified in
+`docs/v2/specs/ffi.md`; `CDouble` is added here.
+
+| Raven type | C type         | Cranelift ABI type    |
+|------------|----------------|-----------------------|
+| `CInt`     | `int`          | `i32`                 |
+| `CLong`    | `long`         | `i64`                 |
+| `CSize`    | `size_t`       | pointer width (`i64`) |
+| `CStr`     | `const char *` | pointer width (`i64`) |
+| `CDouble`  | `double`       | `f64`                 |
+| `CPtr<T>`  | `T *` (opaque) | pointer width (`i64`) |
+
+`CDouble` is C `double`. It maps to `f64`, the exact representation a
+Raven `Float` already crosses the C ABI as, so a `Float` argument is
+accepted where a `CDouble` parameter is expected with no conversion at the
+call boundary, and a `CDouble` return is an `f64`. A libm function such as
+`sqrt(x: CDouble) -> CDouble` is callable with a `Float`.
+
+`CString` is accepted as an alias for `CStr`.
+
+### CFloat (deferred)
+
+C `float` (`CFloat`, an f32) is not provided in this release. A Raven
+`Float` is f64, so passing one to a C `float` parameter or reading a C
+`float` return would require an `fdemote`/`fpromote` narrowing at the call
+boundary that the codegen FFI path does not yet emit. Shipping the f32
+type without that conversion would be a silently wrong ABI, so the variant
+is deferred rather than half-wired. `CDouble` covers the common floating
+case (libm and most C math take `double`).
+
+## C string literals
+
+A `c"..."` literal types as `CStr` and lowers to a static, read-only,
+null-terminated buffer with no allocation and no runtime call. Use it for
+compile-time-known strings; use `to_cstr` for a `String` value. See
+`docs/v2/specs/ffi.md` for the literal's codegen.
+
+## libc verification
+
+`examples/v2/use_ffi.rv` converts runtime Strings and calls libc:
+
+```raven
+import std/ffi { to_cstr, from_cstr }
+import std/io { println }
+
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+    fun strcmp(a: CStr, b: CStr) -> CInt
+}
+
+fun main() {
+    let s = "hello"
+    let n = strlen(to_cstr(s))
+    print_int(n)
+    let eq = strcmp(to_cstr("abc"), to_cstr("abc"))
+    print_int(eq)
+    let lt = strcmp(to_cstr("abc"), to_cstr("abd"))
+    print_int(lt)
+    println(from_cstr(to_cstr("roundtrip")))
+}
+```
+
+Output:
+
+```
+5
+0
+-1
+roundtrip
+```
+
+`strlen` counts the 5 bytes of the converted `String`. `strcmp` returns 0
+for equal strings and a negative value when the first differing byte is
+smaller (`-1` here for `'c'` against `'d'`). `from_cstr(to_cstr("roundtrip"))`
+recovers the original text.
+
+The C integer results print through `print_int`, which accepts the integer
+FFI types (`CInt`, `CLong`, `CSize`) and widens a narrower one to i64. The
+surface has no `ToString` impl for the FFI integer types, so a `CSize` or
+`CInt` cannot be interpolated into a `"${...}"` string or compared to a
+native `Int` directly; route them through `print_int` to observe a value.
+
+## Out of scope
+
+* A `free`/`drop` for buffers from `to_cstr` (copy-and-leak semantics).
+* C `float` (`CFloat`); deferred as noted above.
+* Everything listed out of scope in `docs/v2/specs/ffi.md` (struct by
+  value, variadics, callbacks into Raven, `CPtr<T>` dereference, non-CRT
+  libraries).
+```

--- a/examples/v2/use_ffi.rv
+++ b/examples/v2/use_ffi.rv
@@ -1,0 +1,23 @@
+// std/ffi: convert a runtime Raven String to a C string and call libc.
+// strlen counts the bytes of "hello" (5). strcmp returns 0 for equal
+// strings and a nonzero value otherwise. from_cstr round-trips a CStr
+// back to a Raven String. The C integer results print through print_int,
+// which accepts the FFI integer types and widens them to i64.
+import std/ffi { to_cstr, from_cstr }
+import std/io { println }
+
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+    fun strcmp(a: CStr, b: CStr) -> CInt
+}
+
+fun main() {
+    let s = "hello"
+    let n = strlen(to_cstr(s))
+    print_int(n)
+    let eq = strcmp(to_cstr("abc"), to_cstr("abc"))
+    print_int(eq)
+    let lt = strcmp(to_cstr("abc"), to_cstr("abd"))
+    print_int(lt)
+    println(from_cstr(to_cstr("roundtrip")))
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -516,6 +516,66 @@ pub extern "C" fn raven_int_to_float(value: i64) -> f64 {
     value as f64
 }
 
+/// Copy a Raven `String` into a freshly allocated, null-terminated byte
+/// buffer and return a `*const c_char` (`CStr`) to its first byte.
+///
+/// The returned buffer is a standalone copy, not the String's own bytes,
+/// so embedded NUL bytes in the String are preserved up to the first one
+/// a C reader will stop at. The buffer is allocated outside the GC heap
+/// and is intentionally not reclaimed: it is valid for the rest of the
+/// program run. Use this for short-lived calls into C (for example
+/// `strlen`). Backs `std/ffi`'s `to_cstr`.
+///
+/// # Safety
+///
+/// `s` must be a valid `raven_string_from_bytes`-built `String` or null.
+#[no_mangle]
+pub extern "C" fn raven_string_to_cstr(s: *const object::String) -> *const u8 {
+    let len = object::raven_string_len(s) as usize;
+    // One extra byte for the terminating NUL. `raven_alloc` returns a
+    // non-null dangling pointer at size zero, which is fine for the empty
+    // string: byte index 0 is the NUL we write below.
+    let buf = raven_alloc(len + 1, 1);
+    if buf.is_null() {
+        return std::ptr::null();
+    }
+    let src = object::raven_string_bytes(s);
+    // SAFETY: `buf` has `len + 1` writable bytes; `src` holds `len`
+    // initialized bytes (or is null when `len` is zero, guarded here).
+    unsafe {
+        if len > 0 && !src.is_null() {
+            std::ptr::copy_nonoverlapping(src, buf, len);
+        }
+        *buf.add(len) = 0;
+    }
+    buf as *const u8
+}
+
+/// Read the null-terminated bytes at `p` and build a Raven `String`.
+///
+/// The length is computed up to the first NUL byte; the terminator is
+/// not included in the result. A null `p` yields an empty `String`.
+/// Backs `std/ffi`'s `from_cstr`.
+///
+/// # Safety
+///
+/// `p` must point to a null-terminated byte sequence or be null.
+#[no_mangle]
+pub extern "C" fn raven_cstr_to_string(p: *const u8) -> *mut object::String {
+    if p.is_null() {
+        return object::raven_string_from_bytes(std::ptr::null(), 0);
+    }
+    let mut len = 0usize;
+    // SAFETY: the caller guarantees a NUL terminator, so the scan stops
+    // inside the buffer.
+    unsafe {
+        while *p.add(len) != 0 {
+            len += 1;
+        }
+    }
+    object::raven_string_from_bytes(p, len)
+}
+
 /// Return a non-deterministic 64-bit seed for entropy seeding.
 ///
 /// Mixes a high-resolution timestamp with the process id through a

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -55,6 +55,7 @@ pub fn cranelift_ty(ty: &MirType, ptr: CType) -> Option<CType> {
         MirType::Ffi(ffi) => Some(match ffi {
             MirFfiTy::CInt => types::I32,
             MirFfiTy::CLong => types::I64,
+            MirFfiTy::CDouble => types::F64,
             MirFfiTy::CSize | MirFfiTy::CStr | MirFfiTy::CPtr(_) => ptr,
         }),
     }

--- a/src/mir/ty.rs
+++ b/src/mir/ty.rs
@@ -22,6 +22,8 @@ pub enum MirFfiTy {
     CSize,
     /// `*const c_char`. Codegen maps it to a pointer-width int.
     CStr,
+    /// C `double`. Codegen maps it to `f64`.
+    CDouble,
     /// `CPtr<T>`, an opaque pointer. Codegen maps it to a pointer-width
     /// int. The pointee mangle is kept for symbol uniqueness only.
     CPtr(Box<MirType>),
@@ -209,6 +211,7 @@ impl MirFfiTy {
             FfiTy::CLong => MirFfiTy::CLong,
             FfiTy::CSize => MirFfiTy::CSize,
             FfiTy::CStr => MirFfiTy::CStr,
+            FfiTy::CDouble => MirFfiTy::CDouble,
             FfiTy::CPtr(inner) => MirFfiTy::CPtr(Box::new(MirType::from_ty(inner))),
         }
     }
@@ -220,6 +223,7 @@ impl MirFfiTy {
             MirFfiTy::CLong => "CLong".into(),
             MirFfiTy::CSize => "CSize".into(),
             MirFfiTy::CStr => "CStr".into(),
+            MirFfiTy::CDouble => "CDouble".into(),
             MirFfiTy::CPtr(inner) => format!("CPtr_{}", inner.mangle()),
         }
     }
@@ -232,6 +236,7 @@ impl fmt::Display for MirFfiTy {
             MirFfiTy::CLong => f.write_str("CLong"),
             MirFfiTy::CSize => f.write_str("CSize"),
             MirFfiTy::CStr => f.write_str("CStr"),
+            MirFfiTy::CDouble => f.write_str("CDouble"),
             MirFfiTy::CPtr(inner) => write!(f, "CPtr<{}>", inner),
         }
     }

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -57,6 +57,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("json", include_str!("../../stdlib/std/json.rv")),
     ("regex", include_str!("../../stdlib/std/regex.rv")),
     ("process", include_str!("../../stdlib/std/process.rv")),
+    ("ffi", include_str!("../../stdlib/std/ffi.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
 ];
 
@@ -494,6 +495,11 @@ mod tests {
     #[test]
     fn process_module_is_bundled() {
         assert!(bundled_source("process").is_some());
+    }
+
+    #[test]
+    fn ffi_module_is_bundled() {
+        assert!(bundled_source("ffi").is_some());
     }
 
     #[test]

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -632,6 +632,7 @@ fn resolve_type_path(
         // older `extern` signatures keep checking. Both denote a pointer
         // to a null-terminated byte buffer.
         "CStr" | "CString" => return ok_zero_generics(head, Ty::Ffi(FfiTy::CStr)),
+        "CDouble" => return ok_zero_generics(head, Ty::Ffi(FfiTy::CDouble)),
         "CPtr" => {
             let inner = expect_one_generic(head, resolved, env, self_ty, scope)?;
             return Ok(Ty::Ffi(FfiTy::CPtr(Box::new(inner))));

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1138,6 +1138,14 @@ impl<'a, 'b> Checker<'a, 'b> {
             {
                 continue;
             }
+            // A `CDouble` parameter is C `double` (f64), the same
+            // representation a Raven `Float` uses, so a `Float` argument
+            // passes directly with no conversion at the call.
+            if matches!(resolved_param.strip_self(), Ty::Ffi(FfiTy::CDouble))
+                && matches!(resolved_arg.strip_self(), Ty::Float)
+            {
+                continue;
+            }
             self.unify(param_ty, &a, &arg.span)?;
         }
         Ok(ret)

--- a/src/tycheck/ty.rs
+++ b/src/tycheck/ty.rs
@@ -93,6 +93,10 @@ pub enum FfiTy {
     /// `*const c_char`: a pointer to a null-terminated byte buffer.
     /// Maps to a pointer-width int.
     CStr,
+    /// C `double`, 64-bit IEEE float. Maps to `f64`, the same
+    /// representation a Raven `Float` already uses, so a `Float`
+    /// argument is accepted where a `CDouble` is expected.
+    CDouble,
     /// An opaque typed pointer `CPtr<T>`. Maps to a pointer-width int.
     /// The pointee type is carried for documentation and future
     /// conversions; the v2.0 back end treats it as an opaque pointer.
@@ -106,6 +110,7 @@ impl fmt::Display for FfiTy {
             FfiTy::CLong => f.write_str("CLong"),
             FfiTy::CSize => f.write_str("CSize"),
             FfiTy::CStr => f.write_str("CStr"),
+            FfiTy::CDouble => f.write_str("CDouble"),
             FfiTy::CPtr(inner) => write!(f, "CPtr<{}>", inner),
         }
     }

--- a/stdlib/std/ffi.rv
+++ b/stdlib/std/ffi.rv
@@ -1,0 +1,25 @@
+// std/ffi: helpers for the C foreign-function interface. The C type set
+// (CInt, CLong, CSize, CStr, CPtr<T>, CDouble) is built into the type
+// checker; this module adds runtime conversions between a Raven `String`
+// and a C `CStr`. The primitives bind the raven-runtime C ABI through
+// `extern "C"`; the wrappers are pure Raven. See docs/v2/specs/std-ffi.md.
+
+extern "C" {
+    fun raven_string_to_cstr(s: String) -> CStr
+    fun raven_cstr_to_string(p: CStr) -> String
+}
+
+// Copy `s` into a fresh, null-terminated C string and return a `CStr`
+// pointing at it. The buffer is a standalone copy valid for the rest of
+// the program run, so it is safe to pass to a C function that reads (or
+// retains) the pointer. Embedded NUL bytes are kept up to the first one
+// a C reader stops at.
+fun to_cstr(s: String) -> CStr {
+    return raven_string_to_cstr(s)
+}
+
+// Read the null-terminated bytes at `p` and build a Raven `String`. The
+// length is taken up to the first NUL; the terminator is dropped.
+fun from_cstr(p: CStr) -> String {
+    return raven_cstr_to_string(p)
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -241,6 +241,18 @@ fn ffi_abs_program_compiles_and_runs() {
 }
 
 #[test]
+fn use_ffi_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/ffi converts a runtime Raven String to a C string. strlen on
+    // "hello" is 5, strcmp on equal strings is 0 and on "abc"/"abd" is a
+    // negative value (-1 on the supported libc), and from_cstr round-trips
+    // a CStr back to the String "roundtrip".
+    compile_link_run_and_check("use_ffi.rv", "5\n0\n-1\nroundtrip\n", &runtime);
+}
+
+#[test]
 fn std_io_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Adds the `std/ffi` companion module: runtime conversions between a Raven `String` and a C `CStr`, plus the `CDouble` C type.

Closes #80

## Surface

`stdlib/std/ffi.rv` exposes two wrappers over new raven-runtime symbols:

```raven
fun to_cstr(s: String) -> CStr     // null-terminated copy, valid for the program run
fun from_cstr(p: CStr) -> String   // reads up to the first NUL
```

`to_cstr` copies the String bytes into a fresh null-terminated buffer (`raven_string_to_cstr`) allocated outside the GC heap, so a C callee may read or retain the pointer safely. The copy is intentionally leaked (copy semantics, no `free` helper this release). `from_cstr` (`raven_cstr_to_string`) reads the null-terminated bytes and builds a GC-managed String, stopping at the first NUL.

## C types

`CInt`, `CLong`, `CSize`, `CStr`, `CPtr<T>` were already built in. This adds `CDouble` (C `double`), threaded through tycheck, MIR, and codegen exactly like the existing variants; it maps to `f64`, the representation a Raven `Float` already crosses the ABI as, so a `Float` is accepted where a `CDouble` is expected with no call-boundary conversion.

`CFloat` (C `float`, f32) is deferred. A Raven `Float` is f64, so a correct `CFloat` path needs `fdemote`/`fpromote` narrowing at the call boundary that codegen does not yet emit. Shipping f32 without it would be a silently wrong ABI, so the variant is left out rather than half-wired. Documented in `docs/v2/specs/std-ffi.md`.

## Verification

`examples/v2/use_ffi.rv` converts runtime Strings and calls libc `strlen` and `strcmp`, then round-trips through `from_cstr`. Compiled and run on `x86_64-pc-windows-msvc`:

```
5
0
-1
roundtrip
```

`strlen("hello")` is 5, `strcmp` is 0 for equal strings and negative (`-1`) for `"abc"` vs `"abd"`, and the round trip recovers `"roundtrip"`. C integer results print through `print_int` (the FFI integer types have no `ToString` for interpolation).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (new `use_ffi_program_compiles_and_runs` and `ffi_module_is_bundled`; existing `ffi_strlen`, `ffi_abs`, and tycheck FFI tests still pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Built and ran `examples/v2/use_ffi.rv`, observed the output above

Registers `ffi` in `BUNDLED_MODULES`; it was already in `STDLIB_MODULES`. Specs: new `docs/v2/specs/std-ffi.md`, cross-referenced from `docs/v2/specs/ffi.md`.

Note: "Closes #80" will not auto-close on merge to `v2.x` since it is not the default branch; expected.
