### PR TITLE
feat(rvpm): canonical formatter and fmt command

### DIFF
--- a/docs/v2/specs/formatter.md
+++ b/docs/v2/specs/formatter.md
@@ -1,0 +1,177 @@
+# Formatter
+
+Raven ships a single canonical source formatter, exposed through `rvpm
+fmt`. There are no style options. Given any source that parses, the
+formatter produces one canonical rendering. The library entry point is
+`raven::format::format_source(src: &str) -> Result<String, FormatError>`.
+
+## Guarantees
+
+The formatter is built around two invariants, both enforced by tests:
+
+* Idempotency: `format(format(x)) == format(x)`. Formatting an already
+  formatted file is a no-op.
+* Semantic preservation: `parse(format(x))` succeeds and yields an AST
+  equal to `parse(x)` (ignoring spans). Formatting never changes meaning.
+
+The only failure mode is input that does not lex or parse:
+`format_source` returns `FormatError::Parse` with the underlying
+diagnostic. The formatter never emits source that fails to re-parse.
+
+## Style rules
+
+### Indentation
+
+Four spaces per level. Tabs are never emitted. Block bodies (functions,
+`if`, `while`, `loop`, `for`, `match` arm blocks, lambda blocks, struct
+and enum and trait and impl and extern bodies) indent their contents one
+level deeper than the opening line.
+
+### Braces
+
+K&R / gofmt style: the opening brace sits on the same line as the
+construct that introduces it (`fun`, `if`, `while`, `struct`, `enum`,
+`trait`, `impl`, `extern`, `match`, lambda). The closing brace sits on
+its own line at the construct's indentation.
+
+An empty body renders inline as `{}` (for example `fun noop() {}`,
+`struct Empty {}`, `impl T for U {}`).
+
+### Statements
+
+One statement per line. Raven has no statement terminators, so none are
+emitted. `continue`, `break`, and `return` render bare or with their
+optional value.
+
+### Blank lines
+
+* Runs of two or more blank lines collapse to a single blank line.
+* A blank line that the author placed between two top level items, or
+  between two statements, or before a comment that precedes an item, is
+  preserved (collapsed to one).
+* Leading and trailing blank lines inside a block are removed.
+* Members of a `trait` or `impl` are separated by one blank line.
+* The file ends with exactly one newline and no trailing blank lines.
+
+### Spacing
+
+* One space around binary operators (`a + b`, `x == y`, `n << 2`).
+* No space between a unary operator and its operand (`-x`, `!ok`, `&v`).
+* One space after a comma; none before it.
+* One space after the `:` in a type annotation and in struct fields
+  (`x: Int`, `name: String`); none before it.
+* No space before the `(` of a call or the `[` of an index.
+* One space around `=` in `let`, `const`, assignment, and single
+  expression function and lambda bodies.
+* One space around `->` in return types and `=>`-free arrow forms, and
+  around `->` in `match` arms.
+* Generic argument and parameter lists use `<A, B>` with no inner
+  padding. Trait bounds render as `T: Bound1 + Bound2`.
+
+### Trailing whitespace
+
+Removed from every line.
+
+### Constructs
+
+* Functions: `fun name<G>(params) -> Ret { ... }`, or `fun name(...) =
+  expr` for single expression bodies. Trait members with no body render
+  as the signature alone.
+* `struct` and `enum` and trait and extern members render one per line.
+  Struct fields and enum variants carry a trailing comma. Enum struct
+  payloads use the parenthesized field syntax `Variant(name: Type, ...)`
+  that the parser accepts.
+* Imports: `import std/io`, `import std/collections { Map, Set }`,
+  `import "github.com/user/repo" as alias`. Selector lists render with
+  one space of inner padding and comma separation.
+* `match` arms render one per line, each ending in a comma:
+  `pattern if guard -> body,`.
+* Struct literals: shorthand `{ name }` is used when a field's value is
+  the identifier of the same name (so `Point { x: x }` becomes
+  `Point { x }`). A struct literal that spanned multiple lines in the
+  source renders multi line with a trailing comma per field; one that fit
+  on a single line renders inline as `Name { a: 1, b: 2 }`.
+* Lambdas: the shorthand `{ x -> body }` form renders inline when the
+  body is a single expression, and multi line when it contains
+  statements. The `fun(params) -> Ret = expr` and `fun(params) { ... }`
+  forms render with the same spacing as named functions.
+* Ranges render as `start..end` and `start..=end` with no surrounding
+  spaces.
+* String literals are re-escaped canonically. A `$` immediately before
+  `{` inside a plain (non interpolated) string is escaped to `\$` so the
+  result does not re-parse as an interpolation. Interpolated strings
+  render their embedded expressions with `${ ... }` and the formatter
+  recurses into them.
+* Float literals always show a decimal point (`3` written where a float
+  is expected renders as `3.0`).
+
+There is no line length limit and no expression wrapping: an expression
+renders on one line unless it contains a block bearing sub expression
+(`if`, `match`, a block, or a multi line struct literal). This keeps the
+formatter simple and idempotent. Authors who want a long call broken
+across lines should refactor into intermediate `let` bindings.
+
+## Comments
+
+The lexer discards comments, so the formatter recovers them by rescanning
+the source for `//` line comments and `/* ... */` block comments, skipping
+string and char literals so a `//` inside a string is not mistaken for a
+comment. Each comment is classified as own line (only whitespace precedes
+it on its line) or trailing (it follows code).
+
+Comment handling:
+
+* Own line comments are kept on their own line, attached to the item or
+  statement that follows them, at that item's indentation. A blank line
+  the author left before such a comment is preserved.
+* Trailing comments are kept on the same line as the code they follow,
+  separated by one space (`let x = 1 // count`).
+* Comments inside nested blocks (for example inside an `if` or `while`
+  body) are placed at the correct position because block rendering draws
+  from the same position ordered comment stream.
+
+Fidelity achieved: full preservation of line and block comments by source
+position, for comments that sit at statement or item boundaries or trail a
+line. Known limitation: a comment placed in the interior of a single
+expression that the formatter renders on one line (for example between two
+arguments of a call written across several source lines) is reattached to
+the nearest preceding boundary rather than kept mid expression, because
+the formatter collapses such expressions onto one line. No comment is ever
+dropped.
+
+## `rvpm fmt`
+
+```
+rvpm fmt [--check] [paths...]
+```
+
+* With no paths, formats every `.rv` file under the project `src/`
+  directory, recursively, in place.
+* With paths, formats each named file; a directory argument is walked
+  recursively for `.rv` files.
+* `rvpm fmt` rewrites changed files in place and prints `formatted
+  <path>` for each. Files already canonical are left untouched.
+* `rvpm fmt --check` writes nothing. It lists every file that is not
+  canonically formatted and exits non-zero if any are; it exits zero when
+  all inputs are already formatted.
+* A file that fails to parse is reported on stderr and causes a non-zero
+  exit, without modifying the file.
+
+## Tests
+
+* `src/format/tests.rs`: per construct unit tests, each asserting
+  idempotency and AST equality of the formatted output.
+* `tests/fmt_golden.rs`: a golden corpus under `tests/fmt_corpus/`
+  (input `.rv`, expected `.rv.fmt`) covering every construct, plus an
+  idempotency and semantic preservation check over the whole corpus and
+  every bundled `stdlib/std/*.rv` file. Refresh baselines with
+  `RAVEN_UPDATE_FMT=1 cargo test --test fmt_golden`.
+* `tests/rvpm_fmt.rs`: drives the `rvpm` binary for the in place and
+  `--check` behaviors.
+
+The bundled standard library parses, formats idempotently, and preserves
+its AST under these rules. It is not byte for byte canonical yet (the
+formatter canonicalizes struct literal field shorthand, removes leading
+blank lines inside blocks, and adds trailing commas after block bodied
+match arms). Reformatting the stdlib is left as a separate change to keep
+this one focused on the formatter.

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -8,6 +8,7 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use raven::format::format_source;
 use raven::lock::{self, LockFile, LOCK_FILE_NAME};
 use raven::manifest::init::{init_project, name_from_dir, InitError};
 use raven::manifest::Manifest;
