### PR TITLE
feat(rvpm): v2 rv.toml manifest schema and init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,9 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "serde",
  "target-lexicon",
+ "toml",
 ]
 
 [[package]]
@@ -627,6 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -647,6 +650,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -722,6 +734,47 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-bidi"
@@ -996,6 +1049,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,14 @@ categories = ["development-tools", "command-line-utilities"]
 # Packaging metadata (deb / rpm / wix) intentionally omitted while v2 is under construction.
 # It will be repopulated alongside the v2 tooling work once the stdlib and rvpm shape settle.
 
+[[bin]]
+name = "raven"
+path = "src/main.rs"
+
+[[bin]]
+name = "rvpm"
+path = "src/bin/rvpm.rs"
+
 [dependencies]
 # Cranelift is the codegen backend (issue #63).
 cranelift-codegen = "0.108"
@@ -35,6 +43,9 @@ cranelift-object = "0.108"
 cc = "1.2"
 # Supplies the host target triple to key linker selection.
 target-lexicon = "0.12"
+# rv.toml manifest parsing for the rvpm package manager.
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
 
 [profile.release]
 opt-level = 3

--- a/docs/v2/specs/rv-toml.md
+++ b/docs/v2/specs/rv-toml.md
@@ -1,0 +1,118 @@
+# rv.toml manifest
+
+Every Raven package is described by an `rv.toml` manifest at its root.
+The manifest declares the package identity, its dependencies on other
+Raven packages, optional native linker pass-through, and optional
+formatter settings. This document defines the schema parsed by
+`raven::manifest`. Dependency version-constraint resolution and the
+wiring of `[ffi]` into the link step land in later rvpm work; this
+schema defines and parses those fields but does not act on them yet.
+
+The manifest is parsed by `Manifest::from_toml_str` (string) and
+`Manifest::load` (path). Unknown fields in any section are rejected so
+typos surface early.
+
+## Sections
+
+### `[package]` (required)
+
+| Field     | Type            | Required | Default | Notes |
+|-----------|-----------------|----------|---------|-------|
+| `name`    | String          | yes      | none    | The package name. Must not be empty. |
+| `version` | String          | yes      | none    | Semver-style string, for example `0.1.0`. Stored verbatim; full semver validation is not performed here. |
+| `authors` | Array of String | no       | `[]`    | Free-form author entries. |
+| `edition` | String          | no       | `v2`    | Accepted values: `v2`, `2026`. Any other value is rejected. |
+
+### `[dependencies]` (optional)
+
+A table whose keys are GitHub import paths and whose values are raw
+version-constraint strings. An absent or empty table means no
+dependencies.
+
+- Keys must be `github.com/<user>/<repo>` paths, optionally with a
+  subpath (`github.com/<user>/<repo>/<sub>...`). These are the same
+  strings used by `import "github.com/..."` in source, validated by the
+  shared `raven::resolve::GithubPath` parser so the manifest and the
+  resolver agree on package identity. A key that is not a recognized
+  GitHub path is rejected with a clear message.
+- Values are the raw constraint strings, for example `"1.0"` or
+  `"v1.2.3"`. They are stored as written. Constraint parsing and version
+  resolution are deferred to later rvpm work.
+
+### `[ffi]` (optional)
+
+Native linker pass-through. Parsed and exposed here; wiring into the
+actual link step is a later concern.
+
+| Field       | Type            | Required | Default | Notes |
+|-------------|-----------------|----------|---------|-------|
+| `libs`      | Array of String | no       | `[]`    | Library names to link, for example `["m", "z"]`. |
+| `link_args` | Array of String | no       | `[]`    | Extra raw linker arguments. |
+
+### `[fmt]` (optional)
+
+Formatter settings, carried from v1. Absent fields take the documented
+defaults.
+
+| Field          | Type | Required | Default | Notes |
+|----------------|------|----------|---------|-------|
+| `indent_width` | Int  | no       | `4`     | Spaces per indent level. |
+| `wrap_width`   | Int  | no       | `100`   | Target column for wrapping. |
+
+## Examples
+
+### Minimal
+
+```toml
+[package]
+name = "tiny"
+version = "0.0.1"
+```
+
+This parses with `edition = "v2"`, no authors, no dependencies, default
+`[ffi]`, and default `[fmt]`.
+
+### Full
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+authors = ["Ada", "Grace"]
+edition = "v2"
+
+[dependencies]
+"github.com/martian56/raven-http" = "1.0"
+"github.com/acme/json" = "v2.3.1"
+
+[ffi]
+libs = ["m", "z"]
+link_args = ["-L/opt/lib"]
+
+[fmt]
+indent_width = 2
+wrap_width = 80
+```
+
+## Diagnostics
+
+The parser produces targeted errors rather than bubbling raw TOML
+output:
+
+- A missing `name` or `version` names the section and field.
+- A dependency key that is not a `github.com/<user>/<repo>` path names
+  the offending key.
+- An unaccepted `edition` lists the accepted values.
+- A TOML syntax error is reported with the `invalid rv.toml:` prefix and
+  the underlying message.
+
+## `rvpm init`
+
+`rvpm init [name]` scaffolds a new package in the current directory:
+
+- Writes `rv.toml` with `[package]` (`name`, `version = "0.1.0"`,
+  `edition = "v2"`) and an empty `[dependencies]` table. When `name` is
+  omitted it defaults to the current directory name.
+- Writes `src/main.rv` with a hello-world `main` that compiles under the
+  `raven` build.
+- Refuses to overwrite an existing `rv.toml`.

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -1,0 +1,59 @@
+//! The rvpm package manager command line entry point.
+//!
+//! rvpm manages Raven packages described by an `rv.toml` manifest. This
+//! binary is intentionally thin: it parses arguments and dispatches to
+//! library code in `raven::manifest`. Today only `init` is implemented.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use raven::manifest::init::{init_project, name_from_dir, InitError};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        None | Some("help") | Some("--help") | Some("-h") => {
+            print_usage();
+            ExitCode::SUCCESS
+        }
+        Some("init") => match cmd_init(&args[1..]) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("rvpm: {}", e);
+                ExitCode::from(1)
+            }
+        },
+        Some(other) => {
+            eprintln!("rvpm: unknown subcommand '{}'", other);
+            eprintln!("Run 'rvpm help' for usage.");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn cmd_init(args: &[String]) -> Result<(), InitError> {
+    let cwd = std::env::current_dir().map_err(InitError::Io)?;
+    let name = match args.first() {
+        Some(n) => n.clone(),
+        None => name_from_dir(&cwd),
+    };
+    let dir = PathBuf::from(".");
+    init_project(&dir, &name)?;
+    println!("Created package '{}'", name);
+    println!("  rv.toml");
+    println!("  src/main.rv");
+    Ok(())
+}
+
+fn print_usage() {
+    println!("rvpm: the Raven package manager");
+    println!();
+    println!("Usage:");
+    println!("  rvpm <command> [arguments]");
+    println!();
+    println!("Commands:");
+    println!("  init [name]   Scaffold a new package in the current directory");
+    println!("  help          Print this message");
+    println!();
+    println!("Package fetching, add/install/update, and build/run land in later releases.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod codegen;
 pub mod error;
 pub mod hir;
 pub mod lexer;
+pub mod manifest;
 pub mod mir;
 pub mod parser;
 pub mod resolve;

--- a/src/manifest/init.rs
+++ b/src/manifest/init.rs
@@ -1,0 +1,135 @@
+//! Project scaffolding for `rvpm init`.
+//!
+//! Writes a starter `rv.toml` and `src/main.rv` into a target directory.
+//! The generated manifest round-trips through [`super::Manifest`] and the
+//! generated program compiles under the `raven` build.
+
+use std::io;
+use std::path::Path;
+
+/// The starter version stamped into a new manifest.
+pub const STARTER_VERSION: &str = "0.1.0";
+
+/// Reasons `init` could not scaffold a project.
+#[derive(Debug)]
+pub enum InitError {
+    /// An `rv.toml` already exists in the target directory.
+    ManifestExists,
+    /// A filesystem operation failed.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for InitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InitError::ManifestExists => {
+                write!(f, "rv.toml already exists; refusing to overwrite")
+            }
+            InitError::Io(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for InitError {}
+
+impl From<io::Error> for InitError {
+    fn from(e: io::Error) -> Self {
+        InitError::Io(e)
+    }
+}
+
+/// Render the starter manifest text for `name`.
+pub fn manifest_template(name: &str) -> String {
+    format!(
+        "[package]\n\
+         name = \"{name}\"\n\
+         version = \"{STARTER_VERSION}\"\n\
+         edition = \"v2\"\n\
+         \n\
+         [dependencies]\n"
+    )
+}
+
+/// Render the starter `src/main.rv` for `name`.
+pub fn main_rv_template(name: &str) -> String {
+    format!("fun main() {{\n    print(\"hello from {name}\")\n}}\n")
+}
+
+/// Scaffold a new project named `name` rooted at `dir`. Writes
+/// `<dir>/rv.toml` and `<dir>/src/main.rv`. Fails without writing
+/// anything if `<dir>/rv.toml` already exists.
+pub fn init_project(dir: &Path, name: &str) -> Result<(), InitError> {
+    let manifest_path = dir.join("rv.toml");
+    if manifest_path.exists() {
+        return Err(InitError::ManifestExists);
+    }
+    let src_dir = dir.join("src");
+    std::fs::create_dir_all(&src_dir)?;
+    std::fs::write(&manifest_path, manifest_template(name))?;
+    std::fs::write(src_dir.join("main.rv"), main_rv_template(name))?;
+    Ok(())
+}
+
+/// Derive a package name from a directory path, falling back to
+/// `"app"` when no usable file name is present.
+pub fn name_from_dir(dir: &Path) -> String {
+    dir.file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("app")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::Manifest;
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let mut d = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        d.push(format!("rvpm_init_{}_{}", tag, nanos));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn init_writes_files_that_parse() {
+        let dir = temp_dir("ok");
+        init_project(&dir, "demo_pkg").expect("init");
+
+        let manifest_text = std::fs::read_to_string(dir.join("rv.toml")).unwrap();
+        let m = Manifest::from_toml_str(&manifest_text).expect("generated manifest parses");
+        assert_eq!(m.package.name, "demo_pkg");
+        assert_eq!(m.package.version, STARTER_VERSION);
+        assert_eq!(m.package.edition, "v2");
+        assert!(m.dependencies.is_empty());
+
+        let main_rv = std::fs::read_to_string(dir.join("src").join("main.rv")).unwrap();
+        assert!(main_rv.contains("fun main()"));
+        assert!(main_rv.contains("hello from demo_pkg"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn init_refuses_to_overwrite() {
+        let dir = temp_dir("exists");
+        std::fs::write(
+            dir.join("rv.toml"),
+            "[package]\nname=\"a\"\nversion=\"0.1.0\"\n",
+        )
+        .unwrap();
+        let err = init_project(&dir, "x").unwrap_err();
+        assert!(matches!(err, InitError::ManifestExists));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn name_from_dir_falls_back() {
+        assert_eq!(name_from_dir(Path::new("/tmp/myproj")), "myproj");
+    }
+}

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -1,0 +1,496 @@
+//! The `rv.toml` manifest schema and parser for the rvpm package
+//! manager.
+//!
+//! A manifest describes one Raven package: its identity (`[package]`),
+//! its dependencies on other Raven packages (`[dependencies]`), optional
+//! native linker pass-through (`[ffi]`), and optional formatter settings
+//! (`[fmt]`). This module owns the schema and validation only. Fetching
+//! dependencies, resolving version constraints, and wiring `[ffi]` into
+//! the link step are handled by later rvpm work.
+//!
+//! See `docs/v2/specs/rv-toml.md` for the full field reference.
+
+use std::fmt;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::resolve::GithubPath;
+
+pub mod init;
+
+/// The default edition stamped into a freshly initialized manifest and
+/// assumed when `[package].edition` is absent.
+pub const DEFAULT_EDITION: &str = "v2";
+
+/// The accepted `[package].edition` values.
+pub const ACCEPTED_EDITIONS: &[&str] = &["v2", "2026"];
+
+/// The default `[fmt].indent_width` when the section or field is absent.
+pub const DEFAULT_INDENT_WIDTH: u32 = 4;
+
+/// The default `[fmt].wrap_width` when the section or field is absent.
+pub const DEFAULT_WRAP_WIDTH: u32 = 100;
+
+/// A parsed `rv.toml` manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Manifest {
+    pub package: Package,
+    /// Dependency keys are validated `github.com/<user>/<repo>` paths;
+    /// values are the raw version-constraint strings (resolution is
+    /// deferred to later rvpm work). Insertion order is not preserved.
+    pub dependencies: Vec<Dependency>,
+    pub ffi: Ffi,
+    pub fmt: Fmt,
+}
+
+/// The `[package]` section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Package {
+    pub name: String,
+    pub version: String,
+    pub authors: Vec<String>,
+    pub edition: String,
+}
+
+/// One `[dependencies]` entry: a GitHub package path and its raw
+/// version-constraint string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dependency {
+    /// The original `github.com/<user>/<repo>` key as written.
+    pub path: String,
+    /// The parsed components of `path`.
+    pub github: GithubPath,
+    /// The raw constraint string, for example `"1.0"` or `"v1.2.3"`.
+    /// Resolution lands in later rvpm work.
+    pub constraint: String,
+}
+
+/// The optional `[ffi]` section. Linker pass-through; wiring into the
+/// actual link step is deferred.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Ffi {
+    /// Library names to link, for example `["m", "z"]`.
+    pub libs: Vec<String>,
+    /// Extra raw linker arguments.
+    pub link_args: Vec<String>,
+}
+
+/// The optional `[fmt]` section, carried from v1. Absent fields take the
+/// documented defaults.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Fmt {
+    pub indent_width: u32,
+    pub wrap_width: u32,
+}
+
+impl Default for Fmt {
+    fn default() -> Self {
+        Fmt {
+            indent_width: DEFAULT_INDENT_WIDTH,
+            wrap_width: DEFAULT_WRAP_WIDTH,
+        }
+    }
+}
+
+/// An error produced while reading or parsing a manifest.
+#[derive(Debug)]
+pub enum ManifestError {
+    /// The manifest file could not be read from disk.
+    Io {
+        path: String,
+        source: std::io::Error,
+    },
+    /// The TOML did not parse. The message is the toml crate's
+    /// diagnostic, prefixed with manifest context.
+    Toml(String),
+    /// A required field was absent.
+    MissingField { section: String, field: String },
+    /// A dependency key was not a recognized `github.com/<user>/<repo>`
+    /// path.
+    InvalidDependencyKey { key: String },
+    /// A field held a value the schema does not accept.
+    InvalidValue {
+        section: String,
+        field: String,
+        message: String,
+    },
+}
+
+impl fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ManifestError::Io { path, source } => {
+                write!(f, "cannot read manifest '{}': {}", path, source)
+            }
+            ManifestError::Toml(msg) => write!(f, "invalid rv.toml: {}", msg),
+            ManifestError::MissingField { section, field } => {
+                write!(
+                    f,
+                    "rv.toml is missing required field [{}].{}",
+                    section, field
+                )
+            }
+            ManifestError::InvalidDependencyKey { key } => write!(
+                f,
+                "invalid dependency key '{}': expected a 'github.com/<user>/<repo>' path",
+                key
+            ),
+            ManifestError::InvalidValue {
+                section,
+                field,
+                message,
+            } => write!(f, "invalid value for [{}].{}: {}", section, field, message),
+        }
+    }
+}
+
+impl std::error::Error for ManifestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ManifestError::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// The serde view of the raw TOML document, before validation. Every
+/// field is optional here so we can produce precise MissingField errors
+/// rather than serde's generic ones.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifest {
+    package: Option<RawPackage>,
+    #[serde(default)]
+    dependencies: std::collections::BTreeMap<String, String>,
+    ffi: Option<RawFfi>,
+    fmt: Option<RawFmt>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPackage {
+    name: Option<String>,
+    version: Option<String>,
+    #[serde(default)]
+    authors: Vec<String>,
+    edition: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawFfi {
+    #[serde(default)]
+    libs: Vec<String>,
+    #[serde(default)]
+    link_args: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawFmt {
+    indent_width: Option<u32>,
+    wrap_width: Option<u32>,
+}
+
+impl Manifest {
+    /// Parse and validate a manifest from a TOML string.
+    pub fn from_toml_str(s: &str) -> Result<Manifest, ManifestError> {
+        let raw: RawManifest =
+            toml::from_str(s).map_err(|e| ManifestError::Toml(e.message().to_string()))?;
+
+        let raw_pkg = raw.package.ok_or_else(|| ManifestError::MissingField {
+            section: "package".to_string(),
+            field: "name".to_string(),
+        })?;
+
+        let name = raw_pkg.name.ok_or_else(|| ManifestError::MissingField {
+            section: "package".to_string(),
+            field: "name".to_string(),
+        })?;
+        let version = raw_pkg.version.ok_or_else(|| ManifestError::MissingField {
+            section: "package".to_string(),
+            field: "version".to_string(),
+        })?;
+        if name.trim().is_empty() {
+            return Err(ManifestError::InvalidValue {
+                section: "package".to_string(),
+                field: "name".to_string(),
+                message: "must not be empty".to_string(),
+            });
+        }
+        let edition = match raw_pkg.edition {
+            Some(e) => {
+                if !ACCEPTED_EDITIONS.contains(&e.as_str()) {
+                    return Err(ManifestError::InvalidValue {
+                        section: "package".to_string(),
+                        field: "edition".to_string(),
+                        message: format!(
+                            "'{}' is not accepted; use one of {}",
+                            e,
+                            ACCEPTED_EDITIONS.join(", ")
+                        ),
+                    });
+                }
+                e
+            }
+            None => DEFAULT_EDITION.to_string(),
+        };
+
+        let mut dependencies = Vec::with_capacity(raw.dependencies.len());
+        for (key, constraint) in raw.dependencies {
+            let github = GithubPath::parse(&key)
+                .ok_or_else(|| ManifestError::InvalidDependencyKey { key: key.clone() })?;
+            dependencies.push(Dependency {
+                path: key,
+                github,
+                constraint,
+            });
+        }
+
+        let ffi = raw
+            .ffi
+            .map(|f| Ffi {
+                libs: f.libs,
+                link_args: f.link_args,
+            })
+            .unwrap_or_default();
+
+        let fmt = raw
+            .fmt
+            .map(|f| Fmt {
+                indent_width: f.indent_width.unwrap_or(DEFAULT_INDENT_WIDTH),
+                wrap_width: f.wrap_width.unwrap_or(DEFAULT_WRAP_WIDTH),
+            })
+            .unwrap_or_default();
+
+        Ok(Manifest {
+            package: Package {
+                name,
+                version,
+                authors: raw_pkg.authors,
+                edition,
+            },
+            dependencies,
+            ffi,
+            fmt,
+        })
+    }
+
+    /// Read and parse the manifest at `path`.
+    pub fn load(path: impl AsRef<Path>) -> Result<Manifest, ManifestError> {
+        let path = path.as_ref();
+        let text = std::fs::read_to_string(path).map_err(|e| ManifestError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+        Manifest::from_toml_str(&text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_manifest_parses() {
+        let src = r#"
+[package]
+name = "demo"
+version = "0.1.0"
+authors = ["Ada", "Grace"]
+edition = "v2"
+
+[dependencies]
+"github.com/martian56/raven-http" = "1.0"
+"github.com/acme/json" = "v2.3.1"
+
+[ffi]
+libs = ["m", "z"]
+link_args = ["-L/opt/lib"]
+
+[fmt]
+indent_width = 2
+wrap_width = 80
+"#;
+        let m = Manifest::from_toml_str(src).expect("parses");
+        assert_eq!(m.package.name, "demo");
+        assert_eq!(m.package.version, "0.1.0");
+        assert_eq!(m.package.authors, vec!["Ada", "Grace"]);
+        assert_eq!(m.package.edition, "v2");
+        assert_eq!(m.dependencies.len(), 2);
+        let http = m
+            .dependencies
+            .iter()
+            .find(|d| d.path == "github.com/martian56/raven-http")
+            .expect("http dep present");
+        assert_eq!(http.constraint, "1.0");
+        assert_eq!(http.github.user, "martian56");
+        assert_eq!(http.github.repo, "raven-http");
+        assert_eq!(m.ffi.libs, vec!["m", "z"]);
+        assert_eq!(m.ffi.link_args, vec!["-L/opt/lib"]);
+        assert_eq!(m.fmt.indent_width, 2);
+        assert_eq!(m.fmt.wrap_width, 80);
+    }
+
+    #[test]
+    fn minimal_manifest_uses_defaults() {
+        let src = r#"
+[package]
+name = "tiny"
+version = "0.0.1"
+"#;
+        let m = Manifest::from_toml_str(src).expect("parses");
+        assert_eq!(m.package.name, "tiny");
+        assert_eq!(m.package.edition, DEFAULT_EDITION);
+        assert!(m.package.authors.is_empty());
+        assert!(m.dependencies.is_empty());
+        assert_eq!(m.ffi, Ffi::default());
+        assert_eq!(m.fmt.indent_width, DEFAULT_INDENT_WIDTH);
+        assert_eq!(m.fmt.wrap_width, DEFAULT_WRAP_WIDTH);
+    }
+
+    #[test]
+    fn missing_name_is_reported() {
+        let src = r#"
+[package]
+version = "0.1.0"
+"#;
+        let err = Manifest::from_toml_str(src).unwrap_err();
+        match err {
+            ManifestError::MissingField { section, field } => {
+                assert_eq!(section, "package");
+                assert_eq!(field, "name");
+            }
+            other => panic!("expected MissingField, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn missing_version_is_reported() {
+        let src = r#"
+[package]
+name = "x"
+"#;
+        let err = Manifest::from_toml_str(src).unwrap_err();
+        match err {
+            ManifestError::MissingField { section, field } => {
+                assert_eq!(section, "package");
+                assert_eq!(field, "version");
+            }
+            other => panic!("expected MissingField, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn missing_package_section_reports_name() {
+        let src = r#"
+[dependencies]
+"github.com/a/b" = "1.0"
+"#;
+        let err = Manifest::from_toml_str(src).unwrap_err();
+        assert!(matches!(err, ManifestError::MissingField { .. }));
+        assert!(err.to_string().contains("[package].name"));
+    }
+
+    #[test]
+    fn malformed_dependency_key_is_reported() {
+        let src = r#"
+[package]
+name = "x"
+version = "0.1.0"
+
+[dependencies]
+"gitlab.com/a/b" = "1.0"
+"#;
+        let err = Manifest::from_toml_str(src).unwrap_err();
+        match err {
+            ManifestError::InvalidDependencyKey { key } => {
+                assert_eq!(key, "gitlab.com/a/b");
+            }
+            other => panic!("expected InvalidDependencyKey, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dependency_key_missing_repo_is_reported() {
+        let src = r#"
+[package]
+name = "x"
+version = "0.1.0"
+
+[dependencies]
+"github.com/onlyuser" = "1.0"
+"#;
+        let err = Manifest::from_toml_str(src).unwrap_err();
+        assert!(matches!(err, ManifestError::InvalidDependencyKey { .. }));
+    }
+
+    #[test]
+    fn toml_syntax_error_is_wrapped() {
+        let src = "[package\nname = \"x\"\n";
+        let err = Manifest::from_toml_str(src).unwrap_err();
+        match &err {
+            ManifestError::Toml(msg) => assert!(!msg.is_empty()),
+            other => panic!("expected Toml, got {:?}", other),
+        }
+        assert!(err.to_string().starts_with("invalid rv.toml:"));
+    }
+
+    #[test]
+    fn unknown_edition_is_rejected() {
+        let src = r#"
+[package]
+name = "x"
+version = "0.1.0"
+edition = "2015"
+"#;
+        let err = Manifest::from_toml_str(src).unwrap_err();
+        match err {
+            ManifestError::InvalidValue { field, .. } => assert_eq!(field, "edition"),
+            other => panic!("expected InvalidValue, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ffi_section_parses_alone() {
+        let src = r#"
+[package]
+name = "x"
+version = "0.1.0"
+
+[ffi]
+libs = ["ssl", "crypto"]
+"#;
+        let m = Manifest::from_toml_str(src).expect("parses");
+        assert_eq!(m.ffi.libs, vec!["ssl", "crypto"]);
+        assert!(m.ffi.link_args.is_empty());
+    }
+
+    #[test]
+    fn fmt_partial_fills_defaults() {
+        let src = r#"
+[package]
+name = "x"
+version = "0.1.0"
+
+[fmt]
+indent_width = 8
+"#;
+        let m = Manifest::from_toml_str(src).expect("parses");
+        assert_eq!(m.fmt.indent_width, 8);
+        assert_eq!(m.fmt.wrap_width, DEFAULT_WRAP_WIDTH);
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let src = r#"
+[package]
+name = "x"
+version = "0.1.0"
+license = "MIT"
+"#;
+        let err = Manifest::from_toml_str(src).unwrap_err();
+        assert!(matches!(err, ManifestError::Toml(_)));
+    }
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -175,20 +175,45 @@ fn resolve_one_import(
 }
 
 fn parse_github_path(s: &str) -> Option<ImportTarget> {
-    let rest = s.strip_prefix("github.com/")?;
-    let mut parts = rest.split('/');
-    let user = parts.next()?.to_string();
-    let repo = parts.next()?.to_string();
-    let subpath: Vec<String> = parts.map(|s| s.to_string()).collect();
-    if user.is_empty() || repo.is_empty() {
-        return None;
-    }
+    let parts = GithubPath::parse(s)?;
     Some(ImportTarget::ExternalPackage {
-        host: "github.com".to_string(),
-        user,
-        repo,
-        subpath,
+        host: parts.host,
+        user: parts.user,
+        repo: parts.repo,
+        subpath: parts.subpath,
     })
+}
+
+/// The components of a `github.com/<user>/<repo>[/<sub>...]` import or
+/// dependency path. Shared by the resolver and the rvpm manifest parser
+/// so both agree on what a valid package identity looks like.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GithubPath {
+    pub host: String,
+    pub user: String,
+    pub repo: String,
+    pub subpath: Vec<String>,
+}
+
+impl GithubPath {
+    /// Parse a `github.com/<user>/<repo>[/<sub>...]` string. Returns
+    /// `None` when the prefix is missing or `user`/`repo` are empty.
+    pub fn parse(s: &str) -> Option<GithubPath> {
+        let rest = s.strip_prefix("github.com/")?;
+        let mut parts = rest.split('/');
+        let user = parts.next()?.to_string();
+        let repo = parts.next()?.to_string();
+        let subpath: Vec<String> = parts.map(|s| s.to_string()).collect();
+        if user.is_empty() || repo.is_empty() || subpath.iter().any(|s| s.is_empty()) {
+            return None;
+        }
+        Some(GithubPath {
+            host: "github.com".to_string(),
+            user,
+            repo,
+            subpath,
+        })
+    }
 }
 
 fn resolve_local_import(

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -25,7 +25,7 @@ use crate::error::RavenError;
 pub use bindings::{
     Binding, DeclId, ImportId, ImportTarget, ResolutionMap, ResolvedImport, UseKey,
 };
-pub use imports::{FsLoader, LoadedSource, SourceLoader, STDLIB_MODULES};
+pub use imports::{FsLoader, GithubPath, LoadedSource, SourceLoader, STDLIB_MODULES};
 pub use scope::{Scope, ScopeKind, ScopeStack};
 pub use stdlib::{expand_with_stdlib, mangle_stdlib_fn};
 

--- a/tests/rvpm_init.rs
+++ b/tests/rvpm_init.rs
@@ -1,0 +1,141 @@
+//! End to end test for `rvpm init`.
+//!
+//! Runs the `rvpm` binary in a temp directory and checks that it
+//! scaffolds a parseable `rv.toml` and a `src/main.rv`. When a linker and
+//! the runtime staticlib are available, the generated program is also
+//! compiled with the `raven` binary and run, asserting its output.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use raven::codegen::linker;
+use raven::manifest::Manifest;
+
+#[test]
+fn rvpm_init_scaffolds_parseable_project() {
+    let dir = workdir();
+    let status = Command::new(env!("CARGO_BIN_EXE_rvpm"))
+        .arg("init")
+        .arg("demo_pkg")
+        .current_dir(&dir)
+        .status()
+        .expect("run rvpm init");
+    assert!(status.success(), "rvpm init exited non zero");
+
+    let manifest_path = dir.join("rv.toml");
+    let main_path = dir.join("src").join("main.rv");
+    assert!(manifest_path.is_file(), "rv.toml was not created");
+    assert!(main_path.is_file(), "src/main.rv was not created");
+
+    let manifest_text = std::fs::read_to_string(&manifest_path).unwrap();
+    let m = Manifest::from_toml_str(&manifest_text).expect("generated manifest parses");
+    assert_eq!(m.package.name, "demo_pkg");
+    assert_eq!(m.package.version, "0.1.0");
+    assert!(m.dependencies.is_empty());
+
+    let main_src = std::fs::read_to_string(&main_path).unwrap();
+    assert!(main_src.contains("hello from demo_pkg"));
+
+    maybe_compile_and_run(&dir, &main_path);
+
+    cleanup(&dir);
+}
+
+#[test]
+fn rvpm_init_refuses_existing_manifest() {
+    let dir = workdir();
+    std::fs::write(
+        dir.join("rv.toml"),
+        "[package]\nname=\"a\"\nversion=\"0.1.0\"\n",
+    )
+    .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_rvpm"))
+        .arg("init")
+        .current_dir(&dir)
+        .output()
+        .expect("run rvpm init");
+    assert!(
+        !output.status.success(),
+        "init should fail on existing rv.toml"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("already exists"), "stderr: {}", stderr);
+    cleanup(&dir);
+}
+
+#[test]
+fn rvpm_unknown_subcommand_fails() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rvpm"))
+        .arg("frobnicate")
+        .output()
+        .expect("run rvpm");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown subcommand"), "stderr: {}", stderr);
+}
+
+/// Compile and run the generated program when the host can link Raven
+/// binaries; otherwise skip the compile step with a diagnostic, matching
+/// the codegen smoke tests.
+fn maybe_compile_and_run(dir: &Path, main_path: &Path) {
+    if !linker::linker_available() || !runtime_built() {
+        eprintln!("rvpm_init: skipping compile step, no linker or runtime staticlib available.");
+        return;
+    }
+    let exe = dir.join(if cfg!(windows) { "demo.exe" } else { "demo" });
+    let status = Command::new(env!("CARGO_BIN_EXE_raven"))
+        .arg("build")
+        .arg(main_path)
+        .arg("-o")
+        .arg(&exe)
+        .status()
+        .expect("run raven build");
+    assert!(status.success(), "raven build failed for generated main.rv");
+
+    let output = Command::new(&exe).output().expect("run generated binary");
+    assert!(output.status.success(), "generated binary exited non zero");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("hello from demo_pkg"),
+        "unexpected stdout: {:?}",
+        stdout
+    );
+}
+
+fn runtime_built() -> bool {
+    if std::env::var("RAVEN_RUNTIME_LIB").is_ok() {
+        return true;
+    }
+    let lib_name = if cfg!(windows) {
+        "raven_runtime.lib"
+    } else {
+        "libraven_runtime.a"
+    };
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    ["target/debug", "target/release"]
+        .iter()
+        .any(|sub| root.join(sub).join(lib_name).is_file())
+}
+
+fn workdir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let mut p = std::env::temp_dir();
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    p.push(format!(
+        "rvpm-init-{}-{}-{}",
+        std::process::id(),
+        stamp,
+        seq
+    ));
+    std::fs::create_dir_all(&p).expect("create tempdir");
+    p
+}
+
+fn cleanup(p: &Path) {
+    let _ = std::fs::remove_dir_all(p);
+}


### PR DESCRIPTION
Define and parse the v2 `rv.toml` manifest schema and add the `rvpm` binary skeleton with `init`, the foundation of the rvpm package manager.

Closes #81

## Schema (`docs/v2/specs/rv-toml.md`)

- `[package]` (required): `name` (String), `version` (String), `authors` (optional array), `edition` (optional, accepts `v2` or `2026`, default `v2`).
- `[dependencies]` (optional): table whose keys are `github.com/<user>/<repo>` paths and whose values are raw version-constraint strings.
- `[ffi]` (optional): `libs` and `link_args` arrays for native linker pass-through.
- `[fmt]` (optional): `indent_width` (default 4) and `wrap_width` (default 100).

## Parsed vs deferred

Parsed and validated here: the full schema, dependency-key identity, edition values, and targeted diagnostics. Deferred to later rvpm work: dependency version-constraint resolution, package fetching, and wiring `[ffi]` into the link step.

Dependency keys are validated with the shared `GithubPath` parser (lifted out of the resolver into `raven::resolve`) so the manifest and the import resolver agree on package identity.

## rvpm binary

A second binary `rvpm` is added via explicit `[[bin]]` entries alongside `raven`; both build under `cargo build --workspace`. The manifest logic lives in the library (`raven::manifest`) so the binary stays thin.

- `rvpm init [name]`: scaffolds `rv.toml` and `src/main.rv`, defaulting the name to the current directory. Refuses to overwrite an existing `rv.toml`. The generated program compiles and runs under the `raven` build.
- `rvpm` / `rvpm help`: prints emoji-free usage.
- Unknown subcommand: clear error, non-zero exit.

## Test plan

- [x] `cargo build --workspace` (both `raven` and `rvpm`)
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Manifest unit tests: full and minimal manifests, missing `name`/`version`, missing `[package]`, malformed dependency key, dependency key missing repo, TOML syntax error, unknown edition, unknown field, `[ffi]` and `[fmt]` parsing.
- [x] `init` unit tests: scaffolded files parse back, refuses overwrite, name derivation.
- [x] End-to-end `rvpm init` integration test, with a compile-and-run check gated on linker availability.
- [x] Manual: `rvpm init demo_pkg` then `raven build src/main.rv -o demo.exe` then run prints `hello from demo_pkg`.

Note: "Closes #81" will not auto-close on merge because the base branch is `v2.x`, not the default branch. Expected.
