### PR TITLE
feat(rvpm): build and run wired to the compiler

### DIFF
--- a/docs/v2/specs/resolver.md
+++ b/docs/v2/specs/resolver.md
@@ -155,9 +155,18 @@ already in module scope; no rebinding is needed.
 
 The module-source loading sits behind the `SourceLoader` abstraction
 (bundled `include_str!` source for stdlib, filesystem for local modules).
-External `github.com/...` packages (issue #85) resolve their source from the
-rvpm cache and then reuse this same merge: the seam is a new source backend,
-not a new merge path.
+External `github.com/...` packages resolve their source from the rvpm cache
+and then reuse this same merge: the seam is a new source backend, not a new
+merge path. An external import's source is located through the project's
+`rv.lock` (which pins each `github.com/<user>/<repo>` to a version) and the
+rvpm cache directory for that version, then namespaced under
+`ext.<host>.<user>.<repo>.<hash>` and merged through `merge_module_items`,
+transitively pulling in the external package's own dependencies. The cache
+root and the loaded lock are carried by a `PackageContext` threaded into
+`expand_with_stdlib_ctx` and `resolve_file_ctx`; without it (a single-file
+`raven build`) an external import stays deferred. See the build/run and
+external-import sections of `docs/v2/specs/rvpm.md` for the entry-file,
+output-path, and subpath conventions.
 
 ## SourceLoader trait
 

--- a/docs/v2/specs/rvpm.md
+++ b/docs/v2/specs/rvpm.md
@@ -333,3 +333,97 @@ Under the literal-ref model, "update" picks up a ref that was edited in
 package) to bump the pinned version and hash in the lock. When range based
 constraints land, `update` will choose a newer ref within the range while
 `rv.toml` keeps the range; that selection is future work.