@@ -48,6 +49,7 @@ fn main() -> ExitCode {
         Some("update") => run(cmd_update(&args[1..])),
         Some("build") => run(cmd_build(&args[1..])),
         Some("run") => cmd_run(&args[1..]),
+        Some("fmt") => cmd_fmt(&args[1..]),
         Some(other) => {
             eprintln!("rvpm: unknown subcommand '{}'", other);
             eprintln!("Run 'rvpm help' for usage.");
@@ -206,6 +208,127 @@ fn cmd_run(args: &[String]) -> ExitCode {
     }
 }
 
+/// Format Raven sources in place, or check formatting with `--check`.
+///
+/// With no path arguments, formats every `.rv` file under the project
+/// `src/` directory. With `--check`, no file is written: the command lists
+/// files that are not canonically formatted and exits non-zero if any are.
+fn cmd_fmt(args: &[String]) -> ExitCode {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("{}", fmt_usage());
+        return ExitCode::SUCCESS;
+    }
+    let check = args.iter().any(|a| a == "--check");
+    let paths: Vec<&String> = args.iter().filter(|a| !a.starts_with('-')).collect();
+
+    let files = if paths.is_empty() {
+        match collect_rv_files(PathBuf::from("src")) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("rvpm: {}", e);
+                return ExitCode::from(1);
+            }
+        }
+    } else {
+        let mut acc = Vec::new();
+        for p in &paths {
+            let path = PathBuf::from(p);
+            if path.is_dir() {
+                match collect_rv_files(path) {
+                    Ok(mut f) => acc.append(&mut f),
+                    Err(e) => {
+                        eprintln!("rvpm: {}", e);
+                        return ExitCode::from(1);
+                    }
+                }
+            } else {
+                acc.push(path);
+            }
+        }
+        acc
+    };
+
+    if files.is_empty() {
+        eprintln!("rvpm: no .rv files to format");
+        return ExitCode::from(1);
+    }
+
+    let mut changed: Vec<PathBuf> = Vec::new();
+    let mut errored = false;
+    for path in &files {
+        let src = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("rvpm: {}: {}", path.display(), e);
+                errored = true;
+                continue;
+            }
+        };
+        let formatted = match format_source(&src) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("rvpm: {}: {}", path.display(), e);
+                errored = true;
+                continue;
+            }
+        };
+        if formatted == src {
+            continue;
+        }
+        if check {
+            changed.push(path.clone());
+        } else if let Err(e) = std::fs::write(path, &formatted) {
+            eprintln!("rvpm: {}: {}", path.display(), e);
+            errored = true;
+        } else {
+            println!("formatted {}", path.display());
+        }
+    }
+
+    if errored {
+        return ExitCode::from(1);
+    }
+    if check {
+        if changed.is_empty() {
+            return ExitCode::SUCCESS;
+        }
+        eprintln!("The following files are not formatted:");
+        for p in &changed {
+            eprintln!("  {}", p.display());
+        }
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}
+
+/// Recursively collect `.rv` files under `dir`, sorted for deterministic
+/// output.
+fn collect_rv_files(dir: PathBuf) -> Result<Vec<PathBuf>, String> {
+    if !dir.exists() {
+        return Err(format!("'{}' does not exist", dir.display()));
+    }
+    let mut out = Vec::new();
+    let mut stack = vec![dir];
+    while let Some(d) = stack.pop() {
+        let entries = std::fs::read_dir(&d).map_err(|e| format!("{}: {}", d.display(), e))?;
+        for entry in entries {
+            let entry = entry.map_err(|e| e.to_string())?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|s| s.to_str()) == Some("rv") {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn fmt_usage() -> String {
+    "Usage: rvpm fmt [--check] [paths...]".to_string()
+}
+
 fn build_usage() -> String {
     "Usage: rvpm build".to_string()
 }
@@ -239,6 +362,7 @@ fn print_usage() {
     println!("  update [pkg]   Re-resolve rv.toml and rewrite rv.lock for one package or all");
     println!("  build          Compile src/main.rv to target/raven-out/<name>");
     println!("  run [args]     Build the package then run it, forwarding args");
+    println!("  fmt [paths]    Format .rv files in place (--check to verify only)");
     println!("  fetch <pkg>    Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
     println!("  lock           Generate or validate rv.lock for the current package");
     println!("  help           Print this message");

--- a/src/format/comments.rs
+++ b/src/format/comments.rs
@@ -1,0 +1,130 @@
+//! Comment recovery for the formatter.
+//!
+//! The lexer drops comments, so the formatter rescans the raw source to
+//! recover them with their byte offsets. Each comment is classified as
+//! own-line (nothing but whitespace precedes it on its line) or trailing
+//! (it follows code on the same line). The formatter weaves them back in
+//! by position. String and char literals are skipped so a `//` inside a
+//! string is not mistaken for a comment.
+
+/// A recovered source comment.
+#[derive(Debug, Clone)]
+pub struct Comment {
+    /// Byte offset of the `//` or `/*`.
+    pub start: usize,
+    /// Canonical comment text (no trailing whitespace; line comments keep
+    /// their `//` prefix, block comments their `/* */`).
+    pub text: String,
+    /// True when only whitespace precedes the comment on its line.
+    pub own_line: bool,
+}
+
+/// Scan `src` for all comments, in source order.
+pub fn scan(src: &str) -> Vec<Comment> {
+    let bytes = src.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    // Track whether the current line has seen non-whitespace before the
+    // comment, to classify own-line vs trailing.
+    let mut line_has_code = false;
+    let n = bytes.len();
+    while i < n {
+        let b = bytes[i];
+        match b {
+            b'\n' => {
+                line_has_code = false;
+                i += 1;
+            }
+            b' ' | b'\t' | b'\r' => {
+                i += 1;
+            }
+            b'"' => {
+                line_has_code = true;
+                i = skip_string(bytes, i);
+            }
+            b'\'' => {
+                line_has_code = true;
+                i = skip_char(bytes, i);
+            }
+            b'/' if i + 1 < n && bytes[i + 1] == b'/' => {
+                let start = i;
+                let own_line = !line_has_code;
+                let mut j = i + 2;
+                while j < n && bytes[j] != b'\n' {
+                    j += 1;
+                }
+                let raw = &src[start..j];
+                out.push(Comment {
+                    start,
+                    text: raw.trim_end().to_string(),
+                    own_line,
+                });
+                i = j;
+                line_has_code = true;
+            }
+            b'/' if i + 1 < n && bytes[i + 1] == b'*' => {
+                let start = i;
+                let own_line = !line_has_code;
+                let mut j = i + 2;
+                while j + 1 < n && !(bytes[j] == b'*' && bytes[j + 1] == b'/') {
+                    j += 1;
+                }
+                j = (j + 2).min(n);
+                let raw = &src[start..j];
+                out.push(Comment {
+                    start,
+                    text: raw.to_string(),
+                    own_line,
+                });
+                // A block comment may keep the line "in code" if more follows.
+                line_has_code = true;
+                i = j;
+            }
+            _ => {
+                line_has_code = true;
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Skip a `"..."` string literal starting at the opening quote. Returns the
+/// index just past the closing quote (or end of input). Triple-quoted block
+/// strings are handled too.
+fn skip_string(bytes: &[u8], start: usize) -> usize {
+    let n = bytes.len();
+    // Triple quote?
+    if start + 2 < n && bytes[start + 1] == b'"' && bytes[start + 2] == b'"' {
+        let mut j = start + 3;
+        while j + 2 < n && !(bytes[j] == b'"' && bytes[j + 1] == b'"' && bytes[j + 2] == b'"') {
+            j += 1;
+        }
+        return (j + 3).min(n);
+    }
+    let mut j = start + 1;
+    while j < n {
+        match bytes[j] {
+            b'\\' => j += 2,
+            b'"' => return j + 1,
+            b'\n' => return j,
+            _ => j += 1,
+        }
+    }
+    j
+}
+
+/// Skip a `'c'` char literal starting at the opening quote.
+fn skip_char(bytes: &[u8], start: usize) -> usize {
+    let n = bytes.len();
+    let mut j = start + 1;
+    while j < n {
+        match bytes[j] {
+            b'\\' => j += 2,
+            b'\'' => return j + 1,
+            b'\n' => return j,
+            _ => j += 1,
+        }
+    }
+    j
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,0 +1,1262 @@
+//! Canonical source formatter for the Raven v2 grammar.
+//!
+//! There are no style options. Given any parseable source, the formatter
+//! emits a single canonical rendering that re-parses to an equivalent AST
+//! and is idempotent: formatting an already-formatted file is a no-op.
+//!
+//! The pipeline lexes and parses the input, then walks the AST emitting
+//! canonical text. Line comments are recovered from the source separately
+//! (the lexer drops them) and woven back in by source position. See
+//! `docs/v2/specs/formatter.md` for the full set of rules.
+
+use std::fmt::Write as _;
+
+use crate::ast::{
+    AssignOp, BinaryOp, Block, Const, Decl, DeclKind, ElseBranch, Enum, Expr, ExprKind, Extern,
+    ExternFn, File, Function, FunctionBody, GenericParam, Impl, Import, ImportSource, LambdaBody,
+    LambdaParam, LetDecl, LiteralPattern, MatchArm, Param, Pattern, PatternKind, Stmt, StmtKind,
+    StrFragment, Struct, StructField, Trait, Type, TypeKind, TypePath, UnaryOp, VariantPayload,
+};
+use crate::lexer::Lexer;
+use crate::parser::parse;
+
+mod comments;
+
+use comments::Comment;
+
+const INDENT: &str = "    ";
+
+/// A formatting failure. The only way to fail is to be handed source that
+/// does not lex or parse: the formatter cannot canonicalize what it cannot
+/// understand.
+#[derive(Debug)]
+pub enum FormatError {
+    /// The source failed to lex or parse. The inner message is the
+    /// underlying compiler diagnostic.
+    Parse(String),
+}
+
+impl std::fmt::Display for FormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FormatError::Parse(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for FormatError {}
+
+/// Format Raven source text into its canonical form.
+pub fn format_source(src: &str) -> Result<String, FormatError> {
+    let tokens = Lexer::new(src, "<fmt>")
+        .tokenize()
+        .map_err(|e| FormatError::Parse(e.to_string()))?;
+    let file = parse(&tokens).map_err(|e| FormatError::Parse(e.to_string()))?;
+    let comments = comments::scan(src);
+    let mut p = Printer::new(src, comments);
+    p.file(&file);
+    Ok(p.finish())
+}
+
+/// Accumulates the canonical output and tracks indentation, the current
+/// source line, and the pending comment cursor.
+struct Printer<'a> {
+    out: String,
+    indent: usize,
+    src: &'a str,
+    comments: Vec<Comment>,
+    /// Index of the next comment not yet emitted.
+    next_comment: usize,
+}
+
+impl<'a> Printer<'a> {
+    fn new(src: &'a str, comments: Vec<Comment>) -> Self {
+        Printer {
+            out: String::new(),
+            indent: 0,
+            src,
+            comments,
+            next_comment: 0,
+        }
+    }
+
+    fn finish(mut self) -> String {
+        // Flush any comments that trail the final item.
+        self.flush_comments_before(usize::MAX, false);
+        // Collapse trailing blank lines, ensure exactly one final newline.
+        while self.out.ends_with('\n') {
+            self.out.pop();
+        }
+        // Strip trailing whitespace on the last line too.
+        while self.out.ends_with(' ') || self.out.ends_with('\t') {
+            self.out.pop();
+        }
+        if !self.out.is_empty() {
+            self.out.push('\n');
+        }
+        self.out
+    }
+
+    // ----- low level emit -----
+
+    fn line(&mut self, text: &str) {
+        if text.is_empty() {
+            self.out.push('\n');
+            return;
+        }
+        for _ in 0..self.indent {
+            self.out.push_str(INDENT);
+        }
+        self.out.push_str(text);
+        self.out.push('\n');
+    }
+
+    fn blank(&mut self) {
+        // Collapse consecutive blanks: only emit if the last char is a
+        // single newline (not already a blank line) and output is non-empty.
+        if self.out.is_empty() {
+            return;
+        }
+        if self.out.ends_with("\n\n") {
+            return;
+        }
+        if self.out.ends_with('\n') {
+            self.out.push('\n');
+        }
+    }
+
+    fn line_of(&self, byte: usize) -> usize {
+        self.src[..byte.min(self.src.len())]
+            .bytes()
+            .filter(|b| *b == b'\n')
+            .count()
+    }
+
+    // ----- comment weaving -----
+
+    /// Emit every pending comment whose start byte is before `limit`.
+    /// `as_leading` controls indentation: leading comments use the current
+    /// indent and sit on their own lines.
+    fn flush_comments_before(&mut self, limit: usize, leading: bool) {
+        let _ = leading;
+        while self.next_comment < self.comments.len() {
+            let c = &self.comments[self.next_comment];
+            if c.start >= limit {
+                break;
+            }
+            let text = c.text.clone();
+            self.line(&text);
+            self.next_comment += 1;
+        }
+    }
+
+    /// Take the trailing comment that begins on `line` (same source line as
+    /// the item just emitted), if any, without emitting a newline first.
+    fn take_trailing_comment(&mut self, line: usize) -> Option<String> {
+        if self.next_comment < self.comments.len() {
+            let c = &self.comments[self.next_comment];
+            if c.own_line {
+                return None;
+            }
+            if self.line_of(c.start) == line {
+                let text = c.text.clone();
+                self.next_comment += 1;
+                return Some(text);
+            }
+        }
+        None
+    }
+
+    // ----- top level -----
+
+    fn file(&mut self, file: &File) {
+        // Source line of the last thing emitted (item end or comment line),
+        // used to decide blank-line separation. The canonical rule preserves
+        // a single blank between top level entities when the source had a
+        // gap, and collapses larger gaps to one.
+        let mut prev_end_line: Option<usize> = None;
+        for item in &file.items {
+            // Emit any own-line comments that precede this item, each with a
+            // gap-preserving blank, then the item itself.
+            prev_end_line = self.emit_toplevel_comments(item.span.start, prev_end_line);
+            self.maybe_blank(prev_end_line, item.span.start);
+            let trailing = self.decl(item);
+            if let Some(t) = trailing {
+                self.attach_trailing(&t);
+            }
+            prev_end_line = Some(self.line_of(item.span.end));
+        }
+        // Trailing own-line comments after the last item.
+        self.emit_toplevel_comments(usize::MAX, prev_end_line);
+    }
+
+    /// Emit own-line comments before `byte` at the current indent, inserting
+    /// a single blank line whenever the source had a gap before a comment.
+    /// Returns the updated `prev_end_line`.
+    fn emit_toplevel_comments(
+        &mut self,
+        byte: usize,
+        mut prev_end_line: Option<usize>,
+    ) -> Option<usize> {
+        loop {
+            let Some(c) = self.comments.get(self.next_comment) else {
+                break;
+            };
+            if c.start >= byte || !c.own_line {
+                break;
+            }
+            let c_start = c.start;
+            let text = c.text.clone();
+            self.maybe_blank(prev_end_line, c_start);
+            self.line(&text);
+            prev_end_line = Some(self.line_of(c_start));
+            self.next_comment += 1;
+        }
+        prev_end_line
+    }
+
+    fn attach_trailing(&mut self, comment: &str) {
+        // Replace the trailing newline with " // ...".
+        if self.out.ends_with('\n') {
+            self.out.pop();
+        }
+        self.out.push(' ');
+        self.out.push_str(comment);
+        self.out.push('\n');
+    }
+}
+
+// ----- declarations -----
+
+impl Printer<'_> {
+    /// Emit a declaration. Returns a trailing comment to attach on the same
+    /// line, if one was found.
+    fn decl(&mut self, decl: &Decl) -> Option<String> {
+        match &decl.kind {
+            DeclKind::Function(f) => self.function(f, ""),
+            DeclKind::Struct(s) => self.struct_decl(s),
+            DeclKind::Trait(t) => self.trait_decl(t),
+            DeclKind::Impl(i) => self.impl_decl(i),
+            DeclKind::Enum(e) => self.enum_decl(e),
+            DeclKind::Extern(e) => self.extern_decl(e),
+            DeclKind::Import(im) => self.import_decl(im),
+            DeclKind::Const(c) => self.const_decl(c),
+            DeclKind::Let(l) => self.let_decl(l),
+        }
+    }
+
+    fn function(&mut self, f: &Function, prefix: &str) -> Option<String> {
+        let mut head = String::new();
+        head.push_str(prefix);
+        head.push_str("fun ");
+        head.push_str(&f.name);
+        head.push_str(&render_generics(&f.generics));
+        head.push('(');
+        head.push_str(&render_params(&f.params));
+        head.push(')');
+        if let Some(ret) = &f.ret {
+            head.push_str(" -> ");
+            head.push_str(&render_type(ret));
+        }
+
+        match &f.body {
+            FunctionBody::None => {
+                self.line(&head);
+                let line = self.line_of(f.span.end);
+                self.take_trailing_comment(line)
+            }
+            FunctionBody::Expr(e) => {
+                head.push_str(" = ");
+                head.push_str(&self.render_expr(e));
+                self.line(&head);
+                let line = self.line_of(f.span.end);
+                self.take_trailing_comment(line)
+            }
+            FunctionBody::Block(b) => {
+                if b.stmts.is_empty() && b.trailing.is_none() {
+                    head.push_str(" {}");
+                    self.line(&head);
+                    let line = self.line_of(f.span.end);
+                    return self.take_trailing_comment(line);
+                }
+                head.push_str(" {");
+                self.line(&head);
+                self.block_body(b);
+                self.line("}");
+                None
+            }
+        }
+    }
+
+    fn struct_decl(&mut self, s: &Struct) -> Option<String> {
+        let mut head = String::from("struct ");
+        head.push_str(&s.name);
+        head.push_str(&render_generics(&s.generics));
+        if s.fields.is_empty() {
+            head.push_str(" {}");
+            self.line(&head);
+            return None;
+        }
+        head.push_str(" {");
+        self.line(&head);
+        self.indent += 1;
+        for field in &s.fields {
+            self.struct_field_line(field);
+        }
+        self.indent -= 1;
+        self.line("}");
+        None
+    }
+
+    fn struct_field_line(&mut self, field: &StructField) {
+        let line = self.line_of(field.span.start);
+        self.emit_indented_comments_before(field.span.start, line);
+        let text = format!("{}: {},", field.name, render_type(&field.ty));
+        self.line(&text);
+        if let Some(t) = self.take_trailing_comment(self.line_of(field.span.end)) {
+            self.attach_trailing(&t);
+        }
+    }
+
+    fn trait_decl(&mut self, t: &Trait) -> Option<String> {
+        let mut head = String::from("trait ");
+        head.push_str(&t.name);
+        head.push_str(&render_generics(&t.generics));
+        if t.members.is_empty() {
+            head.push_str(" {}");
+            self.line(&head);
+            return None;
+        }
+        head.push_str(" {");
+        self.line(&head);
+        self.indent += 1;
+        for (i, m) in t.members.iter().enumerate() {
+            if i > 0 {
+                self.blank();
+            }
+            self.emit_indented_comments_before(m.span.start, self.line_of(m.span.start));
+            if let Some(tr) = self.function(m, "") {
+                self.attach_trailing(&tr);
+            }
+        }
+        self.indent -= 1;
+        self.line("}");
+        None
+    }
+
+    fn impl_decl(&mut self, im: &Impl) -> Option<String> {
+        let mut head = String::from("impl");
+        head.push_str(&render_generics(&im.generics));
+        head.push(' ');
+        head.push_str(&render_type_path(&im.trait_or_type));
+        if let Some(for_ty) = &im.for_type {
+            head.push_str(" for ");
+            head.push_str(&render_type_path(for_ty));
+        }
+        if im.items.is_empty() {
+            head.push_str(" {}");
+            self.line(&head);
+            return None;
+        }
+        head.push_str(" {");
+        self.line(&head);
+        self.indent += 1;
+        for (i, m) in im.items.iter().enumerate() {
+            if i > 0 {
+                self.blank();
+            }
+            self.emit_indented_comments_before(m.span.start, self.line_of(m.span.start));
+            if let Some(tr) = self.function(m, "") {
+                self.attach_trailing(&tr);
+            }
+        }
+        self.indent -= 1;
+        self.line("}");
+        None
+    }
+
+    fn enum_decl(&mut self, e: &Enum) -> Option<String> {
+        let mut head = String::from("enum ");
+        head.push_str(&e.name);
+        head.push_str(&render_generics(&e.generics));
+        if e.variants.is_empty() {
+            head.push_str(" {}");
+            self.line(&head);
+            return None;
+        }
+        head.push_str(" {");
+        self.line(&head);
+        self.indent += 1;
+        for v in &e.variants {
+            self.emit_indented_comments_before(v.span.start, self.line_of(v.span.start));
+            let mut text = v.name.clone();
+            match &v.payload {
+                VariantPayload::Unit => {}
+                VariantPayload::Tuple(tys) => {
+                    text.push('(');
+                    let parts: Vec<String> = tys.iter().map(render_type).collect();
+                    text.push_str(&parts.join(", "));
+                    text.push(')');
+                }
+                VariantPayload::Struct(fields) => {
+                    text.push('(');
+                    let parts: Vec<String> = fields
+                        .iter()
+                        .map(|f| format!("{}: {}", f.name, render_type(&f.ty)))
+                        .collect();
+                    text.push_str(&parts.join(", "));
+                    text.push(')');
+                }
+            }
+            text.push(',');
+            self.line(&text);
+            if let Some(t) = self.take_trailing_comment(self.line_of(v.span.end)) {
+                self.attach_trailing(&t);
+            }
+        }
+        self.indent -= 1;
+        self.line("}");
+        None
+    }
+
+    fn extern_decl(&mut self, e: &Extern) -> Option<String> {
+        let head = format!("extern \"{}\" {{", e.abi);
+        self.line(&head);
+        self.indent += 1;
+        for it in &e.items {
+            self.emit_indented_comments_before(it.span.start, self.line_of(it.span.start));
+            self.extern_fn_line(it);
+        }
+        self.indent -= 1;
+        self.line("}");
+        None
+    }
+
+    fn extern_fn_line(&mut self, it: &ExternFn) {
+        let mut text = String::from("fun ");
+        text.push_str(&it.name);
+        text.push('(');
+        text.push_str(&render_params(&it.params));
+        text.push(')');
+        if let Some(ret) = &it.ret {
+            text.push_str(" -> ");
+            text.push_str(&render_type(ret));
+        }
+        self.line(&text);
+        if let Some(t) = self.take_trailing_comment(self.line_of(it.span.end)) {
+            self.attach_trailing(&t);
+        }
+    }
+
+    fn import_decl(&mut self, im: &Import) -> Option<String> {
+        let mut text = String::from("import ");
+        match &im.source {
+            ImportSource::Std(parts) => {
+                text.push_str("std");
+                for part in parts {
+                    text.push('/');
+                    text.push_str(part);
+                }
+            }
+            ImportSource::Quoted(s) => {
+                text.push('"');
+                text.push_str(s);
+                text.push('"');
+            }
+        }
+        if let Some(alias) = &im.alias {
+            text.push_str(" as ");
+            text.push_str(alias);
+        }
+        if !im.selectors.is_empty() {
+            text.push_str(" { ");
+            text.push_str(&im.selectors.join(", "));
+            text.push_str(" }");
+        }
+        self.line(&text);
+        self.take_trailing_comment(self.line_of(im.span.end))
+    }
+
+    fn const_decl(&mut self, c: &Const) -> Option<String> {
+        let text = format!(
+            "const {}: {} = {}",
+            c.name,
+            render_type(&c.ty),
+            self.render_expr(&c.value)
+        );
+        self.line(&text);
+        self.take_trailing_comment(self.line_of(c.span.end))
+    }
+
+    fn let_decl(&mut self, l: &LetDecl) -> Option<String> {
+        let text = self.render_let(&l.name, &l.ty, &l.init);
+        self.line(&text);
+        self.take_trailing_comment(self.line_of(l.span.end))
+    }
+
+    fn render_let(&mut self, name: &str, ty: &Option<Type>, init: &Option<Expr>) -> String {
+        let mut text = String::from("let ");
+        text.push_str(name);
+        if let Some(t) = ty {
+            text.push_str(": ");
+            text.push_str(&render_type(t));
+        }
+        if let Some(e) = init {
+            let e = self.render_expr(e);
+            text.push_str(" = ");
+            text.push_str(&e);
+        }
+        text
+    }
+
+    /// Emit own-line comments before `byte`, at the current indent.
+    fn emit_indented_comments_before(&mut self, byte: usize, _item_line: usize) {
+        while self.next_comment < self.comments.len() {
+            let c = &self.comments[self.next_comment];
+            if c.start >= byte || !c.own_line {
+                break;
+            }
+            let text = c.text.clone();
+            self.line(&text);
+            self.next_comment += 1;
+        }
+    }
+}
+
+// ----- statements and blocks -----
+
+impl Printer<'_> {
+    /// Emit the statements of a block at one deeper indent level. Used for
+    /// function, loop, if, while, for bodies.
+    fn block_body(&mut self, b: &Block) {
+        self.indent += 1;
+        self.stmts(b);
+        self.indent -= 1;
+    }
+
+    fn stmts(&mut self, b: &Block) {
+        let mut prev_end_line: Option<usize> = None;
+        for (i, s) in b.stmts.iter().enumerate() {
+            if i > 0 {
+                self.maybe_blank(prev_end_line, s.span.start);
+            }
+            self.emit_stmt_leading_comments(s.span.start);
+            self.stmt(s);
+            prev_end_line = Some(self.line_of(s.span.end));
+        }
+        if let Some(t) = &b.trailing {
+            if !b.stmts.is_empty() {
+                self.maybe_blank(prev_end_line, t.span.start);
+            }
+            self.emit_stmt_leading_comments(t.span.start);
+            let text = self.render_expr(t);
+            self.emit_multiline(&text);
+            if let Some(c) = self.take_trailing_comment(self.line_of(t.span.end)) {
+                self.attach_trailing(&c);
+            }
+        }
+    }
+
+    /// Emit one blank line when the source separated `prev_end_line` from the
+    /// next item by at least one blank line, counting the first own-line
+    /// leading comment (if any) as the start of the next item so a comment
+    /// glued to its item does not drift across format passes.
+    fn maybe_blank(&mut self, prev_end_line: Option<usize>, next_byte: usize) {
+        let Some(pe) = prev_end_line else {
+            return;
+        };
+        let anchor = self.leading_anchor_line(next_byte);
+        if anchor > pe + 1 {
+            self.blank();
+        }
+    }
+
+    /// Source line of the first own-line comment preceding `byte` (without
+    /// consuming it), or the line of `byte` when there is none.
+    fn leading_anchor_line(&self, byte: usize) -> usize {
+        if let Some(c) = self.comments.get(self.next_comment) {
+            if c.start < byte && c.own_line {
+                return self.line_of(c.start);
+            }
+        }
+        self.line_of(byte)
+    }
+
+    fn emit_stmt_leading_comments(&mut self, byte: usize) {
+        loop {
+            let Some(c) = self.comments.get(self.next_comment) else {
+                break;
+            };
+            if c.start >= byte || !c.own_line {
+                break;
+            }
+            let text = c.text.clone();
+            self.line(&text);
+            self.next_comment += 1;
+        }
+    }
+
+    fn stmt(&mut self, s: &Stmt) {
+        let end_line = self.line_of(s.span.end);
+        match &s.kind {
+            StmtKind::Let { name, ty, init } => {
+                let text = self.render_let(name, ty, init);
+                self.emit_multiline(&text);
+            }
+            StmtKind::Return(e) => {
+                let text = match e {
+                    Some(e) => format!("return {}", self.render_expr(e)),
+                    None => "return".to_string(),
+                };
+                self.emit_multiline(&text);
+            }
+            StmtKind::Break(e) => {
+                let text = match e {
+                    Some(e) => format!("break {}", self.render_expr(e)),
+                    None => "break".to_string(),
+                };
+                self.emit_multiline(&text);
+            }
+            StmtKind::Continue => self.line("continue"),
+            StmtKind::Defer(e) => {
+                let text = format!("defer {}", self.render_expr(e));
+                self.emit_multiline(&text);
+            }
+            StmtKind::Assign { target, op, value } => {
+                let text = format!(
+                    "{} {} {}",
+                    self.render_expr(target),
+                    assign_op(*op),
+                    self.render_expr(value)
+                );
+                self.emit_multiline(&text);
+            }
+            StmtKind::Expr(e) => {
+                let text = self.render_expr(e);
+                self.emit_multiline(&text);
+            }
+        }
+        if let Some(c) = self.take_trailing_comment(end_line) {
+            self.attach_trailing(&c);
+        }
+    }
+
+    /// Emit text that may already contain newlines (block-bearing
+    /// expressions render with embedded newlines and indentation baked in
+    /// by `render_expr`). The first line gets the current indent; following
+    /// lines are emitted verbatim because they were produced with absolute
+    /// indentation already applied.
+    fn emit_multiline(&mut self, text: &str) {
+        if !text.contains('\n') {
+            self.line(text);
+            return;
+        }
+        // Multi-line renders are produced with their own indentation relative
+        // to indent 0; shift every line by the current indent.
+        for (i, part) in text.split('\n').enumerate() {
+            if i > 0 {
+                self.out.push('\n');
+            }
+            if part.is_empty() {
+                continue;
+            }
+            for _ in 0..self.indent {
+                self.out.push_str(INDENT);
+            }
+            self.out.push_str(part);
+        }
+        self.out.push('\n');
+    }
+}
+
+// ----- expressions -----
+//
+// Expressions render to a `String`. Block-bearing expressions (if, match,
+// while, loop, for, block, lambda-with-block) render multi-line, indented
+// relative to column zero; `emit_multiline` shifts them by the enclosing
+// indent. Leaf and operator expressions render on one line.
+
+impl Printer<'_> {
+    fn render_expr(&mut self, e: &Expr) -> String {
+        self.expr_at(e, 0)
+    }
+
+    /// Render an expression whose block continuations should be indented at
+    /// `base` levels relative to column zero. Comments inside nested blocks
+    /// are woven in from the shared cursor as the block renders.
+    fn expr_at(&mut self, e: &Expr, base: usize) -> String {
+        match &e.kind {
+            ExprKind::Int(n) => n.to_string(),
+            ExprKind::Float(v) => render_float(*v),
+            ExprKind::Bool(b) => b.to_string(),
+            ExprKind::Str(s) => render_string_lit(s),
+            ExprKind::InterpolatedString(frags) => self.render_interpolated(frags),
+            ExprKind::BlockStr(s) => format!("\"\"\"{}\"\"\"", s),
+            ExprKind::Char(c) => format!("'{}'", render_char(*c)),
+            ExprKind::CStr(s) => format!("c{}", render_string_lit(s)),
+            ExprKind::SelfLower => "self".to_string(),
+            ExprKind::SelfUpper => "Self".to_string(),
+            ExprKind::Ident { name, generics } => {
+                let mut s = name.clone();
+                if !generics.is_empty() {
+                    s.push_str(&render_type_args(generics));
+                }
+                s
+            }
+            ExprKind::StructLit {
+                name,
+                generics,
+                fields,
+            } => {
+                let mut s = name.clone();
+                if !generics.is_empty() {
+                    s.push_str(&render_type_args(generics));
+                }
+                if fields.is_empty() {
+                    s.push_str(" {}");
+                    return s;
+                }
+                let multiline = self.spans_multiple_lines(e.span.start, e.span.end);
+                if multiline {
+                    s.push_str(" {\n");
+                    for f in fields {
+                        for _ in 0..base + 1 {
+                            s.push_str(INDENT);
+                        }
+                        let value = self.field_value(f);
+                        if is_field_shorthand(&f.name, &f.value) {
+                            let _ = writeln!(s, "{},", f.name);
+                        } else {
+                            let _ = writeln!(s, "{}: {},", f.name, value);
+                        }
+                    }
+                    for _ in 0..base {
+                        s.push_str(INDENT);
+                    }
+                    s.push('}');
+                } else {
+                    s.push_str(" { ");
+                    let mut parts: Vec<String> = Vec::with_capacity(fields.len());
+                    for f in fields {
+                        if is_field_shorthand(&f.name, &f.value) {
+                            parts.push(f.name.clone());
+                        } else {
+                            let v = self.field_value(f);
+                            parts.push(format!("{}: {}", f.name, v));
+                        }
+                    }
+                    s.push_str(&parts.join(", "));
+                    s.push_str(" }");
+                }
+                s
+            }
+            ExprKind::Array(items) => {
+                let parts = self.expr_list(items, base);
+                format!("[{}]", parts.join(", "))
+            }
+            ExprKind::Tuple(items) => {
+                let parts = self.expr_list(items, base);
+                format!("({})", parts.join(", "))
+            }
+            ExprKind::Paren(inner) => {
+                let inner = self.expr_at(inner, base);
+                format!("({})", inner)
+            }
+            ExprKind::Block(b) => self.render_block(b, base),
+            ExprKind::Unary { op, operand } => {
+                let operand = self.expr_at(operand, base);
+                format!("{}{}", unary_op(*op), operand)
+            }
+            ExprKind::Binary { op, lhs, rhs } => {
+                let l = self.expr_at(lhs, base);
+                let r = self.expr_at(rhs, base);
+                format!("{} {} {}", l, binary_op(*op), r)
+            }
+            ExprKind::Range {
+                start,
+                end,
+                inclusive,
+            } => {
+                let sep = if *inclusive { "..=" } else { ".." };
+                let s = self.expr_at(start, base);
+                let e = self.expr_at(end, base);
+                format!("{}{}{}", s, sep, e)
+            }
+            ExprKind::Call { callee, args } => {
+                let callee = self.expr_at(callee, base);
+                let parts = self.expr_list(args, base);
+                format!("{}({})", callee, parts.join(", "))
+            }
+            ExprKind::MethodCall {
+                receiver,
+                name,
+                generics,
+                args,
+            } => {
+                let mut s = self.expr_at(receiver, base);
+                s.push('.');
+                s.push_str(name);
+                if !generics.is_empty() {
+                    s.push_str(&render_type_args(generics));
+                }
+                let parts = self.expr_list(args, base);
+                let _ = write!(s, "({})", parts.join(", "));
+                s
+            }
+            ExprKind::Field { receiver, name } => {
+                let r = self.expr_at(receiver, base);
+                format!("{}.{}", r, name)
+            }
+            ExprKind::Index { receiver, index } => {
+                let r = self.expr_at(receiver, base);
+                let i = self.expr_at(index, base);
+                format!("{}[{}]", r, i)
+            }
+            ExprKind::Try(inner) => {
+                let inner = self.expr_at(inner, base);
+                format!("{}?", inner)
+            }
+            ExprKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => self.render_if(cond, then_branch, else_branch, base),
+            ExprKind::Match { scrutinee, arms } => self.render_match(scrutinee, arms, base),
+            ExprKind::Loop(b) => {
+                let body = self.render_block(b, base);
+                format!("loop {}", body)
+            }
+            ExprKind::While { cond, body } => {
+                let cond = self.expr_at(cond, base);
+                let body = self.render_block(body, base);
+                format!("while {} {}", cond, body)
+            }
+            ExprKind::For {
+                pattern,
+                iter,
+                body,
+            } => {
+                let pat = render_pattern(pattern);
+                let iter = self.expr_at(iter, base);
+                let body = self.render_block(body, base);
+                format!("for {} in {} {}", pat, iter, body)
+            }
+            ExprKind::Lambda {
+                params,
+                ret,
+                body,
+                params_inferred,
+            } => self.render_lambda(params, ret, body, *params_inferred, base),
+        }
+    }
+
+    fn expr_list(&mut self, items: &[Expr], base: usize) -> Vec<String> {
+        let mut parts = Vec::with_capacity(items.len());
+        for it in items {
+            parts.push(self.expr_at(it, base));
+        }
+        parts
+    }
+
+    fn field_value(&mut self, f: &crate::ast::FieldInit) -> String {
+        self.render_expr(&f.value)
+    }
+
+    fn spans_multiple_lines(&self, start: usize, end: usize) -> bool {
+        self.line_of(start) != self.line_of(end)
+    }
+
+    fn render_interpolated(&mut self, frags: &[StrFragment]) -> String {
+        let mut s = String::from("\"");
+        for frag in frags {
+            match frag {
+                StrFragment::Literal(text) => s.push_str(&escape_str_body(text)),
+                StrFragment::Expr(e) => {
+                    let inner = self.render_expr(e);
+                    s.push_str("${");
+                    s.push_str(&inner);
+                    s.push('}');
+                }
+            }
+        }
+        s.push('"');
+        s
+    }
+
+    /// Render the statements of a block into a captured string at `indent`,
+    /// drawing comments from the shared cursor by source position.
+    fn capture_stmts(&mut self, b: &Block, indent: usize) -> String {
+        let saved_out = std::mem::take(&mut self.out);
+        let saved_indent = self.indent;
+        self.indent = indent;
+        self.stmts(b);
+        self.indent = saved_indent;
+        let inner = std::mem::replace(&mut self.out, saved_out);
+        inner.trim_end_matches('\n').to_string()
+    }
+
+    fn render_block(&mut self, b: &Block, base: usize) -> String {
+        if b.stmts.is_empty() && b.trailing.is_none() {
+            return "{}".to_string();
+        }
+        let inner = self.capture_stmts(b, base + 1);
+        let mut s = String::from("{\n");
+        s.push_str(&inner);
+        s.push('\n');
+        for _ in 0..base {
+            s.push_str(INDENT);
+        }
+        s.push('}');
+        s
+    }
+
+    fn render_if(
+        &mut self,
+        cond: &Expr,
+        then_branch: &Block,
+        else_branch: &Option<Box<ElseBranch>>,
+        base: usize,
+    ) -> String {
+        let cond = self.expr_at(cond, base);
+        let then_block = self.render_block(then_branch, base);
+        let mut s = format!("if {} {}", cond, then_block);
+        if let Some(eb) = else_branch {
+            match eb.as_ref() {
+                ElseBranch::If(e) => {
+                    let e = self.expr_at(e, base);
+                    s.push_str(" else ");
+                    s.push_str(&e);
+                }
+                ElseBranch::Block(b) => {
+                    let b = self.render_block(b, base);
+                    s.push_str(" else ");
+                    s.push_str(&b);
+                }
+            }
+        }
+        s
+    }
+
+    fn render_match(&mut self, scrutinee: &Expr, arms: &[MatchArm], base: usize) -> String {
+        let scrut = self.expr_at(scrutinee, base);
+        let mut s = format!("match {} {{\n", scrut);
+        for arm in arms {
+            let pat = render_pattern(&arm.pattern);
+            let guard = arm.guard.as_ref().map(|g| self.expr_at(g, base + 1));
+            let body = self.expr_at(&arm.body, base + 1);
+            for _ in 0..base + 1 {
+                s.push_str(INDENT);
+            }
+            s.push_str(&pat);
+            if let Some(g) = guard {
+                s.push_str(" if ");
+                s.push_str(&g);
+            }
+            s.push_str(" -> ");
+            s.push_str(&body);
+            s.push_str(",\n");
+        }
+        for _ in 0..base {
+            s.push_str(INDENT);
+        }
+        s.push('}');
+        s
+    }
+
+    fn render_lambda(
+        &mut self,
+        params: &[LambdaParam],
+        ret: &Option<Type>,
+        body: &LambdaBody,
+        params_inferred: bool,
+        base: usize,
+    ) -> String {
+        if params_inferred {
+            // Shorthand `{ x, y -> body }`. The parser always stores the body
+            // as a block. When that block is a single trailing expression
+            // with no statements, render it inline; otherwise render the
+            // statements between the arrow and the closing brace.
+            let names: Vec<String> = params.iter().map(|p| p.name.clone()).collect();
+            let head = if names.is_empty() {
+                "{ ->".to_string()
+            } else {
+                format!("{{ {} ->", names.join(", "))
+            };
+            let LambdaBody::Block(b) = body else {
+                // Defensive: shorthand always carries a block.
+                let body_str = match body {
+                    LambdaBody::Expr(e) => self.expr_at(e, base),
+                    LambdaBody::Block(b) => self.render_block(b, base),
+                };
+                return format!("{} {} }}", head, body_str);
+            };
+            if b.stmts.is_empty() {
+                match &b.trailing {
+                    Some(t) => {
+                        let t = self.expr_at(t, base);
+                        format!("{} {} }}", head, t)
+                    }
+                    None => format!("{} }}", head),
+                }
+            } else {
+                let inner = self.capture_stmts(b, base + 1);
+                let mut s = format!("{}\n", head);
+                s.push_str(&inner);
+                s.push('\n');
+                for _ in 0..base {
+                    s.push_str(INDENT);
+                }
+                s.push('}');
+                s
+            }
+        } else {
+            let mut s = String::from("fun(");
+            let parts: Vec<String> = params
+                .iter()
+                .map(|p| match &p.ty {
+                    Some(t) => format!("{}: {}", p.name, render_type(t)),
+                    None => p.name.clone(),
+                })
+                .collect();
+            s.push_str(&parts.join(", "));
+            s.push(')');
+            if let Some(r) = ret {
+                s.push_str(" -> ");
+                s.push_str(&render_type(r));
+            }
+            match body {
+                LambdaBody::Expr(e) => {
+                    let e = self.expr_at(e, base);
+                    s.push_str(" = ");
+                    s.push_str(&e);
+                }
+                LambdaBody::Block(b) => {
+                    let b = self.render_block(b, base);
+                    s.push(' ');
+                    s.push_str(&b);
+                }
+            }
+            s
+        }
+    }
+}
+
+fn is_field_shorthand(name: &str, value: &Expr) -> bool {
+    matches!(&value.kind, ExprKind::Ident { name: n, generics } if n == name && generics.is_empty())
+}
+
+// ----- shared free-function renderers (no comment state) -----
+
+fn render_generics(gens: &[GenericParam]) -> String {
+    if gens.is_empty() {
+        return String::new();
+    }
+    let parts: Vec<String> = gens
+        .iter()
+        .map(|g| {
+            if g.bounds.is_empty() {
+                g.name.clone()
+            } else {
+                let bounds: Vec<String> = g.bounds.iter().map(render_type_path).collect();
+                format!("{}: {}", g.name, bounds.join(" + "))
+            }
+        })
+        .collect();
+    format!("<{}>", parts.join(", "))
+}
+
+fn render_params(params: &[Param]) -> String {
+    params
+        .iter()
+        .map(render_param)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn render_param(p: &Param) -> String {
+    // `self` parameter: rendered bare when its type is the implicit Self.
+    if p.name == "self" {
+        if let TypeKind::Path(path) = &p.ty.kind {
+            if path.segments.len() == 1 && path.segments[0].name == "Self" {
+                return "self".to_string();
+            }
+        }
+    }
+    format!("{}: {}", p.name, render_type(&p.ty))
+}
+
+fn render_type(ty: &Type) -> String {
+    match &ty.kind {
+        TypeKind::Path(p) => render_type_path(p),
+        TypeKind::Optional(inner) => format!("{}?", render_type(inner)),
+        TypeKind::Dyn(p) => format!("dyn {}", render_type_path(p)),
+        TypeKind::Unit => "()".to_string(),
+        TypeKind::Function { params, ret } => {
+            let parts: Vec<String> = params.iter().map(render_type).collect();
+            format!("fun({}) -> {}", parts.join(", "), render_type(ret))
+        }
+    }
+}
+
+fn render_type_path(p: &TypePath) -> String {
+    let mut out = String::new();
+    for (i, seg) in p.segments.iter().enumerate() {
+        if i > 0 {
+            out.push('.');
+        }
+        out.push_str(&seg.name);
+        if !seg.generics.is_empty() {
+            out.push_str(&render_type_args(&seg.generics));
+        }
+    }
+    out
+}
+
+fn render_type_args(args: &[Type]) -> String {
+    let parts: Vec<String> = args.iter().map(render_type).collect();
+    format!("<{}>", parts.join(", "))
+}
+
+fn render_pattern(pat: &Pattern) -> String {
+    match &pat.kind {
+        PatternKind::Wildcard => "_".to_string(),
+        PatternKind::Literal(LiteralPattern::Int(n)) => n.to_string(),
+        PatternKind::Literal(LiteralPattern::Float(v)) => render_float(*v),
+        PatternKind::Literal(LiteralPattern::Bool(b)) => b.to_string(),
+        PatternKind::Literal(LiteralPattern::String(s)) => render_string_lit(s),
+        PatternKind::Literal(LiteralPattern::Char(c)) => format!("'{}'", render_char(*c)),
+        PatternKind::Ident(name) => name.clone(),
+        PatternKind::Tuple { name, elements } => {
+            let parts: Vec<String> = elements.iter().map(render_pattern).collect();
+            match name {
+                Some(n) => format!("{}({})", n, parts.join(", ")),
+                None => format!("({})", parts.join(", ")),
+            }
+        }
+        PatternKind::Struct { name, fields } => {
+            let parts: Vec<String> = fields
+                .iter()
+                .map(|f| match &f.pattern {
+                    Some(p) => format!("{}: {}", f.name, render_pattern(p)),
+                    None => f.name.clone(),
+                })
+                .collect();
+            if parts.is_empty() {
+                format!("{} {{}}", name)
+            } else {
+                format!("{} {{ {} }}", name, parts.join(", "))
+            }
+        }
+        PatternKind::Range { lo, hi, inclusive } => {
+            let sep = if *inclusive { "..=" } else { ".." };
+            format!("{}{}{}", lo, sep, hi)
+        }
+    }
+}
+
+fn render_float(v: f64) -> String {
+    if v.is_infinite() || v.is_nan() {
+        // Not representable as a literal; emit a best-effort token. The
+        // parser never produces these from literals, so this is unreachable
+        // in practice.
+        return format!("{}", v);
+    }
+    let s = format!("{}", v);
+    if s.contains('.') || s.contains('e') || s.contains('E') {
+        s
+    } else {
+        format!("{}.0", s)
+    }
+}
+
+fn render_char(c: char) -> String {
+    match c {
+        '\n' => "\\n".to_string(),
+        '\t' => "\\t".to_string(),
+        '\r' => "\\r".to_string(),
+        '\\' => "\\\\".to_string(),
+        '\'' => "\\'".to_string(),
+        '\0' => "\\0".to_string(),
+        c if (c as u32) < 0x20 => format!("\\u{{{:x}}}", c as u32),
+        c => c.to_string(),
+    }
+}
+
+/// Render a plain string literal value back to a quoted, escaped literal.
+fn render_string_lit(s: &str) -> String {
+    format!("\"{}\"", escape_str_body(s))
+}
+
+/// Escape a string body for emission inside double quotes. A bare `$`
+/// directly before `{` is escaped to `\$` so the result does not re-parse
+/// as an interpolation.
+fn escape_str_body(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &ch) in chars.iter().enumerate() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            '\0' => out.push_str("\\0"),
+            '$' if chars.get(i + 1) == Some(&'{') => out.push_str("\\$"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{{{:x}}}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn unary_op(op: UnaryOp) -> &'static str {
+    match op {
+        UnaryOp::Neg => "-",
+        UnaryOp::Not => "!",
+        UnaryOp::Ref => "&",
+    }
+}
+
+fn binary_op(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Add => "+",
+        BinaryOp::Sub => "-",
+        BinaryOp::Mul => "*",
+        BinaryOp::Div => "/",
+        BinaryOp::Mod => "%",
+        BinaryOp::Eq => "==",
+        BinaryOp::Ne => "!=",
+        BinaryOp::Lt => "<",
+        BinaryOp::Le => "<=",
+        BinaryOp::Gt => ">",
+        BinaryOp::Ge => ">=",
+        BinaryOp::And => "&&",
+        BinaryOp::Or => "||",
+        BinaryOp::BitAnd => "&",
+        BinaryOp::BitOr => "|",
+        BinaryOp::BitXor => "^",
+        BinaryOp::Shl => "<<",
+        BinaryOp::Shr => ">>",
+    }
+}
+
+fn assign_op(op: AssignOp) -> &'static str {
+    match op {
+        AssignOp::Assign => "=",
+        AssignOp::Add => "+=",
+        AssignOp::Sub => "-=",
+        AssignOp::Mul => "*=",
+        AssignOp::Div => "/=",
+        AssignOp::Mod => "%=",
+        AssignOp::BitAnd => "&=",
+        AssignOp::BitOr => "|=",
+        AssignOp::BitXor => "^=",
+        AssignOp::Shl => "<<=",
+        AssignOp::Shr => ">>=",
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -1,0 +1,212 @@
+use super::format_source;
+use crate::ast::pretty_file;
+use crate::lexer::Lexer;
+use crate::parser::parse;
+
+fn ast_string(src: &str) -> String {
+    let tokens = Lexer::new(src, "<t>").tokenize().expect("lex");
+    let file = parse(&tokens).expect("parse");
+    pretty_file(&file)
+}
+
+/// Format, then assert idempotency and semantic preservation.
+fn fmt(src: &str) -> String {
+    let once = format_source(src).expect("format once");
+    let twice = format_source(&once).expect("format twice");
+    assert_eq!(once, twice, "formatter is not idempotent");
+    assert_eq!(
+        ast_string(src),
+        ast_string(&once),
+        "formatting changed the AST"
+    );
+    once
+}
+
+#[test]
+fn function_block_body() {
+    let out = fmt("fun   main ( )  {\nlet x=1\nreturn x\n}");
+    assert_eq!(out, "fun main() {\n    let x = 1\n    return x\n}\n");
+}
+
+#[test]
+fn function_expr_body() {
+    let out = fmt("fun double(x:Int)->Int=x*2");
+    assert_eq!(out, "fun double(x: Int) -> Int = x * 2\n");
+}
+
+#[test]
+fn generics_and_bounds() {
+    let out = fmt("fun id<T:Ord+Clone>(x:T)->T{return x}");
+    assert_eq!(
+        out,
+        "fun id<T: Ord + Clone>(x: T) -> T {\n    return x\n}\n"
+    );
+}
+
+#[test]
+fn struct_decl() {
+    let out = fmt("struct Point{x:Int,y:Int}");
+    assert_eq!(out, "struct Point {\n    x: Int,\n    y: Int,\n}\n");
+}
+
+#[test]
+fn enum_with_payloads() {
+    let out = fmt("enum E{A,B(Int,String),C(x:Int)}");
+    assert_eq!(
+        out,
+        "enum E {\n    A,\n    B(Int, String),\n    C(x: Int),\n}\n"
+    );
+}
+
+#[test]
+fn trait_and_impl() {
+    let out = fmt("trait T{fun f(self)->Int}\nimpl T for Int{fun f(self)->Int{return 0}}");
+    assert!(out.contains("trait T {"));
+    assert!(out.contains("impl T for Int {"));
+    assert!(out.contains("fun f(self) -> Int {"));
+}
+
+#[test]
+fn match_with_guard() {
+    let src = "fun f(x:Int)->Int{return match x{0->1,n if n>0->2,_->3}}";
+    let out = fmt(src);
+    assert!(out.contains("match x {"));
+    assert!(out.contains("        0 -> 1,"));
+    assert!(out.contains("        n if n > 0 -> 2,"));
+    assert!(out.contains("        _ -> 3,"));
+}
+
+#[test]
+fn if_expression() {
+    let out = fmt("fun f()->Int{let y=if true{1}else{2}\nreturn y}");
+    assert!(out.contains("let y = if true {"));
+    assert!(out.contains("} else {"));
+}
+
+#[test]
+fn for_loop_and_range() {
+    let out = fmt("fun f(){for i in 0..10{print(i)}}");
+    assert!(out.contains("for i in 0..10 {"));
+}
+
+#[test]
+fn while_loop() {
+    let out = fmt("fun f(){while x<10{x=x+1}}");
+    assert!(out.contains("while x < 10 {"));
+}
+
+#[test]
+fn defer_stmt() {
+    let out = fmt("fun f(){defer cleanup()}");
+    assert!(out.contains("    defer cleanup()"));
+}
+
+#[test]
+fn extern_block() {
+    let out = fmt("extern \"C\"{fun foo(x:Int)->Int\nfun bar()}");
+    assert!(out.contains("extern \"C\" {"));
+    assert!(out.contains("    fun foo(x: Int) -> Int"));
+    assert!(out.contains("    fun bar()"));
+}
+
+#[test]
+fn imports() {
+    let out = fmt("import std/io\nimport std/collections{Map,Set}\nimport \"./local\" as loc");
+    assert!(out.contains("import std/io\n"));
+    assert!(out.contains("import std/collections { Map, Set }"));
+    assert!(out.contains("import \"./local\" as loc"));
+}
+
+#[test]
+fn interpolation() {
+    let out = fmt("fun f(n:Int)->String{return \"value=${n}\"}");
+    assert!(out.contains("\"value=${n}\""));
+}
+
+#[test]
+fn method_chain() {
+    let out = fmt("fun f(xs:List<Int>)->Int{return xs.map(g).filter(h).len()}");
+    assert!(out.contains("xs.map(g).filter(h).len()"));
+}
+
+#[test]
+fn compound_assignment() {
+    let out = fmt("fun f(){x+=1\ny*=2}");
+    assert!(out.contains("    x += 1"));
+    assert!(out.contains("    y *= 2"));
+}
+
+#[test]
+fn lambda_forms() {
+    let out = fmt("fun f(){let g={x->x+1}\nlet h=fun(a:Int)->Int=a}");
+    assert!(out.contains("{ x -> x + 1 }"));
+    assert!(out.contains("fun(a: Int) -> Int = a"));
+}
+
+#[test]
+fn collapse_blank_lines() {
+    let out = fmt("fun a(){}\n\n\n\nfun b(){}");
+    assert_eq!(out, "fun a() {}\n\nfun b() {}\n");
+}
+
+#[test]
+fn float_literal_keeps_point() {
+    let out = fmt("const PI: Float = 3.0");
+    assert_eq!(out, "const PI: Float = 3.0\n");
+}
+
+#[test]
+fn leading_comment_preserved() {
+    let out = fmt("// a header\nfun main(){}");
+    assert_eq!(out, "// a header\nfun main() {}\n");
+}
+
+#[test]
+fn trailing_comment_preserved() {
+    let out = fmt("fun main(){let x=1 // count\n}");
+    assert!(out.contains("let x = 1 // count"));
+}
+
+#[test]
+fn comment_between_items() {
+    let src = "fun a() {}\n\n// describe b\nfun b() {}\n";
+    let out = fmt(src);
+    assert!(out.contains("// describe b\nfun b() {}"));
+}
+
+#[test]
+fn nested_block_indentation() {
+    let src = "fun f(){if true{if false{return 1}}}";
+    let out = fmt(src);
+    assert!(out.contains("    if true {"));
+    assert!(out.contains("        if false {"));
+    assert!(out.contains("            return 1"));
+}
+
+#[test]
+fn multiline_struct_literal_preserved() {
+    let src = "fun f()->P{return P{\nx: 1,\ny: 2,\n}}";
+    let out = fmt(src);
+    assert!(out.contains("P {\n        x: 1,\n        y: 2,\n    }"));
+}
+
+#[test]
+fn inline_struct_literal_stays_inline() {
+    let src = "fun f()->P{return P{x: 1, y: 2}}";
+    let out = fmt(src);
+    assert!(out.contains("P { x: 1, y: 2 }"));
+}
+
+#[test]
+fn empty_input() {
+    assert_eq!(format_source("").unwrap(), "");
+    assert_eq!(format_source("\n\n").unwrap(), "");
+}
+
+#[test]
+fn dollar_brace_in_plain_string_escaped() {
+    // A literal `${` (written escaped in source) must stay escaped so it
+    // does not re-parse as interpolation.
+    let out = fmt("fun f()->String{return \"\\${x}\"}");
+    assert!(out.contains("\\${x}"));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod ast;
 pub mod codegen;
 pub mod driver;
 pub mod error;
+pub mod format;
 pub mod hir;
 pub mod lexer;
 pub mod lock;

--- a/tests/fmt_corpus/comments.rv
+++ b/tests/fmt_corpus/comments.rv
@@ -1,0 +1,15 @@
+// a leading file comment
+
+// describes the constant
+const N: Int = 3
+
+fun first() {
+    let x = 1 // trailing on a statement
+    // standalone before return
+    return
+}
+
+
+
+// extra blank lines above this comment should collapse
+fun second() {}

--- a/tests/fmt_corpus/comments.rv.fmt
+++ b/tests/fmt_corpus/comments.rv.fmt
@@ -1,0 +1,13 @@
+// a leading file comment
+
+// describes the constant
+const N: Int = 3
+
+fun first() {
+    let x = 1 // trailing on a statement
+    // standalone before return
+    return
+}
+
+// extra blank lines above this comment should collapse
+fun second() {}

--- a/tests/fmt_corpus/control_flow.rv
+++ b/tests/fmt_corpus/control_flow.rv
@@ -1,0 +1,39 @@
+// if-expression, match with guards, while, loop, for, defer, break/continue
+
+fun classify(x: Int) -> String {
+    let label = if x < 0 {
+        "neg"
+    } else if x == 0 {
+        "zero"
+    } else {
+        "pos"
+    }
+    return label
+}
+
+fun sign(x: Int) -> Int {
+    return match x {
+        0 -> 0,
+        n if n > 0 -> 1,
+        _ -> -1,
+    }
+}
+
+fun count() -> Int {
+    let total = 0
+    for i in 0..10 {
+        if i == 5 {
+            continue
+        }
+        total += i
+    }
+    let n = 0
+    while n < 3 {
+        n += 1
+    }
+    loop {
+        break
+    }
+    defer cleanup()
+    return total
+}

--- a/tests/fmt_corpus/control_flow.rv.fmt
+++ b/tests/fmt_corpus/control_flow.rv.fmt
@@ -1,0 +1,39 @@
+// if-expression, match with guards, while, loop, for, defer, break/continue
+
+fun classify(x: Int) -> String {
+    let label = if x < 0 {
+        "neg"
+    } else if x == 0 {
+        "zero"
+    } else {
+        "pos"
+    }
+    return label
+}
+
+fun sign(x: Int) -> Int {
+    return match x {
+        0 -> 0,
+        n if n > 0 -> 1,
+        _ -> -1,
+    }
+}
+
+fun count() -> Int {
+    let total = 0
+    for i in 0..10 {
+        if i == 5 {
+            continue
+        }
+        total += i
+    }
+    let n = 0
+    while n < 3 {
+        n += 1
+    }
+    loop {
+        break
+    }
+    defer cleanup()
+    return total
+}

--- a/tests/fmt_corpus/exprs.rv
+++ b/tests/fmt_corpus/exprs.rv
@@ -1,0 +1,28 @@
+// imports, interpolation, ranges, lambdas, method chains, struct literals,
+// arrays, compound assignment, try operator
+
+import std/io
+import std/collections { Map, Set }
+import "./local" as loc
+
+const LIMIT: Int = 100
+
+fun build() -> Point {
+    let p = Point {
+        x: 1,
+        y: 2,
+    }
+    let q = Point { x: 3, y: 4 }
+    let xs = [1, 2, 3]
+    let g = { x -> x + 1 }
+    let h = fun(a: Int) -> Int = a * a
+    let total = xs.map(g).filter(h).len()
+    let msg = "point at ${p.x}, ${p.y}"
+    let r = 0..=total
+    return p
+}
+
+extern "C" {
+    fun raven_now() -> Int
+    fun raven_sleep(ms: Int)
+}

--- a/tests/fmt_corpus/exprs.rv.fmt
+++ b/tests/fmt_corpus/exprs.rv.fmt
@@ -1,0 +1,28 @@
+// imports, interpolation, ranges, lambdas, method chains, struct literals,
+// arrays, compound assignment, try operator
+
+import std/io
+import std/collections { Map, Set }
+import "./local" as loc
+
+const LIMIT: Int = 100
+
+fun build() -> Point {
+    let p = Point {
+        x: 1,
+        y: 2,
+    }
+    let q = Point { x: 3, y: 4 }
+    let xs = [1, 2, 3]
+    let g = { x -> x + 1 }
+    let h = fun(a: Int) -> Int = a * a
+    let total = xs.map(g).filter(h).len()
+    let msg = "point at ${p.x}, ${p.y}"
+    let r = 0..=total
+    return p
+}
+
+extern "C" {
+    fun raven_now() -> Int
+    fun raven_sleep(ms: Int)
+}

--- a/tests/fmt_corpus/functions.rv
+++ b/tests/fmt_corpus/functions.rv
@@ -1,0 +1,14 @@
+// free functions: block body, expression body, generics with bounds
+
+
+fun   add ( a : Int , b : Int ) -> Int {
+return a+b
+}
+
+fun double(x:Int)->Int=x*2
+
+fun id<T : Ord + Clone>(x:T)->T{
+    return x
+}
+
+fun no_args(){}

--- a/tests/fmt_corpus/functions.rv.fmt
+++ b/tests/fmt_corpus/functions.rv.fmt
@@ -1,0 +1,13 @@
+// free functions: block body, expression body, generics with bounds
+
+fun add(a: Int, b: Int) -> Int {
+    return a + b
+}
+
+fun double(x: Int) -> Int = x * 2
+
+fun id<T: Ord + Clone>(x: T) -> T {
+    return x
+}
+
+fun no_args() {}

--- a/tests/fmt_corpus/types.rv
+++ b/tests/fmt_corpus/types.rv
@@ -1,0 +1,28 @@
+// structs, enums with all payload kinds, traits, and impls
+
+struct Point{x:Int,y:Int}
+
+struct Empty {}
+
+enum Shape{
+    Circle(Float),
+    Rect(w:Float,h:Float),
+    Nothing,
+}
+
+trait Area{
+    fun area(self)->Float
+    fun name(self)->String = "shape"
+}
+
+impl Area for Point{
+    fun area(self)->Float{
+        return 0.0
+    }
+}
+
+impl<T> Wrapper<T> {
+    fun get(self) -> T {
+        return self.value
+    }
+}

--- a/tests/fmt_corpus/types.rv.fmt
+++ b/tests/fmt_corpus/types.rv.fmt
@@ -1,0 +1,32 @@
+// structs, enums with all payload kinds, traits, and impls
+
+struct Point {
+    x: Int,
+    y: Int,
+}
+
+struct Empty {}
+
+enum Shape {
+    Circle(Float),
+    Rect(w: Float, h: Float),
+    Nothing,
+}
+
+trait Area {
+    fun area(self) -> Float
+
+    fun name(self) -> String = "shape"
+}
+
+impl Area for Point {
+    fun area(self) -> Float {
+        return 0.0
+    }
+}
+
+impl<T> Wrapper<T> {
+    fun get(self) -> T {
+        return self.value
+    }
+}

--- a/tests/fmt_golden.rs
+++ b/tests/fmt_golden.rs
@@ -1,0 +1,169 @@
+//! Golden, idempotency, and semantic-preservation tests for the formatter.
+//!
+//! For every `tests/fmt_corpus/*.rv` source file this test formats the
+//! source and compares against a committed `.rv.fmt` baseline. It also
+//! verifies, for every corpus file and a sample of bundled stdlib files,
+//! that formatting is idempotent (`format(format(x)) == format(x)`) and
+//! semantics-preserving (`parse(format(x))` yields the same AST as
+//! `parse(x)`, ignoring spans).
+//!
+//! Refresh baselines with `RAVEN_UPDATE_FMT=1 cargo test --test
+//! fmt_golden`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use raven::ast::pretty_file;
+use raven::format::format_source;
+use raven::lexer::Lexer;
+use raven::parser::parse;
+
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fmt_corpus")
+}
+
+fn ast_dump(src: &str) -> String {
+    let tokens = Lexer::new(src, "<t>").tokenize().expect("lex");
+    let file = parse(&tokens).expect("parse");
+    pretty_file(&file)
+}
+
+#[test]
+fn fmt_golden() {
+    let dir = corpus_dir();
+    let update = std::env::var("RAVEN_UPDATE_FMT").is_ok();
+
+    let mut entries: Vec<PathBuf> = fs::read_dir(&dir)
+        .expect("corpus directory must exist")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("rv"))
+        .collect();
+    entries.sort();
+
+    assert!(!entries.is_empty(), "fmt corpus is empty");
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for src_path in entries {
+        let src = fs::read_to_string(&src_path).expect("read source");
+        let formatted = match format_source(&src) {
+            Ok(f) => f,
+            Err(e) => {
+                failures.push(format!("{}: format error: {}", src_path.display(), e));
+                continue;
+            }
+        };
+
+        // Idempotency.
+        let twice = format_source(&formatted).expect("format twice");
+        if twice != formatted {
+            failures.push(format!("{}: not idempotent", src_path.display()));
+        }
+
+        // Semantic preservation.
+        if ast_dump(&src) != ast_dump(&formatted) {
+            failures.push(format!(
+                "{}: formatting changed the AST",
+                src_path.display()
+            ));
+        }
+
+        let golden_path = src_path.with_extension("rv.fmt");
+        if update {
+            fs::write(&golden_path, &formatted).expect("write golden");
+            continue;
+        }
+        let expected = match fs::read_to_string(&golden_path) {
+            Ok(s) => s,
+            Err(_) => {
+                failures.push(format!(
+                    "{}: missing baseline (run RAVEN_UPDATE_FMT=1)",
+                    golden_path.display()
+                ));
+                continue;
+            }
+        };
+        if expected != formatted {
+            failures.push(format!(
+                "{}: output differs from baseline\n{}",
+                src_path.display(),
+                diff(&expected, &formatted)
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "fmt golden failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// The bundled stdlib must format idempotently and without changing its
+/// AST. Whether it is already byte-for-byte canonical is reported but not
+/// enforced here (reformatting the stdlib is a separate change).
+#[test]
+fn stdlib_idempotent_and_semantics_preserving() {
+    let stdlib = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("stdlib")
+        .join("std");
+    let mut entries: Vec<PathBuf> = fs::read_dir(&stdlib)
+        .expect("stdlib dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("rv"))
+        .collect();
+    entries.sort();
+    assert!(!entries.is_empty());
+
+    let mut failures = Vec::new();
+    let mut already_canonical = 0usize;
+    for path in &entries {
+        let src = fs::read_to_string(path).expect("read");
+        let formatted = match format_source(&src) {
+            Ok(f) => f,
+            Err(e) => {
+                failures.push(format!("{}: {}", path.display(), e));
+                continue;
+            }
+        };
+        let twice = format_source(&formatted).expect("twice");
+        if twice != formatted {
+            failures.push(format!("{}: not idempotent", path.display()));
+        }
+        if ast_dump(&src) != ast_dump(&formatted) {
+            failures.push(format!("{}: AST changed", path.display()));
+        }
+        if src == formatted {
+            already_canonical += 1;
+        }
+    }
+    eprintln!(
+        "stdlib: {}/{} files already canonical under formatter rules",
+        already_canonical,
+        entries.len()
+    );
+    assert!(
+        failures.is_empty(),
+        "stdlib failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+fn diff(expected: &str, actual: &str) -> String {
+    let mut out = String::new();
+    let e: Vec<&str> = expected.lines().collect();
+    let a: Vec<&str> = actual.lines().collect();
+    let n = e.len().max(a.len());
+    for i in 0..n {
+        let el = e.get(i).copied().unwrap_or("");
+        let al = a.get(i).copied().unwrap_or("");
+        if el != al {
+            out.push_str(&format!("-{}\n+{}\n", el, al));
+        }
+    }
+    out
+}

--- a/tests/rvpm_fmt.rs
+++ b/tests/rvpm_fmt.rs
@@ -1,0 +1,89 @@
+//! End to end tests for `rvpm fmt` and `rvpm fmt --check`, driving the
+//! actual binary on temp files.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn rvpm(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rvpm"))
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run rvpm")
+}
+
+fn workdir() -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let unique = format!(
+        "rvpm_fmt_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    p.push(unique);
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+const MESSY: &str = "fun  main ( ) {\nlet   x=1\nreturn x\n}";
+const CANONICAL: &str = "fun main() {\n    let x = 1\n    return x\n}\n";
+
+#[test]
+fn check_flags_unformatted_file_and_format_fixes_it() {
+    let dir = workdir();
+    let file = dir.join("messy.rv");
+    std::fs::write(&file, MESSY).unwrap();
+
+    // --check reports a change and exits non-zero, naming the file.
+    let out = rvpm(&dir, &["fmt", "--check", "messy.rv"]);
+    assert!(!out.status.success(), "check should fail on messy file");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("messy.rv"), "stderr should name the file");
+
+    // fmt rewrites the file canonically.
+    let out = rvpm(&dir, &["fmt", "messy.rv"]);
+    assert!(out.status.success(), "fmt should succeed");
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert_eq!(after, CANONICAL);
+
+    // --check now passes.
+    let out = rvpm(&dir, &["fmt", "--check", "messy.rv"]);
+    assert!(out.status.success(), "check should pass after formatting");
+}
+
+#[test]
+fn check_passes_on_canonical_file() {
+    let dir = workdir();
+    let file = dir.join("clean.rv");
+    std::fs::write(&file, CANONICAL).unwrap();
+    let out = rvpm(&dir, &["fmt", "--check", "clean.rv"]);
+    assert!(out.status.success(), "canonical file should pass --check");
+}
+
+#[test]
+fn fmt_with_no_paths_formats_src_dir() {
+    let dir = workdir();
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    let file = src.join("main.rv");
+    std::fs::write(&file, MESSY).unwrap();
+
+    let out = rvpm(&dir, &["fmt"]);
+    assert!(out.status.success());
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert_eq!(after, CANONICAL);
+}
+
+#[test]
+fn parse_error_reports_and_exits_nonzero() {
+    let dir = workdir();
+    let file = dir.join("bad.rv");
+    std::fs::write(&file, "fun (").unwrap();
+    let out = rvpm(&dir, &["fmt", "bad.rv"]);
+    assert!(
+        !out.status.success(),
+        "fmt should fail on unparseable input"
+    );
+}


### PR DESCRIPTION
Add a single canonical source formatter (gofmt-style, no style flags) for the v2 grammar, exposed as `rvpm fmt`.

Closes #86

## Style rules
- Indentation: 4 spaces, no tabs.
- Braces: K&R, opening brace on the same line; empty bodies render inline as `{}`.
- One statement per line, no terminators.
- Blank lines: runs collapse to one; author gaps between items/statements are preserved (collapsed to one); leading/trailing blanks inside a block are removed; trait and impl members get one blank between them; file ends with a single newline.
- Spacing: one space around binary operators and `=`, after commas and after `:` in annotations; none before `(` of a call or `[` of an index; no space for unary operators or ranges.
- Trailing whitespace removed.
- Constructs: struct fields and enum variants one per line with a trailing comma; enum struct payloads use the parenthesized field form; imports as `import std/io` / `import path { a, b }` / `import "url" as alias`; match arms one per line ending in a comma; struct-literal field shorthand `{ name }`; multi-line struct literals preserved when the source spanned multiple lines, inline otherwise; lambdas inline when single-expression; float literals always keep a decimal point. No line-length wrapping (keeps the formatter simple and idempotent).

Full details in `docs/v2/specs/formatter.md`.

## Guarantees
- Idempotency: `format(format(x)) == format(x)`, enforced over the golden corpus and every bundled stdlib file.
- Semantic preservation: `parse(format(x))` succeeds and yields an AST equal to `parse(x)` (ignoring spans), enforced the same way. The only failure mode is input that does not parse.

## Comment handling
Full fidelity for line and block comments at statement/item boundaries and trailing comments, recovered by source position (the lexer drops them) and woven back into nested blocks via a shared position-ordered stream. Documented limitation: a comment in the interior of an expression that renders on one line is reattached to the nearest preceding boundary rather than kept mid-expression. No comment is ever dropped.

## Tests
- `src/format/tests.rs`: per-construct unit tests, each asserting idempotency and AST equality.
- `tests/fmt_golden.rs`: golden corpus under `tests/fmt_corpus/` (`.rv` input, `.rv.fmt` expected) covering every construct, plus an idempotency and semantic-preservation sweep over the corpus and all `stdlib/std/*.rv`. Refresh with `RAVEN_UPDATE_FMT=1`.
- `tests/rvpm_fmt.rs`: drives the `rvpm` binary for in-place formatting and `--check` (canonical file passes, non-canonical file fails and is named).

## stdlib
The bundled stdlib parses, formats idempotently, and preserves its AST under these rules. It is not byte-for-byte canonical yet (the formatter canonicalizes struct-literal field shorthand, removes leading blank lines inside blocks, and adds trailing commas after block-bodied match arms). The stdlib is intentionally not reformatted here to keep the diff focused; that can be a follow-up.

Note: "Closes #86" will not auto-close on merge because the base is `v2.x`, not the default branch.
