### PR TITLE
refactor: remove print_int builtin, print C FFI ints via ToString

### DIFF
--- a/benchmarks/compile-time/corpus/main.rv
+++ b/benchmarks/compile-time/corpus/main.rv
@@ -125,5 +125,5 @@ fun main() {
     total = total + compute_59(59 + 1)
     total = total + compute_60(60 + 1)
     total = total + compute_61(61 + 1)
-    print_int(total)
+    print(total)
 }

--- a/benchmarks/compile-time/generate.sh
+++ b/benchmarks/compile-time/generate.sh
@@ -199,7 +199,7 @@ ENTRY="$CORPUS_DIR/main.rv"
     for ((i = 0; i < COUNT; i++)); do
         echo "    total = total + compute_${i}(${i} + 1)"
     done
-    echo "    print_int(total)"
+    echo "    print(total)"
     echo "}"
 } > "$ENTRY"
 

--- a/docs/v2/migration.md
+++ b/docs/v2/migration.md
@@ -587,7 +587,7 @@ import std/iter { collect, fold, count }
 fun main() {
     let xs = [1, 2, 3, 4, 5, 6]
     let kept = collect(xs.iter().map(fun(x: Int) -> Int = x * 10).filter(fun(y: Int) -> Bool = y > 20))
-    print_int(kept.len())
+    print(kept.len())
 }
 ```
 
@@ -702,12 +702,12 @@ v2 (`examples/v2/loops.rv`):
 fun main() {
     let i = 0
     while i < 5 {
-        print_int(i)
+        print(i)
         i = i + 1
     }
 
     for j in 0..5 {
-        print_int(j)
+        print(j)
     }
 }
 ```
@@ -845,9 +845,9 @@ import std/math { abs_int, min_int, max_int, pow_int }
 import std/string
 
 fun main() {
-    print_int(abs_int(-10))
-    print_int(min_int(-10, 15))
-    print_int(max_int(-10, 15))
+    print(abs_int(-10))
+    print(min_int(-10, 15))
+    print(max_int(-10, 15))
     print("  hello world  ".trim())
     print("raven".to_upper())
 }

--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -7,7 +7,7 @@ with the `raven-runtime` staticlib through the host toolchain linker, and
 produce an executable. The backend reuses Cranelift for instruction
 selection and register allocation. The covered surface is primitives,
 binary and unary operators, branches, switches, function calls with
-static dispatch, returns, the `print` and `print_int` intrinsics, and
+static dispatch, returns, the `print` intrinsic, and
 heap value construction: structs, enums (including `Option` and
 `Result`), field access, enum dispatch, and closures (capturing,
 returned, passed, and invoked through their value), all with garbage
@@ -221,23 +221,19 @@ directly; `!=` lowers an extra `UnaryOp(Not)` over it. `Int`, `Float`,
 value compare above. Comparison of user structs and enums is not
 special-cased and remains an identity (pointer) compare.
 
-### `print_int` intrinsic
+### Printing C integer FFI values
 
-`print_int(n: Int)` is the integer companion of `print`. It is a built
-in free function recognized by the resolver allowlist and the type
-checker the same way `print` is, with the signature `fn(Int) -> Unit`.
-The codegen recognizes the mangled name `print_int`, loads its single
-`Int` operand, and emits a `call` to the runtime symbol
-`raven_println_int(value: i64)`, which formats the value in base ten and
-writes it followed by a newline. This gives programs a way to observe a
-computed integer without a string conversion, which is what the
-struct and enum smoke programs use to print their results.
-
-The decision to add a dedicated `print_int` rather than a general
-`Int.to_string()` keeps the heap value work focused: `to_string`
-implies a `String` builder and the full string object machinery, while
-`print_int` is one runtime symbol and one intrinsic arm. A richer
-stringification path lands with the string and stdlib issues.
+The integer C FFI types (`CInt`, `CLong`, `CSize`) have no `ToString`
+impl of their own; they reach `print` and string interpolation by
+widening to `Int`. The type checker accepts them where `ToString` is
+required, and MIR lowering rewrites the `to_string` call (inserted for a
+`print` argument or an interpolation fragment) on an FFI integer receiver
+into a `Cast` to `Int` followed by the `__raven_int_to_string` intrinsic.
+The cast sign-extends a narrower value (`CInt` is i32); `CLong` and
+`CSize` are already pointer-width and pass through. `CSize` is rendered as
+a signed `Int`, correct for realistic sizes (below 2^63). Reusing the
+`Int` to-string path means no dedicated integer print symbol or intrinsic
+arm.
 
 ## Heap value layout and lowering
 

--- a/docs/v2/specs/defer.md
+++ b/docs/v2/specs/defer.md
@@ -91,18 +91,18 @@ expressions registered so far in declaration order.
 
 ```
 fun f(early: Bool) -> Int {
-    defer print_int(9)      // push 9         -> defers = [9]
+    defer print(9)      // push 9         -> defers = [9]
     if early {
         return 1            // emit [9] reversed -> print 9; return 1
     }
-    defer print_int(8)      // push 8         -> defers = [9, 8]
+    defer print(8)      // push 8         -> defers = [9, 8]
     return 2                // emit [9, 8] reversed -> print 8, print 9; return 2
 }
 ```
 
 The MIR has two return-bearing blocks. The early-return block contains
-`print_int(9); return 1`. The fall-through block contains
-`print_int(8); print_int(9); return 2`. So `f(true)` prints `9` and
+`print(9); return 1`. The fall-through block contains
+`print(8); print(9); return 2`. So `f(true)` prints `9` and
 `f(false)` prints `8` then `9`. The corresponding executable confirms
 this on a real run.
 
@@ -110,13 +110,13 @@ For the classic ordering case:
 
 ```
 fun demo() -> Int {
-    defer print_int(1)      // defers = [1]
-    defer print_int(2)      // defers = [1, 2]
+    defer print(1)      // defers = [1]
+    defer print(2)      // defers = [1, 2]
     return 0                // emit reversed: print 2, print 1; return 0
 }
 ```
 
-The single return block is `print_int(2); print_int(1); return 0`, so the
+The single return block is `print(2); print(1); return 0`, so the
 program prints `2` then `1`.
 
 ## Interaction with `?`

--- a/docs/v2/specs/ffi.md
+++ b/docs/v2/specs/ffi.md
@@ -51,7 +51,7 @@ A call uses the foreign name directly:
 ```raven
 fun main() {
     let n = strlen(c"hello")
-    print_int(n)
+    print(n)
 }
 ```
 
