### PR TITLE
feat(vscode): update grammar and snippets for v2 syntax

### DIFF
--- a/raven-vscode/README.md
+++ b/raven-vscode/README.md
@@ -1,6 +1,6 @@
 # Raven Language
 
-[Raven](https://github.com/martian56/raven) is a statically typed language with a small runtime. This extension adds VS Code support for `.rv` files: highlighting, snippets, and a few editor conveniences.
+[Raven](https://github.com/martian56/raven) is a statically typed systems language with a small runtime. This extension adds VS Code support for `.rv` files (Raven v2 syntax): highlighting, snippets, and a few editor conveniences.
 
 **Docs:** [raven documentation](https://martian56.github.io/raven/) · **Language & compiler:** [GitHub](https://github.com/martian56/raven)
 
@@ -8,8 +8,8 @@
 
 ## Features
 
-- **Syntax highlighting** for Raven source
-- **Snippets** for common patterns (variables, functions, control flow, structs, enums, `main`, printing)
+- **Syntax highlighting** for Raven v2 source, including PascalCase types, traits, generics, `match` arms, `${...}` string interpolation, `c"..."` and `"""..."""` strings, ranges, and `extern` blocks
+- **Snippets** for common patterns (bindings, functions, control flow, structs, enums, traits, impls, `match`, closures, `defer`, imports, `main`, printing)
 - **Comments & brackets** — line comments (`//`), block comments, sensible bracket/indent behavior for `.rv` files
 - **Run Raven File** — opens a terminal and runs the current file with the `raven` CLI (see below)
 - **Hovers & completions** for built-in functions and common keywords
@@ -45,11 +45,12 @@ Type the prefix, then **Tab** to expand:
 
 | Prefix | Use for |
 |--------|---------|
-| `let`, `fun` | Variables and functions |
-| `if`, `ifelse`, `elseif`, `ifelseif` | Branches (Raven uses **`elseif`**, not `else if`) |
-| `while`, `for` | Loops |
-| `struct`, `impl`, `enum` | Types and methods |
-| `print`, `printf`, `main` | Output and program entry |
+| `let`, `leti`, `const`, `fun`, `fune`, `fung` | Bindings and functions |
+| `if`, `ifelse`, `elseif`, `match` | Branches and pattern matching |
+| `while`, `loop`, `for`, `foreach` | Loops |
+| `struct`, `structg`, `enum`, `trait`, `impl`, `implfor` | Types, traits, and methods |
+| `import`, `imports`, `extern`, `defer`, `closure` | Modules, FFI, deferral, closures |
+| `print`, `printi`, `main` | Output and program entry |
 
 ---
 

--- a/raven-vscode/README.md
+++ b/raven-vscode/README.md
@@ -10,8 +10,8 @@
 
 - **Syntax highlighting** for Raven v2 source, including PascalCase types, traits, generics, `match` arms, `${...}` string interpolation, `c"..."` and `"""..."""` strings, ranges, and `extern` blocks
 - **Snippets** for common patterns (bindings, functions, control flow, structs, enums, traits, impls, `match`, closures, `defer`, imports, `main`, printing)
-- **Comments & brackets** — line comments (`//`), block comments, sensible bracket/indent behavior for `.rv` files
-- **Run Raven File** — opens a terminal and runs the current file with the `raven` CLI (see below)
+- **Comments & brackets**: line comments (`//`), block comments, sensible bracket/indent behavior for `.rv` files
+- **Run Raven File**: opens a terminal and runs the current file with the `raven` CLI (see below)
 - **Hovers & completions** for built-in functions and common keywords
 
 This extension does not embed the compiler. For full type-checking and navigation, use the `raven` CLI or your usual workflow outside the editor.

--- a/raven-vscode/language-configuration.json
+++ b/raven-vscode/language-configuration.json
@@ -12,11 +12,11 @@
     ["(", ")"]
   ],
   "autoClosingPairs": [
-    ["{", "}"],
-    ["[", "]"],
-    ["(", ")"],
-    ["\"", "\""],
-    ["'", "'"]
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string", "comment"] }
   ],
   "surroundingPairs": [
     ["{", "}"],

--- a/raven-vscode/package.json
+++ b/raven-vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "raven-language",
   "displayName": "Raven Language",
-  "description": "Syntax highlighting and language support for Raven programming language",
-  "version": "1.2.2",
+  "description": "Syntax highlighting and language support for the Raven v2 programming language",
+  "version": "2.0.0",
   "publisher": "martian56",
   "icon": "icons/raven-fullsize.png",
   "engines": {
@@ -17,7 +17,10 @@
     "programming",
     "language",
     "syntax",
-    "highlighting"
+    "highlighting",
+    "systems",
+    "traits",
+    "generics"
   ],
   "contributes": {
     "languages": [

--- a/raven-vscode/sample.rv
+++ b/raven-vscode/sample.rv
@@ -1,35 +1,56 @@
-struct Person {
-    name: string,
-    age: int,
-    isActive: bool
+// Sample Raven v2 program for exercising the VS Code extension grammar.
+
+import std/io { println }
+
+struct Point<T> {
+    x: T,
+    y: T,
 }
 
-enum HttpStatus {
-    OK,
-    NotFound,
-    InternalError
+enum Shape {
+    Circle(Float),
+    Square(Float),
 }
 
-// Sample Raven program for testing VS Code extension
-fun main() -> void {
-    print("Hello from Raven VS Code Extension!");
-    
-    let name: string = input("Enter your name: ");
-    print(format("Hello, {}!", name));
-    
-    let numbers: int[] = [1, 2, 3, 4, 5];
-    numbers.push(6);
-    print(format("Numbers: {}", numbers));
-    
-    let person: Person = Person { 
-        name: "Alice", 
-        age: 25, 
-        isActive: true 
-    };
-    
-    print(format("Person: {}, Age: {}", person.name, person.age));
-    
-    let status: HttpStatus = HttpStatus::OK;
-    print(format("Status: {}", status));
+trait Area {
+    fun area(self) -> Float
 }
-main();
+
+impl Area for Shape {
+    fun area(self) -> Float = match self {
+        Circle(r) -> r * r * 3.14159,
+        Square(w) -> w * w,
+    }
+}
+
+fun describe<T: ToString>(value: T) -> String = value.to_string()
+
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+}
+
+fun main() {
+    let name = "Raven"
+    let count = 0x2a
+    println("Hello, ${name}! count = ${count}")
+
+    let nums = [1, 2, 3, 4, 5]
+    let total = 0
+    for n in nums {
+        total += n
+    }
+    print_int(total)
+
+    for i in 0..3 {
+        if i == 1 {
+            continue
+        }
+        print_int(i)
+    }
+
+    let s = Shape.Circle(2.0)
+    print(describe(s.area()))
+
+    let n = strlen(c"hello")
+    print_int(n)
+}

--- a/raven-vscode/snippets/raven.json
+++ b/raven-vscode/snippets/raven.json
@@ -1,196 +1,246 @@
 {
-  "Variable Declaration": {
+  "Variable Binding": {
     "prefix": "let",
     "body": [
-      "let ${1:name}: ${2:type} = ${3:value};"
+      "let ${1:name}: ${2:Int} = ${3:value}"
     ],
-    "description": "Declare a variable with type annotation"
+    "description": "Bind a variable with a type annotation"
+  },
+  "Variable Binding (inferred)": {
+    "prefix": "leti",
+    "body": [
+      "let ${1:name} = ${2:value}"
+    ],
+    "description": "Bind a variable with an inferred type"
+  },
+  "Constant Binding": {
+    "prefix": "const",
+    "body": [
+      "const ${1:NAME}: ${2:Int} = ${3:value}"
+    ],
+    "description": "Bind a constant with a type annotation"
   },
   "Function Declaration": {
     "prefix": "fun",
     "body": [
-      "fun ${1:name}(${2:params}) -> ${3:returnType} {",
+      "fun ${1:name}(${2:params}) -> ${3:Unit} {",
       "\t${4:body}",
       "}"
     ],
-    "description": "Declare a function with parameters and return type"
+    "description": "Declare a function with parameters and a return type"
+  },
+  "Expression Function": {
+    "prefix": "fune",
+    "body": [
+      "fun ${1:name}(${2:params}) -> ${3:Int} = ${4:expr}"
+    ],
+    "description": "Declare an expression-bodied function"
+  },
+  "Generic Function": {
+    "prefix": "fung",
+    "body": [
+      "fun ${1:name}<${2:T}: ${3:ToString}>(${4:x}: ${2:T}) -> ${5:String} {",
+      "\t${6:body}",
+      "}"
+    ],
+    "description": "Declare a generic function with a trait bound"
+  },
+  "Main Function": {
+    "prefix": "main",
+    "body": [
+      "fun main() {",
+      "\t${1:body}",
+      "}"
+    ],
+    "description": "Program entry point"
   },
   "If Statement": {
     "prefix": "if",
     "body": [
-      "if (${1:condition}) {",
+      "if ${1:condition} {",
       "\t${2:body}",
       "}"
     ],
-    "description": "If conditional statement"
+    "description": "If statement"
   },
   "If-Else Statement": {
     "prefix": "ifelse",
     "body": [
-      "if (${1:condition}) {",
+      "if ${1:condition} {",
       "\t${2:body}",
       "} else {",
       "\t${3:elseBody}",
       "}"
     ],
-    "description": "If-else (use elseif, not else if, for extra branches)"
+    "description": "If / else statement"
   },
-  "If-Elseif-Else chain": {
-    "prefix": "ifelseif",
+  "Else-If Chain": {
+    "prefix": "elseif",
     "body": [
-      "if (${1:condition}) {",
+      "if ${1:condition} {",
       "\t${2:body}",
-      "} elseif (${3:condition2}) {",
+      "} else if ${3:condition2} {",
       "\t${4:body2}",
       "} else {",
       "\t${5:elseBody}",
       "}"
     ],
-    "description": "If / elseif / else — Raven requires the elseif keyword (single word)"
-  },
-  "Elseif branch": {
-    "prefix": "elseif",
-    "body": [
-      "} elseif (${1:condition}) {",
-      "\t${2:body}"
-    ],
-    "description": "Else-if branch after a closing brace (elseif is one keyword)"
+    "description": "If / else if / else chain"
   },
   "While Loop": {
     "prefix": "while",
     "body": [
-      "while (${1:condition}) {",
+      "while ${1:condition} {",
       "\t${2:body}",
       "}"
     ],
     "description": "While loop"
   },
-  "For Loop": {
+  "Infinite Loop": {
+    "prefix": "loop",
+    "body": [
+      "loop {",
+      "\t${1:body}",
+      "}"
+    ],
+    "description": "Infinite loop (exit with break)"
+  },
+  "For Loop (range)": {
     "prefix": "for",
     "body": [
-      "for (let ${1:i}: int = ${2:0}; ${1:i} < ${3:limit}; ${1:i} = ${1:i} + 1) {",
+      "for ${1:i} in ${2:0}..${3:n} {",
       "\t${4:body}",
       "}"
     ],
-    "description": "For loop"
+    "description": "For loop over a range"
   },
-  "Print Statement": {
-    "prefix": "print",
+  "For Loop (collection)": {
+    "prefix": "foreach",
     "body": [
-      "print(${1:message});"
+      "for ${1:item} in ${2:items} {",
+      "\t${3:body}",
+      "}"
     ],
-    "description": "Print statement"
+    "description": "For loop over a collection"
   },
-  "Print Format": {
-    "prefix": "printf",
+  "Match Expression": {
+    "prefix": "match",
     "body": [
-      "print(format(\"${1:message}\", ${2:args}));"
+      "match ${1:value} {",
+      "\t${2:Pattern} -> ${3:result},",
+      "\t_ -> ${4:fallback},",
+      "}"
     ],
-    "description": "Print with format"
+    "description": "Match expression with arms"
   },
   "Struct Definition": {
     "prefix": "struct",
     "body": [
       "struct ${1:Name} {",
-      "\t${2:field}: ${3:type},",
-      "\t${4:field2}: ${5:type}",
+      "\t${2:field}: ${3:Int},",
       "}"
     ],
     "description": "Define a struct"
   },
-  "Impl Block": {
-    "prefix": "impl",
+  "Generic Struct": {
+    "prefix": "structg",
     "body": [
-      "impl ${1:StructName} {",
-      "\tfun ${2:method}(self) -> ${3:void} {",
-      "\t\t${4:body}",
-      "\t}",
+      "struct ${1:Name}<${2:T}> {",
+      "\t${3:value}: ${2:T},",
       "}"
     ],
-    "description": "Define struct methods"
+    "description": "Define a generic struct"
   },
   "Enum Definition": {
     "prefix": "enum",
     "body": [
       "enum ${1:Name} {",
       "\t${2:Variant1},",
-      "\t${3:Variant2}",
+      "\t${3:Variant2}(${4:Int}),",
       "}"
     ],
-    "description": "Define an enum"
+    "description": "Define an enum with unit and payload variants"
   },
-  "Array Declaration": {
-    "prefix": "array",
+  "Trait Definition": {
+    "prefix": "trait",
     "body": [
-      "let ${1:name}: ${2:type}[] = [${3:values}];"
+      "trait ${1:Name} {",
+      "\tfun ${2:method}(self) -> ${3:Unit}",
+      "}"
     ],
-    "description": "Declare an array"
+    "description": "Define a trait"
   },
-  "Function Call": {
-    "prefix": "call",
+  "Impl Block": {
+    "prefix": "impl",
     "body": [
-      "${1:functionName}(${2:args});"
+      "impl ${1:Type} {",
+      "\tfun ${2:method}(self) -> ${3:Unit} {",
+      "\t\t${4:body}",
+      "\t}",
+      "}"
     ],
-    "description": "Function call"
+    "description": "Implement methods on a type"
   },
-  "Import Statement": {
+  "Impl Trait For Type": {
+    "prefix": "implfor",
+    "body": [
+      "impl ${1:Trait} for ${2:Type} {",
+      "\tfun ${3:method}(self) -> ${4:Unit} {",
+      "\t\t${5:body}",
+      "\t}",
+      "}"
+    ],
+    "description": "Implement a trait for a type"
+  },
+  "Extern Block": {
+    "prefix": "extern",
+    "body": [
+      "extern \"C\" {",
+      "\tfun ${1:name}(${2:arg}: ${3:CInt}) -> ${4:CInt}",
+      "}"
+    ],
+    "description": "Declare external C functions"
+  },
+  "Import Module": {
     "prefix": "import",
     "body": [
-      "import ${1:moduleName};"
+      "import ${1:std/io}"
     ],
     "description": "Import a module"
   },
-  "Export Function": {
-    "prefix": "export",
+  "Import Selective": {
+    "prefix": "imports",
     "body": [
-      "export fun ${1:name}(${2:params}) -> ${3:returnType} {",
-      "\t${4:body}",
-      "}"
+      "import ${1:std/io} { ${2:println} }"
     ],
-    "description": "Export a function"
+    "description": "Import selected items from a module"
   },
-  "Main Function": {
-    "prefix": "main",
+  "Closure": {
+    "prefix": "closure",
     "body": [
-      "fun main() -> void {",
-      "\t${1:body}",
-      "}"
+      "fun(${1:x}: ${2:Int}) -> ${3:Int} = ${4:expr}"
     ],
-    "description": "Main function"
+    "description": "Closure expression"
   },
-  "File I/O Read": {
-    "prefix": "read",
+  "Defer": {
+    "prefix": "defer",
     "body": [
-      "let ${1:content}: string = read_file(\"${2:filename}\");"
+      "defer ${1:expr}"
     ],
-    "description": "Read file contents"
+    "description": "Defer an expression until the function returns"
   },
-  "File I/O Write": {
-    "prefix": "write",
+  "Print": {
+    "prefix": "print",
     "body": [
-      "write_file(\"${1:filename}\", ${2:content});"
+      "print(${1:message})"
     ],
-    "description": "Write to file"
+    "description": "Print a string"
   },
-  "string Format": {
-    "prefix": "format",
+  "Print Interpolated": {
+    "prefix": "printi",
     "body": [
-      "format(\"${1:template}\", ${2:args})"
+      "print(\"${1:label}: ${${2:value}}\")"
     ],
-    "description": "string formatting"
-  },
-  "Enum Variant": {
-    "prefix": "enumvar",
-    "body": [
-      "${1:EnumName}::${2:VariantName}"
-    ],
-    "description": "Enum variant"
-  },
-  "Enum From string": {
-    "prefix": "enumfromstr",
-    "body": [
-      "enum_from_string(\"${1:EnumName}\", \"${2:VariantName}\")"
-    ],
-    "description": "Convert string to enum"
+    "description": "Print with string interpolation"
   }
 }

--- a/raven-vscode/src/extension.ts
+++ b/raven-vscode/src/extension.ts
@@ -26,16 +26,10 @@ export function activate(context: vscode.ExtensionContext) {
             const word = document.getText(range);
             
             const builtinFunctions: { [key: string]: string } = {
-                'print': 'Prints output to console. Usage: `print(message)`',
-                'input': 'Gets user input. Usage: `let name: string = input("Enter name: ")`',
-                'format': 'Formats string with placeholders. Usage: `format("Hello {}", name)`',
-                'len': 'Gets length of string or array. Usage: `len(text)` or `len(array)`',
-                'type': 'Gets type information. Usage: `type(variable)`',
-                'read_file': 'Reads file contents. Usage: `let content: string = read_file("file.txt")`',
-                'write_file': 'Writes to file. Usage: `write_file("file.txt", content)`',
-                'append_file': 'Appends to file. Usage: `append_file("file.txt", content)`',
-                'file_exists': 'Checks if file exists. Usage: `file_exists("file.txt")`',
-                'enum_from_string': 'Converts string to enum. Usage: `enum_from_string("EnumName", "VariantName")`'
+                'print': 'Prints a String followed by a newline. Usage: `print(message)`',
+                'print_int': 'Prints an Int followed by a newline. Usage: `print_int(n)`',
+                'println': 'Prints a String with a trailing newline (from `std/io`). Usage: `import std/io { println }`',
+                'panic': 'Aborts the program with a message (from `std/test`).'
             };
 
             if (builtinFunctions[word]) {
@@ -52,18 +46,20 @@ export function activate(context: vscode.ExtensionContext) {
     let completionProvider = vscode.languages.registerCompletionItemProvider('raven', {
         provideCompletionItems(document, position, token, context) {
             const builtinFunctions = [
-                'print', 'input', 'format', 'len', 'type',
-                'read_file', 'write_file', 'append_file', 'file_exists', 'enum_from_string'
+                'print', 'print_int', 'println', 'panic'
             ];
 
             const keywords = [
-                'let', 'fun', 'if', 'elseif', 'else', 'while', 'for', 'return',
-                'import', 'export', 'from', 'struct', 'impl', 'enum', 'print',
-                'true', 'false', 'void', 'const', 'and', 'or', 'not'
+                'let', 'const', 'fun', 'return', 'if', 'else', 'while', 'for',
+                'loop', 'in', 'break', 'continue', 'match', 'struct', 'enum',
+                'trait', 'impl', 'import', 'as', 'extern', 'defer', 'dyn',
+                'true', 'false', 'self', 'Self'
             ];
 
             const types = [
-                'int', 'float', 'bool', 'string', 'int[]', 'float[]', 'bool[]', 'string[]'
+                'Int', 'Float', 'Bool', 'String', 'Char', 'Unit',
+                'Option', 'Result', 'List', 'Map', 'Set',
+                'CInt', 'CLong', 'CSize', 'CStr', 'CPtr', 'CDouble'
             ];
 
             const completions: vscode.CompletionItem[] = [];

--- a/raven-vscode/syntaxes/raven.tmLanguage.json
+++ b/raven-vscode/syntaxes/raven.tmLanguage.json
@@ -4,31 +4,23 @@
   "fileTypes": ["rv"],
   "patterns": [
     { "include": "#comments" },
-    { "include": "#importSelectiveBlock" },
-    { "include": "#importModuleSemicolon" },
-    { "include": "#importString" },
     { "include": "#imports" },
-    { "include": "#exportDecl" },
-    { "include": "#forLoopHeader" },
-    { "include": "#letBindings" },
-    { "include": "#constBindings" },
-    { "include": "#structBlock" },
-    { "include": "#enumBlock" },
+    { "include": "#externBlock" },
+    { "include": "#bindings" },
     { "include": "#functionDeclarations" },
-    { "include": "#structs" },
-    { "include": "#enums" },
-    { "include": "#implLine" },
+    { "include": "#typeDeclarations" },
+    { "include": "#implDeclarations" },
+    { "include": "#matchArrow" },
     { "include": "#keywords" },
+    { "include": "#constants" },
     { "include": "#selfKeyword" },
     { "include": "#strings" },
     { "include": "#numbers" },
+    { "include": "#enumPath" },
+    { "include": "#types" },
+    { "include": "#functionCalls" },
     { "include": "#members" },
     { "include": "#operators" },
-    { "include": "#types" },
-    { "include": "#functions" },
-    { "include": "#parameters" },
-    { "include": "#structFields" },
-    { "include": "#variables" },
     { "include": "#punctuation" }
   ],
   "repository": {
@@ -37,43 +29,37 @@
         {
           "name": "comment.line.double-slash.raven",
           "begin": "//",
-          "end": "$",
-          "patterns": [
-            {
-              "name": "keyword.other.region.raven",
-              "match": "(#region|#endregion)"
-            }
-          ]
+          "end": "$"
         },
         {
           "name": "comment.block.raven",
           "begin": "/\\*",
-          "end": "\\*/",
-          "patterns": [
-            {
-              "name": "keyword.other.region.raven",
-              "match": "(#region|#endregion)"
-            }
-          ]
+          "end": "\\*/"
         }
       ]
     },
-    "importSelectiveBlock": {
+    "imports": {
       "patterns": [
         {
           "name": "meta.import.selective.raven",
-          "begin": "(\\bimport)\\s*\\{",
+          "begin": "\\b(import)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:/[a-zA-Z_][a-zA-Z0-9_]*)*)\\s*(\\{)",
           "beginCaptures": {
-            "1": { "name": "keyword.control.import.raven" }
+            "1": { "name": "keyword.control.import.raven" },
+            "2": { "name": "entity.name.namespace.raven" },
+            "3": { "name": "punctuation.section.block.begin.raven" }
           },
-          "end": "\\}\\s*(from)\\b",
+          "end": "\\}",
           "endCaptures": {
-            "1": { "name": "keyword.control.import.raven" }
+            "0": { "name": "punctuation.section.block.end.raven" }
           },
           "patterns": [
             { "include": "#comments" },
             {
-              "name": "variable.import.raven",
+              "name": "keyword.control.import.raven",
+              "match": "\\b(as)\\b"
+            },
+            {
+              "name": "variable.other.import.raven",
               "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
             },
             {
@@ -81,232 +67,85 @@
               "match": ","
             }
           ]
-        }
-      ]
-    },
-    "importModuleSemicolon": {
-      "patterns": [
+        },
         {
-          "name": "meta.import.module.raven",
-          "match": "\\b(import)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*;",
+          "match": "\\b(import)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:/[a-zA-Z_][a-zA-Z0-9_]*)*)(?:\\s+(as)\\s+([a-zA-Z_][a-zA-Z0-9_]*))?",
           "captures": {
             "1": { "name": "keyword.control.import.raven" },
-            "2": { "name": "variable.namespace.raven" }
+            "2": { "name": "entity.name.namespace.raven" },
+            "3": { "name": "keyword.control.import.raven" },
+            "4": { "name": "variable.other.import.raven" }
           }
         }
       ]
     },
-    "importString": {
+    "externBlock": {
       "patterns": [
         {
-          "name": "meta.import.path.raven",
-          "match": "\\b(import)\\s+(\"[^\"]*\")\\s*;",
+          "name": "meta.extern.raven",
+          "match": "\\b(extern)\\s+(\"[^\"]*\")",
           "captures": {
-            "1": { "name": "keyword.control.import.raven" },
+            "1": { "name": "keyword.control.raven" },
             "2": { "name": "string.quoted.double.raven" }
           }
         }
       ]
     },
-    "imports": {
+    "bindings": {
       "patterns": [
         {
-          "name": "meta.import.raven",
-          "match": "\\b(import)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s+(from)\\s+",
+          "match": "\\b(let|const)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b",
           "captures": {
-            "1": { "name": "keyword.control.import.raven" },
-            "2": { "name": "variable.namespace.raven" },
-            "3": { "name": "keyword.control.import.raven" }
-          }
-        }
-      ]
-    },
-    "exportDecl": {
-      "patterns": [
-        {
-          "name": "meta.export.let.raven",
-          "match": "\\b(export)\\s+(let)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
-          "captures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "keyword.control.raven" },
-            "3": { "name": "variable.other.readwrite.raven" }
-          }
-        },
-        {
-          "name": "meta.export.fun.raven",
-          "match": "\\b(export)\\s+(fun)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
-          "captures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "keyword.control.raven" },
-            "3": { "name": "entity.name.function.raven" }
-          }
-        }
-      ]
-    },
-    "forLoopHeader": {
-      "patterns": [
-        {
-          "name": "meta.for.let.raven",
-          "match": "\\b(for)\\s*\\(\\s*(let)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
-          "captures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "keyword.control.raven" },
-            "3": { "name": "variable.other.readwrite.raven" }
-          }
-        }
-      ]
-    },
-    "letBindings": {
-      "patterns": [
-        {
-          "name": "meta.variable.let.raven",
-          "match": "\\b(let)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
-          "captures": {
-            "1": { "name": "keyword.control.raven" },
+            "1": { "name": "storage.type.raven" },
             "2": { "name": "variable.other.readwrite.raven" }
           }
-        },
-        {
-          "name": "meta.variable.let.raven",
-          "match": "\\b(let)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*=",
-          "captures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "variable.other.readwrite.raven" }
-          }
-        }
-      ]
-    },
-    "constBindings": {
-      "patterns": [
-        {
-          "name": "meta.variable.const.raven",
-          "match": "\\b(const)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
-          "captures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "variable.other.constant.raven" }
-          }
-        },
-        {
-          "name": "meta.variable.const.raven",
-          "match": "\\b(const)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*=",
-          "captures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "variable.other.constant.raven" }
-          }
-        }
-      ]
-    },
-    "structBlock": {
-      "patterns": [
-        {
-          "name": "meta.struct.raven",
-          "begin": "(\\bstruct)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\{",
-          "beginCaptures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "entity.name.type.raven" }
-          },
-          "end": "\\}",
-          "endCaptures": {
-            "0": { "name": "punctuation.section.block.end.raven" }
-          },
-          "patterns": [
-            { "include": "#comments" },
-            { "include": "#strings" },
-            { "include": "#numbers" },
-            {
-              "name": "meta.field.declaration.raven",
-              "match": "(?:\\{|,)\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
-              "captures": {
-                "1": { "name": "variable.other.field.raven" }
-              }
-            },
-            {
-              "name": "meta.field.declaration.raven",
-              "match": "(?:\\{|,)\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s+:",
-              "captures": {
-                "1": { "name": "variable.other.field.raven" }
-              }
-            },
-            { "include": "#types" },
-            { "include": "#operators" },
-            { "include": "#punctuation" }
-          ]
-        }
-      ]
-    },
-    "enumBlock": {
-      "patterns": [
-        {
-          "name": "meta.enum.raven",
-          "begin": "(\\benum)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\{",
-          "beginCaptures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "entity.name.type.raven" }
-          },
-          "end": "\\}",
-          "endCaptures": {
-            "0": { "name": "punctuation.section.block.end.raven" }
-          },
-          "patterns": [
-            { "include": "#comments" },
-            {
-              "match": "\\b(?!(?:true|false|null|void|int|float|bool|string|and|or|not|if|elseif|else|while|for|return|let|const|fun|struct|enum|impl|import|export|print|from)\\b)([a-zA-Z_][a-zA-Z0-9_]*)\\b",
-              "captures": {
-                "1": { "name": "constant.other.enum.variant.raven" }
-              }
-            },
-            {
-              "name": "punctuation.separator.comma.raven",
-              "match": ","
-            }
-          ]
         }
       ]
     },
     "functionDeclarations": {
       "patterns": [
         {
-          "name": "meta.function.declaration.raven",
-          "match": "\\b(fun)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
+          "match": "\\b(fun)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
           "captures": {
-            "1": { "name": "keyword.control.raven" },
+            "1": { "name": "storage.type.function.raven" },
             "2": { "name": "entity.name.function.raven" }
           }
+        },
+        {
+          "name": "storage.type.function.raven",
+          "match": "\\bfun\\b"
         }
       ]
     },
-    "structs": {
+    "typeDeclarations": {
       "patterns": [
         {
-          "name": "entity.name.type.struct.instantiation.raven",
-          "match": "\\b([A-Z][a-zA-Z0-9]*)\\s*\\{",
+          "match": "\\b(struct|enum|trait)\\s+([A-Za-z_][A-Za-z0-9_]*)",
           "captures": {
-            "1": { "name": "entity.name.type.raven" }
+            "1": { "name": "storage.type.raven" },
+            "2": { "name": "entity.name.type.raven" }
           }
         }
       ]
     },
-    "enums": {
+    "implDeclarations": {
       "patterns": [
         {
-          "name": "entity.name.type.enum.variant.raven",
-          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)::([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+          "match": "\\b(impl)\\b(?:\\s*<[^>]*>)?\\s+([A-Za-z_][A-Za-z0-9_]*)(?:\\s+(for)\\s+([A-Za-z_][A-Za-z0-9_]*))?",
           "captures": {
-            "1": { "name": "entity.name.type.raven" },
-            "2": { "name": "constant.other.enum.variant.raven" }
+            "1": { "name": "storage.type.raven" },
+            "2": { "name": "entity.name.type.raven" },
+            "3": { "name": "keyword.control.raven" },
+            "4": { "name": "entity.name.type.raven" }
           }
         }
       ]
     },
-    "implLine": {
+    "matchArrow": {
       "patterns": [
         {
-          "name": "meta.impl.raven",
-          "match": "\\b(impl)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\{",
-          "captures": {
-            "1": { "name": "keyword.control.raven" },
-            "2": { "name": "entity.name.type.class.raven" }
-          }
+          "name": "keyword.operator.arrow.match.raven",
+          "match": "->"
         }
       ]
     },
@@ -314,60 +153,80 @@
       "patterns": [
         {
           "name": "keyword.control.raven",
-          "match": "\\b(const|fun|if|elseif|else|while|for|return|export|print)\\b"
+          "match": "\\b(if|else|while|for|loop|in|break|continue|return|match|defer)\\b"
+        },
+        {
+          "name": "keyword.control.import.raven",
+          "match": "\\b(import)\\b"
+        },
+        {
+          "name": "storage.type.raven",
+          "match": "\\b(let|const|fun|struct|enum|trait|impl|extern)\\b"
+        },
+        {
+          "name": "storage.modifier.raven",
+          "match": "\\b(dyn)\\b"
         },
         {
           "name": "keyword.operator.cast.raven",
           "match": "\\b(as)\\b"
-        },
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
         {
-          "name": "keyword.control.import.raven",
-          "match": "\\bimport\\b"
-        },
-        {
-          "name": "keyword.operator.raven",
-          "match": "\\b(and|or|not)\\b"
-        },
-        {
-          "name": "constant.language.raven",
-          "match": "\\b(true|false|null|void)\\b"
+          "name": "constant.language.boolean.raven",
+          "match": "\\b(true|false)\\b"
         }
       ]
     },
     "selfKeyword": {
       "patterns": [
         {
-          "name": "variable.language.parameter.raven",
+          "name": "variable.language.self.raven",
           "match": "\\bself\\b"
+        },
+        {
+          "name": "support.type.self.raven",
+          "match": "\\bSelf\\b"
         }
       ]
     },
     "types": {
       "patterns": [
         {
-          "name": "support.type.primitive.raven",
-          "match": "\\b(int|float|bool|string)\\b"
+          "name": "support.type.builtin.raven",
+          "match": "\\b(Int|Float|Bool|String|Char|Unit|Option|Result|List|Map|Set)\\b"
         },
         {
-          "name": "support.type.array.raven",
-          "match": "\\b(int\\[\\]|float\\[\\]|bool\\[\\]|string\\[\\])\\b"
-        },
-        {
-          "name": "support.type.array.raven",
-          "match": "\\b(int\\[\\]\\[\\]|float\\[\\]\\[\\]|bool\\[\\]\\[\\]|string\\[\\]\\[\\])\\b"
-        },
-        {
-          "name": "support.type.array.raven",
-          "match": "\\b(int\\[\\]\\[\\]\\[\\]|float\\[\\]\\[\\]\\[\\]|bool\\[\\]\\[\\]\\[\\]|string\\[\\]\\[\\]\\[\\])\\b"
+          "name": "support.type.ffi.raven",
+          "match": "\\b(CInt|CLong|CSize|CStr|CPtr|CDouble|CChar|CFloat|CVoid)\\b"
         },
         {
           "name": "entity.name.type.raven",
-          "match": "\\b[A-Z][a-zA-Z0-9]*\\b"
+          "match": "\\b[A-Z][A-Za-z0-9_]*\\b"
         }
       ]
     },
     "strings": {
       "patterns": [
+        {
+          "name": "string.quoted.triple.raven",
+          "begin": "\"\"\"",
+          "end": "\"\"\""
+        },
+        {
+          "name": "string.quoted.double.c.raven",
+          "begin": "c\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.raven",
+              "match": "\\\\(n|t|r|0|\\\\|\"|'|\\$|x[0-9A-Fa-f]{2}|u\\{[0-9A-Fa-f]{1,6}\\})"
+            }
+          ]
+        },
         {
           "name": "string.quoted.double.raven",
           "begin": "\"",
@@ -375,11 +234,21 @@
           "patterns": [
             {
               "name": "constant.character.escape.raven",
-              "match": "\\\\."
+              "match": "\\\\(n|t|r|0|\\\\|\"|'|\\$|x[0-9A-Fa-f]{2}|u\\{[0-9A-Fa-f]{1,6}\\})"
             },
             {
-              "name": "variable.other.placeholder.raven",
-              "match": "\\{\\}"
+              "name": "meta.interpolation.raven",
+              "begin": "\\$\\{",
+              "beginCaptures": {
+                "0": { "name": "punctuation.section.interpolation.begin.raven" }
+              },
+              "end": "\\}",
+              "endCaptures": {
+                "0": { "name": "punctuation.section.interpolation.end.raven" }
+              },
+              "patterns": [
+                { "include": "#interpolationBody" }
+              ]
             }
           ]
         },
@@ -390,28 +259,96 @@
           "patterns": [
             {
               "name": "constant.character.escape.raven",
-              "match": "\\\\."
+              "match": "\\\\(n|t|r|0|\\\\|\"|'|x[0-9A-Fa-f]{2}|u\\{[0-9A-Fa-f]{1,6}\\})"
             }
           ]
+        }
+      ]
+    },
+    "interpolationBody": {
+      "patterns": [
+        { "include": "#strings" },
+        { "include": "#numbers" },
+        { "include": "#constants" },
+        { "include": "#selfKeyword" },
+        { "include": "#enumPath" },
+        { "include": "#types" },
+        { "include": "#functionCalls" },
+        { "include": "#members" },
+        { "include": "#operators" },
+        {
+          "name": "variable.other.raven",
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
         }
       ]
     },
     "numbers": {
       "patterns": [
         {
+          "name": "constant.numeric.hex.raven",
+          "match": "\\b0[xX][0-9a-fA-F_]+\\b"
+        },
+        {
+          "name": "constant.numeric.binary.raven",
+          "match": "\\b0[bB][01_]+\\b"
+        },
+        {
+          "name": "constant.numeric.octal.raven",
+          "match": "\\b0[oO][0-7_]+\\b"
+        },
+        {
           "name": "constant.numeric.float.raven",
-          "match": "\\b\\d+\\.\\d+\\b"
+          "match": "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?([eE][+-]?[0-9_]+)\\b"
+        },
+        {
+          "name": "constant.numeric.float.raven",
+          "match": "\\b[0-9][0-9_]*\\.[0-9][0-9_]*\\b"
         },
         {
           "name": "constant.numeric.integer.raven",
-          "match": "\\b\\d+\\b"
+          "match": "\\b[0-9][0-9_]*\\b"
+        }
+      ]
+    },
+    "enumPath": {
+      "patterns": [
+        {
+          "match": "\\b([A-Z][A-Za-z0-9_]*)\\.([A-Z][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": { "name": "entity.name.type.raven" },
+            "2": { "name": "constant.other.enum.variant.raven" }
+          }
+        },
+        {
+          "match": "\\b([A-Za-z_][A-Za-z0-9_]*)::([A-Za-z_][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": { "name": "entity.name.type.raven" },
+            "2": { "name": "variable.other.member.raven" }
+          }
+        }
+      ]
+    },
+    "functionCalls": {
+      "patterns": [
+        {
+          "name": "support.function.builtin.raven",
+          "match": "\\b(print|print_int)\\s*(?=\\()"
+        },
+        {
+          "name": "entity.name.function.call.raven",
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\()"
         }
       ]
     },
     "members": {
       "patterns": [
         {
-          "name": "meta.property.access.raven",
+          "match": "\\.([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\()",
+          "captures": {
+            "1": { "name": "entity.name.function.method.raven" }
+          }
+        },
+        {
           "match": "\\.([a-zA-Z_][a-zA-Z0-9_]*)",
           "captures": {
             "1": { "name": "variable.other.member.raven" }
@@ -422,8 +359,32 @@
     "operators": {
       "patterns": [
         {
+          "name": "keyword.operator.range.raven",
+          "match": "\\.\\.=?"
+        },
+        {
           "name": "keyword.operator.arrow.raven",
-          "match": "->"
+          "match": "(->|=>)"
+        },
+        {
+          "name": "keyword.operator.try.raven",
+          "match": "\\?"
+        },
+        {
+          "name": "keyword.operator.assignment.compound.raven",
+          "match": "(\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=|<<=|>>=)"
+        },
+        {
+          "name": "keyword.operator.comparison.raven",
+          "match": "(==|!=|<=|>=)"
+        },
+        {
+          "name": "keyword.operator.logical.raven",
+          "match": "(&&|\\|\\||!)"
+        },
+        {
+          "name": "keyword.operator.bitwise.raven",
+          "match": "(<<|>>|&|\\||\\^|~)"
         },
         {
           "name": "keyword.operator.arithmetic.raven",
@@ -431,97 +392,15 @@
         },
         {
           "name": "keyword.operator.comparison.raven",
-          "match": "(==|!=|<=|>=|<|>)"
-        },
-        {
-          "name": "keyword.operator.logical.raven",
-          "match": "(&&|\\|\\|)"
+          "match": "(<|>)"
         },
         {
           "name": "keyword.operator.assignment.raven",
           "match": "="
         },
         {
-          "name": "keyword.operator.unary.raven",
-          "match": "[!\\-]"
-        },
-        {
-          "name": "keyword.operator.access.raven",
-          "match": "\\."
-        },
-        {
-          "name": "keyword.operator.enum.raven",
+          "name": "keyword.operator.namespace.raven",
           "match": "::"
-        }
-      ]
-    },
-    "functions": {
-      "patterns": [
-        {
-          "name": "entity.name.function.raven",
-          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\()"
-        },
-        {
-          "name": "support.function.builtin.raven",
-          "match": "\\b(print|input|format|len|type|read_file|write_file|append_file|file_exists|enum_from_string|panic|parse_int|char_code)\\b"
-        }
-      ]
-    },
-    "parameters": {
-      "patterns": [
-        {
-          "name": "meta.parameter.raven",
-          "match": "(?:\\(|,)\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
-          "captures": {
-            "1": { "name": "variable.parameter.raven" }
-          }
-        },
-        {
-          "name": "meta.parameter.raven",
-          "match": "(?:\\(|,)\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s+:",
-          "captures": {
-            "1": { "name": "variable.parameter.raven" }
-          }
-        }
-      ]
-    },
-    "structFields": {
-      "patterns": [
-        {
-          "name": "meta.field.declaration.raven",
-          "match": "\\{\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
-          "captures": {
-            "1": { "name": "variable.other.field.raven" }
-          }
-        },
-        {
-          "name": "meta.field.declaration.raven",
-          "match": "\\{\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s+:",
-          "captures": {
-            "1": { "name": "variable.other.field.raven" }
-          }
-        },
-        {
-          "name": "meta.field.declaration.raven",
-          "match": ",\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
-          "captures": {
-            "1": { "name": "variable.other.field.raven" }
-          }
-        },
-        {
-          "name": "meta.field.declaration.raven",
-          "match": ",\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s+:",
-          "captures": {
-            "1": { "name": "variable.other.field.raven" }
-          }
-        }
-      ]
-    },
-    "variables": {
-      "patterns": [
-        {
-          "name": "variable.other.readwrite.raven",
-          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
         }
       ]
     },
@@ -534,6 +413,10 @@
         {
           "name": "punctuation.terminator.statement.raven",
           "match": ";"
+        },
+        {
+          "name": "punctuation.separator.colon.raven",
+          "match": ":"
         },
         {
           "name": "punctuation.section.block.begin.raven",


### PR DESCRIPTION
Updates the `raven-vscode` extension to match Raven v2 syntax.

Closes #87

## Grammar (`syntaxes/raven.tmLanguage.json`)
- v2 keywords: `let`, `const`, `fun`, `struct`, `enum`, `trait`, `impl`, `for`, `in`, `while`, `loop`, `if`, `else`, `match`, `return`, `break`, `continue`, `defer`, `extern`, `import`, `as`, `dyn`, `self`, `Self`, `true`, `false`.
- PascalCase types as `support.type.builtin` (`Int`, `Float`, `Bool`, `String`, `Char`, `Unit`, `Option`, `Result`, `List`, `Map`, `Set`) and C FFI types (`CInt`, `CLong`, `CSize`, `CStr`, `CPtr`, `CDouble`), with user PascalCase types as `entity.name.type`.
- Function names highlighted at declaration (`entity.name.function`) and call sites; method calls after `.`.
- String interpolation `${...}` highlighted as embedded expressions inside `"..."`, plus `c"..."` and triple-quoted `"""..."""` strings, and full escape set (`\n`, `\t`, `\x41`, `\u{...}`, `\$`).
- Operators: arithmetic, comparison, logical, bitwise (`& | ^ << >>`), ranges (`..`, `..=`), `->`, `=>`, `?`, compound assignment, `::`.
- Enum variant access `Type.Variant`, match arms via `->`, generics and bounds, `impl<T>`, `impl Trait for Type`, `extern "C"`, and `import std/x { item as alias }`.
- Removed v1 constructs (lowercase `int`/`string`/`bool`, `elseif`, `export`, `from`, `import { } from`, `and`/`or`/`not`, `void`/`null`).

## Snippets (`snippets/raven.json`)
Rewritten for v2: `let`, `leti`, `const`, `fun`, `fune`, `fung`, `main`, `if`, `ifelse`, `elseif`, `while`, `loop`, `for`, `foreach`, `match`, `struct`, `structg`, `enum`, `trait`, `impl`, `implfor`, `extern`, `import`, `imports`, `closure`, `defer`, `print`, `printi`.

## Config and supporting files
- `language-configuration.json`: auto-closing pairs now skip inside strings.
- `src/extension.ts`: hover and completion lists updated to v2 builtins (`print`, `print_int`, `println`, `panic`), keywords, and PascalCase types.
- `sample.rv`: rewritten as a v2 program covering generics, traits, enums, interpolation, ranges, and FFI.
- `README.md`: v2 wording and snippet table.
- `package.json`: version bumped to `2.0.0` (description and keywords updated). Marketplace publish is staged for the v2.0.0 release and is not done here.

## CI
This is a `raven-vscode/`-only change, so the Rust build, test, and lint jobs do not trigger (only GitGuardian runs). Verified locally: every grammar, snippet, and config JSON parses, `tsc` type-checks clean, and `cargo build --workspace` still succeeds.
