### PR TITLE
feat(parser): set and map literal syntax

### DIFF
--- a/docs/v2/specs/parser.md
+++ b/docs/v2/specs/parser.md
@@ -165,7 +165,10 @@ Suffix         := "." Identifier [ TypeArgs ] [ "(" ArgList ")" ]
 Primary       := Literal
               | Identifier [ TypeArgs ] [ StructLit ]
               | "(" Expr ")"
-              | "[" ExprList "]"
+              | "[" ExprList "]"            // list literal
+              | "[" MapEntries "]"          // map literal
+              | "[" ":" "]"                 // empty map
+              | SetLit
               | "{" Block "}"
               | IfExpr | MatchExpr | LoopExpr | WhileExpr | ForExpr | LambdaExpr
               | "self" | "Self"
@@ -173,6 +176,8 @@ Literal       := IntLit | FloatLit | BoolLit | StringLit | BlockStringLit | Char
 StructLit     := "{" [ FieldInit { Separator FieldInit }* [ Separator ] ] "}"
 FieldInit     := Identifier ":" Expr
               | Identifier
+SetLit        := "{" Expr { "," Expr }* [ "," ] "}"   // at least one element
+MapEntries    := Expr ":" Expr { "," Expr ":" Expr }* [ "," ]
 ArgList       := [ Expr { "," Expr }* [ "," ] ]
 ExprList      := [ Expr { "," Expr }* [ "," ] ]
 ```
@@ -198,6 +203,17 @@ Both `if` and `match` are expressions and have a value. `while` and `for` evalua
 #### Lambda shorthand
 
 `{ x, y -> body }` is a closure whose parameter types are inferred. The parser distinguishes shorthand lambdas from plain block expressions by looking ahead for an `Arrow` token (`->`) at the same brace depth before a statement separator. If found, the brace introduces a shorthand lambda; otherwise it is a block expression. A `{}` empty brace is always a block (the unit value).
+
+#### Set and map literals
+
+A set literal is `{ e1, e2, ... }`: a brace around one or more comma-separated expressions. A map literal is `[ k1: v1, k2: v2, ... ]`: a bracket around one or more comma-separated `key: value` pairs. Both lower to the bundled `std/collections` constructors (`Set.new()` plus `add` per element, `Map.new()` plus `set` per pair), so the literal needs `import std/collections` in scope. The parser produces dedicated `ExprKind::SetLit` and `ExprKind::MapLit` nodes; the desugaring to constructors happens during HIR lowering.
+
+Disambiguation rules:
+
+- Brace `{ ... }`. The parser first checks for a shorthand lambda (an `->` at brace depth 1 before a separator). Failing that, it checks for a set literal: a set is a brace whose first element is an expression followed, at brace depth 1, by a `,` before any statement separator (`;` or newline) or the closing `}`. A leading statement keyword (`let`, `return`, `break`, `continue`) marks a block immediately. A single-element `{ x }` (no comma) stays a block whose tail expression is `x`, preserving existing block behavior, so a single-element set is written `{x,}`. An empty `{}` is a block; an empty set is `Set.new()`.
+- Bracket `[ ... ]`. The empty `[]` is an empty list and `[:]` is an empty map. Otherwise the parser reads the first element expression, then looks at the next top-level token: a `:` makes it a map literal (the first element was a key), anything else makes it a list literal. So `[1, 2, 3]` is a list and `["a": 1]` is a map.
+
+These rules do not change how blocks, struct literals, `match` arm bodies, or `if`/`while`/`for` bodies parse: a set literal requires the comma form, and a map literal requires a top-level `:`, neither of which those forms produce.
 
 #### Patterns
 

--- a/docs/v2/specs/std-collections.md
+++ b/docs/v2/specs/std-collections.md
@@ -30,7 +30,46 @@ call: `Set<Int>.new()`.
 
 The free functions `empty_set()` and `empty_map()` remain available for a
 selective import (`import std/collections { empty_set, empty_map }`) and
-behave identically to `Set.new()` and `Map.new()`.
+behave identically to `Set.new()` and `Map.new()`. They are superseded by
+the set and map literals below and by the `new()` constructors; new code
+should prefer those.
+
+## Set and map literals
+
+Set and map values have literal syntax (issue #156). Both lower to the
+constructors above, so they need the same `import std/collections` in
+scope.
+
+```raven
+import std/collections
+
+fun main() {
+    let s = {1, 2, 2, 3}        // Set<Int>, dedups to {1, 2, 3}
+    let m = ["a": 1, "b": 2]    // Map<String, Int>
+    let flags = ["x": true]     // Map<String, Bool>
+    let empty: Map<String, Int> = [:]
+}
+```
+
+Grammar and disambiguation:
+
+- A set literal is `{ e1, e2, ... }`: braces around one or more
+  comma-separated expressions. It must carry at least one comma, so a
+  single-element set is written `{x,}`. A bare `{ x }` stays a block whose
+  tail expression is `x`, and `{}` is an empty block, both unchanged. An
+  empty set is written `Set.new()`.
+- A map literal is `[ k1: v1, k2: v2, ... ]`: brackets around one or more
+  comma-separated `key: value` pairs. The empty map is the distinct `[:]`
+  form, so the bare `[]` stays an empty list. A bracket whose first element
+  has no top-level `:` is a list (`[1, 2, 3]`); a `:` after the first
+  element makes it a map.
+
+Element, key, and value types are inferred from the literal contents
+(`{1, 2}` is `Set<Int>`; `["x": true]` is `Map<String, Bool>`). The set's
+`T` and the map's `K` must implement `Eq`, the same bound the types carry.
+The desugaring is the same constructor-plus-insert sequence as hand-written
+code: `{a, b}` builds `Set.new()` then `add(a); add(b)`, and `[k: v]`
+builds `Map.new()` then `set(k, v)`.
 
 ## Set<T: Eq>
 
@@ -42,7 +81,7 @@ behave identically to `Set.new()` and `Map.new()`.
 | `add(x)` | | adds only if absent |
 | `remove(x)` | `Bool` | whether it was present; order not preserved |
 
-Construct with `empty_set()`.
+Construct with a set literal `{1, 2}`, `Set.new()`, or `empty_set()`.
 
 ## Map<K: Eq, V>
 
@@ -55,7 +94,8 @@ Construct with `empty_set()`.
 | `set(k, v)` | | inserts or overwrites |
 | `remove(k)` | `Bool` | whether it was present; order not preserved |
 
-Construct with `empty_map()`. Keys and values are stored in parallel
+Construct with a map literal `["a": 1]` (or `[:]` for an empty map),
+`Map.new()`, or `empty_map()`. Keys and values are stored in parallel
 `List`s.
 
 ## Complexity

--- a/docs/v2/specs/tycheck.md
+++ b/docs/v2/specs/tycheck.md
@@ -188,6 +188,7 @@ Three generic shapes are hard coded:
 * `Option<T>`. Variants: `None`, `Some(T)`. Constructed by writing `None` or `Some(value)` at a use site whose context type fixes `T`. The resolver already accepts `Option` and `Result` as built in type names; the type checker recognizes the variant identifiers when the contextual type is known.
 * `Result<T, E>`. Variants: `Ok(T)`, `Err(E)`.
 * `List<T>`. The array literal `[a, b, c]` infers `T` as the unified element type. Empty list literals require a context type and are otherwise rejected with `TypeMismatch`.
+* `Set<T>` and `Map<K, V>` (bundled `std/collections` types). The set literal `{a, b}` types as `Set<T>` with `T` unified across the elements; the map literal `["k": v]` (and the empty `[:]`) types as `Map<K, V>` with `K` and `V` unified across the keys and values. The literal binds to the imported `Set`/`Map` declaration, so it requires `import std/collections` in scope and otherwise reports a `TypeError`. `T` and `K` carry the declarations' `Eq` bound. HIR lowers the literals to the `Set.new()`/`Map.new()` constructors plus an `add`/`set` per element or pair.
 
 Member access against these types goes through a small inherent method table. None of these types participate in the general generic mechanism: their `T` and `E` are pattern matched directly by the type checker. When the full generic mechanism lands (issue #59), these special cases collapse into the unified path.
 

--- a/examples/v2/use_collection_literals.rv
+++ b/examples/v2/use_collection_literals.rv
@@ -1,0 +1,39 @@
+// golden:skip
+import std/collections
+import std/io { println }
+
+fun main() {
+    // Set literal: duplicates collapse, membership and length work.
+    let s: Set<Int> = {1, 2, 2, 3}
+    print(s.len())
+    print(s.contains(2))
+    print(s.contains(9))
+
+    // Set inference without an annotation.
+    let inferred = {10, 20, 30}
+    print(inferred.len())
+
+    // Map literal: keys map to values, get returns Option, length counts pairs.
+    let m = ["a": 1, "b": 2]
+    print(m.len())
+    match m.get("a") {
+        Some(v) -> print(v)
+        None -> print(0)
+    }
+    match m.get("z") {
+        Some(v) -> print(v)
+        None -> print(-1)
+    }
+
+    // Map value inference: String keys to Bool values.
+    let flags = ["x": true, "y": false]
+    print(flags.len())
+    match flags.get("x") {
+        Some(b) -> print(b)
+        None -> print(false)
+    }
+
+    // Empty map form `[:]` builds an empty Map.
+    let empty: Map<String, Int> = [:]
+    print(empty.len())
+}

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -62,6 +62,15 @@ pub enum ExprKind {
     },
     /// `[a, b, c]` array literal.
     Array(Vec<Expr>),
+    /// `{a, b, c}` set literal. Always at least one element (an empty set
+    /// is written `Set.new()` and a single-element `{x}` is a block). The
+    /// HIR lowers this to a `Set.new()` constructor plus one `add` call
+    /// per element.
+    SetLit(Vec<Expr>),
+    /// `[k1: v1, k2: v2]` map literal. The empty map is the distinct `[:]`
+    /// form, which still lowers here with no pairs. The HIR lowers this to
+    /// a `Map.new()` constructor plus one `set` call per pair.
+    MapLit(Vec<(Expr, Expr)>),
     /// `(a, b, c)` tuple literal. Always at least two elements. The
     /// parser produces this and the resolver rejects it until tuples
     /// land; see `docs/v2/specs/parser.md`.

--- a/src/ast/pretty.rs
+++ b/src/ast/pretty.rs
@@ -397,6 +397,27 @@ fn pretty_expr(buf: &mut String, expr: &Expr, depth: usize) {
             indent(buf, depth);
             buf.push_str(")\n");
         }
+        ExprKind::SetLit(items) => {
+            buf.push_str("(set\n");
+            for it in items {
+                pretty_expr(buf, it, depth + 1);
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
+        ExprKind::MapLit(pairs) => {
+            buf.push_str("(map\n");
+            for (k, v) in pairs {
+                indent(buf, depth + 1);
+                buf.push_str("(pair\n");
+                pretty_expr(buf, k, depth + 2);
+                pretty_expr(buf, v, depth + 2);
+                indent(buf, depth + 1);
+                buf.push_str(")\n");
+            }
+            indent(buf, depth);
+            buf.push_str(")\n");
+        }
         ExprKind::Paren(inner) => {
             buf.push_str("(paren\n");
             pretty_expr(buf, inner, depth + 1);

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -758,6 +758,26 @@ impl Printer<'_> {
                 let parts = self.expr_list(items, base);
                 format!("({})", parts.join(", "))
             }
+            ExprKind::SetLit(items) => {
+                let parts = self.expr_list(items, base);
+                // A single-element set keeps a trailing comma so it does
+                // not re-parse as a one-expression block `{ x }`.
+                if parts.len() == 1 {
+                    format!("{{{},}}", parts[0])
+                } else {
+                    format!("{{{}}}", parts.join(", "))
+                }
+            }
+            ExprKind::MapLit(pairs) => {
+                if pairs.is_empty() {
+                    return "[:]".to_string();
+                }
+                let parts: Vec<String> = pairs
+                    .iter()
+                    .map(|(k, v)| format!("{}: {}", self.expr_at(k, base), self.expr_at(v, base)))
+                    .collect();
+                format!("[{}]", parts.join(", "))
+            }
             ExprKind::Paren(inner) => {
                 let inner = self.expr_at(inner, base);
                 format!("({})", inner)

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -210,3 +210,33 @@ fn dollar_brace_in_plain_string_escaped() {
     let out = fmt("fun f()->String{return \"\\${x}\"}");
     assert!(out.contains("\\${x}"));
 }
+
+#[test]
+fn set_literal_round_trips() {
+    let out = fmt("fun f(){let s={1,2,  3}}");
+    assert_eq!(out, "fun f() {\n    let s = {1, 2, 3}\n}\n");
+}
+
+#[test]
+fn single_element_set_keeps_one_element() {
+    let out = fmt("fun f(){let s={1,}}");
+    assert_eq!(out, "fun f() {\n    let s = {1,}\n}\n");
+}
+
+#[test]
+fn map_literal_round_trips() {
+    let out = fmt("fun f(){let m=[\"a\":1,\"b\":2]}");
+    assert_eq!(out, "fun f() {\n    let m = [\"a\": 1, \"b\": 2]\n}\n");
+}
+
+#[test]
+fn empty_map_literal_round_trips() {
+    let out = fmt("fun f(){let m=[:]}");
+    assert_eq!(out, "fun f() {\n    let m = [:]\n}\n");
+}
+
+#[test]
+fn empty_list_stays_a_list() {
+    let out = fmt("fun f(){let e=[]}");
+    assert_eq!(out, "fun f() {\n    let e = []\n}\n");
+}

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -115,6 +115,8 @@ pub(crate) fn lower_expr(
             }
             HirExprKind::Array(out)
         }
+        ExprKind::SetLit(items) => return lower_set_lit(items, &ty, &span, cx),
+        ExprKind::MapLit(pairs) => return lower_map_lit(pairs, &ty, &span, cx),
         ExprKind::Tuple(_) => {
             // The parser produces tuples but the resolver/tycheck
             // reject them; this branch should not run in practice.
@@ -437,6 +439,140 @@ pub(crate) fn lower_expr(
         });
     }
     Ok(inner)
+}
+
+/// Lower a set literal `{e1, e2, ...}` to a block that builds the set
+/// with the `Set.new()` associated constructor and one `add` call per
+/// element:
+///
+/// ```text
+/// { let __set = Set.new(); __set.add(e1); __set.add(e2); ...; __set }
+/// ```
+///
+/// The set type comes from the type checker (recorded at the literal's
+/// span), so `Set.new()` is an `AssocCall` on that concrete `Set<T>` and
+/// each `add` is an ordinary method call. Monomorphization resolves both
+/// to the element type's impl symbols, exactly as for hand-written code.
+fn lower_set_lit(
+    items: &[Expr],
+    set_ty: &Ty,
+    span: &Span,
+    cx: &LowerCtx<'_>,
+) -> Result<HirExpr, RavenError> {
+    let elem_ty = match set_ty.strip_self() {
+        Ty::Struct { args, .. } => args.first().cloned().unwrap_or(Ty::Error),
+        _ => Ty::Error,
+    };
+    let name = cx.fresh("set");
+    let ctor = make_expr(
+        HirExprKind::AssocCall {
+            self_ty: set_ty.clone(),
+            name: "new".into(),
+            args: Vec::new(),
+        },
+        set_ty.clone(),
+        span.clone(),
+    );
+    let mut stmts = vec![let_stmt(&name, set_ty.clone(), ctor, span.clone())];
+    for it in items {
+        let value = lower_expr(it, &elem_ty, cx)?;
+        let recv = ident_expr(&name, set_ty.clone(), it.span.clone());
+        let add = make_expr(
+            HirExprKind::MethodCall {
+                receiver: Box::new(recv),
+                name: "add".into(),
+                args: vec![value],
+            },
+            Ty::Unit,
+            it.span.clone(),
+        );
+        stmts.push(HirStmt {
+            kind: HirStmtKind::Expr(add),
+            span: it.span.clone(),
+        });
+    }
+    let tail = ident_expr(&name, set_ty.clone(), span.clone());
+    let block = HirBlock {
+        stmts,
+        tail: Some(Box::new(tail)),
+        ty: set_ty.clone(),
+        span: span.clone(),
+    };
+    Ok(make_expr(
+        HirExprKind::Block(block),
+        set_ty.clone(),
+        span.clone(),
+    ))
+}
+
+/// Lower a map literal `[k1: v1, ...]` (and the empty `[:]`) to a block
+/// that builds the map with the `Map.new()` associated constructor and
+/// one `set` call per pair:
+///
+/// ```text
+/// { let __map = Map.new(); __map.set(k1, v1); ...; __map }
+/// ```
+fn lower_map_lit(
+    pairs: &[(Expr, Expr)],
+    map_ty: &Ty,
+    span: &Span,
+    cx: &LowerCtx<'_>,
+) -> Result<HirExpr, RavenError> {
+    let (key_ty, val_ty) = match map_ty.strip_self() {
+        Ty::Struct { args, .. } => (
+            args.first().cloned().unwrap_or(Ty::Error),
+            args.get(1).cloned().unwrap_or(Ty::Error),
+        ),
+        _ => (Ty::Error, Ty::Error),
+    };
+    let name = cx.fresh("map");
+    let ctor = make_expr(
+        HirExprKind::AssocCall {
+            self_ty: map_ty.clone(),
+            name: "new".into(),
+            args: Vec::new(),
+        },
+        map_ty.clone(),
+        span.clone(),
+    );
+    let mut stmts = vec![let_stmt(&name, map_ty.clone(), ctor, span.clone())];
+    for (k, v) in pairs {
+        let pair_span = Span::new(
+            k.span.file.clone(),
+            k.span.start.min(v.span.start),
+            k.span.end.max(v.span.end),
+            k.span.line,
+            k.span.col,
+        );
+        let key = lower_expr(k, &key_ty, cx)?;
+        let value = lower_expr(v, &val_ty, cx)?;
+        let recv = ident_expr(&name, map_ty.clone(), pair_span.clone());
+        let set = make_expr(
+            HirExprKind::MethodCall {
+                receiver: Box::new(recv),
+                name: "set".into(),
+                args: vec![key, value],
+            },
+            Ty::Unit,
+            pair_span.clone(),
+        );
+        stmts.push(HirStmt {
+            kind: HirStmtKind::Expr(set),
+            span: pair_span,
+        });
+    }
+    let tail = ident_expr(&name, map_ty.clone(), span.clone());
+    let block = HirBlock {
+        stmts,
+        tail: Some(Box::new(tail)),
+        ty: map_ty.clone(),
+        span: span.clone(),
+    };
+    Ok(make_expr(
+        HirExprKind::Block(block),
+        map_ty.clone(),
+        span.clone(),
+    ))
 }
 
 fn lower_unop(op: UnaryOp) -> HirUnaryOp {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -497,20 +497,53 @@ impl Parser {
         Err(RavenError::parse(ParseError::UnsupportedTuple, span))
     }
 
+    /// Parse a `[...]` bracket primary: a list literal `[a, b]`, an empty
+    /// list `[]`, an empty map `[:]`, or a map literal `[k: v, ...]`. A
+    /// map is distinguished from a list by a `:` at the top level of the
+    /// first element; the empty map uses the explicit `[:]` form so the
+    /// bare `[]` stays an empty list.
     fn parse_array_lit(&mut self) -> ParseResult<Expr> {
         let lb = self.advance();
-        let mut items = Vec::new();
         self.skip_newlines();
-        if !matches!(self.peek_kind(), TokenKind::RBracket) {
+        // Empty map: `[:]`.
+        if matches!(self.peek_kind(), TokenKind::Colon)
+            && matches!(self.peek_kind_at(1), TokenKind::RBracket)
+        {
+            self.advance(); // :
+            let rb = self.advance(); // ]
+            let span = merge_spans(&lb.span, &rb.span);
+            return Ok(Expr {
+                kind: ExprKind::MapLit(Vec::new()),
+                span,
+            });
+        }
+        // Empty list: `[]`.
+        if matches!(self.peek_kind(), TokenKind::RBracket) {
+            let rb = self.advance();
+            let span = merge_spans(&lb.span, &rb.span);
+            return Ok(Expr {
+                kind: ExprKind::Array(Vec::new()),
+                span,
+            });
+        }
+        // Parse the first element expression, then decide list vs map by
+        // whether a `:` follows it at the top level.
+        let first = self.parse_expr()?;
+        self.skip_newlines();
+        if matches!(self.peek_kind(), TokenKind::Colon) {
+            return self.parse_map_lit(lb.span, first);
+        }
+        let mut items = vec![first];
+        self.skip_newlines();
+        if self.eat(&TokenKind::Comma) {
             loop {
                 self.skip_newlines();
+                if matches!(self.peek_kind(), TokenKind::RBracket) {
+                    break;
+                }
                 items.push(self.parse_expr()?);
                 self.skip_newlines();
                 if !self.eat(&TokenKind::Comma) {
-                    break;
-                }
-                self.skip_newlines();
-                if matches!(self.peek_kind(), TokenKind::RBracket) {
                     break;
                 }
             }
@@ -523,6 +556,38 @@ impl Parser {
         })
     }
 
+    /// Parse the remainder of a map literal after the first key has been
+    /// read and the following `:` is the next token. `first_key` is that
+    /// key. Produces an `ExprKind::MapLit` of `(key, value)` pairs; the
+    /// HIR lowers it to `Map.new()` plus one `set(k, v)` per pair.
+    fn parse_map_lit(&mut self, lbracket: Span, first_key: Expr) -> ParseResult<Expr> {
+        let mut pairs: Vec<(Expr, Expr)> = Vec::new();
+        self.expect(&TokenKind::Colon, "`:`")?;
+        self.skip_newlines();
+        let first_val = self.parse_expr()?;
+        pairs.push((first_key, first_val));
+        self.skip_newlines();
+        while self.eat(&TokenKind::Comma) {
+            self.skip_newlines();
+            if matches!(self.peek_kind(), TokenKind::RBracket) {
+                break;
+            }
+            let key = self.parse_expr()?;
+            self.skip_newlines();
+            self.expect(&TokenKind::Colon, "`:`")?;
+            self.skip_newlines();
+            let val = self.parse_expr()?;
+            pairs.push((key, val));
+            self.skip_newlines();
+        }
+        let rb = self.expect(&TokenKind::RBracket, "`]`")?;
+        let span = merge_spans(&lbracket, &rb.span);
+        Ok(Expr {
+            kind: ExprKind::MapLit(pairs),
+            span,
+        })
+    }
+
     /// Parse a `{...}` primary: either a shorthand lambda or a block
     /// expression. The distinguisher is an `Arrow` token at depth 0
     /// before any statement separator outside parens or brackets.
@@ -530,10 +595,92 @@ impl Parser {
         if self.is_shorthand_lambda() {
             return self.parse_lambda_shorthand();
         }
+        if self.is_set_literal() {
+            return self.parse_set_lit();
+        }
         let block = self.parse_block()?;
         let span = block.span.clone();
         Ok(Expr {
             kind: ExprKind::Block(block),
+            span,
+        })
+    }
+
+    /// Heuristic for a set literal `{ e1, e2, ... }`. The cursor is at the
+    /// opening `{`. A set is a brace whose first element is an expression
+    /// followed, at brace depth 1, by a `,` before any statement separator
+    /// (`;` or newline) or the closing `}`. A single-element `{ x }` is a
+    /// block (it preserves the existing one-tail-expression behavior), so a
+    /// set always carries at least one comma. An empty `{}` is a block, and
+    /// an empty set is written `Set.new()`.
+    fn is_set_literal(&self) -> bool {
+        let mut depth_paren = 0i32;
+        let mut depth_bracket = 0i32;
+        let mut depth_brace = 0i32;
+        let mut i = self.pos;
+        let mut seen_token = false;
+        while i < self.tokens.len() {
+            let k = &self.tokens[i].kind;
+            match k {
+                TokenKind::LBrace => depth_brace += 1,
+                TokenKind::RBrace => {
+                    depth_brace -= 1;
+                    if depth_brace == 0 {
+                        return false;
+                    }
+                }
+                TokenKind::LParen => depth_paren += 1,
+                TokenKind::RParen => depth_paren -= 1,
+                TokenKind::LBracket => depth_bracket += 1,
+                TokenKind::RBracket => depth_bracket -= 1,
+                TokenKind::Comma if depth_brace == 1 && depth_paren == 0 && depth_bracket == 0 => {
+                    return seen_token;
+                }
+                // A statement keyword right after `{` is always a block.
+                TokenKind::Let | TokenKind::Return | TokenKind::Break | TokenKind::Continue
+                    if depth_brace == 1 && !seen_token =>
+                {
+                    return false;
+                }
+                TokenKind::Semi | TokenKind::Newline
+                    if depth_brace == 1 && depth_paren == 0 && depth_bracket == 0 =>
+                {
+                    return false;
+                }
+                TokenKind::Eof => return false,
+                _ => {
+                    if depth_brace == 1 {
+                        seen_token = true;
+                    }
+                }
+            }
+            i += 1;
+        }
+        false
+    }
+
+    /// Parse a set literal `{ e1, e2, ... }`. Produces an
+    /// `ExprKind::SetLit`; the HIR lowers it to `Set.new()` plus one
+    /// `add(e)` per element. The cursor is at the opening `{`.
+    fn parse_set_lit(&mut self) -> ParseResult<Expr> {
+        let lb = self.advance(); // {
+        let mut items = Vec::new();
+        self.skip_newlines();
+        loop {
+            self.skip_newlines();
+            if matches!(self.peek_kind(), TokenKind::RBrace) {
+                break;
+            }
+            items.push(self.parse_expr()?);
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        let rb = self.expect(&TokenKind::RBrace, "`}`")?;
+        let span = merge_spans(&lb.span, &rb.span);
+        Ok(Expr {
+            kind: ExprKind::SetLit(items),
             span,
         })
     }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -169,6 +169,101 @@ fn parses_array_literal() {
     assert_eq!(items.len(), 3);
 }
 
+// ----- set and map literals -----
+
+/// Extract the initializer expression of the first top-level `let`.
+fn let_init(f: &crate::ast::File) -> &ExprKind {
+    let DeclKind::Let(d) = &f.items[0].kind else {
+        panic!("expected a let decl");
+    };
+    &d.init.as_ref().expect("let initializer").kind
+}
+
+#[test]
+fn parses_set_literal() {
+    let f = parse_ok("let s = {1, 2, 2}\n");
+    let ExprKind::SetLit(items) = let_init(&f) else {
+        panic!("expected a set literal, got {:?}", let_init(&f));
+    };
+    assert_eq!(items.len(), 3);
+}
+
+#[test]
+fn parses_single_element_set_with_trailing_comma() {
+    let f = parse_ok("let s = {1,}\n");
+    let ExprKind::SetLit(items) = let_init(&f) else {
+        panic!("expected a set literal");
+    };
+    assert_eq!(items.len(), 1);
+}
+
+#[test]
+fn single_element_brace_is_a_block_not_a_set() {
+    // `{ x }` stays a block whose tail expression is `x`, preserving the
+    // existing block behavior. A set needs the comma form.
+    let f = parse_ok("let a = { 5 }\n");
+    let ExprKind::Block(b) = let_init(&f) else {
+        panic!("expected a block, not a set");
+    };
+    assert!(b.stmts.is_empty());
+    assert!(matches!(
+        b.trailing.as_ref().unwrap().kind,
+        ExprKind::Int(5)
+    ));
+}
+
+#[test]
+fn brace_with_statement_is_a_block() {
+    let f = parse_ok("let b = { let x = 3; x + 1 }\n");
+    assert!(matches!(let_init(&f), ExprKind::Block(_)));
+}
+
+#[test]
+fn empty_brace_is_a_block() {
+    let f = parse_ok("let u = {}\n");
+    let ExprKind::Block(b) = let_init(&f) else {
+        panic!("expected a block");
+    };
+    assert!(b.stmts.is_empty());
+    assert!(b.trailing.is_none());
+}
+
+#[test]
+fn parses_map_literal() {
+    let f = parse_ok("let m = [\"a\": 1, \"b\": 2]\n");
+    let ExprKind::MapLit(pairs) = let_init(&f) else {
+        panic!("expected a map literal, got {:?}", let_init(&f));
+    };
+    assert_eq!(pairs.len(), 2);
+}
+
+#[test]
+fn empty_map_literal_is_a_map_lit_with_no_pairs() {
+    let f = parse_ok("let m = [:]\n");
+    let ExprKind::MapLit(pairs) = let_init(&f) else {
+        panic!("expected an empty map literal");
+    };
+    assert!(pairs.is_empty());
+}
+
+#[test]
+fn empty_bracket_is_an_empty_list() {
+    let f = parse_ok("let e = []\n");
+    let ExprKind::Array(items) = let_init(&f) else {
+        panic!("expected an empty array");
+    };
+    assert!(items.is_empty());
+}
+
+#[test]
+fn bracket_without_colon_is_a_list() {
+    let f = parse_ok("let l = [1, 2, 3]\n");
+    let ExprKind::Array(items) = let_init(&f) else {
+        panic!("expected an array");
+    };
+    assert_eq!(items.len(), 3);
+}
+
 #[test]
 fn parses_paren_expr() {
     let f = parse_ok("let a = (1 + 2)\n");

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -770,9 +770,15 @@ fn rewrite_expr(expr: &mut Expr, rename: &HashMap<String, String>) {
                 }
             }
         }
-        ExprKind::Array(items) | ExprKind::Tuple(items) => {
+        ExprKind::Array(items) | ExprKind::Tuple(items) | ExprKind::SetLit(items) => {
             for e in items {
                 rewrite_expr(e, rename);
+            }
+        }
+        ExprKind::MapLit(pairs) => {
+            for (k, v) in pairs {
+                rewrite_expr(k, rename);
+                rewrite_expr(v, rename);
             }
         }
         ExprKind::StructLit { fields, .. } => {

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -376,9 +376,15 @@ fn walk_expr(
                 }
             }
         }
-        ExprKind::Array(items) | ExprKind::Tuple(items) => {
+        ExprKind::Array(items) | ExprKind::Tuple(items) | ExprKind::SetLit(items) => {
             for e in items {
                 walk_expr(e, scope, map)?;
+            }
+        }
+        ExprKind::MapLit(pairs) => {
+            for (k, v) in pairs {
+                walk_expr(k, scope, map)?;
+                walk_expr(v, scope, map)?;
             }
         }
         ExprKind::Paren(e) => walk_expr(e, scope, map)?,

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -698,6 +698,8 @@ impl<'a, 'b> Checker<'a, 'b> {
             ExprKind::Paren(inner) => self.check_expr(inner),
             ExprKind::Ident { name, generics } => self.check_ident(name, generics, &expr.span),
             ExprKind::Array(items) => self.check_array(items, &expr.span),
+            ExprKind::SetLit(items) => self.check_set_lit(items, &expr.span),
+            ExprKind::MapLit(pairs) => self.check_map_lit(pairs, &expr.span),
             ExprKind::Tuple(_) => Err(RavenError::ty(
                 TypeError::Custom("tuple expressions are not yet supported".into()),
                 expr.span.clone(),
@@ -1068,6 +1070,73 @@ impl<'a, 'b> Checker<'a, 'b> {
             self.unify(&first, &t, &it.span)?;
         }
         Ok(Ty::List(Box::new(first)))
+    }
+
+    /// Find a struct declaration by its source name and build a fresh
+    /// instantiation `Ty::Struct` whose type arguments are inference
+    /// variables carrying the declaration's trait bounds. Used by the set
+    /// and map literals, which name the bundled `Set` and `Map` types. A
+    /// missing declaration means the collections module is not in scope.
+    fn instantiate_named_struct(
+        &mut self,
+        name: &str,
+        span: &Span,
+    ) -> Result<(crate::resolve::DeclId, Vec<Ty>), RavenError> {
+        let found = self
+            .env
+            .structs
+            .iter()
+            .find(|(_, s)| s.name == name)
+            .map(|(id, s)| (*id, s.generics.clone()));
+        let Some((id, generics)) = found else {
+            return Err(RavenError::ty(
+                TypeError::Custom(format!(
+                    "`{}` literal requires the collections module; add `import std/collections`",
+                    name
+                )),
+                span.clone(),
+            ));
+        };
+        let args = self.instantiate_type_args(&generics, &[], span, name)?;
+        Ok((id, args))
+    }
+
+    /// Check a set literal `{e1, e2, ...}`. The result is `Set<T>` where
+    /// `T` unifies with every element type. The `Eq` bound on `Set`'s type
+    /// parameter rides along on the fresh argument variable.
+    fn check_set_lit(&mut self, items: &[Expr], span: &Span) -> Result<Ty, RavenError> {
+        let (id, args) = self.instantiate_named_struct("Set", span)?;
+        let elem = args.first().cloned().unwrap_or(Ty::Error);
+        for it in items {
+            let t = self.check_expr(it)?;
+            self.unify(&elem, &t, &it.span)?;
+        }
+        Ok(Ty::Struct {
+            id,
+            name: "Set".to_string(),
+            args,
+        })
+    }
+
+    /// Check a map literal `[k1: v1, ...]` (and the empty `[:]`). The
+    /// result is `Map<K, V>` where `K` unifies with every key type and `V`
+    /// with every value type. The `Eq` bound on `Map`'s key parameter
+    /// rides along on the fresh key argument variable.
+    fn check_map_lit(&mut self, pairs: &[(Expr, Expr)], span: &Span) -> Result<Ty, RavenError> {
+        let (id, args) = self.instantiate_named_struct("Map", span)?;
+        let key_ty = args.first().cloned().unwrap_or(Ty::Error);
+        let val_ty = args.get(1).cloned().unwrap_or(Ty::Error);
+        for (k, v) in pairs {
+            let kt = self.check_expr(k)?;
+            self.unify(&key_ty, &kt, &k.span)?;
+            let vt = self.check_expr(v)?;
+            self.unify(&val_ty, &vt, &v.span)?;
+        }
+        Ok(Ty::Struct {
+            id,
+            name: "Map".to_string(),
+            args,
+        })
     }
 
     fn check_unary(&mut self, op: UnaryOp, operand: &Expr) -> Result<Ty, RavenError> {

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -537,3 +537,58 @@ fn ffi_type_mismatch_is_rejected() {
     .unwrap_err();
     assert!(matches!(err, RavenError::Type(_, _, _)));
 }
+
+#[test]
+fn set_literal_type_checks() {
+    check_with_prelude(
+        "import std/collections\nfun main() {\n    let s: Set<Int> = {1, 2, 2}\n    let _ = s.len()\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn set_literal_infers_element_type() {
+    check_with_prelude(
+        "import std/collections\nfun main() {\n    let s = {1, 2, 3}\n    let _ = s.contains(2)\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn map_literal_type_checks_and_infers() {
+    check_with_prelude(
+        "import std/collections\nfun main() {\n    let m = [\"a\": 1, \"b\": 2]\n    let _ = m.get(\"a\")\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn map_literal_infers_bool_values() {
+    check_with_prelude(
+        "import std/collections\nfun main() {\n    let m = [\"x\": true]\n    let _ = m.has(\"x\")\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn empty_map_literal_type_checks_with_annotation() {
+    check_with_prelude(
+        "import std/collections\nfun main() {\n    let m: Map<String, Int> = [:]\n    let _ = m.len()\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn set_literal_requires_collections_import() {
+    // A set literal lowers to the bundled `Set` type; without the
+    // collections module in scope there is no `Set` declaration, so the
+    // literal is a type error.
+    let err = check_with_prelude("fun main() {\n    let s = {1, 2}\n}\n").unwrap_err();
+    assert!(matches!(err, RavenError::Type(_, _, _)), "got: {}", err);
+}
+
+#[test]
+fn map_literal_requires_collections_import() {
+    let err = check_with_prelude("fun main() {\n    let m = [\"a\": 1]\n}\n").unwrap_err();
+    assert!(matches!(err, RavenError::Type(_, _, _)), "got: {}", err);
+}

--- a/stdlib/std/collections.rv
+++ b/stdlib/std/collections.rv
@@ -9,6 +9,8 @@ struct Set<T: Eq> {
     items: List<T>,
 }
 
+// Superseded by the set literal `{a, b}` and `Set.new()`. Kept for
+// selective imports.
 fun empty_set<T: Eq>() -> Set<T> {
     let items: List<T> = []
     return Set { items: items }
@@ -70,6 +72,8 @@ struct Map<K: Eq, V> {
     values: List<V>,
 }
 
+// Superseded by the map literal `["a": 1]` (and `[:]`) and `Map.new()`.
+// Kept for selective imports.
 fun empty_map<K: Eq, V>() -> Map<K, V> {
     let keys: List<K> = []
     let values: List<V> = []

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -341,6 +341,24 @@ fn collections_program_compiles_and_runs() {
 }
 
 #[test]
+fn collection_literals_compile_and_run() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Set and map literal syntax (issue #156). `{1, 2, 2, 3}` dedups to a
+    // 3-element Set; `contains` reports membership. An un-annotated set
+    // infers its element type. `["a": 1, "b": 2]` builds a 2-entry Map;
+    // `get` returns Some/None. Map values infer (String to Bool). The
+    // empty-map form `[:]` builds an empty Map. Prints
+    // 3, true, false, 3, 2, 1, -1, 2, true, 0.
+    compile_link_run_and_check(
+        "use_collection_literals.rv",
+        "3\ntrue\nfalse\n3\n2\n1\n-1\n2\ntrue\n0\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn selective_bundled_type_import_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Adds set literals `{1, 2, 3}` and map literals `["a": 1, "b": 2]` to the v2 frontend, lowering both to the bundled `std/collections` constructors plus inserts.

Closes #156

## Grammar

- Set literal: `{ e1, e2, ... }`, a brace around one or more comma-separated expressions.
- Map literal: `[ k1: v1, k2: v2, ... ]`, a bracket around one or more comma-separated `key: value` pairs. The empty map is the distinct `[:]` form.

## Disambiguation

- Brace `{ ... }`: shorthand lambda (`->` lookahead) is checked first, then a set literal (first element followed by a `,` at brace depth 1 before any statement separator or `}`). A single-element `{ x }` stays a block whose tail is `x`, so a one-element set is written `{x,}`. Empty `{}` is a block; an empty set is `Set.new()`.
- Bracket `[ ... ]`: empty `[]` is a list, `[:]` is an empty map. Otherwise the first element decides: a top-level `:` after it makes a map, anything else makes a list.

These rules leave block, struct-literal, `match` arm body, and `if`/`while`/`for` body parsing unchanged.

## Desugaring

Dedicated `ExprKind::SetLit(Vec<Expr>)` and `ExprKind::MapLit(Vec<(Expr, Expr)>)` AST nodes parse cleanly (the formatter round-trips them and `--show-ast` prints them). HIR lowering builds the same sequence hand-written code would: `{a, b}` becomes `Set.new()` then `add(a); add(b)`, and `[k: v]` becomes `Map.new()` then `set(k, v)`, using the concrete `Set<T>`/`Map<K, V>` type the type checker inferred. The set's `T` and the map's `K` carry the collections types' `Eq` bound; element, key, and value types infer from the literal contents.

## Verification

`examples/v2/use_collection_literals.rv` compiles, links, and runs (gated codegen smoke test) printing:

```
3        // {1, 2, 2, 3}.len() after dedup
true     // contains(2)
false    // contains(9)
3        // inferred {10, 20, 30}.len()
2        // ["a": 1, "b": 2].len()
1        // get("a") -> Some(1)
-1       // get("z") -> None
2        // ["x": true, "y": false].len()
true     // get("x") -> Some(true)
0        // empty [:].len()
```

## Coverage and limitations

- Set length and dedup, set membership, map get/None, and inference for set element, map key, and map value all verified end to end.
- Empty cases: `[]` is a list, `[:]` is an empty map, `{}` is a block (empty set is `Set.new()`), single-element set is `{x,}`.
- The literals require `import std/collections` in scope; without it the literal is a type error.
- As with hand-written `Set.new(); add(...)`, the `Eq` bound on the element/key type is not yet enforced at the call site by the checker (it surfaces only when an unconstrained type is used). This is pre-existing behavior for inherent-impl method calls and unchanged here.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] Parser unit tests: set/map literal forms, single-element block vs set, empty block, empty list vs empty map, list vs map.
- [x] Type checker unit tests: set/map type-check and inference, empty map with annotation, missing collections import rejected.
- [x] Formatter round-trip tests: set, single-element set, map, empty map, empty list (idempotent and AST-preserving).
- [x] Codegen smoke test runs the compiled program and checks stdout.
- [x] No regression in block, struct-literal, or `match` arm parsing (full suite green).
