### PR TITLE
feat(rvpm): add, install, and update commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,7 @@ dependencies = [
  "sha2",
  "target-lexicon",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ target-lexicon = "0.12"
 # rv.toml manifest parsing for the rvpm package manager.
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
+# Format-preserving rv.toml edits for `rvpm add`.
+toml_edit = "0.22"
 # Content (tree) hashing for the rvpm lock file (rv.lock).
 sha2 = "0.10"
 

--- a/docs/v2/specs/rvpm.md
+++ b/docs/v2/specs/rvpm.md
@@ -248,5 +248,88 @@ rvpm lock
 It loads `rv.toml` from the current directory. If `rv.lock` exists and
 covers every dependency, it validates the lock against the cache.
 Otherwise it resolves the full transitive set fresh and writes `rv.lock`.
-The full add/install/update UX lands in later releases; `rvpm lock` is a
-direct way to exercise generation and validation.
+`rvpm lock` is a direct way to exercise generation and validation; the
+day to day workflow uses `add`, `install`, and `update` below.
+
+# Dependency commands (add, install, update)
+
+`rvpm add`, `rvpm install`, and `rvpm update` are the day to day
+dependency workflow. They wire `raven::manifest`, `raven::pkg`, and
+`raven::lock` together. The orchestration lives in `raven::ops`
+(`src/ops/mod.rs`); the `rvpm` binary stays thin and calls it. Each
+operation has an `_in(..., cache_root)` variant that takes an explicit
+cache root so it can be tested against a pre-seeded temporary cache
+without the global `RVPM_CACHE_DIR` override.
+
+All three resolve against the literal-ref constraint model: a
+`[dependencies]` value in `rv.toml` is the git tag or branch to fetch, so
+the resolved version equals the constraint as written (see
+"Version-constraint scope" above). Range based selection is future work.
+
+## rvpm add
+
+```
+rvpm add github.com/<user>/<repo>[@<version>]
+```
+
+`add` records the dependency in `rv.toml` under `[dependencies]`, then
+resolves the manifest and writes `rv.lock`, populating the cache.
+
+- The key is the `github.com/<user>/<repo>` path. The optional
+  `@<version>` is the git ref recorded as the constraint.
+- When `@<version>` is omitted, the placeholder constraint `"latest"` is
+  recorded. Real latest-tag resolution is future work, so a placeholder
+  constraint will not resolve until a concrete ref is supplied. Prefer
+  passing `@<version>`.
+- An existing entry for the same package is updated in place, not
+  duplicated. When the recorded version changes, the command reports the
+  previous and new versions. When it is identical, nothing changes.
+
+The manifest edit preserves the rest of the file, including comments,
+because it is applied with `toml_edit`. After the edit the new text is
+re-parsed with `Manifest::from_toml_str` as a guard; the written
+`rv.toml` is always a valid manifest.
+
+The edit is applied before resolution. If resolution then fails (for
+example a placeholder constraint, or a ref absent from the cache and the
+remote), the `rv.toml` edit still persists but `rv.lock` is not written.
+Re-run `add` or `install` with a resolvable ref to complete the lock.
+
+## rvpm install
+
+```
+rvpm install
+```
+
+`install` re-resolves `rv.toml` against `rv.lock` and fills the cache.
+
+- When `rv.lock` exists and covers every direct dependency in `rv.toml`,
+  the lock is validated: each pinned entry is fetched and its tree hash is
+  recomputed and compared. A mismatch aborts with the hash-mismatch error
+  and a non-zero exit, naming the package; the lock is not rewritten.
+- When `rv.lock` is missing, or does not cover the manifest, the full
+  transitive set is resolved fresh and `rv.lock` is written.
+
+`install` prints what happened (validated N packages, or resolved N
+packages and wrote `rv.lock`).
+
+## rvpm update
+
+```
+rvpm update [github.com/<user>/<repo>]
+```
+
+`update` re-resolves `rv.toml` and rewrites `rv.lock`.
+
+- With no package path, every entry is re-resolved from `rv.toml` and the
+  whole lock is rewritten.
+- With a package path, only that dependency's subgraph is re-resolved; its
+  lock entry and its transitive entries are refreshed while the rest of
+  the lock is preserved. The path must already be a dependency in
+  `rv.toml`; otherwise the command reports an error and exits non-zero.
+
+Under the literal-ref model, "update" picks up a ref that was edited in
+`rv.toml`: change the constraint, then run `update` (optionally naming the
+package) to bump the pinned version and hash in the lock. When range based
+constraints land, `update` will choose a newer ref within the range while
+`rv.toml` keeps the range; that selection is future work.

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -2,7 +2,8 @@
 //!
 //! rvpm manages Raven packages described by an `rv.toml` manifest. This
 //! binary is intentionally thin: it parses arguments and dispatches to
-//! library code in `raven::manifest`. Today only `init` is implemented.
+//! library code in `raven::manifest`, `raven::pkg`, `raven::lock`, and
+//! `raven::ops`.
 
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -10,6 +11,7 @@ use std::process::ExitCode;
 use raven::lock::{self, LockFile, LOCK_FILE_NAME};
 use raven::manifest::init::{init_project, name_from_dir, InitError};
 use raven::manifest::Manifest;
+use raven::ops;
 use raven::pkg;
 use raven::resolve::GithubPath;
 
@@ -41,6 +43,9 @@ fn main() -> ExitCode {
                 ExitCode::from(1)
             }
         },
