### PR TITLE
docs(v2): v2 documentation site section

### DIFF
--- a/docs/v2/guide/getting-started.md
+++ b/docs/v2/guide/getting-started.md
@@ -1,0 +1,101 @@
+# Getting started (v2)
+
+Raven v2 is a compiled, statically typed language. The toolchain lexes,
+parses, resolves, type checks, lowers to MIR, and emits a native binary
+through Cranelift, linking against the Raven runtime.
+
+This page takes you from a single source file to a compiled binary, then
+to a managed project with `rvpm`.
+
+## Build the toolchain
+
+Build the `raven` and `rvpm` binaries from source:
+
+```bash
+git clone https://github.com/martian56/raven.git
+cd raven
+cargo build --release
+```
+
+The binaries land in `target/release/`. Add that directory to your
+`PATH`, or call the binaries by full path.
+
+## Your first program
+
+Every program starts at `fun main()`. Create `hello.rv`:
+
+```raven
+fun main() {
+    print("Hello, Raven!")
+}
+```
+
+`print` accepts any value that implements `ToString` (the core traits
+are always in scope) and appends a newline.
+
+## Compile and run
+
+`raven build` compiles a source file to a native binary. Pass the output
+path with `-o`:
+
+```bash
+raven build hello.rv -o hello
+./hello
+```
+
+On Windows the produced binary has a `.exe` extension:
+
+```powershell
+raven build hello.rv -o hello.exe
+.\hello.exe
+```
+
+The build runs the full pipeline (lex, parse, resolve, type check, HIR,
+MIR, Cranelift, link). A type or syntax error is reported with the file,
+line, and column, and no binary is produced.
+
+## A managed project with rvpm
+
+For anything past a single file, use `rvpm`, the package manager. It owns
+the project layout, dependencies, and the build.
+
+Scaffold a new project:
+
+```bash
+rvpm init my_app
+cd my_app
+```
+
+`rvpm init` writes this layout:
+
+```
+my_app/
+  rv.toml        # the package manifest
+  src/
+    main.rv      # the entry point, defining fun main()
+```
+
+The generated `rv.toml`:
+
+```toml
+[package]
+name = "my_app"
+version = "0.1.0"
+edition = "v2"
+
+[dependencies]
+```
+
+Build and run the project:
+
+```bash
+rvpm run
+```
+
+`rvpm run` compiles `src/main.rv` to `target/raven-out/<name>` (with a
+`.exe` extension on Windows), then runs it and forwards any arguments
+after `run` to your program. Use `rvpm build` to compile without running.
+
+Continue with the [language reference](language-reference.md) for every
+construct, the [standard library](standard-library.md) for the bundled
+modules, and the [rvpm guide](rvpm.md) for dependencies and the lock file.

