### PR TITLE
ci(release): cross-platform installers and tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,87 +4,269 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version label for manual artifact builds (for example 2.0.0-test)'
+        required: false
+        default: '0.0.0-dev'
 
 permissions:
   contents: write
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  release-linux:
-    runs-on: ubuntu-latest
+  # Build per target. Each job produces a tarball or zip plus the native
+  # installer for its platform. The raven_runtime static library is placed
+  # next to the binaries in every artifact so the installed compiler locates
+  # it when linking user programs without any environment configuration. The
+  # v2 standard library is embedded in the binaries via include_str!, so no
+  # .rv files are shipped as separate assets.
+  build:
+    name: build ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - name: macos-x86_64
+            os: macos-13
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            os: macos-14
+            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install packaging tools
+      - name: Resolve version
+        id: version
+        shell: bash
         run: |
-          cargo install cargo-deb
-          cargo install cargo-generate-rpm
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            v="${GITHUB_REF_NAME#v}"
+          else
+            v="${{ github.event.inputs.version }}"
+          fi
+          echo "value=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $v"
+
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Build release
-        run: cargo build --release
+        run: |
+          cargo build --release --target ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }} -p raven-runtime
 
-      - name: Create .deb package
-        run: cargo deb --no-strip
+      - name: Stage tarball (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          v="${{ steps.version.outputs.value }}"
+          dir="raven-$v-${{ matrix.target }}"
+          bindir="target/${{ matrix.target }}/release"
+          mkdir -p "stage/$dir"
+          cp "$bindir/raven" "stage/$dir/"
+          cp "$bindir/rvpm" "stage/$dir/"
+          cp "$bindir/libraven_runtime.a" "stage/$dir/"
+          cp README.md "stage/$dir/" || true
+          cat > "stage/$dir/LAYOUT.txt" <<'EOF'
+          Raven toolchain layout.
 
-      - name: Create .rpm package
-        run: cargo generate-rpm
+          raven                compiler and build driver
+          rvpm                 package manager
+          libraven_runtime.a   runtime library the compiler links into programs
 
-      - name: Upload Linux artifacts to release
+          Keep libraven_runtime.a next to the raven binary, or set
+          RAVEN_RUNTIME_LIB to its path. A C toolchain (cc) must be on PATH so
+          raven can link compiled programs. The standard library is embedded in
+          the binaries, so no .rv files ship separately.
+          EOF
+          tar -C stage -czf "$dir.tar.gz" "$dir"
+
+      - name: Stage zip (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $v = "${{ steps.version.outputs.value }}"
+          $dir = "raven-$v-${{ matrix.target }}"
+          $bindir = "target/${{ matrix.target }}/release"
+          New-Item -ItemType Directory -Force -Path "stage/$dir" | Out-Null
+          Copy-Item "$bindir/raven.exe" "stage/$dir/"
+          Copy-Item "$bindir/rvpm.exe" "stage/$dir/"
+          Copy-Item "$bindir/raven_runtime.lib" "stage/$dir/"
+          if (Test-Path README.md) { Copy-Item README.md "stage/$dir/" }
+          $layout = @'
+          Raven toolchain layout.
+
+          raven.exe            compiler and build driver
+          rvpm.exe             package manager
+          raven_runtime.lib    runtime library the compiler links into programs
+
+          Keep raven_runtime.lib next to raven.exe, or set RAVEN_RUNTIME_LIB to
+          its path. The MSVC build tools (link.exe) must be available so raven
+          can link compiled programs. The standard library is embedded in the
+          binaries, so no .rv files ship separately.
+          '@
+          Set-Content -Path "stage/$dir/LAYOUT.txt" -Value $layout -Encoding ascii
+          Compress-Archive -Path "stage/$dir/*" -DestinationPath "$dir.zip" -Force
+
+      - name: Build Linux packages
+        if: matrix.name == 'linux-x86_64'
+        shell: bash
+        run: |
+          cargo install cargo-deb --locked || cargo install cargo-deb
+          cargo install cargo-generate-rpm --locked || cargo install cargo-generate-rpm
+          # cargo-deb and cargo-generate-rpm read assets from target/release,
+          # so mirror the target-specific artifacts there.
+          mkdir -p target/release
+          cp target/${{ matrix.target }}/release/raven target/release/raven
+          cp target/${{ matrix.target }}/release/rvpm target/release/rvpm
+          cp target/${{ matrix.target }}/release/libraven_runtime.a target/release/libraven_runtime.a
+          cargo deb --no-build --no-strip
+          cargo generate-rpm
+
+      - name: Build macOS package
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          v="${{ steps.version.outputs.value }}"
+          bindir="target/${{ matrix.target }}/release"
+          root="pkgroot/usr/local/bin"
+          mkdir -p "$root"
+          cp "$bindir/raven" "$root/"
+          cp "$bindir/rvpm" "$root/"
+          cp "$bindir/libraven_runtime.a" "$root/"
+          pkgbuild --root pkgroot --identifier com.martian56.raven \
+            --version "$v" --install-location / \
+            "raven-$v-${{ matrix.target }}.pkg"
+
+      - name: Build Windows MSI
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install wixtoolset --version 3.14.0 --allow-downgrade --yes
+          cargo install cargo-wix --locked
+          $v = "${{ steps.version.outputs.value }}"
+          # cargo-wix derives the installer version from Cargo.toml; pass the
+          # release version explicitly so the MSI matches the tag.
+          cargo wix --no-build --nocapture --target ${{ matrix.target }} `
+            --install-version $v --output "target/wix/raven-$v-${{ matrix.target }}.msi"
+
+      - name: Sign Windows MSI (optional)
+        if: ${{ runner.os == 'Windows' && env.WINDOWS_CERT_BASE64 != '' }}
+        shell: pwsh
+        env:
+          WINDOWS_CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          Write-Host "Signing the MSI with the provided Authenticode certificate."
+          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\cert.pfx", [Convert]::FromBase64String($env:WINDOWS_CERT_BASE64))
+          $msi = Get-ChildItem target/wix/*.msi | Select-Object -First 1
+          & signtool sign /f "$env:RUNNER_TEMP\cert.pfx" /p $env:WINDOWS_CERT_PASSWORD /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $msi.FullName
+
+      - name: Sign macOS package (optional)
+        if: ${{ runner.os == 'macOS' && env.APPLE_INSTALLER_IDENTITY != '' }}
+        shell: bash
+        env:
+          APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
+        run: |
+          v="${{ steps.version.outputs.value }}"
+          pkg="raven-$v-${{ matrix.target }}.pkg"
+          productsign --sign "$APPLE_INSTALLER_IDENTITY" "$pkg" "signed-$pkg"
+          mv "signed-$pkg" "$pkg"
+
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p dist
+          shopt -s nullglob
+          for f in *.tar.gz *.zip *.pkg target/debian/*.deb target/generate-rpm/*.rpm target/wix/*.msi; do
+            cp "$f" dist/
+          done
+          ls -l dist
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: dist/*
+
+      - name: Upload to release
+        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2
         with:
           name: Raven ${{ github.ref_name }}
           generate_release_notes: true
-          files: |
-            target/debian/*.deb
-            target/generate-rpm/*.rpm
-          fail_on_unmatched_files: true
+          files: dist/*
+          fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  release-windows:
-    needs: release-linux
-    runs-on: windows-latest
+  # Install or extract each produced artifact on a clean runner, then compile
+  # and run a hello-world program with the installed toolchain. This proves the
+  # artifact ships a usable compiler that can find its runtime library and link.
+  smoke:
+    name: smoke ${{ matrix.name }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+          - name: windows-x86_64
+            os: windows-latest
+          - name: macos-x86_64
+            os: macos-13
+          - name: macos-arm64
+            os: macos-14
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Build release
-        run: cargo build --release
-
-      - name: Install WiX and create .msi installer
-        run: |
-          choco install wixtoolset --version 3.14.0 --allow-downgrade --yes
-          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-          cargo install cargo-wix
-          cargo wix --no-build --target-bin-dir target/release -o target/wix/ --nocapture
-
-      - name: Create .exe bootstrapper (setup installer)
-        run: |
-          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-          $msi = (Get-ChildItem target\wix\*.msi | Select-Object -First 1)
-          $version = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"(.*)"$').Matches[0].Groups[1].Value
-          candle -ext WixBalExtension -dMsiPath="$($msi.FullName)" -dVersion="$version" bundle.wxs
-          light -ext WixBalExtension bundle.wixobj -o "target\wix\raven-setup-$version.exe"
-
-      - name: Create portable .zip
-        run: |
-          New-Item -ItemType Directory -Force -Path release
-          Copy-Item target/release/raven.exe release/
-          Copy-Item target/release/rvpm.exe release/
-          New-Item -ItemType Directory -Force -Path release/lib
-          Copy-Item lib/*.rv release/lib/
-          Push-Location release
-          Compress-Archive -Path * -DestinationPath ../raven-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip -Force
-          Pop-Location
-
-      - name: Upload Windows artifacts to release
-        uses: softprops/action-gh-release@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v4
         with:
-          name: Raven ${{ github.ref_name }}
-          files: |
-            target/wix/*.msi
-            target/wix/*.exe
-            raven-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip
-          fail_on_unmatched_files: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ matrix.name }}
+          path: dist
+
+      - name: Smoke test (Unix tarball)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -e
+          tar -xzf dist/*.tar.gz
+          dir="$(find . -maxdepth 1 -type d -name 'raven-*' | head -n1)"
+          export PATH="$PWD/$dir:$PATH"
+          export RAVEN_RUNTIME_LIB="$PWD/$dir/libraven_runtime.a"
+          printf 'fun main() { print("hello") }\n' > hello.rv
+          raven build hello.rv -o hello
+          out="$(./hello)"
+          echo "program output: $out"
+          test "$out" = "hello"
+
+      - name: Smoke test (Windows zip)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem dist/*.zip | Select-Object -First 1
+          Expand-Archive -Path $zip.FullName -DestinationPath extracted -Force
+          $bin = (Get-ChildItem extracted -Directory | Select-Object -First 1).FullName
+          if (-not $bin) { $bin = "extracted" }
+          $env:PATH = "$bin;$env:PATH"
+          $env:RAVEN_RUNTIME_LIB = "$bin\raven_runtime.lib"
+          Set-Content -Path hello.rv -Value 'fun main() { print("hello") }' -Encoding ascii
+          & "$bin\raven.exe" build hello.rv -o hello.exe
+          $out = (& "$bin\hello.exe")
+          Write-Host "program output: $out"
+          if ($out -ne "hello") { exit 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,39 @@ homepage = "https://raven.ufazien.com"
 keywords = ["programming", "language", "compiler"]
 categories = ["development-tools", "command-line-utilities"]
 
-# Packaging metadata (deb / rpm / wix) intentionally omitted while v2 is under construction.
-# It will be repopulated alongside the v2 tooling work once the stdlib and rvpm shape settle.
+# Packaging metadata for the tagged-release workflow (.github/workflows/release.yml).
+# The v2 stdlib is embedded in the binaries via include_str!, so no .rv files ship
+# as installed assets. The raven_runtime static library is placed next to the raven
+# binary so the compiler locates it without configuration when linking user programs.
+[package.metadata.deb]
+maintainer = "martian56"
+copyright = "2026 martian56"
+license-file = ["LICENSE"]
+depends = "gcc"
+section = "devel"
+priority = "optional"
+extended-description = """\
+Raven is a statically typed compiled programming language.
+Ships the raven compiler and the rvpm package manager. The compiler links
+programs at build time, so a C toolchain (gcc) is required at runtime.
+"""
+assets = [
+    ["target/release/raven", "usr/bin/", "755"],
+    ["target/release/rvpm", "usr/bin/", "755"],
+    ["target/release/libraven_runtime.a", "usr/bin/", "644"],
+    ["README.md", "usr/share/doc/raven/", "644"],
+]
+
+[package.metadata.generate-rpm]
+license = "MIT"
+summary = "Statically typed compiled programming language"
+requires = { gcc = "*" }
+assets = [
+    { source = "target/release/raven", dest = "/usr/bin/raven", mode = "755" },
+    { source = "target/release/rvpm", dest = "/usr/bin/rvpm", mode = "755" },
+    { source = "target/release/libraven_runtime.a", dest = "/usr/bin/libraven_runtime.a", mode = "644" },
+    { source = "README.md", dest = "/usr/share/doc/raven/README.md", mode = "644", doc = true },
+]
 
 [[bin]]
 name = "raven"

--- a/docs/v2/specs/release.md
+++ b/docs/v2/specs/release.md
@@ -1,0 +1,103 @@
+# Release process
+
+Tagged releases are produced by `.github/workflows/release.yml`. Pushing an
+annotated tag of the form `vX.Y.Z` (optionally `vX.Y.Z-suffix`) triggers the
+workflow. The workflow can also be started manually with `workflow_dispatch`,
+which builds and uploads workflow artifacts but does not publish a GitHub
+Release.
+
+## Artifacts per platform
+
+The build matrix covers four targets. Each target produces a portable archive
+and the platform native installer.
+
+| Target | Archive | Installer |
+|--------|---------|-----------|
+| Linux x86_64 (`x86_64-unknown-linux-gnu`) | `.tar.gz` | `.deb`, `.rpm` |
+| Windows x86_64 (`x86_64-pc-windows-msvc`) | `.zip` | `.msi` |
+| macOS x86_64 (`x86_64-apple-darwin`) | `.tar.gz` | `.pkg` |
+| macOS arm64 (`aarch64-apple-darwin`) | `.tar.gz` | `.pkg` |
+
+Every artifact bundles two binaries, `raven` (the compiler and build driver)
+and `rvpm` (the package manager), plus the `raven_runtime` static library.
+
+## Embedded standard library
+
+The v2 standard library is compiled into the binaries with `include_str!`
+(registered in `src/resolve/stdlib.rs`). It is not shipped as separate `.rv`
+files, so installing the binaries is sufficient to get the full stdlib.
+
+## Runtime library packaging and location
+
+The compiler links every user program at build time against the
+`raven_runtime` static library (`raven_runtime.lib` on Windows,
+`libraven_runtime.a` on Unix). A packaged compiler is therefore unusable
+unless it can find that library.
+
+`raven` locates the library (see `locate_runtime_staticlib` and
+`candidate_runtime_paths` in `src/driver/mod.rs`) by checking, in order:
+
+1. the `RAVEN_RUNTIME_LIB` environment variable, if it points at a file;
+2. the directory containing the `raven` binary, its `deps` subdirectory, and
+   its parent directory;
+3. `target/debug` and `target/release` under the current working directory.
+
+All packaging puts the runtime library next to the `raven` binary so case (2)
+finds it with no configuration:
+
+- tarball and zip: `raven`, `rvpm`, and the runtime library sit together in
+  one directory.
+- `.deb` and `.rpm`: binaries and the runtime library install to `/usr/bin`.
+- `.msi`: all three files install to the application `bin` directory, which is
+  added to the system PATH.
+- `.pkg`: all three files install to `/usr/local/bin`.
+
+The smoke jobs additionally set `RAVEN_RUNTIME_LIB` to the packaged path as a
+belt-and-suspenders check.
+
+## C toolchain requirement
+
+Linking a compiled program needs a C linker on the machine that runs `raven`:
+MSVC `link.exe` on Windows, `cc` on Unix. The GitHub runners provide one. The
+`.deb` and `.rpm` packages declare a dependency on `gcc`. End users on other
+systems must have a C toolchain installed.
+
+## Smoke tests
+
+After the build jobs, the `smoke` jobs run on a clean runner per platform.
+Each downloads the produced artifact, extracts or relies on the staged
+directory, compiles `fun main() { print("hello") }` with the packaged `raven`,
+runs the result, and asserts the output is `hello`. This proves the artifact
+ships a compiler that can find its runtime library and link a program end to
+end.
+
+## Signing
+
+The issue calls for signed installers. Real signing requires certificates and
+secrets that the maintainer controls, so the signing steps are optional and run
+only when the relevant secrets are present. Unsigned artifacts still build, so
+the workflow is usable before signing is configured.
+
+Windows Authenticode (MSI):
+
+- `WINDOWS_CERT_BASE64`: base64 encoded PFX certificate.
+- `WINDOWS_CERT_PASSWORD`: PFX password.
+
+macOS package signing:
+
+- `APPLE_INSTALLER_IDENTITY`: a Developer ID Installer identity available in the
+  runner keychain, used by `productsign`.
+
+Add these as repository or organization secrets to enable signing. Notarization
+and stapling for macOS can be layered on later with `notarytool` and `stapler`
+once an Apple account is wired up.
+
+## Verification status
+
+The full multi-platform installer build runs only on a tag (or
+`workflow_dispatch`) using the Linux, Windows, and macOS runners, so it is
+confirmed by an actual tagged release run. The packaging configuration and the
+runtime-library location approach were validated locally: a staged Windows
+layout of `raven.exe`, `rvpm.exe`, and `raven_runtime.lib` in one directory
+compiles, links, and runs a hello-world program with no environment
+configuration.

--- a/wix/License.rtf
+++ b/wix/License.rtf
@@ -1,0 +1,12 @@
+{\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+\viewkind4\uc1\pard\f0\fs20
+MIT License\par
+\par
+Copyright (c) 2025 Raven Programming Language\par
+\par
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
+\par
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
+\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
+}

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -1,0 +1,130 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<!--
+  WiX source for the Raven MSI. Installs raven.exe, rvpm.exe, and the
+  raven_runtime static library into a per-machine bin directory and adds
+  that directory to the system PATH. The runtime library sits next to the
+  binaries so the compiler locates it when linking user programs without
+  any environment configuration. The v2 standard library is embedded in
+  the binaries, so no .rv files are installed.
+-->
+<?if $(sys.BUILDARCH) = x64 or $(sys.BUILDARCH) = arm64 ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?endif ?>
+
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+
+    <Product
+        Id='*'
+        Name='Raven'
+        UpgradeCode='1BEAAB65-8A0C-45C7-AFEA-B2D22FF4C9BD'
+        Manufacturer='martian56'
+        Language='1033'
+        Codepage='1252'
+        Version='$(var.Version)'>
+
+        <Package Id='*'
+            Keywords='Installer'
+            Description='Statically typed compiled programming language'
+            Manufacturer='martian56'
+            InstallerVersion='450'
+            Languages='1033'
+            Compressed='yes'
+            InstallScope='perMachine'
+            SummaryCodepage='1252'/>
+
+        <MajorUpgrade
+            Schedule='afterInstallInitialize'
+            DowngradeErrorMessage='A newer version of [ProductName] is already installed. Setup will now exit.'/>
+
+        <Media Id='1' Cabinet='media1.cab' EmbedCab='yes' DiskPrompt='CD-ROM #1'/>
+        <Property Id='DiskPrompt' Value='Raven Installation'/>
+
+        <Directory Id='TARGETDIR' Name='SourceDir'>
+            <Directory Id='$(var.PlatformProgramFilesFolder)' Name='PFiles'>
+                <Directory Id='APPLICATIONFOLDER' Name='Raven'>
+                    <Component Id='License' Guid='*'>
+                        <File Id='LicenseFile'
+                            DiskId='1'
+                            Source='wix\License.rtf'
+                            KeyPath='yes'/>
+                    </Component>
+
+                    <Directory Id='Bin' Name='bin'>
+                        <Component Id='Path' Guid='0AA3C6D3-F2A0-4BD5-BE46-4F4DB611660C' KeyPath='yes'>
+                            <Environment
+                                Id='PATH'
+                                Name='PATH'
+                                Value='[Bin]'
+                                Permanent='no'
+                                Part='last'
+                                Action='set'
+                                System='yes'/>
+                        </Component>
+                        <Component Id='binary0' Guid='*'>
+                            <File
+                                Id='exe0'
+                                Name='raven.exe'
+                                DiskId='1'
+                                Source='$(var.CargoTargetBinDir)\raven.exe'
+                                KeyPath='yes'/>
+                        </Component>
+                        <Component Id='binary1' Guid='*'>
+                            <File
+                                Id='exe1'
+                                Name='rvpm.exe'
+                                DiskId='1'
+                                Source='$(var.CargoTargetBinDir)\rvpm.exe'
+                                KeyPath='yes'/>
+                        </Component>
+                        <Component Id='runtimelib' Guid='*'>
+                            <File
+                                Id='runtime0'
+                                Name='raven_runtime.lib'
+                                DiskId='1'
+                                Source='$(var.CargoTargetBinDir)\raven_runtime.lib'
+                                KeyPath='yes'/>
+                        </Component>
+                    </Directory>
+                </Directory>
+            </Directory>
+        </Directory>
+
+        <Feature
+            Id='Binaries'
+            Title='Application'
+            Description='Installs the Raven compiler, rvpm, and the runtime library.'
+            Level='1'
+            ConfigurableDirectory='APPLICATIONFOLDER'
+            AllowAdvertise='no'
+            Display='expand'
+            Absent='disallow'>
+            <ComponentRef Id='License'/>
+            <ComponentRef Id='binary0'/>
+            <ComponentRef Id='binary1'/>
+            <ComponentRef Id='runtimelib'/>
+
+            <Feature
+                Id='Environment'
+                Title='PATH Environment Variable'
+                Description='Add the install location to the system PATH so raven and rvpm run from any directory.'
+                Level='1'
+                Absent='allow'>
+                <ComponentRef Id='Path'/>
+            </Feature>
+        </Feature>
+
+        <SetProperty Id='ARPINSTALLLOCATION' Value='[APPLICATIONFOLDER]' After='CostFinalize'/>
+
+        <Property Id='ARPHELPLINK' Value='https://github.com/martian56/raven'/>
+
+        <UI>
+            <UIRef Id='WixUI_FeatureTree'/>
+        </UI>
+
+        <WixVariable Id='WixUILicenseRtf' Value='wix\License.rtf'/>
+
+    </Product>
+
+</Wix>


### PR DESCRIPTION
Adds a tagged-release GitHub Actions workflow that builds cross-platform installers and tarballs bundling the `raven` compiler, the `rvpm` package manager, and the `raven_runtime` static library.

Closes #92

## Targets and artifacts

| Target | Archive | Installer |
|--------|---------|-----------|
| Linux x86_64 | `.tar.gz` | `.deb`, `.rpm` |
| Windows x86_64 | `.zip` | `.msi` |
| macOS x86_64 | `.tar.gz` | `.pkg` |
| macOS arm64 | `.tar.gz` | `.pkg` |

## Runtime static library packaging and location

The compiler links every user program against `raven_runtime` at build time, so a packaged compiler is useless unless it can find that library. `raven` looks (in `src/driver/mod.rs`) at `RAVEN_RUNTIME_LIB`, then next to its own binary, then in `target/{debug,release}`. Every artifact places the runtime library next to the `raven` binary (`/usr/bin` for deb/rpm, the MSI `bin` dir on PATH, `/usr/local/bin` for pkg, the same directory for archives) so it is found with no configuration.

## Embedded standard library

The v2 stdlib is compiled into the binaries via `include_str!`, so no `.rv` files ship as installed assets. Shipping the binaries ships the stdlib.

## Smoke tests

Downstream `smoke` jobs (one per platform) download the produced artifact, extract or install it, set `RAVEN_RUNTIME_LIB` to the packaged path as a safety net, compile `fun main() { print("hello") }`, run it, and assert the output is `hello`. This proves each artifact is usable end to end.

## Signing via secrets

Signing runs only when maintainer-provided secrets are present; unsigned artifacts still build. Required secrets to enable signing: `WINDOWS_CERT_BASE64`, `WINDOWS_CERT_PASSWORD` (Authenticode MSI), and `APPLE_INSTALLER_IDENTITY` (macOS `productsign`). Documented in `docs/v2/specs/release.md`.

## Verification

Full multi-platform installer builds run only on a tag push (or `workflow_dispatch`) across the Linux, Windows, and macOS runners, so they are confirmed by an actual tagged release run, not by this PR. The release workflow does not run on this PR (no tag). Validated from the Windows host: YAML parses cleanly, `wix/main.wxs` is well-formed XML, the `Cargo.toml` packaging metadata is valid TOML (`cargo metadata` succeeds), the four standard gates are green, and a staged layout of `raven.exe`, `rvpm.exe`, and `raven_runtime.lib` in one directory compiles, links, and runs a hello-world program with no environment configuration.

## Test plan

- [ ] Standard CI gates green (format, lint, build, benchmark, GitGuardian)
- [ ] Release workflow does not trigger on this PR (correct, tag-gated)
- [ ] Tagged release run produces all four targets and their artifacts (issue #93)
- [ ] Smoke jobs pass on every platform
- [ ] Signing steps activate once maintainer secrets are configured