@@ -126,8 +126,9 @@ A mismatch (for example a `c"..."` where a `CInt` is expected, or a
 the argument's span.
 
 The return type flows out as the call's type. An integer FFI return
-(`CInt`, `CLong`, `CSize`) may be handed to `print_int`, which observes
-it directly; a narrower one is sign-extended to i64 first.
+(`CInt`, `CLong`, `CSize`) satisfies `ToString`: it widens to `Int` (a
+narrower one is sign-extended) and renders through the `Int` to-string
+path, so `print(n)` and `"${n}"` both observe a C call result directly.
 
 ## Codegen
 

--- a/docs/v2/specs/std-ffi.md
+++ b/docs/v2/specs/std-ffi.md
@@ -103,11 +103,11 @@ extern "C" {
 fun main() {
     let s = "hello"
     let n = strlen(to_cstr(s))
-    print_int(n)
+    print(n)
     let eq = strcmp(to_cstr("abc"), to_cstr("abc"))
-    print_int(eq)
+    print(eq)
     let lt = strcmp(to_cstr("abc"), to_cstr("abd"))
-    print_int(lt)
+    print(lt)
     println(from_cstr(to_cstr("roundtrip")))
 }
 ```
@@ -126,11 +126,12 @@ for equal strings and a negative value when the first differing byte is
 smaller (`-1` here for `'c'` against `'d'`). `from_cstr(to_cstr("roundtrip"))`
 recovers the original text.
 
-The C integer results print through `print_int`, which accepts the integer
-FFI types (`CInt`, `CLong`, `CSize`) and widens a narrower one to i64. The
-surface has no `ToString` impl for the FFI integer types, so a `CSize` or
-`CInt` cannot be interpolated into a `"${...}"` string or compared to a
-native `Int` directly; route them through `print_int` to observe a value.
+The C integer results print through `print`. The integer FFI types
+(`CInt`, `CLong`, `CSize`) satisfy `ToString` by widening to `Int` (a
+narrower one is sign-extended) and rendering through the `Int` to-string
+path, so a `CSize` or `CInt` can be printed or interpolated into a
+`"${...}"` string directly. `CSize` is treated as a signed `Int`, correct
+for realistic sizes (below 2^63).
 
 ## Out of scope
 

--- a/docs/v2/specs/stdlib.md
+++ b/docs/v2/specs/stdlib.md
@@ -184,8 +184,9 @@ value and appends a newline. `std/io` is the explicit surface: its `print`
 writes with no newline and its `println` adds one, the conventional split.
 Because an explicit import binds over a builtin, a program that imports
 `std/io`'s `print` gets the module's no newline behavior; a program that
-does not import it keeps the builtin. (A separate `print_int` builtin also
-still exists and is slated for removal now that `print` covers integers.)
+does not import it keeps the builtin. The builtin `print` covers integers
+through `Int`'s `ToString`, and the integer C FFI types reach it by
+widening to `Int`.
 
 ## How later modules plug in
 

--- a/examples/v2/arithmetic.rv
+++ b/examples/v2/arithmetic.rv
@@ -2,10 +2,10 @@
 fun main() {
     let x = 10
     let y = 5
-    print_int(x + y)
-    print_int(x - y)
-    print_int(x * y)
-    print_int(x / y)
+    print(x + y)
+    print(x - y)
+    print(x * y)
+    print(x / y)
 
     let a = 3.14
     let b = 2.0

--- a/examples/v2/builtin_method.rv
+++ b/examples/v2/builtin_method.rv
@@ -5,5 +5,5 @@ impl Int {
 }
 
 fun main() {
-    print_int(21.doubled())
+    print(21.doubled())
 }

--- a/examples/v2/closure_arg.rv
+++ b/examples/v2/closure_arg.rv
@@ -8,5 +8,5 @@ fun apply(f: fun(Int) -> Int, x: Int) -> Int {
 fun main() {
     let factor = 3
     let triple = fun(x: Int) -> Int = x * factor
-    print_int(apply(triple, 7))
+    print(apply(triple, 7))
 }

--- a/examples/v2/closure_capture.rv
+++ b/examples/v2/closure_capture.rv
@@ -7,6 +7,6 @@ fun make_adder(n: Int) -> fun(Int) -> Int {
 
 fun main() {
     let add10 = make_adder(10)
-    print_int(add10(5))
-    print_int(add10(32))
+    print(add10(5))
+    print(add10(32))
 }

--- a/examples/v2/closure_generic_call.rv
+++ b/examples/v2/closure_generic_call.rv
@@ -12,5 +12,5 @@ fun apply(f: fun(Int) -> Int, x: Int) -> Int {
 
 fun main() {
     let f = fun(x: Int) -> Int = identity(x) + 1
-    print_int(apply(f, 41))
+    print(apply(f, 41))
 }

--- a/examples/v2/closure_value.rv
+++ b/examples/v2/closure_value.rv
@@ -5,5 +5,5 @@
 // the allocation and GC root frame run without crashing.
 fun main() {
     let f = fun(x: Int) -> Int = x + 1
-    print_int(42)
+    print(42)
 }

--- a/examples/v2/comprehensive.rv
+++ b/examples/v2/comprehensive.rv
@@ -18,15 +18,15 @@ fun main() {
 
     let i = 0
     while i < 3 {
-        print_int(i)
+        print(i)
         i = i + 1
     }
 
     for j in 0..3 {
-        print_int(j * 2)
+        print(j * 2)
     }
 
-    print_int(multiply(6, 7))
+    print(multiply(6, 7))
 
     let active = true
     let access = true
@@ -34,11 +34,11 @@ fun main() {
         print("Access granted")
     }
 
-    print_int(5 + 10)
-    print_int(20 - 8)
-    print_int(6 * 7)
-    print_int(100 / 4)
+    print(5 + 10)
+    print(20 - 8)
+    print(6 * 7)
+    print(100 / 4)
 
     let r = Rect { w: 4, h: 5 }
-    print_int(area(r))
+    print(area(r))
 }

--- a/examples/v2/defer_early_return.rv
+++ b/examples/v2/defer_early_return.rv
@@ -3,14 +3,14 @@
 // The second defer is registered after the early return, so a run that
 // takes the early path never schedules it.
 //
-// f(true)  reaches only `defer print_int(9)`  -> prints 9
+// f(true)  reaches only `defer print(9)`  -> prints 9
 // f(false) reaches both, LIFO at the return    -> prints 8 then 9
 fun f(early: Bool) -> Int {
-    defer print_int(9)
+    defer print(9)
     if early {
         return 1
     }
-    defer print_int(8)
+    defer print(8)
     return 2
 }
 

--- a/examples/v2/defer_order.rv
+++ b/examples/v2/defer_order.rv
@@ -3,8 +3,8 @@
 // the deferred calls fire, so this program prints 2 then 1 before main
 // observes the result.
 fun demo() -> Int {
-    defer print_int(1)
-    defer print_int(2)
+    defer print(1)
+    defer print(2)
     return 0
 }
 

--- a/examples/v2/dyn_dispatch.rv
+++ b/examples/v2/dyn_dispatch.rv
@@ -21,6 +21,6 @@ fun describe(s: dyn Speak) -> Int = s.sound()
 fun main() {
     let d = Dog {}
     let c = Cat {}
-    print_int(describe(d))
-    print_int(describe(c))
+    print(describe(d))
+    print(describe(c))
 }

--- a/examples/v2/ffi_abs.rv
+++ b/examples/v2/ffi_abs.rv
@@ -7,5 +7,5 @@ extern "C" {
 
 fun main() {
     let n = abs(-7)
-    print_int(n)
+    print(n)
 }

--- a/examples/v2/ffi_strlen.rv
+++ b/examples/v2/ffi_strlen.rv
@@ -1,12 +1,12 @@
 // C FFI: declare libc `strlen` and call it on a C string literal.
 // `c"hello"` lowers to a pointer to a static null-terminated buffer, so
 // strlen counts 5 bytes. CSize is size_t, which is pointer width (i64 on
-// x86_64), and print_int observes it directly. Prints 5.
+// x86_64); `print` widens it to Int and renders the digits. Prints 5.
 extern "C" {
     fun strlen(s: CStr) -> CSize
 }
 
 fun main() {
     let n = strlen(c"hello")
-    print_int(n)
+    print(n)
 }

--- a/examples/v2/for_loops.rv
+++ b/examples/v2/for_loops.rv
@@ -6,7 +6,7 @@ fun main() {
     for x in 0..5 {
         sum = sum + x
     }
-    print_int(sum)            // 10
+    print(sum)            // 10
 
     // List loop: sum the three elements 3 + 5 + 7 = 15.
     let xs = [3, 5, 7]
@@ -14,7 +14,7 @@ fun main() {
     for v in xs {
         total = total + v
     }
-    print_int(total)          // 15
+    print(total)          // 15
 
     // break and continue: continue still advances the counter. Over
     // 0..10 we skip i == 5 with continue and stop at i == 8 with break,
@@ -29,5 +29,5 @@ fun main() {
         }
         count = count + 1
     }
-    print_int(count)          // 7
+    print(count)          // 7
 }

--- a/examples/v2/functions.rv
+++ b/examples/v2/functions.rv
@@ -8,7 +8,7 @@ fun square(n: Int) -> Int = n * n
 fun greet(name: String) -> String = "Hello, ${name}!"
 
 fun main() {
-    print_int(add(7, 8))
-    print_int(square(6))
+    print(add(7, 8))
+    print(square(6))
     print(greet("Raven"))
 }

--- a/examples/v2/generic_struct.rv
+++ b/examples/v2/generic_struct.rv
@@ -19,11 +19,11 @@ impl<T> Box<T> {
 
 fun main() {
     let b = Box { value: 42 }
-    print_int(b.get())          // 42 (concrete impl Box<Int>)
-    print_int(b.unwrap())       // 42 (generic impl<T> Box<T> at T = Int)
+    print(b.get())          // 42 (concrete impl Box<Int>)
+    print(b.unwrap())       // 42 (generic impl<T> Box<T> at T = Int)
 
     let n = Box { value: 7 }
-    print_int(n.value)          // 7 (direct field access)
+    print(n.value)          // 7 (direct field access)
 
     let s = Box { value: "raven" }
     print(s.unwrap())           // raven (generic impl<T> Box<T> at T = String)

--- a/examples/v2/iter_pipeline.rv
+++ b/examples/v2/iter_pipeline.rv
@@ -15,7 +15,7 @@ fun main() {
 
     // map then filter then collect into a List, then read its length.
     let kept = collect(xs.iter().map(fun(x: Int) -> Int = x * 10).filter(fun(y: Int) -> Bool = y > 20))
-    print_int(kept.len())
+    print(kept.len())
 
     // A fresh pipeline folded into a sum (30 + 40 + 50 + 60).
     let total = fold(
@@ -23,8 +23,8 @@ fun main() {
         0,
         fun(acc: Int, v: Int) -> Int = acc + v,
     )
-    print_int(total)
+    print(total)
 
     // Count the elements a filter keeps (4, 5, 6).
-    print_int(count(xs.iter().filter(fun(y: Int) -> Bool = y > 3)))
+    print(count(xs.iter().filter(fun(y: Int) -> Bool = y > 3)))
 }

--- a/examples/v2/list_ops.rv
+++ b/examples/v2/list_ops.rv
@@ -2,9 +2,9 @@
 // Compiling and running this prints 3, 20, 4, 40 on their own lines.
 fun main() {
     let xs = [10, 20, 30]
-    print_int(xs.len())   // 3
-    print_int(xs[1])      // 20
+    print(xs.len())   // 3
+    print(xs[1])      // 20
     xs.push(40)
-    print_int(xs.len())   // 4
-    print_int(xs[3])      // 40
+    print(xs.len())   // 4
+    print(xs[3])      // 40
 }

--- a/examples/v2/list_strings.rv
+++ b/examples/v2/list_strings.rv
@@ -7,5 +7,5 @@ fun main() {
     words.push("bird")
     print(words[0])       // raven
     print(words[2])       // bird
-    print_int(words.len()) // 3
+    print(words.len()) // 3
 }

--- a/examples/v2/loops.rv
+++ b/examples/v2/loops.rv
@@ -2,11 +2,11 @@
 fun main() {
     let i = 0
     while i < 5 {
-        print_int(i)
+        print(i)
         i = i + 1
     }
 
     for j in 0..5 {
-        print_int(j)
+        print(j)
     }
 }

--- a/examples/v2/method_generics.rv
+++ b/examples/v2/method_generics.rv
@@ -18,6 +18,6 @@ fun main() {
     let b = Box { value: 21 }
     let doubled = b.mapped(fun(x: Int) -> Int = x * 2)
     let is_big = b.mapped(fun(x: Int) -> Bool = x > 10)
-    print_int(doubled)
+    print(doubled)
     print(is_big)
 }

--- a/examples/v2/mutation.rv
+++ b/examples/v2/mutation.rv
@@ -13,9 +13,9 @@ fun main() {
     c.bump()
     c.bump()
     c.n = c.n + 5
-    print_int(c.n)            // 7
+    print(c.n)            // 7
 
     let xs = [10, 20, 30]
     xs[1] = 99
-    print_int(xs[1])          // 99
+    print(xs[1])          // 99
 }

--- a/examples/v2/option_sum.rv
+++ b/examples/v2/option_sum.rv
@@ -11,5 +11,5 @@ fun unwrap_or(x: Option<Int>, fallback: Int) -> Int {
 fun main() {
     let present = unwrap_or(Some(5), 0)
     let missing = unwrap_or(None, 99)
-    print_int(present + missing)
+    print(present + missing)
 }

--- a/examples/v2/point.rv
+++ b/examples/v2/point.rv
@@ -6,5 +6,5 @@ fun add_coords(p: Point) -> Int = p.x + p.y
 
 fun main() {
     let p = Point { x: 3, y: 4 }
-    print_int(add_coords(p))
+    print(add_coords(p))
 }

--- a/examples/v2/standard_library_demo.rv
+++ b/examples/v2/standard_library_demo.rv
@@ -5,10 +5,10 @@ import std/string
 
 fun main() {
     print("=== Math ===")
-    print_int(abs_int(-10))
-    print_int(min_int(-10, 15))
-    print_int(max_int(-10, 15))
-    print_int(pow_int(2, 8))
+    print(abs_int(-10))
+    print(min_int(-10, 15))
+    print(max_int(-10, 15))
+    print(pow_int(2, 8))
 
     print("=== String ===")
     print("  hello world  ".trim())

--- a/examples/v2/use_ffi.rv
+++ b/examples/v2/use_ffi.rv
@@ -2,8 +2,8 @@
 // std/ffi: convert a runtime Raven String to a C string and call libc.
 // strlen counts the bytes of "hello" (5). strcmp returns 0 for equal
 // strings and a nonzero value otherwise. from_cstr round-trips a CStr
-// back to a Raven String. The C integer results print through print_int,
-// which accepts the FFI integer types and widens them to i64.
+// back to a Raven String. The C integer results print through `print`,
+// which widens the FFI integer types to Int and renders the digits.
 import std/ffi { to_cstr, from_cstr }
 import std/io { println }
 
@@ -15,10 +15,10 @@ extern "C" {
 fun main() {
     let s = "hello"
     let n = strlen(to_cstr(s))
-    print_int(n)
+    print(n)
     let eq = strcmp(to_cstr("abc"), to_cstr("abc"))
-    print_int(eq)
+    print(eq)
     let lt = strcmp(to_cstr("abc"), to_cstr("abd"))
-    print_int(lt)
+    print(lt)
     println(from_cstr(to_cstr("roundtrip")))
 }

--- a/examples/v2/use_regex.rv
+++ b/examples/v2/use_regex.rv
@@ -14,7 +14,7 @@ fun main() {
                 None -> print("none"),
             }
             let parts = re.split("xaaayaz")
-            print_int(parts.len())
+            print(parts.len())
             print(parts[0])
             print(parts[1])
             print(parts[2])
@@ -25,11 +25,11 @@ fun main() {
     match compile("(\\d+)-(\\d+)") {
         Ok(re) -> {
             let all = re.find_all("12-345 and 67-8")
-            print_int(all.len())
+            print(all.len())
             print(all[0])
             print(all[1])
             let caps = re.captures("12-345")
-            print_int(caps.len())
+            print(caps.len())
             print(caps[0])
             print(caps[1])
             print(caps[2])

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -384,23 +384,6 @@ pub extern "C" fn raven_read_line() -> *mut object::String {
     object::raven_string_from_bytes(line.as_ptr(), line.len())
 }
 
-/// Write a signed 64-bit integer to standard output in base ten,
-/// followed by a single `\n`.
-///
-/// This is the integer companion of `raven_println_str`. The back-end
-/// wires the built-in `print_int(Int)` free function to this symbol so a
-/// program can observe a computed integer without a string conversion.
-#[no_mangle]
-pub extern "C" fn raven_println_int(value: i64) {
-    let stdout = io::stdout();
-    let mut handle = stdout.lock();
-    // Format into a small stack buffer to avoid a heap allocation.
-    let mut buf = itoa_buf();
-    let s = format_i64(value, &mut buf);
-    let _ = handle.write_all(s.as_bytes());
-    let _ = handle.write_all(b"\n");
-}
-
 /// Look up an environment variable and return its value as a heap
 /// `String`. Returns an empty `String` when the variable is unset or its
 /// value is not valid UTF-8, so the caller always gets a usable pointer.
@@ -1678,52 +1661,10 @@ pub extern "C" fn raven_process_free(id: i64) {
     process_registry().lock().unwrap().remove(&id);
 }
 
-/// A stack buffer large enough for any base-ten `i64` plus a sign.
-fn itoa_buf() -> [u8; 20] {
-    [0u8; 20]
-}
-
-/// Format `value` into `buf` and return the written slice as a string.
-/// Twenty bytes hold the widest `i64` (`-9223372036854775808`).
-fn format_i64(value: i64, buf: &mut [u8; 20]) -> &str {
-    // Work with the unsigned magnitude to handle i64::MIN safely.
-    let negative = value < 0;
-    let mut magnitude = value.unsigned_abs();
-    let mut pos = buf.len();
-    loop {
-        pos -= 1;
-        buf[pos] = b'0' + (magnitude % 10) as u8;
-        magnitude /= 10;
-        if magnitude == 0 {
-            break;
-        }
-    }
-    if negative {
-        pos -= 1;
-        buf[pos] = b'-';
-    }
-    // SAFETY: the bytes written are ASCII digits and an optional '-'.
-    unsafe { std::str::from_utf8_unchecked(&buf[pos..]) }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::mem::{align_of, size_of};
-
-    #[test]
-    fn format_i64_handles_edges() {
-        let mut buf = itoa_buf();
-        assert_eq!(format_i64(0, &mut buf), "0");
-        let mut buf = itoa_buf();
-        assert_eq!(format_i64(7, &mut buf), "7");
-        let mut buf = itoa_buf();
-        assert_eq!(format_i64(-7, &mut buf), "-7");
-        let mut buf = itoa_buf();
-        assert_eq!(format_i64(i64::MAX, &mut buf), "9223372036854775807");
-        let mut buf = itoa_buf();
-        assert_eq!(format_i64(i64::MIN, &mut buf), "-9223372036854775808");
-    }
 
     #[test]
     fn object_header_is_sixteen_bytes() {

--- a/raven-vscode/sample.rv
+++ b/raven-vscode/sample.rv
@@ -39,18 +39,18 @@ fun main() {
     for n in nums {
         total += n
     }
-    print_int(total)
+    print(total)
 
     for i in 0..3 {
         if i == 1 {
             continue
         }
-        print_int(i)
+        print(i)
     }
 
     let s = Shape.Circle(2.0)
     print(describe(s.area()))
 
     let n = strlen(c"hello")
-    print_int(n)
+    print(n)
 }

--- a/raven-vscode/src/extension.ts
+++ b/raven-vscode/src/extension.ts
@@ -26,8 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
             const word = document.getText(range);
             
             const builtinFunctions: { [key: string]: string } = {
-                'print': 'Prints a String followed by a newline. Usage: `print(message)`',
-                'print_int': 'Prints an Int followed by a newline. Usage: `print_int(n)`',
+                'print': 'Prints any `ToString` value followed by a newline. Usage: `print(value)`',
                 'println': 'Prints a String with a trailing newline (from `std/io`). Usage: `import std/io { println }`',
                 'panic': 'Aborts the program with a message (from `std/test`).'
             };
@@ -46,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
     let completionProvider = vscode.languages.registerCompletionItemProvider('raven', {
         provideCompletionItems(document, position, token, context) {
             const builtinFunctions = [
-                'print', 'print_int', 'println', 'panic'
+                'print', 'println', 'panic'
             ];
 
             const keywords = [

--- a/raven-vscode/syntaxes/raven.tmLanguage.json
+++ b/raven-vscode/syntaxes/raven.tmLanguage.json
@@ -332,7 +332,7 @@
       "patterns": [
         {
           "name": "support.function.builtin.raven",
-          "match": "\\b(print|print_int)\\s*(?=\\()"
+          "match": "\\b(print)\\s*(?=\\()"
         },
         {
           "name": "entity.name.function.call.raven",

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -287,10 +287,6 @@ impl ModuleCx {
         sig = self.make_sig(&[], &[ptr]);
         self.declare_runtime(intrinsics::RUNTIME_READ_LINE, &sig)?;
 
-        // raven_println_int(i64)
-        sig = self.make_sig(&[i64t], &[]);
-        self.declare_runtime(intrinsics::RUNTIME_PRINTLN_INT, &sig)?;
-
         // raven_struct_new(field_count: u32, type_id: u32) -> ptr
         sig = self.make_sig(&[i32t, i32t], &[ptr]);
         self.declare_runtime(intrinsics::RUNTIME_STRUCT_NEW, &sig)?;

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -1609,38 +1609,6 @@ fn lower_intrinsic(
             let inst = builder.ins().call(local_ref, &[]);
             Ok(builder.inst_results(inst).first().copied())
         }
-        intrinsics::PRINT_INT => {
-            if args.len() != 1 {
-                return Err(CodegenError::Unsupported(format!(
-                    "print_int intrinsic expects 1 arg, got {}",
-                    args.len()
-                )));
-            }
-            let v = require_value(
-                lower_operand(cx, builder, &args[0], slots)?,
-                "print_int argument",
-            )?;
-            // `raven_println_int` takes an i64. A native `Int` is already
-            // i64; a C FFI integer may be narrower (`CInt` is i32) or the
-            // same width (`CLong`/`CSize`). Sign-extend a narrower value
-            // so a negative C `int` prints correctly.
-            let v = {
-                let got = builder.func.dfg.value_type(v);
-                if got == types::I64 {
-                    v
-                } else if got.is_int() && got.bytes() < types::I64.bytes() {
-                    builder.ins().sextend(types::I64, v)
-                } else {
-                    v
-                }
-            };
-            let func_id = cx
-                .runtime_id(intrinsics::RUNTIME_PRINTLN_INT)
-                .expect("runtime imports declared at module init");
-            let local_ref = cx.module().declare_func_in_func(func_id, builder.func);
-            builder.ins().call(local_ref, &[v]);
-            Ok(None)
-        }
         intrinsics::STR_LEN => {
             // `raven_string_len` returns a u32; the bundled source treats
             // the result as a native `Int` (i64), so zero-extend it.

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -8,9 +8,6 @@
 /// MIR mangled name produced by the front end for a `print(s)` call.
 pub const PRINT: &str = "print";
 
-/// MIR mangled name produced by the front end for a `print_int(n)` call.
-pub const PRINT_INT: &str = "print_int";
-
 /// Internal stdlib I/O intrinsics. The bundled `std/io` source calls
 /// these to reach the runtime's byte-level I/O symbols; the leading
 /// `__io_` marks them internal (a user uses `std/io`'s exported
@@ -58,9 +55,6 @@ pub const RUNTIME_PRINT_STR: &str = "raven_print_str";
 
 /// Runtime C symbol reading one line from stdin into a heap `String`.
 pub const RUNTIME_READ_LINE: &str = "raven_read_line";
-
-/// Runtime C symbol the `print_int` intrinsic dispatches to.
-pub const RUNTIME_PRINTLN_INT: &str = "raven_println_int";
 
 /// Runtime C symbol building a heap `String` from a byte slice. Used to
 /// promote a string literal into a heap `String` value.
@@ -171,7 +165,6 @@ pub fn is_intrinsic(mangled: &str) -> bool {
     matches!(
         mangled,
         PRINT
-            | PRINT_INT
             | IO_PRINT_STR
             | IO_PRINTLN_STR
             | IO_READ_LINE

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -122,7 +122,7 @@ fn compiles_extern_c_call_with_cstring_literal() {
         }
         fun main() {
             let n = strlen(c"hello")
-            print_int(n)
+            print(n)
         }
     "#;
     let prog = compile(src);
@@ -171,7 +171,7 @@ fn compiles_extern_c_call_with_int_literal() {
         }
         fun main() {
             let n = abs(-7)
-            print_int(n)
+            print(n)
         }
     "#;
     let prog = compile(src);

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -12,7 +12,7 @@ use super::super::ir::{
     ListMethodOp, MirBinOp, MirBlockId, MirConstant, MirFnRef, MirLocal, MirOperand, MirRvalue,
     MirStatement, MirTerminator, MirUnOp,
 };
-use super::super::ty::MirType;
+use super::super::ty::{MirFfiTy, MirType};
 use super::{mir_ty, stmt, LoopFrame, LowerCx};
 
 /// Lower an expression to an operand. Side effects appear in the
@@ -942,6 +942,42 @@ fn lower_method_call(
     ty: MirType,
 ) -> MirOperand {
     let recv_ty = mir_ty(&receiver.ty, cx.subst);
+
+    // The integer C FFI types have no `ToString` impl of their own. A
+    // `to_string` call on one (inserted by HIR lowering for a `print`
+    // argument or an interpolation fragment) widens the value to `Int`
+    // and renders through the `Int` to-string runtime intrinsic. The
+    // widening is a sign extension (`CInt` is i32; `CLong`/`CSize` are
+    // already pointer-width and pass through). `CSize` is treated as a
+    // signed `Int`, correct for realistic sizes (below 2^63).
+    if name == "to_string" {
+        if let MirType::Ffi(MirFfiTy::CInt | MirFfiTy::CLong | MirFfiTy::CSize) = &recv_ty {
+            let recv = lower_expr(cx, receiver);
+            let widened = cx.builder.fresh_temp("ffiwiden", MirType::Int);
+            cx.builder.assign(
+                cx.current,
+                widened,
+                MirRvalue::Cast {
+                    operand: recv,
+                    target: MirType::Int,
+                },
+            );
+            let dst = cx.builder.fresh_temp("tostr", MirType::Str);
+            cx.builder.assign(
+                cx.current,
+                dst,
+                MirRvalue::Call {
+                    callee: MirFnRef {
+                        mangled: super::super::intrinsics::INT_TO_STRING.into(),
+                        origin: None,
+                    },
+                    args: vec![MirOperand::Copy(widened)],
+                },
+            );
+            return MirOperand::Copy(dst);
+        }
+    }
+
     if let MirType::Dyn { methods, .. } = &recv_ty {
         // Virtual dispatch: the slot index is the method's position in the
         // trait's declaration order, which the dyn type carries.

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -45,6 +45,22 @@ fn compile(src: &str) -> MirProgram {
     lower_program(&hir).expect("mir")
 }
 
+/// Like `compile`, but merges the bundled prelude first so `print` of a
+/// scalar resolves through its `ToString` impl. Tests that print need
+/// this, since `print` requires the prelude's `impl ToString for Int`.
+fn compile_with_prelude(src: &str) -> MirProgram {
+    let tokens = Lexer::new(src.to_string(), PathBuf::from("t.rv"))
+        .tokenize()
+        .expect("lex");
+    let file = parse(&tokens).expect("parse");
+    let file = crate::resolve::expand_with_stdlib(&file).expect("stdlib expand");
+    let mut loader = NoLoader;
+    let resolved = resolve_file(&file, &mut loader).expect("resolve");
+    let typed = check_file(&resolved).expect("tycheck");
+    let hir = lower_file(&typed).expect("hir");
+    lower_program(&hir).expect("mir")
+}
+
 fn find_fn<'a>(p: &'a MirProgram, name: &str) -> &'a MirFunction {
     p.functions
         .iter()
@@ -263,9 +279,12 @@ fn mir_type_mangling_is_stable() {
 
 // ----- Defer lowering -----
 
-/// Collect the integer constant argument of each `print_int` call in the
-/// block, in statement order. Used to assert deferred call ordering.
-fn print_int_args_in_block(block: &MirBlock) -> Vec<i64> {
+/// Collect the integer constant rendered by each `print(N)` call in the
+/// block, in statement order. A `print(N)` lowers to an int-to-string
+/// conversion (the constant `N` is its argument) followed by the `print`
+/// call, so matching the conversion recovers the printed value. Used to
+/// assert deferred call ordering.
+fn printed_int_args_in_block(block: &MirBlock) -> Vec<i64> {
     let mut out = Vec::new();
     for s in &block.statements {
         if let MirStatement::Assign {
@@ -273,7 +292,11 @@ fn print_int_args_in_block(block: &MirBlock) -> Vec<i64> {
             ..
         } = s
         {
-            if callee.mangled == "print_int" {
+            // `print(n)` lowers to `Int$to_string(n)` then a string print,
+            // so the deferred int is the constant argument to that
+            // to_string call. Reading them in block order recovers the
+            // order the deferred prints run.
+            if callee.mangled == "Int$to_string" {
                 if let Some(MirOperand::Const(MirConstant::Int(n))) = args.first() {
                     out.push(*n);
                 }
@@ -285,14 +308,14 @@ fn print_int_args_in_block(block: &MirBlock) -> Vec<i64> {
 
 #[test]
 fn defer_runs_in_reverse_order_before_return() {
-    // Two defers at the function body level: print_int(1) then
-    // print_int(2). The block that ends in `return` must call them in
+    // Two defers at the function body level: print(1) then
+    // print(2). The block that ends in `return` must call them in
     // reverse (LIFO) order: 2 then 1.
-    let prog = compile(
+    let prog = compile_with_prelude(
         r#"
         fun demo() -> Int {
-            defer print_int(1)
-            defer print_int(2)
+            defer print(1)
+            defer print(2)
             return 0
         }
     "#,
@@ -304,7 +327,7 @@ fn defer_runs_in_reverse_order_before_return() {
         .find(|b| matches!(b.terminator, MirTerminator::Return(_)))
         .expect("demo has a return block");
     assert_eq!(
-        print_int_args_in_block(ret_block),
+        printed_int_args_in_block(ret_block),
         vec![2, 1],
         "deferred calls must run LIFO before the return"
     );
@@ -316,14 +339,14 @@ fn only_reached_defers_run_on_each_return_path() {
     // both paths. The second defer follows the early return, so the early
     // path never schedules it. The early-path return block runs only [9];
     // the fall-through return block runs [8, 9] (LIFO).
-    let prog = compile(
+    let prog = compile_with_prelude(
         r#"
         fun f(early: Bool) -> Int {
-            defer print_int(9)
+            defer print(9)
             if early {
                 return 1
             }
-            defer print_int(8)
+            defer print(8)
             return 2
         }
     "#,
@@ -334,7 +357,7 @@ fn only_reached_defers_run_on_each_return_path() {
         .blocks
         .iter()
         .filter(|b| matches!(b.terminator, MirTerminator::Return(_)))
-        .map(print_int_args_in_block)
+        .map(printed_int_args_in_block)
         .collect();
 
     assert!(
@@ -483,7 +506,7 @@ fn generic_call_inside_closure_body_is_monomorphized() {
     // queued only if the lifted body's pending generic call sites reach
     // the monomorphization worklist. Before the fix those calls were
     // dropped and no instance was emitted, leaving an unresolved callee.
-    let prog = compile(
+    let prog = compile_with_prelude(
         r#"
         fun identity<T>(x: T) -> T = x
 
@@ -493,7 +516,7 @@ fn generic_call_inside_closure_body_is_monomorphized() {
 
         fun main() {
             let f = fun(x: Int) -> Int = identity(x) + 1
-            print_int(apply(f, 41))
+            print(apply(f, 41))
         }
     "#,
     );

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -325,7 +325,7 @@ fn walk_expr(
                 }
             } else if is_builtin_ctor_name(name) {
                 // Built in constructor identifiers (`None`, `Some`, `Ok`,
-                // `Err`), the `print`/`print_int` free functions, and the
+                // `Err`), the `print` free function, and the
                 // internal `__io_*` intrinsics bypass scope lookup. The
                 // type checker recognizes them and assigns the correct
                 // type at the call site.
@@ -638,9 +638,9 @@ fn is_builtin_type_name(name: &str) -> bool {
 /// Builtin constructor identifiers. These appear in expressions
 /// (`None`, `Some(x)`, `Ok(v)`, `Err(e)`) and are recognized by the
 /// type checker. The resolver bypasses scope lookup for them so they
-/// can be used without an explicit import. `print` and `print_int` are
-/// treated the same way: they are built in free function intrinsics
-/// whose call sites are wired to the runtime by the codegen back end.
+/// can be used without an explicit import. `print` is treated the same
+/// way: it is a built in free function intrinsic whose call sites are
+/// wired to the runtime by the codegen back end.
 ///
 /// The `__io_*` and `__str_*` names are internal stdlib intrinsics: the
 /// bundled `std/io` and `std/string` sources call them to reach the
@@ -656,7 +656,6 @@ fn is_builtin_ctor_name(name: &str) -> bool {
             | "Ok"
             | "Err"
             | "print"
-            | "print_int"
             | "__io_print_str"
             | "__io_println_str"
             | "__io_read_line"

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -417,6 +417,11 @@ impl<'a, 'b> Checker<'a, 'b> {
         let stripped = resolved.strip_self().clone();
         match &stripped {
             Ty::Str | Ty::Error => Ok(()),
+            // The integer C FFI types have no `ToString` impl of their own;
+            // they widen to `Int` at the use site (HIR lowering inserts the
+            // cast) and render through the `Int` to-string path, so a C call
+            // result such as `strlen(c"hi")` can be printed or interpolated.
+            t if is_int_ffi(t) => Ok(()),
             Ty::Var(v) => {
                 self.infer
                     .add_bound(*v, "ToString".to_string(), span.clone());
@@ -1221,36 +1226,6 @@ impl<'a, 'b> Checker<'a, 'b> {
                 }
                 let arg_ty = self.check_expr(&args[0])?;
                 self.require_to_string(&arg_ty, &args[0].span)?;
-                Ok(Ty::Unit)
-            }
-            "print_int" => {
-                // Built in `print_int(n: Int)` intrinsic. The codegen
-                // backend recognizes the mangled name and emits a call
-                // to the runtime's `raven_println_int` ABI symbol so a
-                // program can observe a computed integer. The integer C
-                // FFI types (`CInt`, `CLong`, `CSize`) are also accepted
-                // so the result of a C call (for example `strlen`) can be
-                // printed directly; the back end widens narrower ones to
-                // the i64 the runtime expects.
-                if args.len() != 1 {
-                    return Err(RavenError::ty(
-                        TypeError::WrongArity {
-                            func: "print_int".into(),
-                            expected: 1,
-                            actual: args.len(),
-                        },
-                        span.clone(),
-                    ));
-                }
-                let arg_ty = self.check_expr(&args[0])?;
-                let resolved = self.infer.resolve(&arg_ty);
-                let is_int_ffi = matches!(
-                    resolved.strip_self(),
-                    Ty::Ffi(FfiTy::CInt) | Ty::Ffi(FfiTy::CLong) | Ty::Ffi(FfiTy::CSize)
-                );
-                if !is_int_ffi {
-                    self.unify(&Ty::Int, &arg_ty, &args[0].span)?;
-                }
                 Ok(Ty::Unit)
             }
             // Internal stdlib I/O intrinsics. The bundled `std/io` source
@@ -2325,6 +2300,11 @@ impl<'a, 'b> Checker<'a, 'b> {
             // The built-in scalars convert through their dedicated runtime
             // rendering. Any other type must implement `ToString`.
             if is_interpolatable(stripped) {
+                continue;
+            }
+            // The integer C FFI types widen to `Int` and render through the
+            // `Int` to-string path (HIR lowering inserts the cast).
+            if is_int_ffi(stripped) {
                 continue;
             }
             if let Ty::Param(p) = stripped {

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -24,6 +24,20 @@ fn check(src: &str) -> Result<(), RavenError> {
     check_file(&resolved).map(|_| ())
 }
 
+/// Like `check`, but merges the bundled prelude first so `print` of a
+/// scalar resolves through its `ToString` impl. Tests that print need
+/// this, since `print` requires the prelude's `impl ToString for Int`.
+fn check_with_prelude(src: &str) -> Result<(), RavenError> {
+    let tokens = Lexer::new(src.to_string(), PathBuf::from("t.rv"))
+        .tokenize()
+        .expect("lex");
+    let file = parse(&tokens).expect("parse");
+    let file = crate::resolve::expand_with_stdlib(&file)?;
+    let mut loader = NoLoader;
+    let resolved = resolve_file(&file, &mut loader)?;
+    check_file(&resolved).map(|_| ())
+}
+
 #[test]
 fn arithmetic_int_is_int() {
     check("fun f() -> Int = 1 + 2 * 3\n").unwrap();
@@ -107,18 +121,18 @@ fn dyn_argument_coercion_and_dispatch_check() {
     let src = format!(
         "{DYN_SPEAK}\
          fun describe(s: dyn Speak) -> Int = s.sound()\n\
-         fun main() {{\n    let d = Dog {{}}\n    print_int(describe(d))\n}}\n"
+         fun main() {{\n    let d = Dog {{}}\n    print(describe(d))\n}}\n"
     );
-    check(&src).unwrap();
+    check_with_prelude(&src).unwrap();
 }
 
 #[test]
 fn dyn_let_coercion_checks() {
     let src = format!(
         "{DYN_SPEAK}\
-         fun main() {{\n    let s: dyn Speak = Cat {{}}\n    print_int(s.sound())\n}}\n"
+         fun main() {{\n    let s: dyn Speak = Cat {{}}\n    print(s.sound())\n}}\n"
     );
-    check(&src).unwrap();
+    check_with_prelude(&src).unwrap();
 }
 
 #[test]
@@ -127,7 +141,7 @@ fn dyn_coercion_of_non_implementor_is_error() {
         "{DYN_SPEAK}\
          struct Rock {{}}\n\
          fun describe(s: dyn Speak) -> Int = s.sound()\n\
-         fun main() {{\n    print_int(describe(Rock {{}}))\n}}\n"
+         fun main() {{\n    print(describe(Rock {{}}))\n}}\n"
     );
     let err = check(&src).unwrap_err();
     assert!(matches!(err, RavenError::Type(_, _, _)));
@@ -478,7 +492,7 @@ fn ty_display_does_not_panic() {
 fn extern_decl_and_cstr_literal_call_checks() {
     // An extern signature with FFI types, called on a `c"..."` literal.
     check(
-        "extern \"C\" {\n    fun strlen(s: CStr) -> CSize\n}\nfun main() {\n    let n = strlen(c\"hello\")\n    print_int(n)\n}\n",
+        "extern \"C\" {\n    fun strlen(s: CStr) -> CSize\n}\nfun main() {\n    let n = strlen(c\"hello\")\n    print(n)\n}\n",
     )
     .unwrap();
 }
@@ -488,7 +502,7 @@ fn extern_int_param_accepts_int_literal() {
     // A native Int literal is accepted where an integer FFI type (CInt)
     // is expected, so `abs(-7)` checks.
     check(
-        "extern \"C\" {\n    fun abs(x: CInt) -> CInt\n}\nfun main() {\n    let n = abs(-7)\n    print_int(n)\n}\n",
+        "extern \"C\" {\n    fun abs(x: CInt) -> CInt\n}\nfun main() {\n    let n = abs(-7)\n    print(n)\n}\n",
     )
     .unwrap();
 }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -214,7 +214,7 @@ fn defer_order_program_compiles_and_runs() {
         return;
     };
     // Two defers run in reverse declaration order at the return: the
-    // function schedules print_int(1) then print_int(2), so the program
+    // function schedules print(1) then print(2), so the program
     // prints 2 then 1.
     compile_link_run_and_check("defer_order.rv", "2\n1\n", &runtime);
 }
@@ -270,11 +270,11 @@ fn std_io_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;
     };
-    // The first stdlib module end to end: `import std/io { println,
-    // println_int }` merges the bundled `std/io` source into the program,
-    // namespaced as `std.io.*`. The selectors bind to those functions,
-    // which call the internal `__io_*` intrinsics wired to the runtime.
-    // Prints the greeting then 42.
+    // The first stdlib module end to end: `import std/io { println }`
+    // merges the bundled `std/io` source into the program, namespaced as
+    // `std.io.*`. The selector binds to that function, which calls the
+    // internal `__io_*` intrinsics wired to the runtime. The second line
+    // prints an interpolated integer. Prints the greeting then 42.
     compile_link_run_and_check("use_io.rv", "Hello from std/io!\n42\n", &runtime);
 }
 
@@ -288,7 +288,7 @@ fn std_string_program_compiles_and_runs() {
     // of the `__str_*` byte intrinsics) into the program, namespaced as
     // `std.string.*`. Exercises case mapping, trim, repeat, replace,
     // substring, contains, and index_of, with the last two observed
-    // through println and println_int.
+    // through println of interpolated integers.
     let expected = "HELLO\n\
                     world\n\
                     spaced\n\


### PR DESCRIPTION
## Summary

The global `print` builtin already accepts any `ToString` value, so the separate `print_int` builtin was redundant for ordinary integers. The one case it still served, printing the C integer FFI types (`CInt`, `CLong`, `CSize`) which do not implement `ToString`, is now handled by widening those types to `Int` where a `ToString` value is required (a `print` argument or a `"${...}"` interpolation fragment), reusing the sign extension the old `print_int` codegen already did.

## Changes

- C integer FFI types now satisfy `print`/interpolation by widening to `Int`, so `print(strlen(c"hello"))` prints `5` and `"${strlen(c"hi")}"` interpolates `2`.
- Removed `print_int` from the resolver allowlist, the type checker, HIR/MIR lowering, the codegen `PRINT_INT` intrinsic, and the `raven_println_int` runtime symbol.
- Migrated every example and the FFI examples (`ffi_strlen`, `ffi_abs`, `use_ffi`) from `print_int(x)` to `print(x)`. Golden `.rv.out` baselines are unchanged because the output is identical.
- Two MIR defer tests and two tycheck dyn tests that print scalars now run through the prelude (`compile_with_prelude` / `check_with_prelude`), since `print` of a scalar requires the prelude's `impl ToString for Int`. The defer inspector reads the `Int$to_string` call the new lowering emits.

## Test plan

- [x] `print(42)`, `print(strlen(c"hello"))` (prints 5), and `"${strlen(c"hi")}"` (interpolates 2) compile and run.
- [x] `grep print_int` returns nothing in the compiler, runtime, examples, or tests.
- [x] `cargo test --test golden` passes with unchanged baselines; FFI smoke tests pass.
- [x] `cargo build --workspace`, `cargo test --lib` (377 pass), `cargo fmt --check`, `cargo clippy --workspace --all-targets` all clean.

Closes #151