+        Some("add") => run(cmd_add(&args[1..])),
+        Some("install") => run(cmd_install(&args[1..])),
+        Some("update") => run(cmd_update(&args[1..])),
         Some(other) => {
             eprintln!("rvpm: unknown subcommand '{}'", other);
             eprintln!("Run 'rvpm help' for usage.");
@@ -105,6 +110,75 @@ fn cmd_lock() -> Result<(), String> {
     Ok(())
 }
 
+/// Print a command's outcome lines, mapping its error to a non-zero exit.
+fn run(result: Result<Vec<String>, String>) -> ExitCode {
+    match result {
+        Ok(lines) => {
+            for line in lines {
+                println!("{}", line);
+            }
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("rvpm: {}", e);
+            ExitCode::from(1)
+        }
+    }
+}
+
+/// Append (or update) a dependency in rv.toml, then resolve and write
+/// rv.lock. Accepts `github.com/<user>/<repo>` with an optional
+/// `@<version>`; without a version a placeholder constraint is recorded.
+fn cmd_add(args: &[String]) -> Result<Vec<String>, String> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return Ok(vec![add_usage()]);
+    }
+    let spec = args
+        .first()
+        .ok_or_else(|| format!("add needs a package argument\n{}", add_usage()))?;
+    let (path, version) = match spec.rsplit_once('@') {
+        Some((p, v)) => (p, Some(v)),
+        None => (spec.as_str(), None),
+    };
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    let report = ops::add(&cwd, path, version).map_err(|e| e.to_string())?;
+    Ok(report.outcome_lines)
+}
+
+/// Re-resolve rv.toml against rv.lock and fill the cache, validating an
+/// existing lock or writing a fresh one.
+fn cmd_install(args: &[String]) -> Result<Vec<String>, String> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return Ok(vec![install_usage()]);
+    }
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    let (_outcome, report) = ops::install(&cwd).map_err(|e| e.to_string())?;
+    Ok(report.outcome_lines)
+}
+
+/// Re-resolve rv.toml and rewrite rv.lock, for one named package or all.
+fn cmd_update(args: &[String]) -> Result<Vec<String>, String> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return Ok(vec![update_usage()]);
+    }
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    let package = args.first().map(String::as_str);
+    let report = ops::update(&cwd, package).map_err(|e| e.to_string())?;
+    Ok(report.outcome_lines)
+}
+
+fn add_usage() -> String {
+    "Usage: rvpm add github.com/<user>/<repo>[@<version>]".to_string()
+}
+
+fn install_usage() -> String {
+    "Usage: rvpm install".to_string()
+}
+
+fn update_usage() -> String {
+    "Usage: rvpm update [github.com/<user>/<repo>]".to_string()
+}
+
 fn print_usage() {
     println!("rvpm: the Raven package manager");
     println!();
@@ -112,10 +186,15 @@ fn print_usage() {
     println!("  rvpm <command> [arguments]");
     println!();
     println!("Commands:");
-    println!("  init [name]   Scaffold a new package in the current directory");
-    println!("  fetch <pkg>   Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
-    println!("  lock          Generate or validate rv.lock for the current package");
-    println!("  help          Print this message");
+    println!("  init [name]    Scaffold a new package in the current directory");
+    println!("  add <pkg>      Add a dependency to rv.toml, then resolve and write rv.lock");
+    println!("  install        Resolve rv.toml against rv.lock and fill the cache");
+    println!("  update [pkg]   Re-resolve rv.toml and rewrite rv.lock for one package or all");
+    println!("  fetch <pkg>    Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
+    println!("  lock           Generate or validate rv.lock for the current package");
+    println!("  help           Print this message");
     println!();
-    println!("add/install/update and build/run land in later releases.");
+    println!("Package arguments use the 'github.com/<user>/<repo>' form.");
+    println!("For 'add', append '@<version>' to pin a git tag or branch; without it");
+    println!("a placeholder constraint is recorded. build and run land in a later release.");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod lexer;
 pub mod lock;
 pub mod manifest;
 pub mod mir;
+pub mod ops;
 pub mod parser;
 pub mod pkg;
 pub mod resolve;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,0 +1,681 @@
+//! High-level rvpm operations: add, install, and update.
+//!
+//! These wire `raven::manifest`, `raven::pkg`, and `raven::lock` into the
+//! workflows the `rvpm` binary exposes. The binary stays thin and calls
+//! these functions; the logic lives here so it is unit-testable against an
+//! explicit cache root (the `_in` variants) without the global
+//! `RVPM_CACHE_DIR` environment variable.
+//!
+//! Constraint model: constraints in `rv.toml` are literal git refs today
+//! (see `raven::lock`). `add` records the requested ref verbatim, and
+//! `update` re-resolves the refs as written. Range-based selection is
+//! future work.
+//!
+//! See `docs/v2/specs/rvpm.md` for the command semantics.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use crate::lock::{self, LockError, LockFile, LOCK_FILE_NAME};
+use crate::manifest::{Manifest, ManifestError};
+use crate::pkg;
+use crate::resolve::GithubPath;
+
+/// The default constraint written for `rvpm add` when no `@version` is
+/// given. Real latest-tag resolution is future work, so the placeholder is
+/// recorded verbatim and resolution of it will fail until a concrete ref is
+/// supplied. Callers should prefer `add github.com/user/repo@<ref>`.
+pub const DEFAULT_ADD_CONSTRAINT: &str = "latest";
+
+/// The conventional manifest file name beside a lock.
+pub const MANIFEST_FILE_NAME: &str = "rv.toml";
+
+/// An error produced by a high-level rvpm operation.
+#[derive(Debug)]
+pub enum OpError {
+    /// A filesystem operation failed.
+    Io {
+        action: String,
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The package path argument was not a `github.com/<user>/<repo>` path.
+    InvalidPath(String),
+    /// Reading or parsing a manifest failed.
+    Manifest(ManifestError),
+    /// Editing `rv.toml` produced TOML that no longer parses.
+    ManifestEdit(String),
+    /// Resolving, locking, reading, or validating the lock failed.
+    Lock(LockError),
+    /// `update` named a package that is not a dependency in `rv.toml`.
+    UnknownPackage(String),
+}
+
+impl fmt::Display for OpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OpError::Io {
+                action,
+                path,
+                source,
+            } => write!(f, "cannot {} '{}': {}", action, path.display(), source),
+            OpError::InvalidPath(p) => {
+                write!(f, "'{}' is not a 'github.com/<user>/<repo>' path", p)
+            }
+            OpError::Manifest(e) => write!(f, "{}", e),
+            OpError::ManifestEdit(msg) => write!(f, "could not update rv.toml: {}", msg),
+            OpError::Lock(e) => write!(f, "{}", e),
+            OpError::UnknownPackage(p) => {
+                write!(f, "'{}' is not a dependency in rv.toml", p)
+            }
+        }
+    }
+}
+
+impl std::error::Error for OpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            OpError::Io { source, .. } => Some(source),
+            OpError::Manifest(e) => Some(e),
+            OpError::Lock(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<ManifestError> for OpError {
+    fn from(e: ManifestError) -> Self {
+        OpError::Manifest(e)
+    }
+}
+
+impl From<LockError> for OpError {
+    fn from(e: LockError) -> Self {
+        OpError::Lock(e)
+    }
+}
+
+/// What an `add` did to `rv.toml`, for reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddOutcome {
+    /// The dependency was new and was appended.
+    Added,
+    /// The dependency already existed with a different version and was
+    /// updated. Carries the previous constraint.
+    Updated { previous: String },
+    /// The dependency already existed at the same version; nothing changed.
+    Unchanged,
+}
+
+/// The result of an `add`, install, or update for the binary to print.
+#[derive(Debug, Clone)]
+pub struct OpReport {
+    pub outcome_lines: Vec<String>,
+    pub package_count: usize,
+}
+
+/// Add a dependency to `rv.toml`, then resolve and write `rv.lock`, using
+/// the default cache root. See [`add_in`].
+pub fn add(project_dir: &Path, path: &str, version: Option<&str>) -> Result<OpReport, OpError> {
+    add_in(project_dir, path, version, &pkg::cache_root())
+}
+
+/// Add (or update) a dependency in `rv.toml` under `project_dir`, then
+/// re-resolve against `cache_root` and rewrite `rv.lock`.
+///
+/// `version` is the requested git ref (the part after `@`). When `None`,
+/// [`DEFAULT_ADD_CONSTRAINT`] is recorded. An existing entry with a
+/// different version is updated, not duplicated, and the change is reported.
+pub fn add_in(
+    project_dir: &Path,
+    path: &str,
+    version: Option<&str>,
+    cache_root: &Path,
+) -> Result<OpReport, OpError> {
+    let gh = GithubPath::parse(path).ok_or_else(|| OpError::InvalidPath(path.to_string()))?;
+    let key = format!("github.com/{}/{}", gh.user, gh.repo);
+    let constraint = version.unwrap_or(DEFAULT_ADD_CONSTRAINT);
+
+    let manifest_path = project_dir.join(MANIFEST_FILE_NAME);
+    let text = read_to_string(&manifest_path)?;
+    let (new_text, outcome) = upsert_dependency(&text, &key, constraint)?;
+
+    // Guard: the edited text must still parse as a manifest.
+    Manifest::from_toml_str(&new_text)?;
+    write_file(&manifest_path, &new_text)?;
+
+    let manifest = Manifest::from_toml_str(&new_text)?;
+    let lock = lock::resolve_and_lock_in(&manifest, cache_root)?;
+    let lock_path = project_dir.join(LOCK_FILE_NAME);
+    lock.write(&lock_path)?;
+
+    let mut lines = Vec::new();
+    match &outcome {
+        AddOutcome::Added => lines.push(format!("Added {} {}", key, constraint)),
+        AddOutcome::Updated { previous } => lines.push(format!(
+            "Updated {} from {} to {}",
+            key, previous, constraint
+        )),
+        AddOutcome::Unchanged => {
+            lines.push(format!("{} {} is already in rv.toml", key, constraint))
+        }
+    }
+    lines.push(format!(
+        "Wrote {} with {} package(s)",
+        LOCK_FILE_NAME,
+        lock.packages.len()
+    ));
+    Ok(OpReport {
+        outcome_lines: lines,
+        package_count: lock.packages.len(),
+    })
+}
+
+/// What an install did, for reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallOutcome {
+    /// An existing lock covered the manifest and was validated.
+    Validated,
+    /// No usable lock was present; a fresh one was resolved and written.
+    Resolved,
+}
+
+/// Re-resolve `rv.toml` against `rv.lock` and fill the cache, using the
+/// default cache root. See [`install_in`].
+pub fn install(project_dir: &Path) -> Result<(InstallOutcome, OpReport), OpError> {
+    install_in(project_dir, &pkg::cache_root())
+}
+
+/// Install dependencies for the project under `project_dir` against
+/// `cache_root`.
+///
+/// When `rv.lock` exists and covers every direct dependency, the lock is
+/// validated: each pinned entry is fetched and its tree hash is verified. A
+/// mismatch aborts. When the lock is missing or does not cover the
+/// manifest, a fresh lock is resolved and written.
+pub fn install_in(
+    project_dir: &Path,
+    cache_root: &Path,
+) -> Result<(InstallOutcome, OpReport), OpError> {
+    let manifest_path = project_dir.join(MANIFEST_FILE_NAME);
+    let manifest = Manifest::load(&manifest_path)?;
+    let lock_path = project_dir.join(LOCK_FILE_NAME);
+
+    if lock_path.exists() {
+        let existing = LockFile::load(&lock_path)?;
+        if existing.covers(&manifest) {
+            lock::validate_lock_in(&existing, cache_root)?;
+            let count = existing.packages.len();
+            return Ok((
+                InstallOutcome::Validated,
+                OpReport {
+                    outcome_lines: vec![format!("Validated {} package(s) against rv.lock", count)],
+                    package_count: count,
+                },
+            ));
+        }
+    }
+
+    let lock = lock::resolve_and_lock_in(&manifest, cache_root)?;
+    lock.write(&lock_path)?;
+    let count = lock.packages.len();
+    Ok((
+        InstallOutcome::Resolved,
+        OpReport {
+            outcome_lines: vec![format!(
+                "Resolved {} package(s) and wrote {}",
+                count, LOCK_FILE_NAME
+            )],
+            package_count: count,
+        },
+    ))
+}
+
+/// Re-resolve and rewrite `rv.lock` for one package (or all), using the
+/// default cache root. See [`update_in`].
+pub fn update(project_dir: &Path, package: Option<&str>) -> Result<OpReport, OpError> {
+    update_in(project_dir, package, &pkg::cache_root())
+}
+
+/// Update pinned versions in `rv.lock` by re-resolving `rv.toml` against
+/// `cache_root`.
+///
+/// With no `package`, every entry is re-resolved from `rv.toml` and the
+/// whole lock is rewritten. With a `package` path, only that dependency is
+/// re-resolved; its lock entry (and its transitive entries) are refreshed
+/// while the rest of the lock is preserved. Because constraints are literal
+/// refs today, an update picks up a ref edited in `rv.toml`. Range-based
+/// bumping is future work.
+pub fn update_in(
+    project_dir: &Path,
+    package: Option<&str>,
+    cache_root: &Path,
+) -> Result<OpReport, OpError> {
+    let manifest_path = project_dir.join(MANIFEST_FILE_NAME);
+    let manifest = Manifest::load(&manifest_path)?;
+    let lock_path = project_dir.join(LOCK_FILE_NAME);
+
+    let full = lock::resolve_and_lock_in(&manifest, cache_root)?;
+
+    match package {
+        None => {
+            full.write(&lock_path)?;
+            Ok(OpReport {
+                outcome_lines: vec![format!(
+                    "Updated {} with {} package(s)",
+                    LOCK_FILE_NAME,
+                    full.packages.len()
+                )],
+                package_count: full.packages.len(),
+            })
+        }
+        Some(path) => {
+            let gh =
+                GithubPath::parse(path).ok_or_else(|| OpError::InvalidPath(path.to_string()))?;
+            let key = format!("github.com/{}/{}", gh.user, gh.repo);
+            if !manifest.dependencies.iter().any(|d| d.path == key) {
+                return Err(OpError::UnknownPackage(key));
+            }
+
+            // Re-resolve only the named dependency's subgraph, then merge its
+            // fresh entries over a preserved copy of the existing lock.
+            let single = single_dep_manifest(&manifest, &key);
+            let refreshed = lock::resolve_and_lock_in(&single, cache_root)?;
+
+            let mut merged = if lock_path.exists() {
+                LockFile::load(&lock_path)?
+            } else {
+                full.clone()
+            };
+            for entry in &refreshed.packages {
+                if let Some(existing) = merged
+                    .packages
+                    .iter_mut()
+                    .find(|p| p.source == entry.source)
+                {
+                    *existing = entry.clone();
+                } else {
+                    merged.packages.push(entry.clone());
+                }
+            }
+            merged
+                .packages
+                .sort_by(|a, b| a.source.cmp(&b.source).then(a.version.cmp(&b.version)));
+            merged.write(&lock_path)?;
+            Ok(OpReport {
+                outcome_lines: vec![format!("Updated {} in {}", key, LOCK_FILE_NAME)],
+                package_count: refreshed.packages.len(),
+            })
+        }
+    }
+}
+
+/// Build a manifest carrying only the one dependency `key`, reusing the
+/// package identity from `base`.
+fn single_dep_manifest(base: &Manifest, key: &str) -> Manifest {
+    let mut m = base.clone();
+    m.dependencies.retain(|d| d.path == key);
+    m
+}
+
+/// Insert or update a `[dependencies]` entry in `toml_text`, preserving
+/// formatting and comments. Returns the new text and what changed.
+fn upsert_dependency(
+    toml_text: &str,
+    key: &str,
+    constraint: &str,
+) -> Result<(String, AddOutcome), OpError> {
+    use toml_edit::{value, DocumentMut, Item, Table};
+
+    let mut doc: DocumentMut = toml_text
+        .parse()
+        .map_err(|e: toml_edit::TomlError| OpError::ManifestEdit(e.to_string()))?;
+
+    if doc.get("dependencies").is_none() {
+        let mut t = Table::new();
+        t.set_implicit(false);
+        doc["dependencies"] = Item::Table(t);
+    }
+    let deps = doc["dependencies"]
+        .as_table_mut()
+        .ok_or_else(|| OpError::ManifestEdit("[dependencies] is not a table".to_string()))?;
+
+    let outcome = match deps.get(key).and_then(|i| i.as_str()) {
+        Some(prev) if prev == constraint => AddOutcome::Unchanged,
+        Some(prev) => AddOutcome::Updated {
+            previous: prev.to_string(),
+        },
+        None => AddOutcome::Added,
+    };
+    deps[key] = value(constraint);
+
+    Ok((doc.to_string(), outcome))
+}
+
+fn read_to_string(path: &Path) -> Result<String, OpError> {
+    std::fs::read_to_string(path).map_err(|e| OpError::Io {
+        action: "read".to_string(),
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
+fn write_file(path: &Path, contents: &str) -> Result<(), OpError> {
+    std::fs::write(path, contents).map_err(|e| OpError::Io {
+        action: "write".to_string(),
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    struct TempProject {
+        root: PathBuf,
+    }
+
+    impl TempProject {
+        fn new(tag: &str) -> TempProject {
+            let mut root = std::env::temp_dir();
+            root.push(format!(
+                "rvpm-ops-{}-{}-{}",
+                tag,
+                std::process::id(),
+                next_counter()
+            ));
+            std::fs::create_dir_all(&root).expect("create temp project");
+            TempProject { root }
+        }
+
+        fn write_manifest(&self, text: &str) {
+            std::fs::write(self.root.join(MANIFEST_FILE_NAME), text).expect("write rv.toml");
+        }
+
+        fn manifest_text(&self) -> String {
+            std::fs::read_to_string(self.root.join(MANIFEST_FILE_NAME)).expect("read rv.toml")
+        }
+
+        fn lock(&self) -> LockFile {
+            LockFile::load(self.root.join(LOCK_FILE_NAME)).expect("load rv.lock")
+        }
+
+        /// Seed a cache entry under `cache_root` for a package version.
+        fn seed(&self, cache_root: &Path, source: &str, version: &str, files: &[(&str, &str)]) {
+            let gh = GithubPath::parse(source).expect("github path");
+            let dir = pkg::cache_dir_in(cache_root, &gh.host, &gh.user, &gh.repo, version);
+            std::fs::create_dir_all(&dir).expect("create cache dir");
+            for (rel, contents) in files {
+                let path = dir.join(rel);
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).expect("create parent");
+                }
+                std::fs::write(&path, contents).expect("write seed");
+            }
+        }
+
+        fn cache_root(&self) -> PathBuf {
+            self.root.join("cache")
+        }
+    }
+
+    impl Drop for TempProject {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn next_counter() -> u64 {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    const APP_MANIFEST: &str =
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n# keep this comment\n";
+
+    #[test]
+    fn add_appends_dependency_and_writes_lock() {
+        let proj = TempProject::new("add");
+        proj.write_manifest(APP_MANIFEST);
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+
+        let report =
+            add_in(&proj.root, "github.com/acme/foo", Some("v1.0.0"), &cache).expect("add");
+        assert_eq!(report.package_count, 1);
+
+        let text = proj.manifest_text();
+        assert!(
+            text.contains("github.com/acme/foo"),
+            "dep written: {}",
+            text
+        );
+        assert!(text.contains("keep this comment"), "comment preserved");
+        let m = Manifest::from_toml_str(&text).expect("re-parses");
+        assert!(m
+            .dependencies
+            .iter()
+            .any(|d| d.path == "github.com/acme/foo"));
+
+        let lock = proj.lock();
+        let foo = lock
+            .packages
+            .iter()
+            .find(|p| p.source == "github.com/acme/foo")
+            .expect("foo in lock");
+        assert_eq!(foo.version, "v1.0.0");
+        assert!(foo.hash.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn add_updates_existing_different_version() {
+        let proj = TempProject::new("addupd");
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.0.0\"\n",
+        );
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/foo",
+            "v1.1.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.1.0\"\n",
+            )],
+        );
+
+        let report =
+            add_in(&proj.root, "github.com/acme/foo", Some("v1.1.0"), &cache).expect("add");
+        assert!(report
+            .outcome_lines
+            .iter()
+            .any(|l| l.contains("Updated") && l.contains("v1.0.0") && l.contains("v1.1.0")));
+
+        let m = Manifest::from_toml_str(&proj.manifest_text()).expect("re-parses");
+        let foo = m
+            .dependencies
+            .iter()
+            .find(|d| d.path == "github.com/acme/foo")
+            .unwrap();
+        assert_eq!(foo.constraint, "v1.1.0");
+        assert_eq!(proj.lock().packages[0].version, "v1.1.0");
+    }
+
+    #[test]
+    fn install_validates_existing_lock() {
+        let proj = TempProject::new("installok");
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.0.0\"\n",
+        );
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        // First install resolves a fresh lock.
+        let (outcome, _) = install_in(&proj.root, &cache).expect("first install");
+        assert_eq!(outcome, InstallOutcome::Resolved);
+        // Second install validates it.
+        let (outcome, _) = install_in(&proj.root, &cache).expect("second install");
+        assert_eq!(outcome, InstallOutcome::Validated);
+    }
+
+    #[test]
+    fn install_detects_tampered_cache() {
+        let proj = TempProject::new("tamper");
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.0.0\"\n",
+        );
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        let (outcome, _) = install_in(&proj.root, &cache).expect("resolve lock");
+        assert_eq!(outcome, InstallOutcome::Resolved);
+
+        // Tamper with a cached file after locking.
+        let gh = GithubPath::parse("github.com/acme/foo").unwrap();
+        let dir = pkg::cache_dir_in(&cache, &gh.host, &gh.user, &gh.repo, "v1.0.0");
+        let f = dir.join("rv.toml");
+        let mut contents = std::fs::read_to_string(&f).unwrap();
+        contents.push_str("\n# tampered\n");
+        std::fs::write(&f, contents).unwrap();
+
+        let err = install_in(&proj.root, &cache).unwrap_err();
+        match err {
+            OpError::Lock(LockError::HashMismatch { source, .. }) => {
+                assert_eq!(source, "github.com/acme/foo");
+            }
+            other => panic!("expected HashMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn install_without_lock_writes_fresh() {
+        let proj = TempProject::new("nolock");
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.0.0\"\n",
+        );
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        assert!(!proj.root.join(LOCK_FILE_NAME).exists());
+        let (outcome, report) = install_in(&proj.root, &cache).expect("install");
+        assert_eq!(outcome, InstallOutcome::Resolved);
+        assert_eq!(report.package_count, 1);
+        assert!(proj.root.join(LOCK_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn update_bumps_locked_version() {
+        let proj = TempProject::new("update");
+        // Start pinned at v1.0.0.
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.0.0\"\n",
+        );
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        proj.seed(
+            &cache,
+            "github.com/acme/foo",
+            "v1.1.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.1.0\"\n",
+            )],
+        );
+        let (_, _) = install_in(&proj.root, &cache).expect("install");
+        let before = proj.lock();
+        assert_eq!(before.packages[0].version, "v1.0.0");
+        let old_hash = before.packages[0].hash.clone();
+
+        // Bump the ref in rv.toml, then update just that package.
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.1.0\"\n",
+        );
+        update_in(&proj.root, Some("github.com/acme/foo"), &cache).expect("update");
+
+        let after = proj.lock();
+        let foo = after
+            .packages
+            .iter()
+            .find(|p| p.source == "github.com/acme/foo")
+            .unwrap();
+        assert_eq!(foo.version, "v1.1.0");
+        assert_ne!(foo.hash, old_hash);
+    }
+
+    #[test]
+    fn update_unknown_package_is_rejected() {
+        let proj = TempProject::new("updunknown");
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.0.0\"\n",
+        );
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/foo",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        let err = update_in(&proj.root, Some("github.com/acme/bar"), &cache).unwrap_err();
+        assert!(matches!(err, OpError::UnknownPackage(_)));
+    }
+
+    #[test]
+    fn upsert_creates_dependencies_section() {
+        let (text, outcome) =
+            upsert_dependency(APP_MANIFEST, "github.com/acme/foo", "v1.0.0").expect("upsert");
+        assert_eq!(outcome, AddOutcome::Added);
+        assert!(text.contains("[dependencies]"));
+        assert!(Manifest::from_toml_str(&text).is_ok());
+    }
+
+    #[test]
+    fn upsert_same_version_is_unchanged() {
+        let base = "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.0.0\"\n";
+        let (_, outcome) =
+            upsert_dependency(base, "github.com/acme/foo", "v1.0.0").expect("upsert");
+        assert_eq!(outcome, AddOutcome::Unchanged);
+    }
+}

--- a/tests/rvpm_commands.rs
+++ b/tests/rvpm_commands.rs
@@ -1,0 +1,190 @@
+//! End to end tests for `rvpm add`, `rvpm install`, and `rvpm update`.
+//!
+//! These drive the actual `rvpm` binary in a temp project directory with
+//! `RVPM_CACHE_DIR` pointed at a pre-seeded cache, so no test contacts the
+//! network. The env override is process-global, so the CLI tests that set
+//! it run their steps sequentially within one test function and use a
+//! cache root unique to that test. Library-level coverage of each command
+//! lives in `raven::ops` unit tests.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use raven::lock::{LockFile, LOCK_FILE_NAME};
+use raven::manifest::Manifest;
+use raven::pkg;
+use raven::resolve::GithubPath;
+
+/// Seed a cache entry under `cache_root` with the given files.
+fn seed(cache_root: &Path, source: &str, version: &str, files: &[(&str, &str)]) {
+    let gh = GithubPath::parse(source).expect("github path");
+    let dir = pkg::cache_dir_in(cache_root, &gh.host, &gh.user, &gh.repo, version);
+    std::fs::create_dir_all(&dir).expect("create cache dir");
+    for (rel, contents) in files {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(&path, contents).expect("write seed file");
+    }
+}
+
+fn rvpm(project: &Path, cache_root: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rvpm"))
+        .args(args)
+        .current_dir(project)
+        .env("RVPM_CACHE_DIR", cache_root)
+        .output()
+        .expect("run rvpm")
+}
+
+#[test]
+fn add_install_update_via_cli() {
+    let root = workdir();
+    let project = root.join("project");
+    let cache = root.join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(
+        project.join("rv.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n# user comment\n",
+    )
+    .unwrap();
+
+    seed(
+        &cache,
+        "github.com/acme/foo",
+        "v1.0.0",
+        &[(
+            "rv.toml",
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )],
+    );
+    seed(
+        &cache,
+        "github.com/acme/foo",
+        "v1.1.0",
+        &[(
+            "rv.toml",
+            "[package]\nname = \"foo\"\nversion = \"1.1.0\"\n",
+        )],
+    );
+
+    // add: writes the dependency and a lock.
+    let out = rvpm(&project, &cache, &["add", "github.com/acme/foo@v1.0.0"]);
+    assert!(
+        out.status.success(),
+        "add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let manifest_text = std::fs::read_to_string(project.join("rv.toml")).unwrap();
+    assert!(manifest_text.contains("github.com/acme/foo"));
+    assert!(manifest_text.contains("user comment"), "comment preserved");
+    let m = Manifest::from_toml_str(&manifest_text).expect("manifest re-parses");
+    assert!(m
+        .dependencies
+        .iter()
+        .any(|d| d.path == "github.com/acme/foo"));
+    let lock = LockFile::load(project.join(LOCK_FILE_NAME)).expect("lock present");
+    assert_eq!(lock.packages[0].version, "v1.0.0");
+
+    // install: validates the existing lock.
+    let out = rvpm(&project, &cache, &["install"]);
+    assert!(
+        out.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Validated"), "install stdout: {}", stdout);
+
+    // install detects a tampered cache and aborts non-zero.
+    let gh = GithubPath::parse("github.com/acme/foo").unwrap();
+    let dir = pkg::cache_dir_in(&cache, &gh.host, &gh.user, &gh.repo, "v1.0.0");
+    let f = dir.join("rv.toml");
+    let mut contents = std::fs::read_to_string(&f).unwrap();
+    contents.push_str("\n# tampered\n");
+    std::fs::write(&f, contents).unwrap();
+    let out = rvpm(&project, &cache, &["install"]);
+    assert!(!out.status.success(), "tampered install should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("hash mismatch"), "stderr: {}", stderr);
+
+    // update: bump the ref in rv.toml, then update the package.
+    std::fs::write(
+        project.join("rv.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/foo\" = \"v1.1.0\"\n",
+    )
+    .unwrap();
+    let out = rvpm(&project, &cache, &["update", "github.com/acme/foo"]);
+    assert!(
+        out.status.success(),
+        "update failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let lock = LockFile::load(project.join(LOCK_FILE_NAME)).expect("lock present");
+    let foo = lock
+        .packages
+        .iter()
+        .find(|p| p.source == "github.com/acme/foo")
+        .unwrap();
+    assert_eq!(foo.version, "v1.1.0");
+
+    cleanup(&root);
+}
+
+#[test]
+fn add_without_version_records_placeholder() {
+    let root = workdir();
+    let project = root.join("project");
+    let cache = root.join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(
+        project.join("rv.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    // No cache entry seeded for the placeholder ref, so resolution fails
+    // and the command exits non-zero, but the manifest edit must persist.
+    let out = rvpm(&project, &cache, &["add", "github.com/acme/foo"]);
+    assert!(!out.status.success(), "placeholder add cannot resolve");
+    let manifest_text = std::fs::read_to_string(project.join("rv.toml")).unwrap();
+    assert!(manifest_text.contains("github.com/acme/foo"));
+    assert!(manifest_text.contains("latest"), "placeholder recorded");
+    cleanup(&root);
+}
+
+#[test]
+fn add_bad_path_fails() {
+    let root = workdir();
+    let project = root.join("project");
+    let cache = root.join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(
+        project.join("rv.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    let out = rvpm(&project, &cache, &["add", "gitlab.com/a/b@v1.0.0"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("github.com"), "stderr: {}", stderr);
+    cleanup(&root);
+}
+
+fn workdir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let mut p = std::env::temp_dir();
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    p.push(format!("rvpm-cmd-{}-{}-{}", std::process::id(), stamp, seq));
+    std::fs::create_dir_all(&p).expect("create tempdir");
+    p
+}
+
+fn cleanup(p: &Path) {
+    let _ = std::fs::remove_dir_all(p);
+}


### PR DESCRIPTION
Adds the `add`, `install`, and `update` dependency commands to rvpm, wiring the manifest, pkg, and lock libraries into the day to day workflow.

Closes #84

## Commands

- `rvpm add github.com/<user>/<repo>[@<version>]`: records the dependency in `rv.toml` under `[dependencies]`, then resolves and writes `rv.lock`, populating the cache. An existing entry for the same package is updated in place (not duplicated) and the change is reported. With no `@<version>`, the placeholder constraint `"latest"` is recorded; real latest-tag resolution is future work, so prefer passing a concrete ref. The manifest edit is applied before resolution, so a failed resolve still leaves a valid edited `rv.toml` (re-run with a resolvable ref to write the lock).
- `rvpm install`: re-resolves `rv.toml` against `rv.lock` and fills the cache. When the lock exists and covers the manifest it is validated (pinned entries fetched, tree hashes verified); a mismatch aborts non-zero and names the package. When the lock is missing or incomplete, a fresh lock is resolved and written.
- `rvpm update [github.com/<user>/<repo>]`: re-resolves `rv.toml` and rewrites `rv.lock`, for one named package (refreshing its subgraph while preserving the rest of the lock) or all packages. Under the literal-ref constraint model, update picks up a ref edited in `rv.toml`; range-based bumping is future work.

## rv.toml editing

The `add` edit uses `toml_edit`, so the rest of the file (including comments) is preserved. The edited text is re-parsed with `Manifest::from_toml_str` as a guard before it is written, so `rv.toml` always stays a valid manifest.

## Implementation

Orchestration lives in a new `raven::ops` module (`src/ops/mod.rs`) with `_in(..., cache_root)` variants. The `rvpm` binary stays thin and delegates to it. Help text (`rvpm`, `rvpm help`, `rvpm <cmd> --help`) is emoji-free and covers every command; unknown subcommands and bad arguments exit non-zero with a clear message.

## Tests

CI-safe and network-free. Each command pre-seeds a temporary cache so fetch is a hit, using the explicit-cache-root library variants to avoid `RVPM_CACHE_DIR` global-env races. One integration test drives the actual `rvpm` binary via `CARGO_BIN_EXE_rvpm` with `RVPM_CACHE_DIR` set to confirm CLI wiring, exit codes, and messages.

- [x] `add` updates `rv.toml` (re-parses, comment preserved) and writes `rv.lock` with the package hash
- [x] `add` updates an existing different-version entry in place and reports it
- [x] `install` validates an existing covering lock
- [x] `install` detects a tampered cache and aborts with the mismatch error
- [x] `install` with no lock writes a fresh one
- [x] `update` bumps the pinned version and hash in the lock
- [x] `update` rejects a package that is not a dependency
- [x] binary-level CLI test covering add, install, install-tamper, and update
- [x] `cargo build --workspace`, `cargo fmt --check`, `cargo clippy --workspace --all-targets` green

The spec at `docs/v2/specs/rvpm.md` documents the three commands, the `@version` requirement and placeholder default, the rv.toml editing behavior, install with and without a lock, and the update model under literal-ref constraints.
