### PR TITLE
feat(rvpm): rv.lock with content hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +109,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cranelift-bforest"
@@ -227,6 +245,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +323,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -506,6 +554,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-object",
  "serde",
+ "sha2",
  "target-lexicon",
  "toml",
 ]
@@ -662,6 +711,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +835,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ target-lexicon = "0.12"
 # rv.toml manifest parsing for the rvpm package manager.
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
+# Content (tree) hashing for the rvpm lock file (rv.lock).
+sha2 = "0.10"
 
 [profile.release]
 opt-level = 3

--- a/docs/v2/specs/rvpm.md
+++ b/docs/v2/specs/rvpm.md
@@ -6,10 +6,10 @@ override, the git clone strategy, cache-hit semantics, `.git` handling,
 and the error cases. The library implementation lives in `raven::pkg`
 (`src/pkg/mod.rs`); the `rvpm` binary exposes it through `rvpm fetch`.
 
-Version-constraint resolution (semver ranges) and the lock file
-(`rv.lock`) are out of scope here and are covered by issue #83. This
+Version-constraint resolution (semver ranges) is out of scope here. This
 layer takes an explicit `version` that is a git tag or branch and fetches
-exactly it.
+exactly it. The lock file (`rv.lock`) is built on top of this layer and is
+documented below.
 
 ## Package identity
 
@@ -112,5 +112,141 @@ rvpm fetch github.com/<user>/<repo>@<version>
 
 It parses the path and version, calls `raven::pkg::fetch`, and prints the
 resulting cache directory. This is a manual way to exercise the fetch
-path; dependency resolution that reads `[dependencies]` from `rv.toml`
-lands with the resolver work in #83.
+path.
+
+# The lock file (rv.lock)
+
+`rv.lock` pins the exact resolved git ref and a content (tree) hash for
+every transitive dependency of a package. It is checked in next to
+`rv.toml` so a build is reproducible: a later install or build fetches the
+pinned refs and verifies that each fetched tree still hashes to the
+recorded value. The library implementation lives in `raven::lock`
+(`src/lock/mod.rs`); the `rvpm` binary exposes it through `rvpm lock`.
+
+## Version-constraint scope
+
+Full semver range resolution is not implemented yet. For now a
+`[dependencies]` constraint string in `rv.toml` is treated as the literal
+git ref (a tag or branch) to fetch, so the resolved version equals the
+constraint as written. Range resolution is future work; when it lands the
+lock will record the chosen ref while `rv.toml` keeps the range. The lock
+always records the resolved ref, not the constraint expression.
+
+## Lock format
+
+`rv.lock` is a TOML file:
+
+```
+version = 1            # lock format version
+
+[[package]]
+source = "github.com/acme/bar"
+version = "v1.0.0"     # resolved git ref
+hash = "sha256:<hex>"  # tree content hash
+
+[[package]]
+source = "github.com/acme/foo"
+version = "v1.0.0"
+hash = "sha256:<hex>"
+```
+
+Fields:
+
+- `version`: the lock format version. The current version is `1`. A lock
+  whose version is newer than the tool understands is rejected.
+- `[[package]]`: one entry per transitive dependency.
+  - `source`: the `github.com/<user>/<repo>` package identity.
+  - `version`: the resolved git ref (tag or branch) that was fetched.
+  - `hash`: the content hash of the fetched tree, `sha256:<hex>`.
+
+Packages are written in a deterministic order, sorted by `source` then
+`version`, so the lock is stable across runs and diffs cleanly.
+
+## Tree content hash
+
+The content hash is a deterministic digest of a package's cached file
+tree. It is computed so the same tree hashes identically on Windows and
+Linux: no file mode or timestamp is included, and path separators are
+normalized.
+
+Algorithm (`raven::lock::tree_hash`):
+
+1. Walk the package directory recursively and collect every regular file.
+   Any `.git` directory is skipped. (The fetch path already removes `.git`
+   from a cache entry; the walk guards against it anyway.)
+2. Compute each file's path relative to the package root and join its
+   components with forward slashes (`/`), so the relative path is
+   identical on every platform.
+3. Sort the files by that relative path.
+4. Feed a single SHA-256 hasher, in sorted order, for each file:
+   - the relative path bytes,
+   - a single NUL byte (`0x00`) separator,
+   - the file length as 8 little-endian bytes,
+   - the file's raw bytes.
+5. The digest is formatted `sha256:<lowercase-hex>`.
+
+The path, the length, and the NUL separator are absorbed so that moving
+content between files, or splitting one file into two, changes the digest.
+
+## Generate vs validate
+
+`rvpm lock` (and the install/build work that builds on it) chooses between
+generating and validating:
+
+- Generate when `rv.lock` is absent, or when `rv.toml` has a dependency
+  whose `source` is not present in the lock. Resolution walks the full
+  transitive dependency set fresh and the lock is rewritten.
+- Validate when `rv.lock` exists and already covers every direct
+  dependency in `rv.toml`. Each pinned entry is fetched and its tree hash
+  is recomputed and compared to the recorded hash.
+
+A dependency present in `rv.toml` but missing from `rv.lock` triggers a
+fresh resolve (and a rewrite of the lock), so adding a dependency to the
+manifest and re-running picks it up.
+
+## Hash mismatch aborts
+
+During validation, if a fetched tree hashes to a value different from the
+recorded hash, validation fails with an error that names the package, its
+version, the locked hash, and the hash that was computed. Validation does
+not silently update the lock on a mismatch; the caller must investigate.
+
+## Transitive resolution and dedup
+
+`raven::lock::resolve_and_lock(manifest)` walks the dependency graph:
+
+1. Each direct dependency from `rv.toml` is queued with its resolved ref.
+2. Each queued package is fetched into the shared cache (via
+   `raven::pkg::fetch`), and its tree hash is computed.
+3. The fetched package's own `rv.toml` is read, and its dependencies are
+   queued in turn.
+4. Packages are deduplicated by `(source, version)`, so a diamond in the
+   graph (two dependents requiring the same package version) is fetched
+   and hashed once.
+
+The result is a `LockFile` with one entry per distinct transitive
+`(source, version)`, sorted deterministically.
+
+`raven::lock::validate_lock(lock)` fetches every pinned entry and verifies
+its tree hash, returning the mismatch error described above on the first
+discrepancy.
+
+For test isolation, `raven::lock` also exposes
+`resolve_and_lock_in(manifest, cache_root)` and
+`validate_lock_in(lock, cache_root)`, which take an explicit cache root
+rather than consulting `RVPM_CACHE_DIR`. Tests pre-seed a temporary cache
+root so resolution is a cache hit and never touches the network.
+
+## rvpm lock
+
+The binary exposes the library through:
+
+```
+rvpm lock
+```
+
+It loads `rv.toml` from the current directory. If `rv.lock` exists and
+covers every dependency, it validates the lock against the cache.
+Otherwise it resolves the full transitive set fresh and writes `rv.lock`.
+The full add/install/update UX lands in later releases; `rvpm lock` is a
+direct way to exercise generation and validation.

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -7,7 +7,9 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use raven::lock::{self, LockFile, LOCK_FILE_NAME};
 use raven::manifest::init::{init_project, name_from_dir, InitError};
