### PR TITLE
fix(resolve): selective imports of bundled types and sibling functions

### DIFF
--- a/docs/v2/specs/resolver.md
+++ b/docs/v2/specs/resolver.md
@@ -137,10 +137,11 @@ How a local module is merged:
   from other modules are rewritten to the matching namespaced symbols, so a
   transitive call resolves to its dependency's merged function.
 * STRUCT, ENUM, and TRAIT types from a local module merge under their own
-  (un-namespaced) names, exactly the way bundled types like `Map` merge.
-  This means two local modules that both define a type named `Foo` collide.
-  That limitation mirrors the existing stdlib-type behavior (issues #178 and
-  #184) and is not addressed here.
+  (un-namespaced) names, exactly the way bundled types like `Map` merge. A
+  selective import of such a type (`import std/collections { Map }`) binds to
+  that single merged declaration rather than introducing a second one, so the
+  name is not declared twice. Two modules that each define a type with the
+  same name still collide, because a type carries no namespace.
 * `impl` blocks merge with their method names intact, dispatched by receiver
   type; their bodies' sibling and imported-name calls are rewritten like a
   free function's.

--- a/docs/v2/specs/stdlib.md
+++ b/docs/v2/specs/stdlib.md
@@ -211,6 +211,14 @@ ships.
   by rewriting intra-module sibling calls to their namespaced names; see
   that spec for the detail.
 
+A bundled module may also selectively import a free function from another
+bundled module (`import std/error { error_kind }`) and call it by its bare
+name: the expander rewrites that call site to the dependency's namespaced
+symbol (`std.error.error_kind`), the same rewrite it applies to intra-module
+sibling calls. `std/fs`, `std/net`, `std/http`, and `std/time` use this to
+build their tagged errors through `error_kind` rather than assembling the
+`Error` struct literal by hand.
+
 ## Out of scope
 
 * The aliased import form `import std/io as io` with `io.member(...)`

--- a/examples/v2/use_collections_selective.rv
+++ b/examples/v2/use_collections_selective.rv
@@ -1,0 +1,22 @@
+// golden:skip
+// Selective import of bundled types: `Map` and `Set` are pulled in by
+// name without a double-declaration of the merged type (issue #184).
+import std/collections { Map, Set }
+import std/io { println }
+
+fun main() {
+    let s = Set.new()
+    s.add(1)
+    s.add(2)
+    s.add(2)
+    print(s.len())
+
+    let m = Map.new()
+    m.set("a", 10)
+    m.set("a", 99)
+    print(m.len())
+    match m.get("a") {
+        Some(v) -> print(v)
+        None -> print(0)
+    }
+}

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -1128,6 +1128,35 @@ mod tests {
     }
 
     #[test]
+    fn bundled_module_sibling_fn_selector_is_namespaced() {
+        // std/fs does `import std/error { error_kind }` and calls
+        // `error_kind(...)` inside `io_error`. After expansion that call
+        // site must reference the dependency's namespaced symbol
+        // (`std.error.error_kind`), not the bare name (issue #178).
+        let user = parse_src("import std/fs { read }\nfun main() {}\n");
+        let combined = expand_with_stdlib(&user).expect("expand");
+        let io_error = combined
+            .items
+            .iter()
+            .filter_map(|d| match &d.kind {
+                DeclKind::Function(f) if f.name == mangle_stdlib_fn("fs", "io_error") => Some(f),
+                _ => None,
+            })
+            .next()
+            .expect("io_error present");
+        let mut idents = Vec::new();
+        collect_fn_body_idents(&io_error.body, &mut idents);
+        assert!(
+            idents.iter().any(|n| n == "std.error.error_kind"),
+            "io_error should call the namespaced sibling, got: {idents:?}"
+        );
+        assert!(
+            !idents.iter().any(|n| n == "error_kind"),
+            "no bare sibling-module call should remain, got: {idents:?}"
+        );
+    }
+
+    #[test]
     fn transitive_std_import_merges_dependency_once() {
         // `std/path` imports `std/string`. A user importing only `std/path`
         // must still get `std/string`'s items merged (so path's `String`

--- a/src/resolve/tests.rs
+++ b/src/resolve/tests.rs
@@ -260,6 +260,21 @@ fn cyclic_local_imports_are_reported() {
 }
 
 #[test]
+fn selective_bundled_type_import_does_not_double_declare() {
+    // A selective import of a bundled type (`import std/collections { Map }`)
+    // must not collide with the merged type declaration the expander adds
+    // under the same name (issue #184). The expander merges `Map`/`Set`
+    // under their own names; the selector must bind to the merged type
+    // rather than introduce a second declaration.
+    let user = parse_src(
+        "import std/collections { Map, Set }\nfun main() { let m = Map.new() let s = Set.new() }\n",
+        "main.rv",
+    );
+    let combined = super::expand_with_stdlib(&user).expect("expand");
+    super::resolve_file(&combined, &mut NoLoader).expect("selective type import resolves");
+}
+
+#[test]
 fn unknown_stdlib_module_is_unresolved() {
     let file = parse_src("import std/nonsense\n", "main.rv");
     let err = resolve_file(&file, &mut NoLoader).unwrap_err();

--- a/stdlib/std/fs.rv
+++ b/stdlib/std/fs.rv
@@ -1,14 +1,14 @@
 // std/fs: filesystem operations over the raven-runtime C ABI. Fallible
 // ops return Result<T, Error> where the error is an std/error `Error`
 // tagged with kind "io" (Raven has no type alias, so IoError is realized
-// as that, built directly as an `Error` struct literal with kind "io").
+// as that, built through std/error's `error_kind("io", ...)`).
 // The runtime keeps a thread-local last-error string; each
 // wrapper runs the op and turns a non-empty last error into an Err. The
 // non-fallible queries (exists, is_file, is_dir) treat a missing path as a
 // normal false. Path manipulation is pure Raven string work on `/`. See
 // docs/v2/specs/std-fs.md.
 
-import std/error
+import std/error { error_kind }
 import std/string
 
 extern "C" {
@@ -29,7 +29,7 @@ extern "C" {
 // An Error tagged with kind "io" (the IoError realization), its message a
 // context prefix joined to the runtime's last-error text.
 fun io_error(ctx: String) -> Error {
-    return Error { kind: "io", message: ctx.concat(": ").concat(raven_fs_last_error()) }
+    return error_kind("io", ctx.concat(": ").concat(raven_fs_last_error()))
 }
 
 // Whole file at `path` as a String.

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -8,7 +8,7 @@
 // path through the runtime's thread-local last-error slot, tagged with
 // kind "http". See docs/v2/specs/std-http.md.
 
-import std/error
+import std/error { error_kind }
 
 struct HttpResponse {
     status_code: Int,
@@ -32,7 +32,7 @@ extern "C" {
 // An Error tagged with kind "http", its message a context prefix joined to
 // the runtime's last-error text.
 fun http_error(ctx: String) -> Error {
-    return Error { kind: "http", message: ctx.concat(": ").concat(raven_http_last_error()) }
+    return error_kind("http", ctx.concat(": ").concat(raven_http_last_error()))
 }
 
 // Run a request and assemble an HttpResponse, or an Err on transport

--- a/stdlib/std/net.rv
+++ b/stdlib/std/net.rv
@@ -6,7 +6,7 @@
 // server, not both at once, because Raven v2 has no threads. See
 // docs/v2/specs/std-net.md.
 
-import std/error
+import std/error { error_kind }
 import std/string
 
 struct TcpStream {
@@ -33,7 +33,7 @@ extern "C" {
 // An Error tagged with kind "net", its message a context prefix joined to
 // the runtime's last-error text.
 fun net_error(ctx: String) -> Error {
-    return Error { kind: "net", message: ctx.concat(": ").concat(raven_net_last_error()) }
+    return error_kind("net", ctx.concat(": ").concat(raven_net_last_error()))
 }
 
 // Connect a TCP stream to `addr` ("host:port").

--- a/stdlib/std/time.rv
+++ b/stdlib/std/time.rv
@@ -6,7 +6,7 @@
 // boundary. Parsing is fallible and returns Result<Int, Error> through the
 // runtime's thread-local last-error slot. See docs/v2/specs/std-time.md.
 
-import std/error
+import std/error { error_kind }
 
 struct Date {
     year: Int,
@@ -84,7 +84,7 @@ fun format_timestamp(ts: Int, pattern: String) -> String {
 fun parse_timestamp(text: String, pattern: String) -> Result<Int, Error> {
     let ts = raven_time_parse(text, pattern)
     if raven_time_last_error().length() > 0 {
-        return Err(Error { kind: "time", message: "parse: ".concat(raven_time_last_error()) })
+        return Err(error_kind("time", "parse: ".concat(raven_time_last_error())))
     }
     return Ok(ts)
 }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -341,6 +341,19 @@ fn collections_program_compiles_and_runs() {
 }
 
 #[test]
+fn selective_bundled_type_import_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A selective import of the bundled types `Map` and `Set`
+    // (`import std/collections { Map, Set }`) must bind each name to the
+    // merged type without declaring it twice (issue #184). The set dedups
+    // to 2; the map has one key whose value was overwritten to 99. Prints
+    // 2, 1, 99.
+    compile_link_run_and_check("use_collections_selective.rv", "2\n1\n99\n", &runtime);
+}
+
+#[test]
 fn error_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Selective imports of bundled types and a bundled module's sibling free functions now resolve correctly.

Closes #184
Closes #178

## Causes and fixes

### #184: selective import of a bundled type
`import std/collections { Map }` previously risked declaring `Map` twice, because the expander merges a bundled module's struct, enum, and trait types under their own un-namespaced names (so the type is globally present) while the selector also wanted to bind `Map`. The binder now detects that a selector names a merged TYPE that is already in module scope (a `Struct`, `Enum`, or `Trait` binding) and resolves the selector to that single declaration instead of introducing a second binding. Only FUNCTION selectors get the bare-name-to-namespaced rebinding. The whole-module form `import std/collections` is unchanged.

### #178: a bundled module importing a sibling's free function
A bundled `.rv` doing `import std/error { error_kind }` and calling `error_kind(...)` is now rewritten at the call site to the dependency's namespaced symbol (`std.error.error_kind`). The expander builds a per-module rename map from the module's own selective `import std/<other> { name }` declarations: each selected FUNCTION name maps to the other module's `std.<other>.<name>` symbol, and `rewrite_fn_body_calls` rewrites the call. Type selectors need no rewrite since types are global.

The same selective-import binding logic serves user programs, bundled modules, local modules, and external packages: function selectors rebind the bare name to the namespaced symbol, type selectors resolve to the merged declaration already in scope.

## Workaround removed (proof of #178)
`std/fs`, `std/net`, `std/http`, and `std/time` built their tagged `Error` struct literals by hand because `error_kind` was not importable from a bundled module. Each now does `import std/error { error_kind }` and calls `error_kind("io", ...)` etc. The std/fs Err path runs through the imported sibling function, so `fs_program_compiles_and_runs` exercises #178 end to end and still prints the same output.

## Regression tests
- `resolve::tests::selective_bundled_type_import_does_not_double_declare`: `import std/collections { Map, Set }` expands and resolves with no double-declaration.
- `resolve::stdlib::tests::bundled_module_sibling_fn_selector_is_namespaced`: std/fs's `io_error` body calls the namespaced `std.error.error_kind`, not the bare name.
- `selective_bundled_type_import_compiles_and_runs` (codegen smoke): `import std/collections { Map, Set }` plus `Map.new()`/`Set.new()` compiles, links, and runs.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (only the pre-existing `http_program_compiles_and_runs` host-linker crash fails; it fails identically on the base branch and is a local `link.exe` access violation, not a regression. CI links with `cc`.)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `import std/collections { Map }` compiles and runs
- [x] bundled module calls a sibling's free function (std/fs Err path through `error_kind`)

These will not auto-close on merge to v2.x (non-default branch); expected.