--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -1,0 +1,463 @@
+# Language reference (v2)
+
+This page covers every construct in Raven v2. Statements are separated by
+newlines, semicolons, or both. Semicolons are optional and rarely used.
+There is no top level statement execution: a program runs from `fun main()`.
+
+## Variables
+
+`let` introduces a binding. Bindings are mutable: you can reassign them
+and mutate their fields and elements.
+
+```raven
+fun main() {
+    let n = 10
+    n = n + 5
+    print(n)            // 15
+}
+```
+
+A type annotation is optional. When omitted the type is inferred from the
+initializer; annotate when the type cannot be inferred (for example an
+empty list).
+
+```raven
+let count: Int = 0
+let names: List<String> = []
+```
+
+`const` is a compile time constant declared at module level. It requires
+both a type and a value.
+
+```raven
+const MAX: Int = 100
+```
+
+## Primitive types
+
+Type names are PascalCase.
+
+| Type     | Meaning |
+|----------|---------|
+| `Int`    | 64-bit signed integer |
+| `Float`  | 64-bit floating point |
+| `Bool`   | `true` or `false` |
+| `String` | UTF-8 text, heap allocated |
+| `Char`   | a single Unicode scalar value |
+| `Unit`   | the empty value, written `()` |
+
+```raven
+let i: Int = 42
+let f: Float = 3.14
+let b: Bool = true
+let s: String = "raven"
+let c: Char = 'x'
+```
+
+Integer literals accept bases: `0xff`, `0b1010`, `0o17`, and underscores
+for grouping such as `1_000_000`.
+
+## Strings and interpolation
+
+A regular string uses double quotes and processes escapes (`\n`, `\t`,
+`\\`, `\"`, `\x41`, `\u{1F600}`). String interpolation embeds an
+expression with `${...}`:
+
+```raven
+fun main() {
+    let name = "Raven"
+    let a = 3
+    let b = 4
+    print("Hello, ${name}!")
+    print("sum is ${a + b}")
+}
+```
+
+A block string uses triple quotes and is raw: no escapes are processed
+and newlines are preserved exactly.
+
+```raven
+let text = """
+line one
+line two
+"""
+```
+
+A C string literal `c"..."` produces a `CStr` for FFI. It lowers to a
+pointer to a static null terminated buffer (see [FFI](#ffi-and-c-types)).
+
+## Operators
+
+Arithmetic: `+`, `-`, `*`, `/`, `%`.
+
+Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`. Comparisons do not chain:
+`a < b < c` is an error.
+
+Logical: `&&`, `||`, `!`.
+
+Bitwise: `&`, `|`, `^`, `~`, `<<`, `>>`.
+
+Ranges produce a range value used by `for`. `a..b` is half open (excludes
+`b`); `a..=b` is inclusive.
+
+```raven
+for x in 0..5 {        // 0, 1, 2, 3, 4
+    print(x)
+}
+```
+
+The postfix `?` operator propagates the error case of a `Result` or the
+`None` case of an `Option`, returning early from the enclosing function.
+
+Compound assignment operators apply an operation in place: `+=`, `-=`,
+`*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`.
+
+## Functions
+
+A function declares typed parameters and an optional return type. A
+function with no return type returns `Unit`.
+
+```raven
+fun add(a: Int, b: Int) -> Int {
+    return a + b
+}
+```
+
+A function may use an expression body with `=`, where the trailing
+expression is the return value:
+
+```raven
+fun square(x: Int) -> Int = x * x
+```
+
+Functions can be generic over type parameters; see [generics](#generics-and-trait-bounds).
+
+## Closures and lambdas
+
+A lambda is written with `fun(params) -> Ret = body` or a block body.
+Closures capture surrounding locals by value. A function type is written
+`fun(ArgTypes) -> Ret`.
+
+```raven
+fun apply(f: fun(Int) -> Int, x: Int) -> Int {
+    return f(x)
+}
+
+fun main() {
+    let factor = 3
+    let triple = fun(x: Int) -> Int = x * factor
+    print(apply(triple, 7))      // 21
+}
+```
+
+A closure can be returned, carrying its captured values:
+
+```raven
+fun make_adder(n: Int) -> fun(Int) -> Int {
+    return fun(x: Int) -> Int = x + n
+}
+```
+
+## Control flow
+
+`if` / `else if` / `else` chooses a branch. It works as a statement and
+as an expression that yields a value:
+
+```raven
+let label = if n > 0 { "positive" } else { "non-positive" }
+```
+
+`while` loops while a condition holds:
+
+```raven
+let i = 0
+while i < 10 {
+    i = i + 1
+}
+```
+
+`loop` is an unconditional loop. It evaluates to the operand of `break`:
+
+```raven
+let first = loop {
+    break 42
+}
+```
+
+`for ... in` iterates a range or a list:
+
+```raven
+let xs = [3, 5, 7]
+let total = 0
+for v in xs {
+    total = total + v
+}
+```
+
+`break` exits the nearest loop (optionally carrying a value for `loop`),
+`continue` skips to the next iteration, and `return` exits the function.
+
+## defer
+
+`defer` schedules an expression to run when the enclosing function
+returns. Deferred expressions run in reverse order of registration
+(last in, first out), and only those actually reached at runtime run.
+
+```raven
+fun demo() -> Int {
+    defer print(1)
+    defer print(2)
+    return 0
+}
+// prints 2 then 1
+```
+
+## Structs
+
+A struct groups named, typed fields. Construct it with a struct literal,
+read fields with `.`, and assign to fields and elements.
+
+```raven
+struct Point { x: Int, y: Int }
+
+fun main() {
+    let p = Point { x: 3, y: 4 }
+    print(p.x + p.y)        // 7
+    p.x = 10
+}
+```
+
+Methods are declared in an `impl` block. A method takes `self` as its
+first parameter. A function in an `impl` block without `self` is an
+associated function, the idiomatic constructor, called as `Type.func()`.
+
+```raven
+struct Counter { n: Int }
+
+impl Counter {
+    fun new() -> Counter {
+        return Counter { n: 0 }
+    }
+
+    fun bump(self) {
+        self.n = self.n + 1
+    }
+}
+
+fun main() {
+    let c = Counter.new()
+    c.bump()
+    print(c.n)              // 1
+}
+```
+
+Methods can also be declared on built in types:
+
+```raven
+impl Int {
+    fun doubled(self) -> Int = self * 2
+}
+```
+
+## Enums
+
+An enum defines a set of variants. A variant can be a unit variant, a
+tuple variant with positional payloads, or a struct variant with named
+fields. Construct a variant with `EnumName.Variant` (or
+`EnumName.Variant(args)` for a payload). Match with the bare variant name.
+
+```raven
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+enum Shape {
+    Circle(Float),
+    Square(Float),
+}
+
+fun area(s: Shape) -> Float {
+    return match s {
+        Circle(r) -> r * r * 3.0,
+        Square(w) -> w * w,
+    }
+}
+
+fun main() {
+    let c = Color.Green
+    print(area(Shape.Circle(2.0)))
+}
+```
+
+## match
+
+`match` tests a value against patterns top to bottom and yields the
+selected arm. Match is exhaustive: every case must be covered. Patterns
+include literals, ranges, the wildcard `_`, enum variants binding their
+payload, and struct fields. An arm may carry a guard with `if`.
+
+```raven
+fun classify(n: Int) -> String {
+    return match n {
+        0 -> "zero",
+        x if x < 0 -> "negative",
+        _ -> "positive",
+    }
+}
+```
+
+## Traits and impl
+
+A trait declares methods that a type can implement. Implement it with
+`impl Trait for Type`. A trait method may have a default body.
+
+```raven
+trait Speak {
+    fun sound(self) -> Int
+}
+
+struct Dog {}
+
+impl Speak for Dog {
+    fun sound(self) -> Int = 1
+}
+```
+
+`impl Type { ... }` adds inherent methods and associated functions;
+`impl Trait for Type { ... }` provides a trait implementation.
+
+## Generics and trait bounds
+
+Functions, structs, enums, and impl blocks can take type parameters in
+angle brackets. A bound `T: Trait` constrains a parameter to types that
+implement the trait. Use `+` to require several bounds.
+
+```raven
+fun show<T: ToString>(label: String, x: T) -> String {
+    return "${label}=${x}"
+}
+
+struct Box<T> {
+    value: T
+}
+
+impl<T> Box<T> {
+    fun unwrap(self) -> T = self.value
+}
+```
+
+Generic code is monomorphized: a distinct machine specialization is
+emitted for each concrete type the program uses. A method can introduce
+its own type parameters separate from the type's:
+
+```raven
+impl<T> Box<T> {
+    fun mapped<U>(self, f: fun(T) -> U) -> U = f(self.value)
+}
+```
+
+## Option and Result
+
+`Option<T>` is `Some(T)` or `None`. `Result<T, E>` is `Ok(T)` or
+`Err(E)`. Both are matched with their variant names and built with the
+bare constructors `Some`, `None`, `Ok`, and `Err`. The type `T?` is sugar
+for `Option<T>`.
+
+```raven
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun unwrap_or(x: Option<Int>, fallback: Int) -> Int {
+    return match x {
+        None -> fallback,
+        Some(n) -> n,
+    }
+}
+```
+
+The `?` operator unwraps `Ok`/`Some` or returns the `Err`/`None` early,
+which keeps error handling flat. `error` and the `Result` helpers live in
+[`std/error`](standard-library.md#stderror).
+
+## dyn Trait
+
+`dyn Trait` is a trait object: a value of any type that implements the
+trait, dispatched at runtime through a vtable. Passing a concrete value
+where `dyn Trait` is expected boxes it as a fat pointer.
+
+```raven
+trait Speak {
+    fun sound(self) -> Int
+}
+
+fun describe(s: dyn Speak) -> Int = s.sound()
+```
+
+Use generics with a bound when the concrete type is known at the call
+site (no indirection), and `dyn Trait` when you need a single type that
+holds different implementers.
+
+## Modules and imports
+
+`import` brings in a module. Standard library modules use the `std/...`
+path. A selective import binds named items; a bare import merges the
+module (used for modules that add methods or constructors).
+
+```raven
+import std/io { println }
+import std/collections
+import "./helpers"
+import "github.com/martian56/raven-http" as http
+```
+
+Forms:
+
+- `import std/io { println }` binds the named items directly.
+- `import std/string` merges the module's `impl String` block so String
+  methods resolve by receiver type.
+- `import std/collections` is a whole module import; `Map` and `Set` are
+  reached as `Map.new()` and `Set.new()` rather than through a selector.
+- `import "./helpers"` loads a local module relative to the current file.
+- `import "github.com/<user>/<repo>"` resolves a dependency through the
+  rvpm cache (see the [rvpm guide](rvpm.md)). Add `as name` for an alias.
+
+The core traits (`ToString`, `Eq`, `Ord`, `Hash`, `Iterator`) are always
+in scope without an import.
+
+## FFI and C types
+
+`extern "C" { ... }` declares foreign function signatures. Call them like
+ordinary functions. Arguments and returns use C types.
+
+```raven
+extern "C" {
+    fun abs(x: CInt) -> CInt
+    fun strlen(s: CStr) -> CSize
+}
+
+fun main() {
+    print(abs(-7))               // 7
+    print(strlen(c"hello"))      // 5
+}
+```
+
+C types map to C as follows:
+
+| Raven   | C              | Width |
+|---------|----------------|-------|
+| `CInt`  | `int`          | 32-bit |
+| `CLong` | `long`         | 64-bit |
+| `CSize` | `size_t`       | pointer width (64-bit) |
+| `CStr`  | `const char *` | pointer width |
+| `CDouble` | `double`     | 64-bit |
+
+A native `Int` is accepted where an integer C type is expected, and a
+`c"..."` literal where a `CStr` is expected. To pass a runtime `String`
+to C, convert it with [`std/ffi`](standard-library.md#stdffi)'s
+`to_cstr`; a native `String` is not itself a valid `const char *`.

--- a/docs/v2/guide/migration.md
+++ b/docs/v2/guide/migration.md
@@ -1,0 +1,145 @@
+# Migrating from v1
+
+Raven v2 is a compiled language with a stricter type system, generics,
+traits, and a package manager. This page maps the v1 surface to v2 so you
+can update existing code. It is practical rather than exhaustive; see the
+[language reference](language-reference.md) for the full v2 surface.
+
+## Quick reference
+
+| v1 | v2 |
+|----|----|
+| `int`, `float`, `bool`, `string` | `Int`, `Float`, `Bool`, `String` |
+| `int[]` | `List<Int>` |
+| statements end with `;` | newlines separate statements; `;` optional |
+| `fun main() -> void { ... }` then `main();` | `fun main() { ... }` runs automatically |
+| `export` | removed; modules expose declared items directly |
+| sentinel return values for errors | `Result<T, E>` and `Option<T>` |
+| C-style `for (i = 0; i < n; i = i + 1)` | `for i in 0..n` |
+| top level statements | code runs from `fun main()` |
+
+## Types are PascalCase
+
+Primitive type names changed from lowercase to PascalCase:
+
+```raven
+// v1
+let name: string = "Raven";
+let count: int = 0;
+
+// v2
+let name: String = "Raven"
+let count: Int = 0
+```
+
+Array types become the generic `List<T>`:
+
+```raven
+// v1
+let numbers: int[] = [1, 2, 3];
+
+// v2
+let numbers: List<Int> = [1, 2, 3]
+```
+
+## No semicolons, no top level execution
+
+v2 separates statements with newlines, and semicolons are optional. There
+is no top level statement execution and no trailing `main();` call:
+execution begins at `fun main()`.
+
+```raven
+// v1
+fun main() -> void {
+    print("hi");
+}
+main();
+
+// v2
+fun main() {
+    print("hi")
+}
+```
+
+A function with no return type returns `Unit`, so the `-> void`
+annotation is dropped.
+
+## export is gone
+
+v1 used `export` to mark module items as public. v2 has no `export`. A
+module exposes its declared functions, structs, enums, and traits; a
+consumer imports them by name with a selective import.
+
+```raven
+// v2 consumer
+import std/io { println }
+import "./helpers" { greet }
+```
+
+## Errors use Result and Option
+
+v1 signaled failure with sentinel return values. v2 uses `Result<T, E>`
+for fallible operations and `Option<T>` for optional values, matched with
+their variant names and propagated with `?`.
+
+```raven
+import std/error { error }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    match divide(10, 2) {
+        Ok(v) -> print(v),
+        Err(e) -> print(e.message()),
+    }
+}
+```
+
+## Loops use for ... in
+
+The C-style `for` is replaced by `for ... in` over a range or a list.
+Ranges are `a..b` (half open) and `a..=b` (inclusive).
+
+```raven
+// v1
+for (i = 0; i < 5; i = i + 1) {
+    print(i);
+}
+
+// v2
+for i in 0..5 {
+    print(i)
+}
+```
+
+## New in v2
+
+These constructs have no v1 equivalent:
+
+- Generics with trait bounds: `fun show<T: ToString>(x: T) -> String`.
+- Traits and `impl Trait for Type`, plus `dyn Trait` for runtime dispatch.
+- `match` with exhaustive patterns and guards.
+- Associated functions as constructors: `Type.new()`.
+- Lazy iterators in `std/iter`.
+- `defer` for cleanup that runs on function return.
+- Package imports through `rvpm`: `import "github.com/<user>/<repo>"`.
+
+## Module imports
+
+v1 imported a whole module by name. v2 standard library modules use a
+`std/...` path with a selective import for free functions, a bare import
+for modules that add methods or constructors (`std/string`,
+`std/collections`), and quoted paths for local (`./`) and GitHub
+dependencies.
+
+```raven
+import std/io { println }
+import std/string
+import std/collections
+import "./util"
+```

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -1,0 +1,169 @@
+# rvpm: the package manager (v2)
+
+`rvpm` owns a Raven project: its manifest, dependencies, lock file, and
+build. It drives the same compile pipeline as `raven build`, adding a
+package context so `github.com/...` imports resolve through a shared
+cache.
+
+## Project layout
+
+A package has an `rv.toml` manifest at its root and an entry file at
+`src/main.rv`:
+
+```
+my_app/
+  rv.toml
+  rv.lock              # written by rvpm, pins resolved dependencies
+  src/
+    main.rv            # must define fun main()
+```
+
+`rvpm init [name]` scaffolds this. The built binary is written to
+`target/raven-out/<name>` (with a `.exe` extension on Windows).
+
+## The rv.toml manifest
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+authors = ["Ada", "Grace"]
+edition = "v2"
+
+[dependencies]
+"github.com/martian56/raven-http" = "1.0"
+
+[ffi]
+libs = ["m", "z"]
+link_args = ["-L/opt/lib"]
+
+[fmt]
+indent_width = 4
+wrap_width = 100
+```
+
+Sections:
+
+- `[package]` (required): `name` and `version` are required. `authors`
+  defaults to empty. `edition` defaults to `v2` (accepted: `v2`, `2026`).
+- `[dependencies]` (optional): keys are `github.com/<user>/<repo>` paths
+  (optionally with a subpath); values are git refs (a tag or branch).
+- `[ffi]` (optional): native linker pass-through, `libs` and `link_args`.
+- `[fmt]` (optional): `indent_width` (default 4) and `wrap_width`
+  (default 100) for the formatter.
+
+Unknown fields are rejected so typos surface early.
+
+## Dependencies
+
+A dependency is a `github.com/<user>/<repo>` path pinned to an explicit
+git ref. In source, import it by its path:
+
+```raven
+import "github.com/martian56/raven-http" as http
+import "github.com/martian56/raven-http" { get }
+```
+
+A bare `github.com/<user>/<repo>` resolves to `lib.rv` at the package
+root. A subpath such as `github.com/acme/greet/util/text` resolves to
+`util/text.rv` within the package.
+
+Version constraint ranges (semver) are future work. For now the
+constraint string is treated as the literal git ref to fetch, so the
+resolved version equals what you write.
+
+## Commands
+
+### rvpm init
+
+```bash
+rvpm init [name]
+```
+
+Scaffolds `rv.toml` and `src/main.rv` in the current directory. The name
+defaults to the directory name. It will not overwrite an existing
+`rv.toml`.
+
+### rvpm add
+
+```bash
+rvpm add github.com/<user>/<repo>[@<version>]
+```
+
+Records the dependency in `rv.toml`, then resolves and writes `rv.lock`,
+populating the cache. An existing entry is updated in place. Prefer
+passing `@<version>`; omitting it records the placeholder `latest`, which
+does not resolve until a concrete ref is supplied. The manifest edit
+preserves comments and formatting.
+
+### rvpm install
+
+```bash
+rvpm install
+```
+
+Resolves `rv.toml` against `rv.lock` and fills the cache. When the lock
+covers every direct dependency, it validates each pinned entry by
+re-hashing its fetched tree; a hash mismatch aborts. When the lock is
+missing or incomplete, it resolves the full transitive set fresh and
+writes `rv.lock`.
+
+### rvpm update
+
+```bash
+rvpm update [github.com/<user>/<repo>]
+```
+
+Re-resolves and rewrites `rv.lock`. With no path, every entry is
+refreshed. With a path, only that dependency's subgraph is refreshed. To
+bump a dependency, edit its ref in `rv.toml`, then run `update`.
+
+### rvpm build
+
+```bash
+rvpm build
+```
+
+Ensures dependencies are installed, builds the package context from the
+lock, then compiles `src/main.rv` to `target/raven-out/<name>` and
+reports the binary path.
+
+### rvpm run
+
+```bash
+rvpm run [program arguments]
+```
+
+Builds the package (the same path as `build`), then runs the produced
+binary, forwarding any arguments after `run` and exiting with the
+program's exit code.
+
+### rvpm fmt
+
+```bash
+rvpm fmt
+```
+
+Formats the package sources using the `[fmt]` settings from `rv.toml`.
+
+## The cache and rv.lock
+
+Fetched dependencies live in a shared cache, one directory per resolved
+version:
+
+```
+<cache_root>/github.com/<user>/<repo>@<version>/
+```
+
+The cache root is `$RVPM_CACHE_DIR` if set, otherwise
+`${HOME}/.rvpm/cache` (`%USERPROFILE%` on Windows). A populated entry is
+reused and never re-cloned. Cloning is shallow, and the `.git` directory
+is dropped after a clone, so the cache stores only working-tree content.
+
+`rv.lock` pins every transitive dependency by `(source, version)` plus a
+SHA-256 tree content hash, sorted deterministically so the file is stable
+across runs. The hash normalizes path separators and ignores file modes
+and timestamps, so the same tree hashes identically on Windows and Linux.
+Check `rv.lock` in next to `rv.toml` for reproducible builds: a later
+install or build fetches the pinned refs and verifies each tree still
+hashes to the recorded value.

--- a/docs/v2/guide/standard-library.md
+++ b/docs/v2/guide/standard-library.md
@@ -1,0 +1,436 @@
+# Standard library (v2)
+
+The standard library ships as bundled `std/...` modules. Import a module
+with a selective import for its free functions, or a bare import for a
+module that adds methods or constructors. The core traits are always in
+scope.
+
+Two import gotchas to keep in mind:
+
+- To use `String` methods such as `concat` or `to_upper`, a module must
+  `import std/string`, which merges the `impl String` block.
+- `import std/collections` whole (not `{ Map }`), so the `Map.new()` and
+  `Set.new()` constructors resolve.
+
+## Core traits
+
+`std/core` defines `ToString`, `Eq`, `Ord`, `Hash`, and `Iterator<T>`,
+and implements them for the primitive types. These are auto imported, so
+no `import std/core` line is needed.
+
+```raven
+fun describe<T: ToString>(x: T) -> String = x.to_string()
+```
+
+## std/io
+
+Console input and output.
+
+- `print(s: String)`: write without a trailing newline.
+- `println(s: String)`: write with a trailing newline.
+- `input(prompt: String) -> String`: print the prompt, read one line.
+- `read_line() -> String`: read one line from standard input.
+
+```raven
+import std/io { println }
+
+fun main() {
+    println("${40 + 2}")        // 42
+}
+```
+
+A global `print` builtin is also always available and accepts any
+`ToString` value (it appends a newline).
+
+## std/string
+
+Methods on `String`, merged by a bare import.
+
+`length`, `is_empty`, `char_at`, `substring(start, end)`, `concat`,
+`to_upper`, `to_lower`, `trim`, `is_blank`, `repeat(n)`, `index_of`,
+`contains`, `starts_with`, `ends_with`, `replace(from, to)`.
+
+```raven
+import std/string
+
+fun main() {
+    print("hello".to_upper())            // HELLO
+    print("a-b".replace("-", "+"))       // a+b
+    print("raven".substring(1, 4))       // ave
+}
+```
+
+## std/collections
+
+Generic `Set<T: Eq>` and `Map<K: Eq, V>`, built with `Set.new()` and
+`Map.new()`. Import the whole module.
+
+- `Set`: `add`, `remove`, `contains`, `len`, `is_empty`.
+- `Map`: `set(k, v)`, `get(k) -> Option<V>`, `has(k)`, `remove(k)`,
+  `len`, `is_empty`.
+
+```raven
+import std/collections
+
+fun main() {
+    let m = Map.new()
+    m.set("a", 10)
+    match m.get("a") {
+        Some(v) -> print(v),
+        None -> print(0),
+    }
+}
+```
+
+## std/math
+
+Float and integer math.
+
+- Integer: `abs_int`, `min_int`, `max_int`, `clamp_int`, `pow_int`.
+- Float: `sqrt`, `pow`, `exp`, `ln`, `abs`, `min`, `max`, `clamp`,
+  `floor`, `ceil`, `round`, `trunc`, `sin`, `cos`.
+- Constants: `pi()`, `e()`, `tau()`.
+
+```raven
+import std/math { sqrt, pow_int }
+
+fun main() {
+    print(sqrt(16.0))           // 4
+    print(pow_int(2, 10))       // 1024
+}
+```
+
+## std/cmp
+
+Comparison helpers generic over `T: Ord`.
+
+- `min(a, b)`, `max(a, b)`, `clamp(x, lo, hi)`.
+- `sort(xs) -> List<T>`, `sorted_by(xs, cmp)`.
+- `max_of(xs) -> Option<T>`, `min_of(xs) -> Option<T>`.
+
+```raven
+import std/cmp { sort, max_of }
+
+fun main() {
+    let s = sort([5, 2, 8, 1])
+    print(s[0])                 // 1
+}
+```
+
+## std/hash
+
+Non cryptographic hashing.
+
+- `fnv1a(s)`, `djb2(s)`, `checksum(s)` over strings.
+- `hash_int(n)`, `combine(seed, value)` for mixing.
+
+```raven
+import std/hash { fnv1a }
+
+fun main() {
+    print(fnv1a("abc") == fnv1a("abc"))     // true
+}
+```
+
+## std/iter
+
+Lazy iterators. `xs.iter()` bridges a `List<T>` into an iterator. The
+adapters `map`, `filter`, `take`, `skip`, and `enumerate` are lazy. The
+consumers `collect`, `count`, `fold`, `any`, `all`, `find`, and
+`for_each` drive the pipeline.
+
+```raven
+import std/iter { collect, fold, count }
+
+fun main() {
+    let xs = [1, 2, 3, 4, 5, 6]
+    let kept = collect(xs.iter().map(fun(x: Int) -> Int = x * 10).filter(fun(y: Int) -> Bool = y > 20))
+    print(kept.len())
+    print(count(xs.iter().filter(fun(y: Int) -> Bool = y > 3)))
+}
+```
+
+## std/fmt
+
+String formatting helpers and a `Debug` trait.
+
+- `repeat`, `pad_left`, `pad_right`, `center`, `join(parts, sep)`.
+- `to_binary`, `to_octal`, `to_hex`, `to_radix(n, base)`, `pad_int`.
+- `Debug` for the primitives, used through `.debug()`.
+
+```raven
+import std/fmt { pad_left, to_hex, join }
+
+fun main() {
+    print(pad_left("7", 3, "0"))            // 007
+    print(to_hex(255))                      // ff
+    print(join(["a", "b", "c"], ", "))      // a, b, c
+}
+```
+
+## std/encoding
+
+Hex and base64.
+
+- `hex_encode(s)`, `hex_decode(s)`.
+- `base64_encode(s)`, `base64_decode(s)`.
+
+```raven
+import std/encoding { base64_encode, base64_decode }
+
+fun main() {
+    print(base64_decode(base64_encode("hi")) == "hi")   // true
+}
+```
+
+## std/random
+
+A seeded random number generator `Rng`, built with `Rng.new(seed)` or
+`Rng.from_entropy()`.
+
+- `next_int`, `gen_range(lo, hi)`, `next_float`, `next_bool`.
+- `choice(xs) -> Option<T>`, `shuffle(xs)`.
+
+```raven
+import std/random
+
+fun main() {
+    let r = Rng.new(42)
+    print(r.gen_range(0, 10) < 10)          // true
+}
+```
+
+## std/env
+
+Process environment, arguments, and platform.
+
+- `get_env(name)`, `get_env_or(name, default)`, `has_env(name)`.
+- `arg_count`, `arg_at(i)`, `args() -> List<String>`.
+- `exit(code)`, `os_name()`, `arch()`.
+
+```raven
+import std/env { os_name, get_env_or }
+
+fun main() {
+    print(os_name())
+    print(get_env_or("HOME", "unknown"))
+}
+```
+
+## std/fs
+
+Filesystem access. The IO operations return `Result<_, Error>`.
+
+- `read(path)`, `write(path, contents)`, `append(path, contents)`.
+- `remove_file`, `create_dir`, `remove_dir`, `list_dir`, `size`.
+- `exists`, `is_file`, `is_dir` return `Bool` directly.
+- Path helpers: `join`, `basename`, `dirname`, `split`.
+
+```raven
+import std/fs { write, read }
+
+fun main() {
+    match write("note.txt", "hello") {
+        Ok(_) -> {},
+        Err(e) -> print("write failed"),
+    }
+    match read("note.txt") {
+        Ok(s) -> print(s),
+        Err(e) -> print("read failed"),
+    }
+}
+```
+
+## std/time
+
+Timestamps and calendar conversions.
+
+- `now() -> Int`, `now_millis()`, `sleep_millis(ms)`.
+- `from_timestamp(ts) -> DateTime`, `weekday(ts)`.
+- `format_timestamp(ts, pattern)`, `parse_timestamp(text, pattern) -> Result<Int, Error>`.
+
+```raven
+import std/time { format_timestamp, now }
+
+fun main() {
+    print(format_timestamp(0, "%Y-%m-%d"))
+    print(now() > 0)
+}
+```
+
+## std/net
+
+TCP sockets.
+
+- `connect(addr) -> Result<TcpStream, Error>`, `listen(addr) -> Result<TcpListener, Error>`.
+- `TcpListener.accept`, `TcpStream` `read(max)`, `write(data)`,
+  `set_read_timeout_ms(ms)`, `close`.
+- `dns_lookup(host)`, `reachable(addr)`.
+
+```raven
+import std/net { connect }
+
+fun main() {
+    match connect("example.com:80") {
+        Ok(s) -> s.close(),
+        Err(e) -> print("connect failed"),
+    }
+}
+```
+
+## std/http
+
+HTTP client built on `std/net`.
+
+- `get(url)`, `post(url, body)`, `put(url, body)`, `delete(url)`.
+- `request(method, url, body, headers)`.
+- All return `Result<HttpResponse, Error>`; the response carries
+  `status_code` and `body`.
+
+```raven
+import std/http { get }
+
+fun main() {
+    match get("http://example.com") {
+        Ok(resp) -> print(resp.status_code),
+        Err(e) -> print("request failed"),
+    }
+}
+```
+
+## std/json
+
+JSON parsing and serialization.
+
+- `parse(text) -> Result<JsonValue, Error>`, `stringify(value) -> String`.
+- `JsonValue` accessors: `is_null`, `as_bool`, `as_number`, `as_string`,
+  `get(key)`, `at(i)`.
+
+```raven
+import std/json { parse, stringify }
+
+fun main() {
+    match parse("{\"a\": 1}") {
+        Ok(v) -> print(stringify(v)),
+        Err(e) -> print("parse failed"),
+    }
+}
+```
+
+## std/regex
+
+Regular expressions. `compile` returns `Result<Regex, Error>`. Free a
+compiled pattern with `free` when done.
+
+- `is_match(text)`, `find(text) -> Option<String>`, `find_all(text)`.
+- `captures(text)`, `replace_all(text, repl)`, `split(text)`.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    match compile("a+") {
+        Ok(re) -> {
+            print(re.is_match("xaaay"))     // true
+            re.free()
+        },
+        Err(e) -> print("compile failed"),
+    }
+}
+```
+
+## std/process
+
+Run external programs.
+
+- `run(program, args) -> Result<Output, Error>`.
+- `run_with_input(program, args, input)`.
+- `Output` carries `code`, `stdout`, `stderr`, and `success()`.
+
+```raven
+import std/process { run }
+
+fun main() {
+    let no_args: List<String> = []
+    match run("echo", no_args) {
+        Ok(out) -> print(out.code),
+        Err(e) -> print("run failed"),
+    }
+}
+```
+
+## std/ffi
+
+Bridge runtime `String` values to C strings for FFI calls.
+
+- `to_cstr(s) -> CStr`, `from_cstr(p) -> String`.
+
+```raven
+import std/ffi { to_cstr, from_cstr }
+
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+}
+
+fun main() {
+    print(strlen(to_cstr("hello")))         // 5
+}
+```
+
+## std/error
+
+The `Error` type and `Result` helpers.
+
+- `error(msg) -> Error`, `error_kind(kind, msg)`.
+- `Error` methods: `message`, `kind`, `with_context(ctx)`, `to_string`.
+- `is_ok(r)`, `is_err(r)`, `unwrap_or(r, default)`, `ok(r) -> Option<T>`,
+  `err(r) -> Option<E>`.
+
+```raven
+import std/error { error, unwrap_or }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    print(unwrap_or(divide(1, 0), -1))      // -1
+}
+```
+
+## std/path
+
+Pure path string manipulation (no filesystem access).
+
+- `join(a, b)`, `basename(p)`, `dirname(p)`, `extension(p)`, `stem(p)`,
+  `is_absolute(p)`.
+
+```raven
+import std/path { join, basename, extension }
+
+fun main() {
+    print(join("a/b", "c.txt"))             // a/b/c.txt
+    print(extension("a/b/c.txt"))           // txt
+}
+```
+
+## std/test
+
+Assertions for test programs. A failing assertion panics and aborts with
+a non-zero exit.
+
+- `assert(cond)`, `assert_msg(cond, msg)`.
+- `assert_true`, `assert_false`.
+- `assert_eq_int(a, b)`, `assert_eq_str(a, b)`.
+
+```raven
+import std/test { assert, assert_eq_int }
+
+fun main() {
+    assert(1 + 1 == 2)
+    assert_eq_int(6 * 7, 42)
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,25 +81,32 @@ plugins:
 
 nav:
   - Home: index.md
-  - Getting Started:
-    - Installation: getting-started/installation.md
-    - Quick Start: getting-started/quick-start.md
-    - rvpm and formatting: getting-started/rvpm-and-format.md
-  - Language Reference:
-    - Syntax: syntax.md
-    - Data Types: language-reference/data-types.md
-  - Standard Library:
-    - Overview: standard-library/overview.md
-  - Examples:
-    - Basic Examples: examples/basic.md
-  - Development:
-    - Contributing: development/contributing.md
-    - Roadmap: PRODUCTION_ROADMAP.md
-    - Standard Library Spec: STDLIB_SPEC.md
-  - Resources:
-    - VS Code Extension: resources/vscode-extension.md
-    - GitHub Repository: https://github.com/martian56/raven
-    - VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=martian56.raven-language
+  - v2:
+    - Getting Started: v2/guide/getting-started.md
+    - Language Reference: v2/guide/language-reference.md
+    - Standard Library: v2/guide/standard-library.md
+    - rvpm: v2/guide/rvpm.md
+    - Migration from v1: v2/guide/migration.md
+  - v1 (maintenance):
+    - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quick-start.md
+      - rvpm and formatting: getting-started/rvpm-and-format.md
+    - Language Reference:
+      - Syntax: syntax.md
+      - Data Types: language-reference/data-types.md
+    - Standard Library:
+      - Overview: standard-library/overview.md
+    - Examples:
+      - Basic Examples: examples/basic.md
+    - Development:
+      - Contributing: development/contributing.md
+      - Roadmap: PRODUCTION_ROADMAP.md
+      - Standard Library Spec: STDLIB_SPEC.md
+    - Resources:
+      - VS Code Extension: resources/vscode-extension.md
+  - Repository: https://github.com/martian56/raven
+  - VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=martian56.raven-language
 
 extra:
   social:


### PR DESCRIPTION
Adds a v2 documentation section to the mkdocs site covering the language, standard library, rvpm, and migration, while keeping the v1 docs reachable.

Closes #88

## Pages added (docs/v2/guide/)

- `getting-started.md`: build the toolchain, `fun main()`, `print`, `raven build file.rv -o out`, then the rvpm flow (`rvpm init`, project layout, `rvpm run`).
- `language-reference.md`: every construct (variables, primitives, strings and interpolation, operators and ranges, functions, closures, control flow, defer, structs, enums and construction, match, traits and impl, generics and bounds, Option/Result and `?`, dyn Trait, modules and imports, extern "C" FFI and C types).
- `standard-library.md`: the public API of every bundled module (core traits, io, string, collections, math, cmp, hash, iter, fmt, encoding, random, env, fs, time, net, http, json, regex, process, ffi, error, path, test) with a short usage example each, plus the import gotchas.
- `rvpm.md`: rv.toml schema, dependencies (github paths), init/add/install/update/build/run/fmt, the shared cache and rv.lock.
- `migration.md`: a practical v1 to v2 mapping.

## Nav structure

`mkdocs.yml` now has a top level `v2` section (Getting Started, Language Reference, Standard Library, rvpm, Migration from v1) and a `v1 (maintenance)` section that keeps all existing v1 pages reachable. No v1 pages were deleted. The `docs/v2/specs/` internals reference is unchanged.

## mkdocs build result

`mkdocs build` succeeds (exit 0). The only warnings are pre-existing: the README/index conflict and the `docs/v2/specs/*` internals pages that have never been in the nav. The new guide pages introduce no broken links or missing-nav errors.

## CI

Docs-only changes (docs/ and mkdocs.yml) are outside the Rust CI path filters, so they do not trigger the Rust workflow. `cargo build --workspace` still succeeds; no Rust was touched.

Every Raven code block was cross-checked against `examples/v2/*.rv` and `stdlib/std/*.rv` for valid v2 syntax.
