### PR TITLE
feat(rvpm): github fetch and shared cache

### DIFF
--- a/docs/v2/specs/rvpm.md
+++ b/docs/v2/specs/rvpm.md
@@ -1,0 +1,116 @@
+# rvpm: package fetching and the shared cache
+
+This spec covers how rvpm fetches a GitHub dependency and where it stores
+the result. It describes the on-disk cache layout, the environment
+override, the git clone strategy, cache-hit semantics, `.git` handling,
+and the error cases. The library implementation lives in `raven::pkg`
+(`src/pkg/mod.rs`); the `rvpm` binary exposes it through `rvpm fetch`.
+
+Version-constraint resolution (semver ranges) and the lock file
+(`rv.lock`) are out of scope here and are covered by issue #83. This
+layer takes an explicit `version` that is a git tag or branch and fetches
+exactly it.
+
+## Package identity
+
+A dependency is identified by a `github.com/<user>/<repo>` path plus an
+explicit `version` (a git tag or branch). The path components match what
+the manifest parser (`raven::manifest`) and the import resolver
+(`raven::resolve::GithubPath`) accept, so all three agree on what a valid
+package identity is.
+
+## Cache layout
+
+The cache is shared across all projects on the machine. Each fetched
+package version occupies its own directory:
+
+```
+<cache_root>/<host>/<user>/<repo>@<version>/
+```
+
+For example:
+
+```
+<cache_root>/github.com/acme/json@v1.2.3/
+```
+
+The directory holds the package's working-tree content (its `rv.toml`,
+`src/`, and so on). It does not hold a git history (see ".git handling").
+
+### Cache root
+
+`raven::pkg::cache_root()` resolves the root as follows:
+
+1. If `RVPM_CACHE_DIR` is set, its value is the cache root. This override
+   is the supported way to redirect the cache and is used by tests and to
+   isolate environments.
+2. Otherwise the root is `${HOME}/.rvpm/cache`, where `HOME` is `$HOME` on
+   Unix and `%USERPROFILE%` on Windows.
+3. If neither is set, the root falls back to `.rvpm/cache` under the
+   current directory.
+
+## Fetch and cache-hit semantics
+
+`raven::pkg::fetch(host, user, repo, version)` returns the cache
+directory for that version.
+
+1. It computes `cache_dir(host, user, repo, version)`.
+2. If that directory exists and is non-empty, it is a cache HIT: the
+   directory is returned immediately and the remote is not contacted.
+3. Otherwise it clones `https://<host>/<user>/<repo>` at `version` into
+   the directory and returns it.
+
+Because a pinned tag or branch is fetched once and reused, a populated
+cache entry is never re-cloned or updated in place.
+
+## Clone strategy
+
+Cloning is performed by `raven::pkg::clone_from(url, reference, dest)`,
+which runs:
+
+```
+git clone --depth 1 --branch <reference> <url> <dest>
+```
+
+The clone is shallow (`--depth 1`): only the tip of the named tag or
+branch is fetched. git is invoked through `std::process::Command`; git is
+expected to be installed and on `PATH`.
+
+`clone_from` is the network seam. The real fetch path passes
+`https://<host>/<user>/<repo>` as `url`. Tests pass a local repository
+path instead, so the cache and fetch logic are exercised without touching
+the network.
+
+## .git handling
+
+After a successful clone, the `dest/.git` directory is removed. The cache
+stores only working-tree content. The history is not needed: a pinned tag
+or branch is never updated in place, and dropping `.git` keeps the cache
+lean.
+
+## Errors
+
+`raven::pkg::PkgError` distinguishes:
+
+- `Io`: a filesystem operation against the cache failed (for example the
+  cache directory could not be created).
+- `GitNotFound`: the `git` executable could not be launched (not
+  installed or not on `PATH`).
+- `MissingRef`: the requested tag or branch does not exist on the remote.
+  git names the missing ref on the clone path, and that detail is
+  surfaced.
+- `CloneFailed`: `git clone` failed for some other reason; git's stderr is
+  included.
+
+## rvpm fetch
+
+The binary exposes the library through:
+
+```
+rvpm fetch github.com/<user>/<repo>@<version>
+```
+
+It parses the path and version, calls `raven::pkg::fetch`, and prints the
+resulting cache directory. This is a manual way to exercise the fetch
+path; dependency resolution that reads `[dependencies]` from `rv.toml`
+lands with the resolver work in #83.

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use raven::manifest::init::{init_project, name_from_dir, InitError};
+use raven::pkg;
+use raven::resolve::GithubPath;
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -17,6 +19,13 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Some("init") => match cmd_init(&args[1..]) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("rvpm: {}", e);
+                ExitCode::from(1)
+            }
+        },
+        Some("fetch") => match cmd_fetch(&args[1..]) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
                 eprintln!("rvpm: {}", e);