+
+# Build and run (build, run)
+
+`rvpm build` and `rvpm run` compile a package and run it. They drive the
+same compile pipeline the `raven` binary uses (lex, parse, expand, resolve,
+type check, HIR, MIR, Cranelift, link), differing only in that rvpm
+supplies a package context so external (`github.com/...`) imports resolve
+through the rvpm cache. The orchestration lives in `raven::ops`
+(`src/ops/mod.rs`); the reusable pipeline lives in `raven::driver`
+(`src/driver/mod.rs`); the `rvpm` binary stays thin and calls them. Both
+have an `_in(..., cache_root)` variant that takes an explicit cache root so
+they can be tested against a pre-seeded temporary cache without the global
+`RVPM_CACHE_DIR` override.
+
+## Entry file and output path conventions
+
+- The package entry file is `src/main.rv`, relative to the project root
+  (the directory holding `rv.toml`). It must define `fun main()`.
+- The built binary is written to `target/raven-out/<name>`, relative to the
+  project root, where `<name>` is `[package].name`. On Windows the binary
+  has a `.exe` extension (`target/raven-out/<name>.exe`); on other hosts it
+  has no extension.
+
+## External import resolution through the cache
+
+An `import "github.com/<user>/<repo>[/<sub>...]"` in the entry file (or in a
+local or external module reachable from it) resolves to a cached source file
+as follows:
+
+1. The project's `rv.lock` maps the `github.com/<user>/<repo>` source to its
+   pinned `version`. `rvpm build` ensures the lock exists first (see "Ensure
+   installed" below).
+2. `raven::pkg::cache_dir_in(cache_root, "github.com", <user>, <repo>,
+   <version>)` gives the package's cached directory.
+3. The import `subpath` selects the `.rv` file within that directory:
+   - A bare `github.com/<user>/<repo>` (no subpath) resolves to `lib.rv` at
+     the cached package root. This is the package entry convention for a
+     library.
+   - A subpath selects a file by joining its components and appending `.rv`.
+     So `github.com/acme/greet/lib` resolves to `<cachedir>/lib.rv`, and
+     `github.com/acme/greet/util/text` resolves to
+     `<cachedir>/util/text.rv`.
+
+The resolved source is fed through the same merge core the bundled stdlib
+and local module paths use (see `docs/v2/specs/resolver.md`), with an
+external namespace `ext.<host>.<user>.<repo>.<hash>`, where `<hash>` is
+derived from the resolved source path. The external package's own
+dependencies (from its cached `rv.toml`) are merged transitively and
+deduplicated by resolved source path, and an external module's own `import
+std/...` lines pull in the bundled modules it needs. A selective import
+`import "github.com/.../lib" { name }` binds the bare `name` to the
+namespaced symbol, exactly as bundled and local imports do, so the type
+checker finds the merged declaration.
+
+## Package-context plumbing
+
+The package context (the cache root plus the loaded `rv.lock` source-to-
+version map) is `raven::resolve::PackageContext`. It is threaded explicitly
+into the pipeline as an `Option<&PackageContext>`:
+
+- `expand_with_stdlib_ctx(file, ctx)` resolves external imports through the
+  cache when `ctx` is `Some`. `expand_with_stdlib(file)` is the no-context
+  form and behaves exactly as the bundled-plus-local path.
+- `resolve_file_ctx(file, loader, ctx)` binds external selectors to the
+  `ext.`-namespaced symbols. `resolve_file(file, loader)` is the no-context
+  form.
+
+`rvpm build` passes `Some(ctx)`; a plain `raven build` passes `None`, so an
+external import in a single-file `raven build` stays deferred and surfaces
+as an unresolved import. This keeps the single-file build and the codegen
+smoke harness unchanged for bundled and local programs.
+
+## rvpm build
+
+```
+rvpm build
+```
+
+`build` loads `rv.toml`, ensures dependencies are installed (the install
+path: validate an up-to-date `rv.lock` against the cache, or resolve a fresh
+lock and write it, reusing `raven::ops::install`), loads the lock to build
+the package context, then compiles `src/main.rv` to
+`target/raven-out/<name>` and reports the binary path. A missing
+`src/main.rv` is reported and the command exits non-zero.
+
+## rvpm run
+
+```
+rvpm run [program arguments]
+```
+
+`run` builds the package (the same path as `build`), then runs the produced
+binary, forwarding any arguments after `run` to the program and exiting with
+the program's exit code.

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -46,6 +46,8 @@ fn main() -> ExitCode {
         Some("add") => run(cmd_add(&args[1..])),
         Some("install") => run(cmd_install(&args[1..])),
         Some("update") => run(cmd_update(&args[1..])),
+        Some("build") => run(cmd_build(&args[1..])),
+        Some("run") => cmd_run(&args[1..]),
         Some(other) => {
             eprintln!("rvpm: unknown subcommand '{}'", other);
             eprintln!("Run 'rvpm help' for usage.");
@@ -167,6 +169,51 @@ fn cmd_update(args: &[String]) -> Result<Vec<String>, String> {
     Ok(report.outcome_lines)
 }
 
+/// Build the package in the current directory: ensure dependencies are
+/// installed, then compile `src/main.rv` to `target/raven-out/<name>`.
+fn cmd_build(args: &[String]) -> Result<Vec<String>, String> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return Ok(vec![build_usage()]);
+    }
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    let report = ops::build(&cwd).map_err(|e| e.to_string())?;
+    Ok(report.outcome_lines)
+}
+
+/// Build the package then run the produced binary, forwarding any args
+/// after `run` to the program and exiting with its code.
+fn cmd_run(args: &[String]) -> ExitCode {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("{}", run_usage());
+        return ExitCode::SUCCESS;
+    }
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("rvpm: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+    match ops::run_package(&cwd, args) {
+        Ok(code) => {
+            let code: u8 = code.try_into().unwrap_or(1);
+            ExitCode::from(code)
+        }
+        Err(e) => {
+            eprintln!("rvpm: {}", e);
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn build_usage() -> String {
+    "Usage: rvpm build".to_string()
+}
+
+fn run_usage() -> String {
+    "Usage: rvpm run [program arguments]".to_string()
+}
+
 fn add_usage() -> String {
     "Usage: rvpm add github.com/<user>/<repo>[@<version>]".to_string()
 }
@@ -190,11 +237,13 @@ fn print_usage() {
     println!("  add <pkg>      Add a dependency to rv.toml, then resolve and write rv.lock");
     println!("  install        Resolve rv.toml against rv.lock and fill the cache");
     println!("  update [pkg]   Re-resolve rv.toml and rewrite rv.lock for one package or all");
+    println!("  build          Compile src/main.rv to target/raven-out/<name>");
+    println!("  run [args]     Build the package then run it, forwarding args");
     println!("  fetch <pkg>    Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
     println!("  lock           Generate or validate rv.lock for the current package");
     println!("  help           Print this message");
     println!();
     println!("Package arguments use the 'github.com/<user>/<repo>' form.");
     println!("For 'add', append '@<version>' to pin a git tag or branch; without it");
-    println!("a placeholder constraint is recorded. build and run land in a later release.");
+    println!("a placeholder constraint is recorded.");
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,0 +1,191 @@
+//! Compile pipeline orchestration shared by the `raven` and `rvpm`
+//! binaries.
+//!
+//! The `raven` binary compiles a single source file; `rvpm build` compiles
+//! a package entry file with a package context so external
+//! (`github.com/...`) imports resolve through the rvpm cache. Both drive
+//! the same pipeline here: lex, parse, expand (bundled stdlib plus local
+//! and external modules), resolve, type check, lower to HIR then MIR, emit
+//! an object with Cranelift, and link it with the `raven-runtime`
+//! staticlib.
+//!
+//! The single difference between the two is the optional
+//! [`PackageContext`]: with it, external imports are read from the cache;
+//! without it (the plain `raven build` path), an external import stays
+//! deferred and surfaces as an unresolved import, exactly as before.
+
+use std::path::{Path, PathBuf};
+
+use crate::codegen::linker::{self, RuntimeStaticLib};
+use crate::codegen::{self, CodegenError};
+use crate::hir::lower_file;
+use crate::lexer::Lexer;
+use crate::mir::lower_program;
+use crate::parser::parse;
+use crate::resolve::{expand_with_stdlib_ctx, resolve_file_ctx, FsLoader, PackageContext};
+use crate::tycheck::check_file;
+
+/// An error from the compile pipeline or the link step.
+#[derive(Debug)]
+pub enum DriverError {
+    Io(String),
+    Frontend(String),
+    Codegen(CodegenError),
+    RuntimeMissing,
+}
+
+impl From<CodegenError> for DriverError {
+    fn from(e: CodegenError) -> Self {
+        DriverError::Codegen(e)
+    }
+}
+
+impl std::fmt::Display for DriverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DriverError::Io(s) => write!(f, "io: {}", s),
+            DriverError::Frontend(s) => write!(f, "frontend: {}", s),
+            DriverError::Codegen(e) => write!(f, "{}", e),
+            DriverError::RuntimeMissing => f.write_str(
+                "could not locate raven_runtime staticlib; build it with `cargo build -p raven-runtime` or set RAVEN_RUNTIME_LIB",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DriverError {}
+
+/// Compile `input` to a native executable at `output`.
+///
+/// When `ctx` is `Some`, external (`github.com/...`) imports in the program
+/// (and its local and external modules) resolve through the rvpm cache.
+/// When `None`, the pipeline behaves exactly as a single-file `raven build`.
+pub fn build_binary(
+    input: &Path,
+    output: &Path,
+    ctx: Option<&PackageContext>,
+) -> Result<(), DriverError> {
+    let source = std::fs::read_to_string(input)
+        .map_err(|e| DriverError::Io(format!("read {}: {}", input.display(), e)))?;
+
+    let object_bytes = compile_to_object(&source, input, ctx)?;
+
+    let runtime = locate_runtime_staticlib()?;
+    let tmp = TempDir::new()?;
+    let object_path = tmp.path().join("raven_program.o");
+    std::fs::write(&object_path, &object_bytes)
+        .map_err(|e| DriverError::Io(format!("write object: {}", e)))?;
+
+    linker::link(&object_path, &runtime, output).map_err(DriverError::from)?;
+    Ok(())
+}
+
+/// Run the front and middle ends and Cranelift to produce a relocatable
+/// object for `source`. Threads `ctx` through expansion and resolution.
+pub fn compile_to_object(
+    source: &str,
+    input: &Path,
+    ctx: Option<&PackageContext>,
+) -> Result<Vec<u8>, DriverError> {
+    let tokens = Lexer::new(source.to_string(), input.to_path_buf())
+        .tokenize()
+        .map_err(|e| DriverError::Frontend(format!("lex: {}", e)))?;
+    let file = parse(&tokens).map_err(|e| DriverError::Frontend(format!("parse: {}", e)))?;
+    let file = expand_with_stdlib_ctx(&file, ctx)
+        .map_err(|e| DriverError::Frontend(format!("stdlib: {}", e)))?;
+    let mut loader = FsLoader;
+    let resolved = resolve_file_ctx(&file, &mut loader, ctx)
+        .map_err(|e| DriverError::Frontend(format!("resolve: {}", e)))?;
+    let typed =
+        check_file(&resolved).map_err(|e| DriverError::Frontend(format!("tycheck: {}", e)))?;
+    let hir = lower_file(&typed).map_err(|e| DriverError::Frontend(format!("hir: {}", e)))?;
+    if std::env::var("RAVEN_DUMP_HIR").is_ok() {
+        eprintln!("{}", crate::hir::pretty_program(&hir));
+    }
+    let mir = lower_program(&hir).map_err(|e| DriverError::Frontend(format!("mir: {}", e)))?;
+    if std::env::var("RAVEN_DUMP_MIR").is_ok() {
+        eprintln!("{}", crate::mir::pretty::pretty_program(&mir));
+    }
+    codegen::compile_program(&mir).map_err(DriverError::from)
+}
+
+/// Locate the `raven-runtime` staticlib next to the compiler binary, in
+/// the current directory's `target/`, or via `RAVEN_RUNTIME_LIB`.
+pub fn locate_runtime_staticlib() -> Result<RuntimeStaticLib, DriverError> {
+    if let Ok(p) = std::env::var("RAVEN_RUNTIME_LIB") {
+        let pb = PathBuf::from(p);
+        if pb.is_file() {
+            return Ok(RuntimeStaticLib { path: pb });
+        }
+    }
+    for c in candidate_runtime_paths() {
+        if c.is_file() {
+            return Ok(RuntimeStaticLib { path: c });
+        }
+    }
+    Err(DriverError::RuntimeMissing)
+}
+
+fn candidate_runtime_paths() -> Vec<PathBuf> {
+    let lib_name = if cfg!(windows) {
+        "raven_runtime.lib"
+    } else {
+        "libraven_runtime.a"
+    };
+    let mut out = Vec::new();
+    if let Ok(exe) = std::env::current_exe() {
+        for dir in exe.parent().into_iter().flat_map(|d| {
+            [
+                d.to_path_buf(),
+                d.join("deps"),
+                d.parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or(d.to_path_buf()),
+            ]
+        }) {
+            out.push(dir.join(lib_name));
+        }
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        for sub in [
+            "target/debug",
+            "target/release",
+            "target\\debug",
+            "target\\release",
+        ] {
+            out.push(cwd.join(sub).join(lib_name));
+        }
+    }
+    out
+}
+
+/// A temporary directory removed on drop, used to hold the intermediate
+/// object file.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new() -> Result<TempDir, DriverError> {
+        let mut base = std::env::temp_dir();
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let pid = std::process::id();
+        base.push(format!("raven-build-{}-{}", pid, stamp));
+        std::fs::create_dir_all(&base)
+            .map_err(|e| DriverError::Io(format!("mkdir {}: {}", base.display(), e)))?;
+        Ok(TempDir { path: base })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod ast;
 pub mod codegen;
+pub mod driver;
 pub mod error;
 pub mod hir;
 pub mod lexer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,19 +10,14 @@
 //! resolve, type check, HIR, MIR) and feeds the resulting `MirProgram`
 //! to the Cranelift back end. The relocatable object is then linked
 //! with the `raven-runtime` staticlib by the toolchain-aware linker
-//! (MSVC `link.exe` on windows-msvc, `cc` elsewhere).
+//! (MSVC `link.exe` on windows-msvc, `cc` elsewhere). The reusable
+//! pipeline lives in `raven::driver` so `rvpm build` can drive it with a
+//! package context.
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use raven::codegen::linker::{self, RuntimeStaticLib};
-use raven::codegen::{self, CodegenError};
-use raven::hir::lower_file;
-use raven::lexer::Lexer;
-use raven::mir::lower_program;
-use raven::parser::parse;
-use raven::resolve::{expand_with_stdlib, resolve_file, FsLoader};
-use raven::tycheck::check_file;
+use raven::driver::{self, DriverError};
 
 /// Stack size for the compiler worker thread.
 ///
@@ -70,56 +65,12 @@ fn run() -> ExitCode {
     }
 }
 
-fn run_build(rest: &[String]) -> Result<(), DriverError> {
+fn run_build(rest: &[String]) -> Result<(), BuildError> {
     let opts = parse_build_args(rest)?;
-    let source = std::fs::read_to_string(&opts.input)
-        .map_err(|e| DriverError::Io(format!("read {}: {}", opts.input.display(), e)))?;
-
-    // Front end.
-    let tokens = Lexer::new(source.clone(), opts.input.clone())
-        .tokenize()
-        .map_err(|e| DriverError::Frontend(format!("lex: {}", e)))?;
-    let file = parse(&tokens).map_err(|e| DriverError::Frontend(format!("parse: {}", e)))?;
-    // Merge any imported bundled stdlib modules (for example `std/io`)
-    // into the program before resolving. The combined file owns the
-    // stdlib functions plus the user's items, so the single-file pipeline
-    // compiles and links them all together. See `docs/v2/specs/stdlib.md`.
-    let file =
-        expand_with_stdlib(&file).map_err(|e| DriverError::Frontend(format!("stdlib: {}", e)))?;
-    let mut loader = FsLoader;
-    let resolved = resolve_file(&file, &mut loader)
-        .map_err(|e| DriverError::Frontend(format!("resolve: {}", e)))?;
-    let typed =
-        check_file(&resolved).map_err(|e| DriverError::Frontend(format!("tycheck: {}", e)))?;
-    let hir = lower_file(&typed).map_err(|e| DriverError::Frontend(format!("hir: {}", e)))?;
-    if std::env::var("RAVEN_DUMP_HIR").is_ok() {
-        eprintln!("{}", raven::hir::pretty_program(&hir));
-    }
-    let mir = lower_program(&hir).map_err(|e| DriverError::Frontend(format!("mir: {}", e)))?;
-
-    if std::env::var("RAVEN_DUMP_MIR").is_ok() {
-        eprintln!("{}", raven::mir::pretty::pretty_program(&mir));
-    }
-
-    // Back end.
-    let object_bytes = codegen::compile_program(&mir).map_err(DriverError::from)?;
-
-    let tmp = tempdir_for_build()?;
-    let object_path = tmp.path().join("raven_program.o");
-    std::fs::write(&object_path, &object_bytes)
-        .map_err(|e| DriverError::Io(format!("write object: {}", e)))?;
-
-    // Locate the runtime staticlib. The driver looks for it in the
-    // standard Cargo target directory next to the compiler binary, the
-    // current working directory's target, and an optional override via
-    // the RAVEN_RUNTIME_LIB environment variable.
-    let runtime = locate_runtime_staticlib()?;
-
-    linker::link(&object_path, &runtime, &opts.output).map_err(DriverError::from)?;
-
-    // Object file lives in a tempdir that is cleaned up on drop.
-    drop(tmp);
-    Ok(())
+    // The single-file `raven build` has no package context, so external
+    // (`github.com/...`) imports stay deferred and surface as unresolved.
+    // Package-aware builds go through `rvpm build`.
+    driver::build_binary(&opts.input, &opts.output, None).map_err(BuildError::Driver)
 }
 
 #[derive(Debug)]
@@ -128,7 +79,7 @@ struct BuildOpts {
     output: PathBuf,
 }
 
-fn parse_build_args(args: &[String]) -> Result<BuildOpts, DriverError> {
+fn parse_build_args(args: &[String]) -> Result<BuildOpts, BuildError> {
     let mut input: Option<PathBuf> = None;
     let mut output: Option<PathBuf> = None;
     let mut i = 0;
@@ -137,22 +88,22 @@ fn parse_build_args(args: &[String]) -> Result<BuildOpts, DriverError> {
         if a == "-o" || a == "--output" {
             i += 1;
             if i >= args.len() {
-                return Err(DriverError::Args("expected an output path after -o".into()));
+                return Err(BuildError::Args("expected an output path after -o".into()));
             }
             output = Some(PathBuf::from(&args[i]));
-        } else if a.starts_with("-") {
-            return Err(DriverError::Args(format!("unknown flag `{}`", a)));
+        } else if a.starts_with('-') {
+            return Err(BuildError::Args(format!("unknown flag `{}`", a)));
         } else if input.is_none() {
             input = Some(PathBuf::from(a));
         } else {
-            return Err(DriverError::Args(format!(
+            return Err(BuildError::Args(format!(
                 "unexpected positional argument `{}`",
                 a
             )));
         }
         i += 1;
     }
-    let input = input.ok_or_else(|| DriverError::Args("missing input source file".into()))?;
+    let input = input.ok_or_else(|| BuildError::Args("missing input source file".into()))?;
     let output = output.unwrap_or_else(|| default_output_for(&input));
     Ok(BuildOpts { input, output })
 }
@@ -170,112 +121,17 @@ fn default_output_for(input: &Path) -> PathBuf {
     }
 }
 
-fn locate_runtime_staticlib() -> Result<RuntimeStaticLib, DriverError> {
-    if let Ok(p) = std::env::var("RAVEN_RUNTIME_LIB") {
-        let pb = PathBuf::from(p);
-        if pb.is_file() {
-            return Ok(RuntimeStaticLib { path: pb });
-        }
-    }
-    // Search relative to the compiler binary and the current directory.
-    let candidates = candidate_runtime_paths();
-    for c in candidates {
-        if c.is_file() {
-            return Ok(RuntimeStaticLib { path: c });
-        }
-    }
-    Err(DriverError::RuntimeMissing)
-}
-
-fn candidate_runtime_paths() -> Vec<PathBuf> {
-    let lib_name = if cfg!(windows) {
-        "raven_runtime.lib"
-    } else {
-        "libraven_runtime.a"
-    };
-    let mut out = Vec::new();
-    if let Ok(exe) = std::env::current_exe() {
-        for dir in exe.parent().into_iter().flat_map(|d| {
-            [
-                d.to_path_buf(),
-                d.join("deps"),
-                d.parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or(d.to_path_buf()),
-            ]
-        }) {
-            out.push(dir.join(lib_name));
-        }
-    }
-    if let Ok(cwd) = std::env::current_dir() {
-        for sub in [
-            "target/debug",
-            "target/release",
-            "target\\debug",
-            "target\\release",
-        ] {
-            out.push(cwd.join(sub).join(lib_name));
-        }
-    }
-    out
-}
-
-/// Create a temporary directory the driver uses to hold the
-/// intermediate object file. The struct removes the directory on drop.
-fn tempdir_for_build() -> Result<TempDir, DriverError> {
-    let mut base = std::env::temp_dir();
-    let stamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let pid = std::process::id();
-    base.push(format!("raven-build-{}-{}", pid, stamp));
-    std::fs::create_dir_all(&base)
-        .map_err(|e| DriverError::Io(format!("mkdir {}: {}", base.display(), e)))?;
-    Ok(TempDir { path: base })
-}
-
-struct TempDir {
-    path: PathBuf,
-}
-
-impl TempDir {
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.path);
-    }
-}
-
 #[derive(Debug)]
-enum DriverError {
+enum BuildError {
     Args(String),
-    Io(String),
-    Frontend(String),
-    Codegen(CodegenError),
-    RuntimeMissing,
+    Driver(DriverError),
 }
 
-impl From<CodegenError> for DriverError {
-    fn from(e: CodegenError) -> Self {
-        DriverError::Codegen(e)
-    }
-}
-
-impl std::fmt::Display for DriverError {
+impl std::fmt::Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DriverError::Args(s) => write!(f, "{}", s),
-            DriverError::Io(s) => write!(f, "io: {}", s),
-            DriverError::Frontend(s) => write!(f, "frontend: {}", s),
-            DriverError::Codegen(e) => write!(f, "{}", e),
-            DriverError::RuntimeMissing => f.write_str(
-                "could not locate raven_runtime staticlib; build it with `cargo build -p raven-runtime` or set RAVEN_RUNTIME_LIB",
-            ),
+            BuildError::Args(s) => write!(f, "{}", s),
+            BuildError::Driver(e) => write!(f, "{}", e),
         }
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -16,10 +16,11 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use crate::driver::{self, DriverError};
 use crate::lock::{self, LockError, LockFile, LOCK_FILE_NAME};
 use crate::manifest::{Manifest, ManifestError};
 use crate::pkg;
-use crate::resolve::GithubPath;
+use crate::resolve::{GithubPath, PackageContext};
 
 /// The default constraint written for `rvpm add` when no `@version` is
 /// given. Real latest-tag resolution is future work, so the placeholder is
@@ -49,6 +50,15 @@ pub enum OpError {
     Lock(LockError),
     /// `update` named a package that is not a dependency in `rv.toml`.
     UnknownPackage(String),
+    /// The package entry file (`src/main.rv`) was not found.
+    MissingEntry(PathBuf),
+    /// Compiling or linking the package failed.
+    Build(DriverError),
+    /// Running the produced binary failed to launch.
+    Run {
+        binary: PathBuf,
+        source: std::io::Error,
+    },
 }
 
 impl fmt::Display for OpError {
@@ -67,6 +77,13 @@ impl fmt::Display for OpError {
             OpError::Lock(e) => write!(f, "{}", e),
             OpError::UnknownPackage(p) => {
                 write!(f, "'{}' is not a dependency in rv.toml", p)
+            }
+            OpError::MissingEntry(p) => {
+                write!(f, "package entry file not found: '{}'", p.display())
+            }
+            OpError::Build(e) => write!(f, "{}", e),
+            OpError::Run { binary, source } => {
+                write!(f, "cannot run '{}': {}", binary.display(), source)
             }
         }
     }
@@ -92,6 +109,12 @@ impl From<ManifestError> for OpError {
 impl From<LockError> for OpError {
     fn from(e: LockError) -> Self {
         OpError::Lock(e)
+    }
+}
+
+impl From<DriverError> for OpError {
+    fn from(e: DriverError) -> Self {
+        OpError::Build(e)
     }
 }
 
@@ -308,6 +331,116 @@ pub fn update_in(
             })
         }
     }
+}
+
+/// The conventional package entry source, relative to the project root.
+pub const ENTRY_FILE: &str = "src/main.rv";
+
+/// The output directory for a built package binary, relative to the
+/// project root.
+pub const OUTPUT_DIR: &str = "target/raven-out";
+
+/// The result of a `build`: the path to the produced binary and the lines
+/// to report.
+#[derive(Debug, Clone)]
+pub struct BuildReport {
+    pub binary: PathBuf,
+    pub outcome_lines: Vec<String>,
+}
+
+/// Build the package under `project_dir`, using the default cache root.
+/// See [`build_in`].
+pub fn build(project_dir: &Path) -> Result<BuildReport, OpError> {
+    build_in(project_dir, &pkg::cache_root())
+}
+
+/// Build the package under `project_dir` against `cache_root`.
+///
+/// Ensures dependencies are installed (resolving and writing `rv.lock` if
+/// needed, or validating an existing lock against the cache), then loads
+/// the lock to build a [`PackageContext`] so external (`github.com/...`)
+/// imports resolve through the cache, compiles the entry file
+/// (`src/main.rv`), and writes the binary to
+/// `target/raven-out/<package-name>` (with `.exe` on Windows).
+pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, OpError> {
+    let manifest_path = project_dir.join(MANIFEST_FILE_NAME);
+    let manifest = Manifest::load(&manifest_path)?;
+
+    // Ensure the lock exists and the cache is populated. `install_in`
+    // validates an up-to-date lock or resolves a fresh one.
+    let (_outcome, _report) = install_in(project_dir, cache_root)?;
+
+    let lock_path = project_dir.join(LOCK_FILE_NAME);
+    let lock = if lock_path.exists() {
+        LockFile::load(&lock_path)?
+    } else {
+        LockFile {
+            version: lock::LOCK_VERSION,
+            packages: Vec::new(),
+        }
+    };
+    let ctx = PackageContext::new(cache_root.to_path_buf(), &lock);
+
+    let entry = project_dir.join(ENTRY_FILE);
+    if !entry.is_file() {
+        return Err(OpError::MissingEntry(entry));
+    }
+
+    let binary = output_binary_path(project_dir, &manifest.package.name);
+    if let Some(parent) = binary.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| OpError::Io {
+            action: "create output directory".to_string(),
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
+
+    driver::build_binary(&entry, &binary, Some(&ctx))?;
+
+    Ok(BuildReport {
+        binary: binary.clone(),
+        outcome_lines: vec![format!(
+            "Compiled {} to {}",
+            manifest.package.name,
+            binary.display()
+        )],
+    })
+}
+
+/// Build the package then run the produced binary, forwarding `args` to it
+/// and returning its exit code. Uses the default cache root.
+pub fn run_package(project_dir: &Path, args: &[String]) -> Result<i32, OpError> {
+    run_package_in(project_dir, args, &pkg::cache_root())
+}
+
+/// Build the package under `project_dir` against `cache_root`, then run the
+/// produced binary with `args`, returning its exit code.
+pub fn run_package_in(
+    project_dir: &Path,
+    args: &[String],
+    cache_root: &Path,
+) -> Result<i32, OpError> {
+    let report = build_in(project_dir, cache_root)?;
+    let status = std::process::Command::new(&report.binary)
+        .args(args)
+        .status()
+        .map_err(|e| OpError::Run {
+            binary: report.binary.clone(),
+            source: e,
+        })?;
+    Ok(status.code().unwrap_or(1))
+}
+
+/// The output binary path for a package: `target/raven-out/<name>` with
+/// the platform executable extension.
+fn output_binary_path(project_dir: &Path, name: &str) -> PathBuf {
+    let mut p = project_dir.join(OUTPUT_DIR);
+    if cfg!(windows) {
+        p.push(format!("{}.exe", name));
+    } else {
+        p.push(name);
+    }
+    p
 }
 
 /// Build a manifest carrying only the one dependency `key`, reusing the
@@ -660,6 +793,37 @@ mod tests {
         );
         let err = update_in(&proj.root, Some("github.com/acme/bar"), &cache).unwrap_err();
         assert!(matches!(err, OpError::UnknownPackage(_)));
+    }
+
+    #[test]
+    fn build_reports_missing_entry() {
+        // A project with no dependencies and no src/main.rv: install
+        // resolves an empty lock, then build fails on the missing entry
+        // before any compilation or linking is attempted.
+        let proj = TempProject::new("noentry");
+        proj.write_manifest("[package]\nname = \"app\"\nversion = \"0.1.0\"\n");
+        let cache = proj.cache_root();
+        std::fs::create_dir_all(&cache).expect("mkdir cache");
+        let err = build_in(&proj.root, &cache).unwrap_err();
+        match err {
+            OpError::MissingEntry(p) => {
+                assert!(p.ends_with("src/main.rv") || p.ends_with("src\\main.rv"))
+            }
+            other => panic!("expected MissingEntry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn output_binary_path_uses_package_name() {
+        let p = output_binary_path(Path::new("/proj"), "demo");
+        if cfg!(windows) {
+            assert!(
+                p.ends_with("target/raven-out/demo.exe")
+                    || p.ends_with("target\\raven-out\\demo.exe")
+            );
+        } else {
+            assert!(p.ends_with("target/raven-out/demo"));
+        }
     }
 
     #[test]

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -110,13 +110,28 @@ pub fn resolve_imports(
     out_imports: &mut Vec<ResolvedImport>,
     in_progress: &mut HashSet<PathBuf>,
 ) -> Result<(), RavenError> {
+    resolve_imports_ctx(file, scope, loader, out_imports, in_progress, None)
+}
+
+/// Resolve every import like [`resolve_imports`], binding external import
+/// selectors against `ctx` (the rvpm cache plus the project lock) so they
+/// resolve to the `ext.`-namespaced symbols the expander merged. When
+/// `ctx` is `None`, external imports stay deferred.
+pub fn resolve_imports_ctx(
+    file: &File,
+    scope: &mut ScopeStack,
+    loader: &mut dyn SourceLoader,
+    out_imports: &mut Vec<ResolvedImport>,
+    in_progress: &mut HashSet<PathBuf>,
+    ctx: Option<&super::stdlib::PackageContext>,
+) -> Result<(), RavenError> {
     for decl in &file.items {
         let DeclKind::Import(import) = &decl.kind else {
             continue;
         };
         let id = ImportId(out_imports.len());
         let resolved = resolve_one_import(import, &decl.span, loader, in_progress, id)?;
-        bind_import(import, &resolved, id, scope)?;
+        bind_import(import, &resolved, id, scope, ctx)?;
         out_imports.push(resolved);
     }
     Ok(())
@@ -324,6 +339,7 @@ fn bind_import(
     resolved: &ResolvedImport,
     id: ImportId,
     scope: &mut ScopeStack,
+    ctx: Option<&super::stdlib::PackageContext>,
 ) -> Result<(), RavenError> {
     // The namespaced prefix a selective import resolves against, used to
     // find the functions the expander merged ahead of this pass. A bundled
@@ -345,7 +361,27 @@ fn bind_import(
                 super::stdlib::mangle_local_fn(&key, name)
             }))
         }
-        ImportTarget::ExternalPackage { .. } => None,
+        ImportTarget::ExternalPackage {
+            host,
+            user,
+            repo,
+            subpath,
+        } => {
+            // Bind external selectors to the `ext.`-namespaced symbols the
+            // expander merged from the cache, computed from the resolved
+            // source path. Without a package context the import stays
+            // deferred (no mangle).
+            let source = format!("github.com/{}/{}", user, repo);
+            match ctx.and_then(|c| c.external_source_path(&source, subpath)) {
+                Some(src_path) => {
+                    let key = super::stdlib::external_module_key(host, user, repo, &src_path);
+                    Some(Box::new(move |name: &str| {
+                        super::stdlib::mangle_external_fn(&key, name)
+                    }))
+                }
+                None => None,
+            }
+        }
     };
 
     if !import.selectors.is_empty() {

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -27,7 +27,10 @@ pub use bindings::{
 };
 pub use imports::{FsLoader, GithubPath, LoadedSource, SourceLoader, STDLIB_MODULES};
 pub use scope::{Scope, ScopeKind, ScopeStack};
-pub use stdlib::{expand_with_stdlib, local_module_key, mangle_local_fn, mangle_stdlib_fn};
+pub use stdlib::{
+    expand_with_stdlib, expand_with_stdlib_ctx, external_module_key, local_module_key,
+    mangle_external_fn, mangle_local_fn, mangle_stdlib_fn, PackageContext,
+};
 
 /// The resolver output for a single file.
 ///
@@ -50,6 +53,18 @@ pub fn resolve_file<'a>(
     file: &'a File,
     loader: &mut dyn SourceLoader,
 ) -> Result<ResolvedFile<'a>, RavenError> {
+    resolve_file_ctx(file, loader, None)
+}
+
+/// Resolve `file` like [`resolve_file`], additionally binding external
+/// (`github.com/...`) import selectors to the `ext.`-namespaced symbols
+/// the expander merged from the rvpm cache. When `ctx` is `None`, external
+/// imports stay deferred exactly as before.
+pub fn resolve_file_ctx<'a>(
+    file: &'a File,
+    loader: &mut dyn SourceLoader,
+    ctx: Option<&PackageContext>,
+) -> Result<ResolvedFile<'a>, RavenError> {
     let mut scope = ScopeStack::new();
     let mut map = ResolutionMap::new();
     let mut imports_out = Vec::new();
@@ -61,7 +76,14 @@ pub fn resolve_file<'a>(
 
     // Pass 1b: resolve imports and merge their bindings into the same
     // module scope.
-    imports::resolve_imports(file, &mut scope, loader, &mut imports_out, &mut in_progress)?;
+    imports::resolve_imports_ctx(
+        file,
+        &mut scope,
+        loader,
+        &mut imports_out,
+        &mut in_progress,
+        ctx,
+    )?;
     map.imports = imports_out;
 
     // Pass 2: walk every body, binding identifier uses.

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -17,7 +17,7 @@
 //! See `docs/v2/specs/stdlib.md` for the full mechanism.
 
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,7 +30,7 @@ use crate::error::{RavenError, ResolveError};
 use crate::lexer::Lexer;
 use crate::parser::parse;
 
-use super::imports::{FsLoader, SourceLoader};
+use super::imports::{FsLoader, GithubPath, SourceLoader};
 
 /// The embedded source of one bundled stdlib module, keyed by its module
 /// path under `std/`. A `std/io` import maps to the `"io"` entry. The
@@ -101,6 +101,92 @@ pub fn mangle_local_fn(key: &str, name: &str) -> String {
     format!("{key}{sep}{name}", sep = NAMESPACE_SEP)
 }
 
+/// Build a namespacing key for one external package source file:
+/// `ext.<host>.<user>.<repo>.<hash>`. The host/user/repo segments are
+/// sanitized (any `.` in `host` becomes `_`) so the key has a fixed dot
+/// arity, and a hash of the resolved source file path disambiguates two
+/// files within the same package. As with the local key, the `.` makes
+/// the result unwritable by a user, so an external function never
+/// collides with a user declaration.
+pub fn external_module_key(host: &str, user: &str, repo: &str, source_path: &Path) -> String {
+    let mut hasher = DefaultHasher::new();
+    source_path.to_string_lossy().hash(&mut hasher);
+    let h = host.replace('.', "_");
+    format!(
+        "ext{sep}{h}{sep}{user}{sep}{repo}{sep}{:016x}",
+        hasher.finish(),
+        sep = NAMESPACE_SEP
+    )
+}
+
+/// Build the mangled name of an external package function:
+/// `ext.<host>.<user>.<repo>.<hash>.<name>`.
+pub fn mangle_external_fn(key: &str, name: &str) -> String {
+    format!("{key}{sep}{name}", sep = NAMESPACE_SEP)
+}
+
+/// The package context an external (`github.com/...`) import resolves
+/// against. It pairs the rvpm cache root with the loaded `rv.lock` map
+/// from `github.com/<user>/<repo>` source paths to their pinned version,
+/// so an `import "github.com/user/repo[/sub]"` can be located in the
+/// cache. Bundled and local imports never consult it.
+#[derive(Debug, Clone)]
+pub struct PackageContext {
+    cache_root: PathBuf,
+    /// Map from a `github.com/<user>/<repo>` source to its pinned version.
+    locked_versions: BTreeMap<String, String>,
+}
+
+impl PackageContext {
+    /// Build a context from an explicit cache root and a lock file.
+    pub fn new(cache_root: PathBuf, lock: &crate::lock::LockFile) -> PackageContext {
+        let mut locked_versions = BTreeMap::new();
+        for p in &lock.packages {
+            locked_versions.insert(p.source.clone(), p.version.clone());
+        }
+        PackageContext {
+            cache_root,
+            locked_versions,
+        }
+    }
+
+    /// Resolve the cached `.rv` source file for a `github.com/<user>/<repo>`
+    /// path (the `source` key in the lock) and an import `subpath`.
+    ///
+    /// The bare `github.com/user/repo` import (no subpath) resolves to the
+    /// package's `lib.rv` at the cached root. A `subpath` selects a `.rv`
+    /// file by joining its components and appending `.rv`, so
+    /// `github.com/acme/greet/lib` resolves to `<cachedir>/lib.rv` and
+    /// `github.com/acme/greet/util/text` resolves to
+    /// `<cachedir>/util/text.rv`. Returns the resolved file path, or `None`
+    /// when the package is not pinned in the lock.
+    pub fn external_source_path(&self, source: &str, subpath: &[String]) -> Option<PathBuf> {
+        let version = self.locked_versions.get(source)?;
+        let gh = GithubPath::parse(source)?;
+        let dir = crate::pkg::cache_dir_in(&self.cache_root, &gh.host, &gh.user, &gh.repo, version);
+        let mut file = dir;
+        if subpath.is_empty() {
+            file.push("lib.rv");
+        } else {
+            for seg in &subpath[..subpath.len() - 1] {
+                file.push(seg);
+            }
+            file.push(format!("{}.rv", subpath[subpath.len() - 1]));
+        }
+        Some(file)
+    }
+
+    /// The path to a cached package's own `rv.toml`, used to read its
+    /// transitive dependencies. Returns `None` when the package is not
+    /// pinned in the lock.
+    fn package_manifest_path(&self, source: &str) -> Option<PathBuf> {
+        let version = self.locked_versions.get(source)?;
+        let gh = GithubPath::parse(source)?;
+        let dir = crate::pkg::cache_dir_in(&self.cache_root, &gh.host, &gh.user, &gh.repo, version);
+        Some(dir.join("rv.toml"))
+    }
+}
+
 /// Look up the embedded source for a bundled module by its `std/` path.
 pub fn bundled_source(module_path: &str) -> Option<&'static str> {
     BUNDLED_MODULES
@@ -121,6 +207,25 @@ pub fn bundled_source(module_path: &str) -> Option<&'static str> {
 /// the import pass to report as `UnresolvedImport`; this function only
 /// merges the modules it can load.
 pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
+    expand_with_stdlib_ctx(user, None)
+}
+
+/// Expand `user` like [`expand_with_stdlib`], additionally resolving any
+/// external (`github.com/...`) imports through `ctx` (the rvpm cache plus
+/// the project's `rv.lock`).
+///
+/// When `ctx` is `None`, the behavior is identical to bundled+local
+/// expansion and an external import is left for the import pass to handle
+/// (it stays a deferred `ExternalPackage` target). When `ctx` is
+/// `Some`, each external import's source is read from the cache, parsed,
+/// namespaced under `ext.<host>.<user>.<repo>.<hash>`, and merged through
+/// the same [`merge_module_items`] core the bundled and local paths use.
+/// The external package's own dependencies (from its cached `rv.toml`)
+/// are merged transitively and deduplicated by resolved source path.
+pub fn expand_with_stdlib_ctx(
+    user: &File,
+    ctx: Option<&PackageContext>,
+) -> Result<File, RavenError> {
     // Modules to merge, collected to a fixed point. A module enters the
     // set from the user file's `std/...` imports or from a bundled
     // module's own `import std/...` line. The set deduplicates, so each
@@ -143,6 +248,17 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
     let local_modules = load_local_modules(user, &mut loader)?;
     for module_file in &local_modules {
         collect_std_module_imports(module_file, &mut wanted);
+    }
+
+    // Load every external (`github.com/...`) package source reachable from
+    // the user file and its local modules, transitively. Each loaded file
+    // may itself `import std/...`, so its bundled modules must merge too.
+    let external_modules = match ctx {
+        Some(ctx) => load_external_modules(user, &local_modules, ctx)?,
+        None => Vec::new(),
+    };
+    for ext in &external_modules {
+        collect_std_module_imports(&ext.file, &mut wanted);
     }
 
     // Follow each bundled module's own `std/...` imports to a fixed point.
@@ -189,6 +305,21 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
             rename.insert(name.clone(), mangle_local_fn(&key, &name));
         }
         merge_module_items(module_file.items, &rename, &mut combined_items);
+    }
+
+    // Merge the external package sources through the same merge core, with
+    // an `ext.<host>.<user>.<repo>.<hash>` namespace. Each module's rename
+    // map carries its own functions plus the names it selectively imports
+    // from sibling external sources (resolved through the same context).
+    if let Some(ctx) = ctx {
+        for ext in external_modules {
+            let key = external_module_key(&ext.host, &ext.user, &ext.repo, &ext.source_path);
+            let mut rename = external_import_rename_map(&ext.file, ctx);
+            for name in top_level_fn_names(&ext.file) {
+                rename.insert(name.clone(), mangle_external_fn(&key, &name));
+            }
+            merge_module_items(ext.file.items, &rename, &mut combined_items);
+        }
     }
 
     // The user's items follow the stdlib items so user DeclIds shift by a
@@ -364,6 +495,158 @@ fn import_rename_map(
         }
     }
     map
+}
+
+/// One loaded external package source file plus the package identity it
+/// belongs to, so the merge can build its `ext.` namespace key.
+struct ExternalModule {
+    host: String,
+    user: String,
+    repo: String,
+    /// The resolved cache path of the `.rv` source file.
+    source_path: PathBuf,
+    file: File,
+}
+
+/// The components of one external import: the `github.com/<user>/<repo>`
+/// lock source key and the import `subpath`.
+fn external_import_targets(file: &File) -> Vec<(String, Vec<String>)> {
+    let mut out = Vec::new();
+    for decl in &file.items {
+        if let DeclKind::Import(import) = &decl.kind {
+            if let ImportSource::Quoted(path) = &import.source {
+                if let Some(gh) = GithubPath::parse(path) {
+                    let source = format!("github.com/{}/{}", gh.user, gh.repo);
+                    out.push((source, gh.subpath));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Load every external package source reachable from `user` and its
+/// `local_modules`, transitively, returning each parsed file exactly once
+/// (deduplicated by its resolved cache path).
+///
+/// Each import resolves to a `.rv` file in the rvpm cache through `ctx`.
+/// The loaded file's own external imports are followed, and the package's
+/// cached `rv.toml` is read so a bare-package dependency (with no explicit
+/// import of one of its files) still has its declarations available. An
+/// import whose package is not pinned in the lock, or whose source file is
+/// missing, is skipped here; the import resolution pass reports it with a
+/// precise span.
+fn load_external_modules(
+    user: &File,
+    local_modules: &[File],
+    ctx: &PackageContext,
+) -> Result<Vec<ExternalModule>, RavenError> {
+    let mut queue: Vec<(String, Vec<String>)> = external_import_targets(user);
+    for m in local_modules {
+        queue.extend(external_import_targets(m));
+    }
+    let mut loaded_paths: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut out: Vec<ExternalModule> = Vec::new();
+
+    while let Some((source, subpath)) = queue.pop() {
+        let Some(path) = ctx.external_source_path(&source, &subpath) else {
+            continue;
+        };
+        if !loaded_paths.insert(path.clone()) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let gh = match GithubPath::parse(&source) {
+            Some(gh) => gh,
+            None => continue,
+        };
+
+        let tokens = Lexer::new(text, path.clone())
+            .tokenize()
+            .map_err(|e| external_error(&path, format!("lex: {e}")))?;
+        let module_file =
+            parse(&tokens).map_err(|e| external_error(&path, format!("parse: {e}")))?;
+
+        // Follow this file's own external imports (to sibling files in the
+        // same package or to other packages).
+        for (dep_source, dep_subpath) in external_import_targets(&module_file) {
+            queue.push((dep_source, dep_subpath));
+        }
+        // Read the package's cached manifest and queue each dependency's
+        // entry file so a transitively required package merges even when
+        // only its package root is imported.
+        if let Some(manifest_path) = ctx.package_manifest_path(&source) {
+            if let Ok(manifest) = crate::manifest::Manifest::load(&manifest_path) {
+                for dep in &manifest.dependencies {
+                    queue.push((dep.path.clone(), Vec::new()));
+                }
+            }
+        }
+
+        out.push(ExternalModule {
+            host: gh.host,
+            user: gh.user,
+            repo: gh.repo,
+            source_path: path,
+            file: module_file,
+        });
+    }
+
+    Ok(out)
+}
+
+/// Build the rename entries an external module needs for the names it
+/// selectively imports from OTHER external sources, mapping each selector
+/// to the sibling's `ext.` namespaced symbol. Mirrors [`import_rename_map`]
+/// for the external case. Selectors that name a type keep their own name
+/// and need no rename.
+fn external_import_rename_map(file: &File, ctx: &PackageContext) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for decl in &file.items {
+        let DeclKind::Import(import) = &decl.kind else {
+            continue;
+        };
+        if import.selectors.is_empty() {
+            continue;
+        }
+        let ImportSource::Quoted(path) = &import.source else {
+            continue;
+        };
+        let Some(gh) = GithubPath::parse(path) else {
+            continue;
+        };
+        let source = format!("github.com/{}/{}", gh.user, gh.repo);
+        let Some(src_path) = ctx.external_source_path(&source, &gh.subpath) else {
+            continue;
+        };
+        let Ok(text) = std::fs::read_to_string(&src_path) else {
+            continue;
+        };
+        let Some(target) = parse_loaded(&text, &src_path) else {
+            continue;
+        };
+        let key = external_module_key(&gh.host, &gh.user, &gh.repo, &src_path);
+        let fns = top_level_fn_names(&target);
+        for name in &import.selectors {
+            if fns.contains(name) {
+                map.insert(name.clone(), mangle_external_fn(&key, name));
+            }
+        }
+    }
+    map
+}
+
+/// Build a resolve error for an external package source that failed to
+/// load. The lex or parse error is anchored at the start of the file.
+fn external_error(path: &Path, detail: String) -> RavenError {
+    let span = crate::span::Span::point(Arc::new(path.to_path_buf()), 0, 1, 1);
+    RavenError::resolve(
+        ResolveError::UnresolvedImport(path.display().to_string()),
+        span,
+    )
+    .with_hint(format!("external package source failed to load: {detail}"))
 }
 
 /// The set of top level free function names declared in `file`.
@@ -898,6 +1181,110 @@ mod tests {
             .filter(|d| matches!(&d.kind, DeclKind::Function(f) if f.name == "std.io.println"))
             .count();
         assert_eq!(println_count, 1);
+    }
+
+    #[test]
+    fn external_key_is_stable_and_namespaced() {
+        let p = PathBuf::from("/cache/github.com/acme/greet@v1.0.0/lib.rv");
+        let k1 = external_module_key("github.com", "acme", "greet", &p);
+        let k2 = external_module_key("github.com", "acme", "greet", &p);
+        assert_eq!(k1, k2);
+        assert!(k1.starts_with("ext.github_com.acme.greet."));
+        assert_eq!(mangle_external_fn(&k1, "shout"), format!("{k1}.shout"));
+        // A different source file in the same package yields a distinct key.
+        let other = PathBuf::from("/cache/github.com/acme/greet@v1.0.0/util.rv");
+        assert_ne!(
+            k1,
+            external_module_key("github.com", "acme", "greet", &other)
+        );
+    }
+
+    #[test]
+    fn external_source_path_maps_through_lock() {
+        let lock = crate::lock::LockFile {
+            version: crate::lock::LOCK_VERSION,
+            packages: vec![crate::lock::LockedPackage {
+                source: "github.com/acme/greet".to_string(),
+                version: "v1.0.0".to_string(),
+                hash: "sha256:abc".to_string(),
+            }],
+        };
+        let ctx = PackageContext::new(PathBuf::from("/cache"), &lock);
+
+        // Bare import resolves to lib.rv at the cached package root.
+        let bare = ctx
+            .external_source_path("github.com/acme/greet", &[])
+            .expect("bare path");
+        assert!(bare.ends_with("github.com/acme/greet@v1.0.0/lib.rv"));
+
+        // A single-segment subpath selects <cachedir>/<seg>.rv.
+        let sub = ctx
+            .external_source_path("github.com/acme/greet", &["lib".to_string()])
+            .expect("sub path");
+        assert!(sub.ends_with("github.com/acme/greet@v1.0.0/lib.rv"));
+
+        // A nested subpath joins directories then appends .rv.
+        let nested = ctx
+            .external_source_path(
+                "github.com/acme/greet",
+                &["util".to_string(), "text".to_string()],
+            )
+            .expect("nested path");
+        assert!(nested.ends_with("github.com/acme/greet@v1.0.0/util/text.rv"));
+
+        // An unlocked package resolves to nothing.
+        assert!(ctx
+            .external_source_path("github.com/acme/missing", &[])
+            .is_none());
+    }
+
+    #[test]
+    fn external_function_merges_under_ext_namespace() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        let cache = std::env::temp_dir().join(format!(
+            "raven_ext_merge_{}_{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let pkg_dir = cache.join("github.com").join("acme").join("greet@v1.0.0");
+        std::fs::create_dir_all(&pkg_dir).expect("mkdir");
+        std::fs::write(
+            pkg_dir.join("rv.toml"),
+            "[package]\nname = \"greet\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write toml");
+        let src_path = pkg_dir.join("lib.rv");
+        std::fs::write(
+            &src_path,
+            "fun shout(s: String) -> String { return s.concat(\"!\") }\n",
+        )
+        .expect("write src");
+
+        let lock = crate::lock::LockFile {
+            version: crate::lock::LOCK_VERSION,
+            packages: vec![crate::lock::LockedPackage {
+                source: "github.com/acme/greet".to_string(),
+                version: "v1.0.0".to_string(),
+                hash: "sha256:abc".to_string(),
+            }],
+        };
+        let ctx = PackageContext::new(cache.clone(), &lock);
+
+        let user = parse_src(
+            "import \"github.com/acme/greet/lib\" { shout }\nfun main() { print(shout(\"hi\")) }\n",
+        );
+        let combined = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
+
+        let key = external_module_key("github.com", "acme", "greet", &src_path);
+        let mangled = mangle_external_fn(&key, "shout");
+        let present = combined
+            .items
+            .iter()
+            .any(|d| matches!(&d.kind, DeclKind::Function(f) if f.name == mangled));
+        assert!(present, "external shout should merge under {mangled}");
+
+        std::fs::remove_dir_all(&cache).ok();
     }
 
     #[test]

--- a/tests/rvpm_build.rs
+++ b/tests/rvpm_build.rs
@@ -1,0 +1,161 @@
+//! End to end test for `rvpm build` and `rvpm run` with a GitHub
+//! dependency resolved through the rvpm cache.
+//!
+//! The acceptance criterion for issue #85 is that a multi-file project
+//! with one GitHub dependency compiles and runs. This is exercised with
+//! NO network by pre-seeding a temporary cache (the established pattern):
+//! a cached `github.com/acme/greet@v1.0.0` package exports a function, the
+//! project imports it, and the produced binary's stdout is asserted.
+//!
+//! The test drives the real `rvpm` binary (`CARGO_BIN_EXE_rvpm`), which in
+//! turn drives the compile pipeline and the linker, so it is gated on a
+//! supported runtime the same way the codegen smoke tests are: it skips
+//! (passing) when no linker or no `raven_runtime` staticlib is present.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use raven::codegen::linker;
+
+#[test]
+fn project_with_github_dependency_builds_and_runs() {
+    if !supported_runtime() {
+        return;
+    }
+
+    let work = workdir();
+    let cache = work.join("cache");
+    let project = work.join("project");
+    std::fs::create_dir_all(&project).expect("mkdir project");
+
+    // Pre-seed the cache with github.com/acme/greet@v1.0.0. Its lib.rv
+    // exports `shout`, built on std/string's `concat`.
+    let pkg_dir = cache.join("github.com").join("acme").join("greet@v1.0.0");
+    std::fs::create_dir_all(&pkg_dir).expect("mkdir pkg");
+    std::fs::write(
+        pkg_dir.join("rv.toml"),
+        "[package]\nname = \"greet\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write pkg toml");
+    std::fs::write(
+        pkg_dir.join("lib.rv"),
+        "import std/string\nfun shout(s: String) -> String { return s.concat(\"!\") }\n",
+    )
+    .expect("write pkg lib");
+
+    // The project: rv.toml with the dependency, and src/main.rv importing it.
+    std::fs::write(
+        project.join("rv.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/greet\" = \"v1.0.0\"\n",
+    )
+    .expect("write project toml");
+    let src = project.join("src");
+    std::fs::create_dir_all(&src).expect("mkdir src");
+    std::fs::write(
+        src.join("main.rv"),
+        "import \"github.com/acme/greet/lib\" { shout }\nfun main() { print(shout(\"hi\")) }\n",
+    )
+    .expect("write main");
+
+    // `rvpm build`: resolves the lock against the pre-seeded cache, then
+    // compiles src/main.rv with the dependency merged in.
+    let build = rvpm(&project, &cache, &["build".to_string()]);
+    assert!(
+        build.status.success(),
+        "rvpm build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+    assert!(
+        project.join("rv.lock").is_file(),
+        "rvpm build should have written rv.lock"
+    );
+    let binary = project
+        .join("target")
+        .join("raven-out")
+        .join(if cfg!(windows) { "demo.exe" } else { "demo" });
+    assert!(
+        binary.is_file(),
+        "expected built binary at {}",
+        binary.display()
+    );
+
+    // `rvpm run`: builds then runs, forwarding the program's exit code and
+    // stdout. The dependency's `shout("hi")` prints `hi!`.
+    let run = rvpm(&project, &cache, &["run".to_string()]);
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&run.stderr).into_owned();
+    cleanup(&work);
+    assert!(
+        run.status.success(),
+        "rvpm run exited non zero: stderr={}",
+        stderr
+    );
+    assert_eq!(stdout, "hi!\n", "unexpected program stdout: {:?}", stdout);
+}
+
+/// Invoke the real `rvpm` binary in `project_dir` with an isolated cache.
+fn rvpm(project_dir: &Path, cache: &Path, args: &[String]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rvpm"))
+        .args(args)
+        .current_dir(project_dir)
+        .env("RVPM_CACHE_DIR", cache)
+        .output()
+        .expect("run rvpm")
+}
+
+/// True when a linker and the runtime staticlib are both present. Mirrors
+/// the codegen smoke gate so this test skips cleanly on hosts that cannot
+/// link a native binary.
+fn supported_runtime() -> bool {
+    if !linker::linker_available() {
+        eprintln!("rvpm_build: skipping, no linker available for the host.");
+        return false;
+    }
+    if locate_runtime().is_none() {
+        eprintln!("rvpm_build: skipping, raven_runtime staticlib not built.");
+        return false;
+    }
+    true
+}
+
+fn locate_runtime() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("RAVEN_RUNTIME_LIB") {
+        let pb = PathBuf::from(p);
+        if pb.is_file() {
+            return Some(pb);
+        }
+    }
+    let lib_name = if cfg!(windows) {
+        "raven_runtime.lib"
+    } else {
+        "libraven_runtime.a"
+    };
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for sub in ["target/debug", "target/release"] {
+        let p = root.join(sub).join(lib_name);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn workdir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let mut p = std::env::temp_dir();
+    let pid = std::process::id();
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    p.push(format!("rvpm-build-{}-{}-{}", pid, stamp, seq));
+    std::fs::create_dir_all(&p).expect("create workdir");
+    p
+}
+
+fn cleanup(p: &Path) {
+    let _ = std::fs::remove_dir_all(p);
+}


### PR DESCRIPTION
Add `rvpm build` and `rvpm run`, wiring the import resolver through the rvpm cache so a project can compile and run a GitHub dependency.

Closes #85

## External source backend (reuses the merge)

An `import "github.com/user/repo[/sub]"` is located through the project's `rv.lock` (which pins the `github.com/<user>/<repo>` source to a version) and `pkg::cache_dir_in` for that version, then fed through the SAME `merge_module_items` core the bundled-stdlib and local-module paths use. External functions are namespaced `ext.<host>.<user>.<repo>.<hash>`; the external package's own dependencies (read from its cached `rv.toml`) merge transitively and dedup by resolved source path, and an external module's `import std/...` lines pull in the bundled modules it needs. A selective import `{ name }` binds the bare name to the namespaced symbol, exactly as local and bundled imports do, so the type checker finds the merged decl.

## Package-context plumbing

The cache root plus the loaded lock map are carried by `resolve::PackageContext`, threaded as an `Option<&PackageContext>` into `expand_with_stdlib_ctx` and `resolve_file_ctx`. `rvpm build` passes `Some`; a single-file `raven build` passes `None` and behaves exactly as before (external imports stay deferred and surface as unresolved). The reusable compile pipeline (lex through link) moves into `raven::driver` so both binaries drive it.

## Conventions

- Entry file: `src/main.rv` (relative to the project root).
- Output binary: `target/raven-out/<package-name>` (`.exe` on Windows).
- Bare `github.com/user/repo` import resolves to `lib.rv` at the cached package root; `github.com/user/repo/sub` resolves to `<cachedir>/sub.rv` (nested subpaths join directories then append `.rv`).

`rvpm build` ensures dependencies are installed (reusing `ops::install`: validate an up-to-date lock or resolve a fresh one), then compiles the entry with the package context. `rvpm run` builds then runs the binary, forwarding any args after `run` and exiting with the program's code.

## End-to-end test (CI-safe, no network)

`tests/rvpm_build.rs` pre-seeds a temporary cache (`RVPM_CACHE_DIR`) with `github.com/acme/greet@v1.0.0` whose `lib.rv` exports `shout`, creates a project that depends on it and imports it in `src/main.rv`, drives the real `rvpm` binary (`CARGO_BIN_EXE_rvpm`) to `build` then `run`, and asserts stdout is exactly `hi!\n`. It is gated on a supported runtime (linker plus `raven_runtime` staticlib) like the codegen smoke tests, and cleans up its temp dirs. A non-gated unit test in `resolve::stdlib` covers the cache-path mapping through the lock and the `ext.` namespacing.

## Spec

Extended `docs/v2/specs/rvpm.md` (build/run semantics, entry-file and output conventions, the subpath and bare-import conventions, external resolution through `rv.lock` plus the cache, and the package-context plumbing choice) and cross-referenced `docs/v2/specs/resolver.md` (the merge seam).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo test --workspace` (348 lib + 52 codegen smoke + the new rvpm_build end-to-end, all green)
- [x] End-to-end: a project with one GitHub dependency compiles and runs, printing `hi!`
- [x] No regression to `raven build`, the bundled-stdlib path, or the local multi-module path (#196)