+use raven::manifest::Manifest;
 use raven::pkg;
 use raven::resolve::GithubPath;
 
@@ -26,6 +28,13 @@ fn main() -> ExitCode {
             }
         },
         Some("fetch") => match cmd_fetch(&args[1..]) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("rvpm: {}", e);
+                ExitCode::from(1)
+            }
+        },
+        Some("lock") => match cmd_lock() {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
                 eprintln!("rvpm: {}", e);
@@ -68,6 +77,34 @@ fn cmd_fetch(args: &[String]) -> Result<(), String> {
     Ok(())
 }
 
+/// Generate or validate `rv.lock` for the package in the current
+/// directory. Generates when the lock is absent or does not cover every
+/// dependency in `rv.toml`; otherwise validates the existing lock against
+/// the cache. The full install/build UX lands in later releases; this is a
+/// way to exercise resolution and validation directly.
+fn cmd_lock() -> Result<(), String> {
+    let manifest = Manifest::load("rv.toml").map_err(|e| e.to_string())?;
+    let lock_path = std::path::Path::new(LOCK_FILE_NAME);
+
+    if lock_path.exists() {
+        let existing = LockFile::load(lock_path).map_err(|e| e.to_string())?;
+        if existing.covers(&manifest) {
+            lock::validate_lock(&existing).map_err(|e| e.to_string())?;
+            println!("rv.lock is up to date and verified");
+            return Ok(());
+        }
+    }
+
+    let lock = lock::resolve_and_lock(&manifest).map_err(|e| e.to_string())?;
+    lock.write(lock_path).map_err(|e| e.to_string())?;
+    println!(
+        "Wrote {} with {} package(s)",
+        LOCK_FILE_NAME,
+        lock.packages.len()
+    );
+    Ok(())
+}
+
 fn print_usage() {
     println!("rvpm: the Raven package manager");
     println!();
@@ -77,7 +114,8 @@ fn print_usage() {
     println!("Commands:");
     println!("  init [name]   Scaffold a new package in the current directory");
     println!("  fetch <pkg>   Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
+    println!("  lock          Generate or validate rv.lock for the current package");
     println!("  help          Print this message");
     println!();
-    println!("Dependency resolution, add/install/update, and build/run land in later releases.");
+    println!("add/install/update and build/run land in later releases.");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //! - `mir`: mid-level intermediate representation (basic blocks)
 //! - `codegen`: Cranelift IR generation and linking
 //! - `pkg`: rvpm package fetching and the shared content cache
+//! - `lock`: rvpm lock file generation and validation (rv.lock)
 //! - `driver`: pipeline orchestrator
 //!
 //! Lexer, span, and error infrastructure ship today; the rest land in
@@ -21,6 +22,7 @@ pub mod codegen;
 pub mod error;
 pub mod hir;
 pub mod lexer;
+pub mod lock;
 pub mod manifest;
 pub mod mir;
 pub mod parser;

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -1,0 +1,712 @@
+//! The `rv.lock` lock file for rvpm.
+//!
+//! `rv.lock` pins the exact resolved git ref and a content (tree) hash
+//! for every transitive dependency of a package. It is checked in next to
+//! `rv.toml`. The lock makes builds reproducible: a later install or build
+//! fetches the pinned refs and verifies that the fetched tree still hashes
+//! to the recorded value.
+//!
+//! Scope: full semver range resolution is not implemented yet. For now a
+//! `[dependencies]` constraint string in `rv.toml` is treated as the
+//! literal git ref (tag or branch) to fetch, so the resolved version
+//! equals the constraint as written. Range resolution is future work; when
+//! it lands the lock will record the chosen ref while `rv.toml` carries
+//! the range.
+//!
+//! See `docs/v2/specs/rvpm.md` for the lock format and the tree-hash
+//! scheme.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::manifest::{Manifest, ManifestError};
+use crate::pkg::{self, PkgError};
+
+/// The lock format version stamped into `rv.lock`.
+pub const LOCK_VERSION: u32 = 1;
+
+/// One locked package: its source identity, the resolved git ref, and the
+/// content hash of its fetched tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockedPackage {
+    /// The `github.com/<user>/<repo>` source path.
+    pub source: String,
+    /// The resolved git ref (tag or branch) that was fetched.
+    pub version: String,
+    /// The tree content hash, formatted `sha256:<hex>`.
+    pub hash: String,
+}
+
+/// A parsed `rv.lock`. Packages are kept sorted by `(source, version)` so
+/// the serialized form is stable across runs and diffs cleanly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockFile {
+    pub version: u32,
+    pub packages: Vec<LockedPackage>,
+}
+
+/// An error produced while resolving, reading, or validating the lock.
+#[derive(Debug)]
+pub enum LockError {
+    /// A filesystem operation against the lock file failed.
+    Io {
+        action: String,
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The lock file did not parse as the expected TOML shape.
+    Parse(String),
+    /// The lock format version is newer than this tool understands.
+    UnsupportedVersion { found: u32 },
+    /// Fetching a dependency failed.
+    Fetch(PkgError),
+    /// A fetched dependency's own `rv.toml` could not be read or parsed.
+    Manifest {
+        source_path: String,
+        error: ManifestError,
+    },
+    /// A dependency constraint was not a usable git ref (empty).
+    EmptyConstraint { source: String },
+    /// A pinned tree hash did not match the fetched tree.
+    HashMismatch {
+        source: String,
+        version: String,
+        expected: String,
+        actual: String,
+    },
+}
+
+impl fmt::Display for LockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LockError::Io {
+                action,
+                path,
+                source,
+            } => write!(f, "cannot {} '{}': {}", action, path.display(), source),
+            LockError::Parse(msg) => write!(f, "invalid rv.lock: {}", msg),
+            LockError::UnsupportedVersion { found } => write!(
+                f,
+                "rv.lock format version {} is newer than this tool supports (max {})",
+                found, LOCK_VERSION
+            ),
+            LockError::Fetch(e) => write!(f, "{}", e),
+            LockError::Manifest { source_path, error } => {
+                write!(f, "in dependency '{}': {}", source_path, error)
+            }
+            LockError::EmptyConstraint { source } => write!(
+                f,
+                "dependency '{}' has an empty version, expected a git tag or branch",
+                source
+            ),
+            LockError::HashMismatch {
+                source,
+                version,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "content hash mismatch for '{}' at '{}': locked {} but fetched tree hashes to {}",
+                source, version, expected, actual
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LockError::Io { source, .. } => Some(source),
+            LockError::Fetch(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl LockFile {
+    /// Read and parse the lock file at `path`.
+    pub fn load(path: impl AsRef<Path>) -> Result<LockFile, LockError> {
+        let path = path.as_ref();
+        let text = std::fs::read_to_string(path).map_err(|e| LockError::Io {
+            action: "read lock file".to_string(),
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+        LockFile::from_toml_str(&text)
+    }
+
+    /// Parse a lock file from a TOML string.
+    pub fn from_toml_str(s: &str) -> Result<LockFile, LockError> {
+        let raw: RawLock =
+            toml::from_str(s).map_err(|e| LockError::Parse(e.message().to_string()))?;
+        if raw.version > LOCK_VERSION {
+            return Err(LockError::UnsupportedVersion { found: raw.version });
+        }
+        let mut packages: Vec<LockedPackage> = raw
+            .package
+            .into_iter()
+            .map(|p| LockedPackage {
+                source: p.source,
+                version: p.version,
+                hash: p.hash,
+            })
+            .collect();
+        sort_packages(&mut packages);
+        Ok(LockFile {
+            version: raw.version,
+            packages,
+        })
+    }
+
+    /// Serialize the lock file to its canonical TOML string. Packages are
+    /// emitted in sorted order.
+    pub fn to_toml_string(&self) -> String {
+        let mut packages = self.packages.clone();
+        sort_packages(&mut packages);
+        let mut out = format!("version = {}\n", self.version);
+        for p in &packages {
+            out.push_str("\n[[package]]\n");
+            out.push_str(&format!("source = {}\n", toml_string(&p.source)));
+            out.push_str(&format!("version = {}\n", toml_string(&p.version)));
+            out.push_str(&format!("hash = {}\n", toml_string(&p.hash)));
+        }
+        out
+    }
+
+    /// Write the lock file to `path` in canonical form.
+    pub fn write(&self, path: impl AsRef<Path>) -> Result<(), LockError> {
+        let path = path.as_ref();
+        std::fs::write(path, self.to_toml_string()).map_err(|e| LockError::Io {
+            action: "write lock file".to_string(),
+            path: path.to_path_buf(),
+            source: e,
+        })
+    }
+
+    /// True when every dependency in `manifest` has a matching entry in
+    /// this lock (matched by source path). Transitive entries are not
+    /// checked here; a missing direct dependency forces a fresh resolve.
+    pub fn covers(&self, manifest: &Manifest) -> bool {
+        manifest.dependencies.iter().all(|d| {
+            self.packages
+                .iter()
+                .any(|p| p.source == dep_source(&d.path))
+        })
+    }
+}
+
+/// The conventional lock file name beside a manifest.
+pub const LOCK_FILE_NAME: &str = "rv.lock";
+
+/// Resolve the full transitive dependency set of `manifest`, fetching each
+/// dependency into the shared cache (default cache root), and return the
+/// computed lock. See [`resolve_and_lock_in`] for the explicit-cache-root
+/// form used by tests.
+pub fn resolve_and_lock(manifest: &Manifest) -> Result<LockFile, LockError> {
+    resolve_and_lock_in(manifest, &pkg::cache_root())
+}
+
+/// Resolve and lock against an explicit cache root.
+///
+/// Walks the dependency graph transitively: each dependency is fetched,
+/// its own `rv.toml` is read for sub-dependencies, and those are queued in
+/// turn. Packages are deduplicated by `(source, version)` so a diamond in
+/// the graph is fetched and hashed once. Each fetched tree is hashed with
+/// [`tree_hash`]. The returned lock is sorted deterministically.
+pub fn resolve_and_lock_in(manifest: &Manifest, cache_root: &Path) -> Result<LockFile, LockError> {
+    let mut seen: BTreeMap<(String, String), LockedPackage> = BTreeMap::new();
+    // Work queue of (source, version) pairs to resolve.
+    let mut queue: Vec<(String, String)> = Vec::new();
+    for dep in &manifest.dependencies {
+        queue.push((dep.path.clone(), resolved_ref(dep)?));
+    }
+
+    while let Some((source, version)) = queue.pop() {
+        let key = (source.clone(), version.clone());
+        if seen.contains_key(&key) {
+            continue;
+        }
+
+        let gh = crate::resolve::GithubPath::parse(&source).ok_or_else(|| {
+            LockError::Parse(format!(
+                "dependency source '{}' is not a github.com path",
+                source
+            ))
+        })?;
+        let dir = pkg::fetch_in(cache_root, &gh.host, &gh.user, &gh.repo, &version)
+            .map_err(LockError::Fetch)?;
+
+        let hash = tree_hash(&dir).map_err(|e| LockError::Io {
+            action: "hash dependency tree".to_string(),
+            path: dir.clone(),
+            source: e,
+        })?;
+
+        seen.insert(
+            key,
+            LockedPackage {
+                source: source.clone(),
+                version: version.clone(),
+                hash,
+            },
+        );
+
+        // Read the fetched package's manifest for its own dependencies.
+        let sub_manifest_path = dir.join("rv.toml");
+        if sub_manifest_path.exists() {
+            let sub = Manifest::load(&sub_manifest_path).map_err(|error| LockError::Manifest {
+                source_path: source.clone(),
+                error,
+            })?;
+            for dep in &sub.dependencies {
+                queue.push((dep.path.clone(), resolved_ref(dep)?));
+            }
+        }
+    }
+
+    let mut packages: Vec<LockedPackage> = seen.into_values().collect();
+    sort_packages(&mut packages);
+    Ok(LockFile {
+        version: LOCK_VERSION,
+        packages,
+    })
+}
+
+/// Validate `lock` against the shared cache (default cache root).
+pub fn validate_lock(lock: &LockFile) -> Result<(), LockError> {
+    validate_lock_in(lock, &pkg::cache_root())
+}
+
+/// Validate `lock` against an explicit cache root: fetch every pinned
+/// entry and verify its tree hash. A mismatch aborts with
+/// [`LockError::HashMismatch`] naming the package.
+pub fn validate_lock_in(lock: &LockFile, cache_root: &Path) -> Result<(), LockError> {
+    for entry in &lock.packages {
+        let gh = crate::resolve::GithubPath::parse(&entry.source).ok_or_else(|| {
+            LockError::Parse(format!(
+                "locked source '{}' is not a github.com path",
+                entry.source
+            ))
+        })?;
+        let dir = pkg::fetch_in(cache_root, &gh.host, &gh.user, &gh.repo, &entry.version)
+            .map_err(LockError::Fetch)?;
+        let actual = tree_hash(&dir).map_err(|e| LockError::Io {
+            action: "hash dependency tree".to_string(),
+            path: dir.clone(),
+            source: e,
+        })?;
+        if actual != entry.hash {
+            return Err(LockError::HashMismatch {
+                source: entry.source.clone(),
+                version: entry.version.clone(),
+                expected: entry.hash.clone(),
+                actual,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Compute the deterministic content hash of the file tree rooted at
+/// `dir`.
+///
+/// Every regular file under `dir` (recursively) is collected, excluding
+/// any `.git` directory. Files are sorted by their relative path using
+/// forward-slash separators so the order is identical on Windows and
+/// Linux. For each file the hash absorbs the relative path bytes, a NUL
+/// separator, the file length as 8 little-endian bytes, and the file
+/// bytes. The result is the SHA-256 digest formatted `sha256:<hex>`. No
+/// file mode or timestamp is included, so the same tree hashes identically
+/// across platforms.
+pub fn tree_hash(dir: &Path) -> std::io::Result<String> {
+    let mut files: Vec<(String, PathBuf)> = Vec::new();
+    collect_files(dir, dir, &mut files)?;
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    for (rel, abs) in &files {
+        let bytes = std::fs::read(abs)?;
+        hasher.update(rel.as_bytes());
+        hasher.update([0u8]);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+    }
+    let digest = hasher.finalize();
+    Ok(format!("sha256:{:x}", digest))
+}
+
+fn collect_files(
+    root: &Path,
+    current: &Path,
+    out: &mut Vec<(String, PathBuf)>,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(current)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            collect_files(root, &path, out)?;
+        } else if file_type.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+            out.push((rel, path));
+        }
+    }
+    Ok(())
+}
+
+/// The resolved git ref for a dependency. Today the constraint string is
+/// the literal ref; range resolution is future work.
+fn resolved_ref(dep: &crate::manifest::Dependency) -> Result<String, LockError> {
+    let r = dep.constraint.trim();
+    if r.is_empty() {
+        return Err(LockError::EmptyConstraint {
+            source: dep_source(&dep.path),
+        });
+    }
+    Ok(r.to_string())
+}
+
+/// The lock `source` value for a dependency path. The manifest key already
+/// is the `github.com/<user>/<repo>` source identity.
+fn dep_source(path: &str) -> String {
+    path.to_string()
+}
+
+fn sort_packages(packages: &mut [LockedPackage]) {
+    packages.sort_by(|a, b| a.source.cmp(&b.source).then(a.version.cmp(&b.version)));
+}
+
+/// Quote a string as a TOML basic string. The values here (github paths,
+/// git refs, hex hashes) contain no control characters or quotes, but the
+/// escaping keeps the writer correct for any input.
+fn toml_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawLock {
+    #[serde(default = "default_lock_version")]
+    version: u32,
+    #[serde(default)]
+    package: Vec<RawLockedPackage>,
+}
+
+fn default_lock_version() -> u32 {
+    LOCK_VERSION
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawLockedPackage {
+    source: String,
+    version: String,
+    hash: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// A throwaway cache root under the OS temp dir, removed on drop.
+    struct TempCache {
+        root: PathBuf,
+    }
+
+    impl TempCache {
+        fn new(tag: &str) -> TempCache {
+            let mut root = std::env::temp_dir();
+            let unique = format!(
+                "rvpm-lock-{}-{}-{}",
+                tag,
+                std::process::id(),
+                next_counter()
+            );
+            root.push(unique);
+            std::fs::create_dir_all(&root).expect("create temp cache root");
+            TempCache { root }
+        }
+
+        /// Seed a cached package directory with the given files. `files`
+        /// is a list of (relative path, contents).
+        fn seed(&self, source: &str, version: &str, files: &[(&str, &str)]) -> PathBuf {
+            let gh = crate::resolve::GithubPath::parse(source).expect("github path");
+            let dir = pkg::cache_dir_in(&self.root, &gh.host, &gh.user, &gh.repo, version);
+            std::fs::create_dir_all(&dir).expect("create cache dir");
+            for (rel, contents) in files {
+                let path = dir.join(rel);
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).expect("create parent");
+                }
+                std::fs::write(&path, contents).expect("write seed file");
+            }
+            dir
+        }
+    }
+
+    impl Drop for TempCache {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn next_counter() -> u64 {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn manifest_with(deps: &[(&str, &str)]) -> Manifest {
+        let mut src =
+            String::from("[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n");
+        for (path, constraint) in deps {
+            src.push_str(&format!("\"{}\" = \"{}\"\n", path, constraint));
+        }
+        Manifest::from_toml_str(&src).expect("manifest parses")
+    }
+
+    #[test]
+    fn fresh_resolve_walks_transitively() {
+        let cache = TempCache::new("fresh");
+        // foo depends on bar; bar has no deps.
+        cache.seed(
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[
+                (
+                    "rv.toml",
+                    "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"github.com/acme/bar\" = \"v1.0.0\"\n",
+                ),
+                ("src/lib.rv", "fun foo() {}\n"),
+            ],
+        );
+        cache.seed(
+            "github.com/acme/bar",
+            "v1.0.0",
+            &[
+                (
+                    "rv.toml",
+                    "[package]\nname = \"bar\"\nversion = \"1.0.0\"\n",
+                ),
+                ("src/lib.rv", "fun bar() {}\n"),
+            ],
+        );
+
+        let manifest = manifest_with(&[("github.com/acme/foo", "v1.0.0")]);
+        let lock = resolve_and_lock_in(&manifest, &cache.root).expect("resolve");
+
+        assert_eq!(lock.version, LOCK_VERSION);
+        assert_eq!(lock.packages.len(), 2);
+        // Sorted by source: bar before foo.
+        assert_eq!(lock.packages[0].source, "github.com/acme/bar");
+        assert_eq!(lock.packages[0].version, "v1.0.0");
+        assert!(lock.packages[0].hash.starts_with("sha256:"));
+        assert_eq!(lock.packages[1].source, "github.com/acme/foo");
+        assert!(lock.packages[1].hash.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn validate_ok_when_tree_unchanged() {
+        let cache = TempCache::new("validok");
+        cache.seed(
+            "github.com/acme/bar",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"bar\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        let manifest = manifest_with(&[("github.com/acme/bar", "v1.0.0")]);
+        let lock = resolve_and_lock_in(&manifest, &cache.root).expect("resolve");
+        validate_lock_in(&lock, &cache.root).expect("validate ok");
+    }
+
+    #[test]
+    fn validate_detects_hash_mismatch() {
+        let cache = TempCache::new("mismatch");
+        let dir = cache.seed(
+            "github.com/acme/bar",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"bar\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        let manifest = manifest_with(&[("github.com/acme/bar", "v1.0.0")]);
+        let lock = resolve_and_lock_in(&manifest, &cache.root).expect("resolve");
+
+        // Tamper with a cached file after locking.
+        let f = dir.join("rv.toml");
+        let mut contents = std::fs::read_to_string(&f).unwrap();
+        contents.push_str("\n# tampered\n");
+        std::fs::write(&f, contents).unwrap();
+
+        let err = validate_lock_in(&lock, &cache.root).unwrap_err();
+        match err {
+            LockError::HashMismatch { source, .. } => {
+                assert_eq!(source, "github.com/acme/bar");
+            }
+            other => panic!("expected HashMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn missing_dep_in_lock_forces_fresh_resolve() {
+        let cache = TempCache::new("missing");
+        cache.seed(
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        cache.seed(
+            "github.com/acme/bar",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"bar\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+
+        // Lock only covers foo; manifest now also depends on bar.
+        let foo_only = manifest_with(&[("github.com/acme/foo", "v1.0.0")]);
+        let lock = resolve_and_lock_in(&foo_only, &cache.root).expect("resolve foo");
+        assert_eq!(lock.packages.len(), 1);
+
+        let both = manifest_with(&[
+            ("github.com/acme/foo", "v1.0.0"),
+            ("github.com/acme/bar", "v1.0.0"),
+        ]);
+        assert!(!lock.covers(&both), "lock should not cover the new dep");
+
+        let relocked = resolve_and_lock_in(&both, &cache.root).expect("relock");
+        assert_eq!(relocked.packages.len(), 2);
+        assert!(relocked
+            .packages
+            .iter()
+            .any(|p| p.source == "github.com/acme/bar"));
+    }
+
+    #[test]
+    fn diamond_dependency_is_deduplicated() {
+        let cache = TempCache::new("diamond");
+        // foo and baz both depend on bar@v1.0.0.
+        cache.seed(
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"github.com/acme/bar\" = \"v1.0.0\"\n",
+            )],
+        );
+        cache.seed(
+            "github.com/acme/baz",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"baz\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"github.com/acme/bar\" = \"v1.0.0\"\n",
+            )],
+        );
+        cache.seed(
+            "github.com/acme/bar",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"bar\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+
+        let manifest = manifest_with(&[
+            ("github.com/acme/foo", "v1.0.0"),
+            ("github.com/acme/baz", "v1.0.0"),
+        ]);
+        let lock = resolve_and_lock_in(&manifest, &cache.root).expect("resolve");
+        let bar_count = lock
+            .packages
+            .iter()
+            .filter(|p| p.source == "github.com/acme/bar")
+            .count();
+        assert_eq!(bar_count, 1, "bar should be locked once");
+        assert_eq!(lock.packages.len(), 3);
+    }
+
+    #[test]
+    fn lock_roundtrips_through_toml() {
+        let lock = LockFile {
+            version: LOCK_VERSION,
+            packages: vec![
+                LockedPackage {
+                    source: "github.com/acme/foo".to_string(),
+                    version: "v1.0.0".to_string(),
+                    hash: "sha256:abc123".to_string(),
+                },
+                LockedPackage {
+                    source: "github.com/acme/bar".to_string(),
+                    version: "v2.0.0".to_string(),
+                    hash: "sha256:def456".to_string(),
+                },
+            ],
+        };
+        let text = lock.to_toml_string();
+        let parsed = LockFile::from_toml_str(&text).expect("parse");
+        // Sorted: bar then foo.
+        assert_eq!(parsed.packages[0].source, "github.com/acme/bar");
+        assert_eq!(parsed.packages[1].source, "github.com/acme/foo");
+        assert_eq!(parsed.version, LOCK_VERSION);
+    }
+
+    #[test]
+    fn tree_hash_is_stable_and_path_sensitive() {
+        let cache = TempCache::new("hashstable");
+        let dir = cache.seed(
+            "github.com/acme/bar",
+            "v1.0.0",
+            &[("a.rv", "one"), ("sub/b.rv", "two")],
+        );
+        let h1 = tree_hash(&dir).expect("hash");
+        let h2 = tree_hash(&dir).expect("hash again");
+        assert_eq!(h1, h2, "hashing is deterministic");
+        assert!(h1.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn git_dir_is_excluded_from_hash() {
+        let cache = TempCache::new("gitexcl");
+        let dir = cache.seed("github.com/acme/bar", "v1.0.0", &[("a.rv", "one")]);
+        let h_before = tree_hash(&dir).expect("hash");
+        // Add a .git directory with content; it must not affect the hash.
+        let git = dir.join(".git");
+        std::fs::create_dir_all(&git).unwrap();
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        let h_after = tree_hash(&dir).expect("hash");
+        assert_eq!(h_before, h_after, ".git must be excluded");
+    }
+}

--- a/src/pkg/mod.rs
+++ b/src/pkg/mod.rs
@@ -4,9 +4,10 @@
 //! by cloning the named tag or branch into a cache shared across
 //! projects. The cache lives at `<cache_root>/<host>/<user>/<repo>@<version>`.
 //!
-//! Version-constraint resolution (semver ranges) and the lock file are
-//! out of scope here; see issue #83. This module takes an explicit
-//! `version` string that is a git tag or branch and fetches it.
+//! Version-constraint resolution (semver ranges) is out of scope here.
+//! This module takes an explicit `version` string that is a git tag or
+//! branch and fetches it. The lock file (`rv.lock`) is built on top in
+//! `raven::lock`.
 //!
 //! See `docs/v2/specs/rvpm.md` for the cache layout and clone strategy.
 
@@ -99,8 +100,14 @@ pub fn cache_root() -> PathBuf {
 /// The cache directory for one package version:
 /// `<cache_root>/<host>/<user>/<repo>@<version>`.
 pub fn cache_dir(host: &str, user: &str, repo: &str, version: &str) -> PathBuf {
-    cache_root()
-        .join(host)
+    cache_dir_in(&cache_root(), host, user, repo, version)
+}
+
+/// The cache directory for one package version under an explicit cache
+/// root. Threading the root explicitly lets callers (and tests) avoid the
+/// global `RVPM_CACHE_DIR` environment variable and the races it brings.
+pub fn cache_dir_in(root: &Path, host: &str, user: &str, repo: &str, version: &str) -> PathBuf {
+    root.join(host)
         .join(user)
         .join(format!("{}@{}", repo, version))
 }
@@ -113,7 +120,21 @@ pub fn cache_dir(host: &str, user: &str, repo: &str, version: &str) -> PathBuf {
 /// remote. Otherwise the repository is cloned from
 /// `https://<host>/<user>/<repo>` at the given tag or branch.
 pub fn fetch(host: &str, user: &str, repo: &str, version: &str) -> Result<PathBuf, PkgError> {
-    let dest = cache_dir(host, user, repo, version);
+    fetch_in(&cache_root(), host, user, repo, version)
+}
+
+/// Fetch `host/user/repo` at `version` into an explicit cache root and
+/// return the cache directory. Behaves like [`fetch`] but does not
+/// consult `RVPM_CACHE_DIR`, so callers can isolate the cache without
+/// touching global environment state.
+pub fn fetch_in(
+    root: &Path,
+    host: &str,
+    user: &str,
+    repo: &str,
+    version: &str,
+) -> Result<PathBuf, PkgError> {
+    let dest = cache_dir_in(root, host, user, repo, version);
     if is_populated(&dest) {
         return Ok(dest);
     }


### PR DESCRIPTION
Adds `raven::lock`, which generates and validates `rv.lock` so rvpm builds pin the exact resolved ref and a content hash for every transitive dependency.

Closes #83.

## Lock format

`rv.lock` is a TOML file with a format version and one entry per transitive dependency, sorted by `(source, version)` for stable diffs:

```
version = 1

[[package]]
source = "github.com/acme/bar"
version = "v1.0.0"
hash = "sha256:<hex>"
```

## Tree content hash

The content hash is deterministic across Windows and Linux: walk the package tree (excluding any `.git` directory), sort files by their relative path using forward-slash separators, then for each file absorb the relative path bytes, a NUL separator, the file length as 8 little-endian bytes, and the file bytes into a single SHA-256 hasher. No file mode or timestamp is included. The digest is formatted `sha256:<hex>`. SHA-256 comes from the pure-Rust `sha2` crate.

## Generate, validate, mismatch

- Generate when `rv.lock` is absent or `rv.toml` has a dependency not present in the lock: resolve the full transitive set fresh and write the lock.
- Validate when the lock exists and covers every direct dependency: fetch each pinned entry and recompute its tree hash.
- A hash mismatch aborts with an error naming the package, version, locked hash, and computed hash. The lock is not silently rewritten on mismatch.
- A dependency in `rv.toml` missing from the lock triggers a fresh resolve and rewrite.

## Transitive resolution and dedup

`resolve_and_lock` fetches each dependency via `raven::pkg`, reads the fetched package's own `rv.toml` for sub-dependencies, and queues them. Packages are deduplicated by `(source, version)`, so a diamond is fetched and hashed once. The lock API threads an explicit cache root (`resolve_and_lock_in` / `validate_lock_in`, backed by `pkg::fetch_in` / `cache_dir_in`) so tests pre-seed a temp cache and never touch the network.

## Scope note: literal ref

Full semver range resolution is not in scope here. A `[dependencies]` constraint string is treated as the literal git ref (tag or branch) to fetch, so the resolved version equals the constraint as written. Range resolution is future work; the lock records the resolved ref.

`rvpm lock` is a thin wrapper that generates or validates the lock for the current package. The full add/install/update UX lands later.

## Test plan

- [x] Fresh resolve walks transitively (foo depends on bar): lock contains both, correctly ordered, with `sha256:` hashes.
- [x] Validate OK when the cached tree is unchanged.
- [x] Hash mismatch: tampering with a cached file after locking makes `validate_lock` return a mismatch naming the package.
- [x] Missing dep in lock forces a fresh resolve that adds the new entry.
- [x] Diamond dependency is deduplicated to one entry.
- [x] Lock round-trips through TOML in sorted order; `.git` excluded from the hash; hashing deterministic.
- [x] `cargo build`, `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets` green locally (the one unrelated `http_program_compiles_and_runs` codegen smoke test fails identically on the clean branch due to a local MSVC link.exe crash under disk pressure, not from this change).