@@ -45,6 +54,20 @@ fn cmd_init(args: &[String]) -> Result<(), InitError> {
     Ok(())
 }
 
+fn cmd_fetch(args: &[String]) -> Result<(), String> {
+    let spec = args
+        .first()
+        .ok_or_else(|| "fetch needs a 'github.com/<user>/<repo>@<version>' argument".to_string())?;
+    let (path, version) = spec
+        .rsplit_once('@')
+        .ok_or_else(|| format!("'{}' is missing an '@<version>' suffix", spec))?;
+    let gh = GithubPath::parse(path)
+        .ok_or_else(|| format!("'{}' is not a 'github.com/<user>/<repo>' path", path))?;
+    let dir = pkg::fetch(&gh.host, &gh.user, &gh.repo, version).map_err(|e| e.to_string())?;
+    println!("{}", dir.display());
+    Ok(())
+}
+
 fn print_usage() {
     println!("rvpm: the Raven package manager");
     println!();
@@ -53,7 +76,8 @@ fn print_usage() {
     println!();
     println!("Commands:");
     println!("  init [name]   Scaffold a new package in the current directory");
+    println!("  fetch <pkg>   Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
     println!("  help          Print this message");
     println!();
-    println!("Package fetching, add/install/update, and build/run land in later releases.");
+    println!("Dependency resolution, add/install/update, and build/run land in later releases.");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `hir`: high-level intermediate representation (desugared AST)
 //! - `mir`: mid-level intermediate representation (basic blocks)
 //! - `codegen`: Cranelift IR generation and linking
+//! - `pkg`: rvpm package fetching and the shared content cache
 //! - `driver`: pipeline orchestrator
 //!
 //! Lexer, span, and error infrastructure ship today; the rest land in
@@ -23,6 +24,7 @@ pub mod lexer;
 pub mod manifest;
 pub mod mir;
 pub mod parser;
+pub mod pkg;
 pub mod resolve;
 pub mod span;
 pub mod tycheck;

--- a/src/pkg/mod.rs
+++ b/src/pkg/mod.rs
@@ -1,0 +1,205 @@
+//! Package fetching and the shared content cache for rvpm.
+//!
+//! A GitHub dependency `github.com/<user>/<repo>@<version>` is resolved
+//! by cloning the named tag or branch into a cache shared across
+//! projects. The cache lives at `<cache_root>/<host>/<user>/<repo>@<version>`.
+//!
+//! Version-constraint resolution (semver ranges) and the lock file are
+//! out of scope here; see issue #83. This module takes an explicit
+//! `version` string that is a git tag or branch and fetches it.
+//!
+//! See `docs/v2/specs/rvpm.md` for the cache layout and clone strategy.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// An error produced while fetching a package or touching the cache.
+#[derive(Debug)]
+pub enum PkgError {
+    /// A filesystem operation against the cache failed.
+    Io {
+        action: String,
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The `git` executable could not be launched.
+    GitNotFound(std::io::Error),
+    /// The requested tag or branch does not exist on the remote.
+    MissingRef { reference: String, stderr: String },
+    /// `git clone` failed for a reason other than a missing ref.
+    CloneFailed {
+        url: String,
+        reference: String,
+        stderr: String,
+    },
+}
+
+impl fmt::Display for PkgError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PkgError::Io {
+                action,
+                path,
+                source,
+            } => write!(f, "cannot {} '{}': {}", action, path.display(), source),
+            PkgError::GitNotFound(source) => {
+                write!(f, "git is not installed or not on PATH: {}", source)
+            }
+            PkgError::MissingRef { reference, stderr } => write!(
+                f,
+                "tag or branch '{}' was not found on the remote: {}",
+                reference,
+                stderr.trim()
+            ),
+            PkgError::CloneFailed {
+                url,
+                reference,
+                stderr,
+            } => write!(
+                f,
+                "git clone of '{}' at '{}' failed: {}",
+                url,
+                reference,
+                stderr.trim()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PkgError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            PkgError::Io { source, .. } => Some(source),
+            PkgError::GitNotFound(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// The root of the shared cache.
+///
+/// Honors the `RVPM_CACHE_DIR` override when set; this is the supported
+/// way to redirect the cache (used by tests and for isolating
+/// environments). Otherwise the default is `${HOME}/.rvpm/cache`, where
+/// `HOME` is `$HOME` on Unix and `%USERPROFILE%` on Windows. If neither
+/// is set the cache falls back to `.rvpm/cache` under the current
+/// directory.
+pub fn cache_root() -> PathBuf {
+    if let Some(dir) = std::env::var_os("RVPM_CACHE_DIR") {
+        return PathBuf::from(dir);
+    }
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    home.join(".rvpm").join("cache")
+}
+
+/// The cache directory for one package version:
+/// `<cache_root>/<host>/<user>/<repo>@<version>`.
+pub fn cache_dir(host: &str, user: &str, repo: &str, version: &str) -> PathBuf {
+    cache_root()
+        .join(host)
+        .join(user)
+        .join(format!("{}@{}", repo, version))
+}
+
+/// Fetch `host/user/repo` at `version` into the shared cache and return
+/// the cache directory.
+///
+/// If the cache directory already exists and is non-empty this is a
+/// cache hit: the existing directory is returned without contacting the
+/// remote. Otherwise the repository is cloned from
+/// `https://<host>/<user>/<repo>` at the given tag or branch.
+pub fn fetch(host: &str, user: &str, repo: &str, version: &str) -> Result<PathBuf, PkgError> {
+    let dest = cache_dir(host, user, repo, version);
+    if is_populated(&dest) {
+        return Ok(dest);
+    }
+    let url = format!("https://{}/{}/{}", host, user, repo);
+    clone_from(&url, version, &dest)?;
+    Ok(dest)
+}
+
+/// True when `dir` exists and contains at least one entry.
+fn is_populated(dir: &Path) -> bool {
+    match std::fs::read_dir(dir) {
+        Ok(mut entries) => entries.next().is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Clone `url` at `reference` (a tag or branch) into `dest`.
+///
+/// This is the network seam: callers pass `https://<host>/<user>/<repo>`
+/// for the real path, while tests pass a local repository path so the
+/// clone never touches the network. The clone is shallow
+/// (`--depth 1 --branch <reference>`). On success the cloned `.git`
+/// directory is removed so the cache holds only working-tree content; a
+/// pinned tag or branch is never updated in place, so the history is not
+/// needed.
+pub fn clone_from(url: &str, reference: &str, dest: &Path) -> Result<(), PkgError> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| PkgError::Io {
+            action: "create cache directory".to_string(),
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
+
+    let output = Command::new("git")
+        .arg("clone")
+        .arg("--depth")
+        .arg("1")
+        .arg("--branch")
+        .arg(reference)
+        .arg(url)
+        .arg(dest)
+        .output()
+        .map_err(PkgError::GitNotFound)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        // git reports a missing tag or branch with this phrasing on the
+        // clone path. Surface it as MissingRef so callers can be specific.
+        if stderr.contains("Remote branch")
+            || stderr.contains("not found in upstream")
+            || stderr.contains("does not exist")
+        {
+            return Err(PkgError::MissingRef {
+                reference: reference.to_string(),
+                stderr,
+            });
+        }
+        return Err(PkgError::CloneFailed {
+            url: url.to_string(),
+            reference: reference.to_string(),
+            stderr,
+        });
+    }
+
+    let git_dir = dest.join(".git");
+    if git_dir.exists() {
+        std::fs::remove_dir_all(&git_dir).map_err(|e| PkgError::Io {
+            action: "remove .git from cache entry".to_string(),
+            path: git_dir,
+            source: e,
+        })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_dir_layout() {
+        std::env::set_var("RVPM_CACHE_DIR", "/tmp/rvpm-test-root");
+        let dir = cache_dir("github.com", "acme", "json", "v1.0.0");
+        std::env::remove_var("RVPM_CACHE_DIR");
+        assert!(dir.ends_with("github.com/acme/json@v1.0.0"));
+    }
+}

--- a/tests/rvpm_fetch.rs
+++ b/tests/rvpm_fetch.rs
@@ -1,0 +1,156 @@
+//! Network-free tests for the rvpm package cache and fetch.
+//!
+//! These drive the fetch against a LOCAL git repository created in a temp
+//! directory, so no test contacts the network. git is required and is
+//! present on dev and CI machines. Commits set a per-invocation identity
+//! with `-c user.email`/`-c user.name` so they work on a clean CI machine
+//! with no global git configuration.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use raven::pkg::{self, PkgError};
+
+/// Create a source git repository in `dir` with one file and tag it
+/// `v1.0.0`. Returns its path, which `git clone` accepts as a source.
+fn make_source_repo(dir: &Path) -> String {
+    git(dir, &["init", "-q"]);
+    git(dir, &["checkout", "-q", "-B", "main"]);
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("rv.toml"),
+        "[package]\nname = \"dep\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.rv"),
+        "fun answer() -> Int { 42 }\n",
+    )
+    .unwrap();
+    git(dir, &["add", "."]);
+    git(
+        dir,
+        &[
+            "-c",
+            "user.email=ci@example.com",
+            "-c",
+            "user.name=ci",
+            "commit",
+            "-q",
+            "-m",
+            "initial",
+        ],
+    );
+    git(dir, &["tag", "v1.0.0"]);
+    // A file path is a valid clone source. Pass it through git's own
+    // path handling rather than building a file:// URL by hand.
+    dir.to_string_lossy().into_owned()
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+#[test]
+fn clone_from_lands_in_cache_and_drops_git() {
+    let root = workdir();
+    let src = root.join("src-repo");
+    std::fs::create_dir_all(&src).unwrap();
+    let url = make_source_repo(&src);
+
+    let dest = root.join("cache").join("dep@v1.0.0");
+    pkg::clone_from(&url, "v1.0.0", &dest).expect("clone into cache");
+
+    assert!(
+        dest.join("src").join("lib.rv").is_file(),
+        "cloned working tree landed in the cache"
+    );
+    assert!(
+        !dest.join(".git").exists(),
+        ".git is removed to keep the cache lean"
+    );
+
+    cleanup(&root);
+}
+
+#[test]
+fn missing_tag_reports_missing_ref() {
+    let root = workdir();
+    let src = root.join("src-repo");
+    std::fs::create_dir_all(&src).unwrap();
+    let url = make_source_repo(&src);
+
+    let dest = root.join("cache").join("dep@v9.9.9");
+    let err = pkg::clone_from(&url, "v9.9.9", &dest).unwrap_err();
+    match err {
+        PkgError::MissingRef { reference, .. } => assert_eq!(reference, "v9.9.9"),
+        other => panic!("expected MissingRef, got {:?}", other),
+    }
+
+    cleanup(&root);
+}
+
+/// Exercises `fetch`, which derives the cache root from `RVPM_CACHE_DIR`.
+/// The env override is process-global, so this single test owns it and
+/// runs its steps sequentially. Other tests use `clone_from` directly and
+/// never read the env.
+#[test]
+fn fetch_clones_then_hits_cache() {
+    let root = workdir();
+    let src = root.join("src-repo");
+    std::fs::create_dir_all(&src).unwrap();
+    let url = make_source_repo(&src);
+
+    // fetch builds an https remote, covered by clone_from above. Here we
+    // verify cache_dir layout and the cache-hit path under the env
+    // override: seed the exact directory fetch would use, then assert a
+    // second fetch is served from the cache without the remote.
+    let cache_root = root.join("cache-root");
+    std::env::set_var("RVPM_CACHE_DIR", &cache_root);
+
+    let expected = pkg::cache_dir("github.com", "acme", "dep", "v1.0.0");
+    assert!(expected.starts_with(&cache_root), "cache honors override");
+
+    // Populate the cache entry by cloning the local repo into the exact
+    // path fetch would use.
+    pkg::clone_from(&url, "v1.0.0", &expected).expect("seed cache");
+
+    // Remove the source repo. A real fetch would now have to hit the
+    // network; a cache HIT must not, so this must still succeed.
+    std::fs::remove_dir_all(&src).unwrap();
+
+    let got = pkg::fetch("github.com", "acme", "dep", "v1.0.0").expect("cache hit");
+    assert_eq!(got, expected);
+    assert!(got.join("src").join("lib.rv").is_file());
+
+    std::env::remove_var("RVPM_CACHE_DIR");
+    cleanup(&root);
+}
+
+fn workdir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let mut p = std::env::temp_dir();
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    p.push(format!(
+        "rvpm-fetch-{}-{}-{}",
+        std::process::id(),
+        stamp,
+        seq
+    ));
+    std::fs::create_dir_all(&p).expect("create tempdir");
+    p
+}
+
+fn cleanup(p: &Path) {
+    let _ = std::fs::remove_dir_all(p);
+}


### PR DESCRIPTION
Resolve a `github.com/<user>/<repo>@<version>` dependency by cloning the named tag or branch into a content cache shared across projects.

Closes #82

## Cache layout

```
<cache_root>/<host>/<user>/<repo>@<version>/
```

`cache_root()` honors the `RVPM_CACHE_DIR` override and otherwise defaults to `${HOME}/.rvpm/cache` (`%USERPROFILE%` on Windows), falling back to `.rvpm/cache` under the current directory.

## Clone strategy

`clone_from(url, reference, dest)` runs `git clone --depth 1 --branch <reference> <url> <dest>` via `std::process::Command`. On success the resulting `.git` is removed so the cache holds only working-tree content; a pinned tag or branch is never updated in place. `fetch(host, user, repo, version)` returns the cache dir, treating a populated directory as a cache hit (no remote contact) and otherwise cloning `https://<host>/<user>/<repo>`.

`PkgError` distinguishes cache IO failures, git-not-found, missing tag or branch (`MissingRef`, surfacing git's own wording), and other clone failures (with git's stderr).

## CI-safe tests

`tests/rvpm_fetch.rs` drives the fetch against a LOCAL git repository created in a temp dir, so no test contacts the network. `clone_from` is the seam: the real path passes an https remote, tests pass a local repository path. Commits set a per-invocation identity with `-c user.email`/`-c user.name` so they work on a clean CI machine with no global git config.

## Deferred to #83

Version-constraint resolution (semver ranges) and the lock file (`rv.lock`). This layer takes an explicit tag or branch string.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] local-repo clone lands the working tree in the cache and drops `.git`
- [x] a populated cache entry is a hit (succeeds after the source repo is removed)
- [x] a non-existent tag reports a clear missing-ref error
