### PR TITLE
feat(derive): @derive for Eq, Hash, ToString, Debug

### DIFF
--- a/docs/v2/specs/core-traits.md
+++ b/docs/v2/specs/core-traits.md
@@ -33,5 +33,5 @@ A function bounded by a prelude trait, for example `fun describe<T: ToString>(x:
 
 - `Hash for Char` and `Hash for Float`: need a `Char`-to-`Int` primitive and a defined float-bit hash; deferred until those land.
 - Associated types on `Iterator` (the element type is a trait type parameter for now).
-- Derivation (`derive(Eq, Hash)`): user types implement the traits explicitly for now.
+- `Ord` derivation: not derivable yet. `Eq`, `Hash`, `ToString`, and `Debug` are derivable through `@derive(...)`; see `derive.md`.
 - The lazy iterator adapter pipeline: specified in `std/iter`.

--- a/docs/v2/specs/derive.md
+++ b/docs/v2/specs/derive.md
@@ -1,0 +1,156 @@
+# derive
+
+`@derive(...)` is a compile-time attribute that synthesizes trait impls
+from a type definition, so a user does not hand write `equals`, `hash`,
+`to_string`, or `debug` for a struct or enum. It is the foundation the later
+metaprogramming work (macros, reflection) builds on, tracked under issue
+#214.
+
+## Syntax
+
+The attribute sits on its own line immediately before a `struct` or `enum`
+declaration:
+
+```raven
+@derive(Eq, Hash, ToString, Debug)
+struct Point { x: Int, y: Int }
+
+@derive(Eq, ToString)
+enum Shape {
+    Dot,
+    Circle(Int),
+    Rect(Int, Int),
+}
+```
+
+The `@` lexes to a dedicated `At` token. The parser reads
+`@derive(Name, Name, ...)`, validates that the attribute name is `derive`,
+and attaches the trait list to the following struct or enum as a
+`derives: Vec<String>`. The attribute is only valid before a `struct` or
+`enum`; placing it before any other item, or using any attribute name other
+than `derive`, is a parse error. A type with no attribute carries an empty
+derive list and is unaffected.
+
+The four supported traits in this slice are `Eq`, `Hash`, `ToString`, and
+`Debug`. Naming any other trait (for example `Ord`) is a compile error.
+
+## Expansion
+
+Derive runs as part of stdlib expansion, before name resolution, alongside
+the bundled-module merge in `src/resolve/stdlib.rs`. For each derive request
+it generates the impl as Raven source text, re-parses it, and appends the
+resulting `impl` items to the program. The generated impls then flow through
+resolve, type checking, HIR, MIR, and codegen exactly like a hand written
+impl, so there is no separate code path to keep in sync.
+
+The generated bodies call the field and payload types' own trait methods
+(`equals`, `hash`, `to_string`, `debug`). A field or payload type must
+therefore implement the trait being derived; the type checker reports the
+missing bound with its normal `trait bound ... is not satisfied` diagnostic.
+
+`@derive(Debug)` produces an `impl Debug`, and the `Debug` trait lives in
+`std/fmt` rather than the prelude. The expander force-merges `std/fmt` when
+any type derives `Debug`, so the user needs no explicit `import std/fmt`.
+
+## Generated impl shapes
+
+### Eq
+
+```raven
+fun equals(self, other: Point) -> Bool
+```
+
+* Struct: the conjunction of `self.field.equals(other.field)` over every
+  field. A field-less struct yields `true`.
+* Enum: `match self` over the variants; each arm matches `other` against the
+  same variant (with a `_ -> false` fallback) and compares the payload slots
+  pairwise with `equals`, so two values are equal only when they are the same
+  variant with equal payloads.
+
+The `other` parameter is annotated with the concrete self type (for example
+`Point`, or `Pair<A, B>`) rather than `Self`, because the type checker does
+not yet accept `Self` as a non-receiver parameter type.
+
+### Hash
+
+```raven
+fun hash(self) -> Int
+```
+
+* Struct: folds the field hashes with `h = h * 31 + self.field.hash()`,
+  seeded at `17`, matching the String hash style in `stdlib/std/core.rv`.
+* Enum: starts from a per-variant seed (the variant index) and folds in each
+  payload slot's hash with the same `* 31 +` step. A unit variant hashes to
+  its seed.
+
+`Eq` and `Hash` together let a derived type act as a `Map` key or a `Set`
+element, since the hash-backed collections require `Eq + Hash` keys.
+
+### ToString
+
+```raven
+fun to_string(self) -> String
+```
+
+* Struct: `TypeName { field: value, ... }`, where each value is the field's
+  own `to_string()`. A field-less struct prints just `TypeName`.
+* Enum: a unit variant prints its bare name (`Dot`); a payload variant prints
+  `VariantName(p0, p1)` using each payload's `to_string()` (`Circle(3)`,
+  `Rect(2, 4)`).
+
+### Debug
+
+```raven
+fun debug(self) -> String
+```
+
+Same shape as `ToString`, but each field or payload is formatted with
+`debug()` instead of `to_string()`. Because `Debug for String` and
+`Debug for Char` quote their value (see `stdlib/std/fmt.rv`), a derived
+`debug()` quotes string and char members while the derived `to_string()`
+does not. For a `User { name: "ann", age: 30 }`:
+
+```
+to_string -> User { name: ann, age: 30 }
+debug     -> User { name: "ann", age: 30 }
+```
+
+## Generics
+
+For a generic type the synthesized impl is generic with the derived trait as
+a bound on every type parameter. Deriving `Eq` on
+
+```raven
+@derive(Eq)
+struct Pair<A, B> { first: A, second: B }
+```
+
+generates
+
+```raven
+impl<A: Eq, B: Eq> Eq for Pair<A, B> {
+    fun equals(self, other: Pair<A, B>) -> Bool {
+        return self.first.equals(other.first) && self.second.equals(other.second)
+    }
+}
+```
+
+The bound is required because `equals` on a field of type `A` needs
+`A: Eq`. The same rule applies to each trait: `Hash` emits `A: Hash`,
+`ToString` emits `A: ToString`, and so on.
+
+## Limitations
+
+* Only `Eq`, `Hash`, `ToString`, and `Debug` are supported. `Ord` and other
+  traits are not derivable yet.
+* Enum variants with struct-style (named-field) payloads, for example
+  `V(a: Int)`, are rejected with a clear error. Unit and tuple variants are
+  fully supported.
+* `Debug` reuses the `ToString` field shape with `debug()` formatting rather
+  than offering a separate layout.
+
+## Follow-ups
+
+Derive is the first metaprogramming slice. Later slices build on it:
+declarative and procedural macros, compile-time and runtime reflection, and
+a `derive(ToJson/FromJson)` slice on top of `std/json`.

--- a/examples/v2/use_derive.rv
+++ b/examples/v2/use_derive.rv
@@ -1,0 +1,50 @@
+// Compile-time `@derive(...)` for the core traits. The attribute
+// synthesizes the trait impls so the type works with hash-backed
+// collections and prints without a hand written `equals`/`hash`/
+// `to_string`/`debug`. Covers a non-generic struct used as a Map key and a
+// Set element, an enum with payload variants, and a bounded generic struct.
+
+import std/collections { Map, Set }
+
+@derive(Eq, Hash, ToString, Debug)
+struct Point { x: Int, y: Int }
+
+@derive(Eq, ToString)
+enum Shape {
+    Dot,
+    Circle(Int),
+    Rect(Int, Int),
+}
+
+@derive(Eq, ToString)
+struct Pair<A, B> { first: A, second: B }
+
+fun main() {
+    let p = Point { x: 1, y: 2 }
+    let q = Point { x: 1, y: 2 }
+    let r = Point { x: 3, y: 4 }
+    print(p.equals(q))      // true
+    print(p.equals(r))      // false
+    print(p.to_string())    // Point { x: 1, y: 2 }
+    print(p.debug())        // Point { x: 1, y: 2 }
+
+    // Derived Eq + Hash let the struct key a Map and join a Set.
+    let m: Map<Point, Int> = Map.new()
+    m.set(p, 100)
+    print(m.has(q))         // true
+    let s: Set<Point> = Set.new()
+    s.add(p)
+    print(s.contains(q))    // true
+    print(s.contains(r))    // false
+
+    let c = Shape.Circle(3)
+    print(c.equals(Shape.Circle(3)))    // true
+    print(c.equals(Shape.Rect(2, 4)))   // false
+    print(c.to_string())                // Circle(3)
+    print(Shape.Dot.to_string())        // Dot
+
+    let pr = Pair { first: 1, second: "hi" }
+    print(pr.equals(Pair { first: 1, second: "hi" }))   // true
+    print(pr.equals(Pair { first: 2, second: "no" }))   // false
+    print(pr.to_string())                               // Pair { first: 1, second: hi }
+}

--- a/examples/v2/use_derive.rv.out
+++ b/examples/v2/use_derive.rv.out
@@ -1,0 +1,14 @@
+true
+false
+Point { x: 1, y: 2 }
+Point { x: 1, y: 2 }
+true
+true
+false
+true
+false
+Circle(3)
+Dot
+true
+false
+Pair { first: 1, second: hi }

--- a/src/ast/decl.rs
+++ b/src/ast/decl.rs
@@ -81,6 +81,10 @@ pub struct Struct {
     pub name: String,
     pub generics: Vec<GenericParam>,
     pub fields: Vec<StructField>,
+    /// Trait names requested by a preceding `@derive(...)` attribute. The
+    /// derive pass synthesizes one impl per name before resolution; empty
+    /// when no attribute is present.
+    pub derives: Vec<String>,
     pub span: Span,
 }
 
@@ -123,6 +127,9 @@ pub struct Enum {
     pub name: String,
     pub generics: Vec<GenericParam>,
     pub variants: Vec<EnumVariant>,
+    /// Trait names requested by a preceding `@derive(...)` attribute. See
+    /// [`Struct::derives`].
+    pub derives: Vec<String>,
     pub span: Span,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -110,6 +110,9 @@ pub enum ResolveError {
         candidates: Vec<Span>,
     },
     SelfOutsideImpl,
+    /// A resolve-stage diagnostic that does not fit the structured variants,
+    /// carrying its own message (for example a `@derive(...)` rejection).
+    Other(String),
 }
 
 impl fmt::Display for ResolveError {
@@ -133,6 +136,7 @@ impl fmt::Display for ResolveError {
             ResolveError::SelfOutsideImpl => {
                 write!(f, "`self` or `Self` used outside an `impl` block")
             }
+            ResolveError::Other(msg) => write!(f, "{}", msg),
         }
     }
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -289,6 +289,9 @@ impl Printer<'_> {
     }
 
     fn struct_decl(&mut self, s: &Struct) -> Option<String> {
+        if !s.derives.is_empty() {
+            self.line(&format!("@derive({})", s.derives.join(", ")));
+        }
         let mut head = String::from("struct ");
         head.push_str(&s.name);
         head.push_str(&render_generics(&s.generics));
@@ -376,6 +379,9 @@ impl Printer<'_> {
     }
 
     fn enum_decl(&mut self, e: &Enum) -> Option<String> {
+        if !e.derives.is_empty() {
+            self.line(&format!("@derive({})", e.derives.join(", ")));
+        }
         let mut head = String::from("enum ");
         head.push_str(&e.name);
         head.push_str(&render_generics(&e.generics));

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -13,18 +13,58 @@ use super::{merge_spans, ParseResult, Parser};
 impl Parser {
     /// Parse one top level declaration.
     pub(crate) fn parse_decl(&mut self) -> ParseResult<Decl> {
+        // A leading `@derive(...)` attribute attaches a derived trait list
+        // to the struct or enum that immediately follows.
+        let derives = if matches!(self.peek_kind(), TokenKind::At) {
+            let d = self.parse_derive_attr()?;
+            self.skip_separators();
+            d
+        } else {
+            Vec::new()
+        };
         match self.peek_kind() {
+            TokenKind::Struct => self.parse_struct_decl(derives),
+            TokenKind::Enum => self.parse_enum_decl(derives),
+            _ if !derives.is_empty() => {
+                Err(self.unexpected("`struct` or `enum` after `@derive(...)`"))
+            }
             TokenKind::Fun => self.parse_function_decl(),
-            TokenKind::Struct => self.parse_struct_decl(),
             TokenKind::Trait => self.parse_trait_decl(),
             TokenKind::Impl => self.parse_impl_decl(),
-            TokenKind::Enum => self.parse_enum_decl(),
             TokenKind::Extern => self.parse_extern_decl(),
             TokenKind::Import => self.parse_import_decl(),
             TokenKind::Const => self.parse_const_decl(),
             TokenKind::Let => self.parse_let_decl(),
             _ => Err(self.unexpected("top level item")),
         }
+    }
+
+    /// Parse `@derive(Name, Name, ...)`, returning the trait names. The `@`
+    /// is at the cursor on entry. Only the `derive` attribute is recognized;
+    /// any other attribute name is a parse error.
+    fn parse_derive_attr(&mut self) -> ParseResult<Vec<String>> {
+        self.expect(&TokenKind::At, "`@`")?;
+        let (name, name_span) = self.expect_ident("attribute name")?;
+        if name != "derive" {
+            return Err(RavenError::parse(
+                ParseError::Custom(format!("unknown attribute `@{name}`, expected `@derive`")),
+                name_span,
+            ));
+        }
+        self.expect(&TokenKind::LParen, "`(`")?;
+        self.skip_newlines();
+        let mut traits = Vec::new();
+        while !matches!(self.peek_kind(), TokenKind::RParen) {
+            let (t, _) = self.expect_ident("trait name")?;
+            traits.push(t);
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+            self.skip_newlines();
+        }
+        self.expect(&TokenKind::RParen, "`)`")?;
+        Ok(traits)
     }
 
     fn parse_function_decl(&mut self) -> ParseResult<Decl> {
@@ -197,7 +237,7 @@ impl Parser {
         Ok(params)
     }
 
-    fn parse_struct_decl(&mut self) -> ParseResult<Decl> {
+    fn parse_struct_decl(&mut self, derives: Vec<String>) -> ParseResult<Decl> {
         let start = self.advance().span; // struct
         let (name, _) = self.expect_ident("struct name")?;
         let generics = self.parse_generic_params_opt()?;
@@ -230,6 +270,7 @@ impl Parser {
                 name,
                 generics,
                 fields,
+                derives,
                 span: span.clone(),
             }),
             span,
@@ -299,7 +340,7 @@ impl Parser {
         })
     }
 
-    fn parse_enum_decl(&mut self) -> ParseResult<Decl> {
+    fn parse_enum_decl(&mut self, derives: Vec<String>) -> ParseResult<Decl> {
         let start = self.advance().span; // enum
         let (name, _) = self.expect_ident("enum name")?;
         let generics = self.parse_generic_params_opt()?;
@@ -386,6 +427,7 @@ impl Parser {
                 name,
                 generics,
                 variants,
+                derives,
                 span: span.clone(),
             }),
             span,

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -666,6 +666,49 @@ fn parses_enum_with_struct_payload() {
     assert_eq!(fields[0].name, "radius");
 }
 
+#[test]
+fn derive_attribute_attaches_to_struct() {
+    let src = "@derive(Eq, Hash, ToString, Debug)\nstruct Point { x: Int, y: Int }\n";
+    let f = parse_ok(src);
+    let DeclKind::Struct(s) = &f.items[0].kind else {
+        panic!("expected struct decl")
+    };
+    assert_eq!(s.derives, vec!["Eq", "Hash", "ToString", "Debug"]);
+    assert_eq!(s.fields.len(), 2);
+}
+
+#[test]
+fn derive_attribute_attaches_to_enum() {
+    let src = "@derive(Eq, ToString)\nenum Shape { Dot, Circle(Int) }\n";
+    let f = parse_ok(src);
+    let DeclKind::Enum(e) = &f.items[0].kind else {
+        panic!("expected enum decl")
+    };
+    assert_eq!(e.derives, vec!["Eq", "ToString"]);
+    assert_eq!(e.variants.len(), 2);
+}
+
+#[test]
+fn struct_without_derive_has_empty_list() {
+    let f = parse_ok("struct Point { x: Int }\n");
+    let DeclKind::Struct(s) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(s.derives.is_empty());
+}
+
+#[test]
+fn unknown_attribute_is_a_parse_error() {
+    let err = parse_err("@inline\nfun f() {}\n");
+    assert!(matches!(err, RavenError::Parse(_, _, _)), "got: {}", err);
+}
+
+#[test]
+fn derive_before_non_type_is_a_parse_error() {
+    let err = parse_err("@derive(Eq)\nfun f() {}\n");
+    assert!(matches!(err, RavenError::Parse(_, _, _)), "got: {}", err);
+}
+
 // ----- imports, externs, const -----
 
 #[test]

--- a/src/resolve/derive.rs
+++ b/src/resolve/derive.rs
@@ -1,0 +1,405 @@
+//! Compile-time `@derive(...)` expansion.
+//!
+//! A `@derive(Eq, Hash, ToString, Debug)` attribute on a struct or enum
+//! asks the compiler to synthesize the corresponding trait impls instead
+//! of the user hand writing `equals`/`hash`/`to_string`/`debug`. This pass
+//! runs after stdlib expansion and before resolution, so the generated
+//! impls flow through resolve, type checking, HIR, MIR, and codegen exactly
+//! like a hand written impl.
+//!
+//! The generated impls are produced as Raven source text and re-parsed,
+//! mirroring how the stdlib itself is merged. The generated bodies call the
+//! field and payload types' own trait methods (`equals`, `hash`,
+//! `to_string`, `debug`), so a field type must itself implement the derived
+//! trait, which the type checker verifies. For a generic type the synthesized
+//! impl carries the per-parameter bound for the trait being derived, for
+//! example `impl<A: Eq, B: Eq> Eq for Pair<A, B>`.
+//!
+//! See `docs/v2/specs/derive.md` for the syntax, the generated-impl shapes,
+//! and the formatting conventions.
+
+use crate::ast::{Decl, DeclKind, Enum, EnumVariant, File, GenericParam, Struct, VariantPayload};
+use crate::error::{RavenError, ResolveError};
+use crate::lexer::Lexer;
+use crate::parser::parse;
+
+/// The four traits this slice can derive.
+const SUPPORTED: &[&str] = &["Eq", "Hash", "ToString", "Debug"];
+
+/// Whether `file` requests `@derive(Debug)` on any type. The `Debug` trait
+/// lives in `std/fmt`, not the prelude, so the expander force-merges that
+/// module when a derive needs it.
+pub fn needs_fmt_module(file: &File) -> bool {
+    file.items.iter().any(|d| match &d.kind {
+        DeclKind::Struct(s) => s.derives.iter().any(|t| t == "Debug"),
+        DeclKind::Enum(e) => e.derives.iter().any(|t| t == "Debug"),
+        _ => false,
+    })
+}
+
+/// Append a synthesized impl for every `@derive(...)` request in `items` to
+/// `combined`. Returns an error if a derive names an unsupported trait or a
+/// type the slice cannot derive (a struct enum variant payload).
+pub fn expand_derives(items: &[Decl], combined: &mut Vec<Decl>) -> Result<(), RavenError> {
+    let mut generated = String::new();
+    for decl in items {
+        match &decl.kind {
+            DeclKind::Struct(s) if !s.derives.is_empty() => {
+                for trait_name in &s.derives {
+                    check_supported(trait_name, &decl.span)?;
+                    generated.push_str(&struct_impl(s, trait_name));
+                    generated.push('\n');
+                }
+            }
+            DeclKind::Enum(e) if !e.derives.is_empty() => {
+                for trait_name in &e.derives {
+                    check_supported(trait_name, &decl.span)?;
+                    generated.push_str(&enum_impl(e, trait_name, &decl.span)?);
+                    generated.push('\n');
+                }
+            }
+            _ => {}
+        }
+    }
+    if generated.is_empty() {
+        return Ok(());
+    }
+    let path = std::path::PathBuf::from("<derive>");
+    let tokens = Lexer::new(generated.clone(), path.clone())
+        .tokenize()
+        .map_err(|e| derive_error(format!("lex: {e}")))?;
+    let parsed = parse(&tokens).map_err(|e| derive_error(format!("parse: {e}")))?;
+    combined.extend(parsed.items);
+    Ok(())
+}
+
+fn check_supported(trait_name: &str, span: &crate::span::Span) -> Result<(), RavenError> {
+    if SUPPORTED.contains(&trait_name) {
+        Ok(())
+    } else {
+        Err(RavenError::resolve(
+            ResolveError::Other(format!(
+                "cannot derive `{trait_name}`: supported traits are Eq, Hash, ToString, Debug"
+            )),
+            span.clone(),
+        ))
+    }
+}
+
+/// Render the impl header generics and the self type, applying the derived
+/// trait as a bound on every type parameter. `struct Pair<A, B>` derived for
+/// `Eq` yields the header pieces `<A: Eq, B: Eq>` and `Pair<A, B>`.
+fn impl_head(name: &str, generics: &[GenericParam], trait_name: &str) -> (String, String) {
+    if generics.is_empty() {
+        return (String::new(), name.to_string());
+    }
+    let bounds: Vec<String> = generics
+        .iter()
+        .map(|g| format!("{}: {trait_name}", g.name))
+        .collect();
+    let args: Vec<String> = generics.iter().map(|g| g.name.clone()).collect();
+    (
+        format!("<{}>", bounds.join(", ")),
+        format!("{name}<{}>", args.join(", ")),
+    )
+}
+
+fn struct_impl(s: &Struct, trait_name: &str) -> String {
+    let (gen, self_ty) = impl_head(&s.name, &s.generics, trait_name);
+    let body = match trait_name {
+        "Eq" => struct_eq_body(s, &self_ty),
+        "Hash" => struct_hash_body(s),
+        "ToString" => struct_to_string_body(s, "to_string"),
+        "Debug" => struct_to_string_body(s, "debug"),
+        _ => unreachable!("checked by check_supported"),
+    };
+    format!("impl{gen} {trait_name} for {self_ty} {{\n{body}}}\n")
+}
+
+fn struct_eq_body(s: &Struct, self_ty: &str) -> String {
+    // The `other` parameter is annotated with the concrete self type rather
+    // than `Self`: the type checker does not yet accept `Self` as a non
+    // receiver parameter type in a method signature.
+    if s.fields.is_empty() {
+        return format!("    fun equals(self, other: {self_ty}) -> Bool {{ return true }}\n");
+    }
+    let parts: Vec<String> = s
+        .fields
+        .iter()
+        .map(|f| format!("self.{0}.equals(other.{0})", f.name))
+        .collect();
+    format!(
+        "    fun equals(self, other: {self_ty}) -> Bool {{ return {} }}\n",
+        parts.join(" && ")
+    )
+}
+
+fn struct_hash_body(s: &Struct) -> String {
+    let mut body = String::from("    fun hash(self) -> Int {\n        let h = 17\n");
+    for f in &s.fields {
+        body.push_str(&format!("        h = h * 31 + self.{}.hash()\n", f.name));
+    }
+    body.push_str("        return h\n    }\n");
+    body
+}
+
+/// Build a `to_string` or `debug` body for a struct. `method` is the field
+/// formatter to call (`to_string` for readable output, `debug` for quoted
+/// output). The output shape is `TypeName { field: value, ... }`.
+fn struct_to_string_body(s: &Struct, method: &str) -> String {
+    let fn_name = if method == "debug" {
+        "debug"
+    } else {
+        "to_string"
+    };
+    if s.fields.is_empty() {
+        return format!(
+            "    fun {fn_name}(self) -> String {{ return \"{}\" }}\n",
+            s.name
+        );
+    }
+    let mut parts = Vec::new();
+    for f in &s.fields {
+        parts.push(format!("{0}: ${{self.{0}.{method}()}}", f.name));
+    }
+    format!(
+        "    fun {fn_name}(self) -> String {{ return \"{} {{ {} }}\" }}\n",
+        s.name,
+        parts.join(", ")
+    )
+}
+
+fn enum_impl(e: &Enum, trait_name: &str, span: &crate::span::Span) -> Result<String, RavenError> {
+    // A struct enum variant (named-field payload) is out of scope here:
+    // a readable derive for it needs field-by-field projection that the
+    // tuple path does not cover, so reject it with a clear message rather
+    // than emit a wrong impl.
+    for v in &e.variants {
+        if let VariantPayload::Struct(_) = v.payload {
+            return Err(RavenError::resolve(
+                ResolveError::Other(format!(
+                    "cannot derive `{trait_name}` for enum `{}`: struct-style variant `{}` is not supported yet",
+                    e.name, v.name
+                )),
+                span.clone(),
+            ));
+        }
+    }
+    let (gen, self_ty) = impl_head(&e.name, &e.generics, trait_name);
+    let body = match trait_name {
+        "Eq" => enum_eq_body(e, &self_ty),
+        "Hash" => enum_hash_body(e),
+        "ToString" => enum_to_string_body(e, "to_string"),
+        "Debug" => enum_to_string_body(e, "debug"),
+        _ => unreachable!("checked by check_supported"),
+    };
+    Ok(format!(
+        "impl{gen} {trait_name} for {self_ty} {{\n{body}}}\n"
+    ))
+}
+
+/// Number of positional payload slots a variant carries.
+fn variant_arity(v: &EnumVariant) -> usize {
+    match &v.payload {
+        VariantPayload::Unit => 0,
+        VariantPayload::Tuple(tys) => tys.len(),
+        VariantPayload::Struct(fields) => fields.len(),
+    }
+}
+
+fn enum_eq_body(e: &Enum, self_ty: &str) -> String {
+    let mut body = format!(
+        "    fun equals(self, other: {self_ty}) -> Bool {{\n        return match self {{\n"
+    );
+    for v in &e.variants {
+        let n = variant_arity(v);
+        if n == 0 {
+            body.push_str(&format!(
+                "            {0} -> match other {{ {0} -> true, _ -> false }},\n",
+                v.name
+            ));
+        } else {
+            let a_binds: Vec<String> = (0..n).map(|i| format!("a{i}")).collect();
+            let b_binds: Vec<String> = (0..n).map(|i| format!("b{i}")).collect();
+            let cmp: Vec<String> = (0..n).map(|i| format!("a{i}.equals(b{i})")).collect();
+            body.push_str(&format!(
+                "            {0}({1}) -> match other {{ {0}({2}) -> {3}, _ -> false }},\n",
+                v.name,
+                a_binds.join(", "),
+                b_binds.join(", "),
+                cmp.join(" && ")
+            ));
+        }
+    }
+    body.push_str("        }\n    }\n");
+    body
+}
+
+fn enum_hash_body(e: &Enum) -> String {
+    let mut body = String::from("    fun hash(self) -> Int {\n        return match self {\n");
+    for (idx, v) in e.variants.iter().enumerate() {
+        let n = variant_arity(v);
+        if n == 0 {
+            body.push_str(&format!("            {} -> {},\n", v.name, idx * 17 + 1));
+        } else {
+            let binds: Vec<String> = (0..n).map(|i| format!("a{i}")).collect();
+            let mut acc = format!("{}", idx * 17 + 1);
+            for i in 0..n {
+                acc = format!("({acc}) * 31 + a{i}.hash()");
+            }
+            body.push_str(&format!(
+                "            {}({}) -> {},\n",
+                v.name,
+                binds.join(", "),
+                acc
+            ));
+        }
+    }
+    body.push_str("        }\n    }\n");
+    body
+}
+
+/// Build a `to_string` or `debug` body for an enum. A unit variant prints
+/// its name; a payload variant prints `Name(p0, p1)` using each payload's
+/// `to_string`/`debug`.
+fn enum_to_string_body(e: &Enum, method: &str) -> String {
+    let fn_name = if method == "debug" {
+        "debug"
+    } else {
+        "to_string"
+    };
+    let mut body = format!("    fun {fn_name}(self) -> String {{\n        return match self {{\n");
+    for v in &e.variants {
+        let n = variant_arity(v);
+        if n == 0 {
+            body.push_str(&format!("            {0} -> \"{0}\",\n", v.name));
+        } else {
+            let binds: Vec<String> = (0..n).map(|i| format!("a{i}")).collect();
+            let parts: Vec<String> = (0..n).map(|i| format!("${{a{i}.{method}()}}")).collect();
+            body.push_str(&format!(
+                "            {0}({1}) -> \"{0}({2})\",\n",
+                v.name,
+                binds.join(", "),
+                parts.join(", ")
+            ));
+        }
+    }
+    body.push_str("        }\n    }\n");
+    body
+}
+
+fn derive_error(detail: String) -> RavenError {
+    let span = crate::span::Span::point(
+        std::sync::Arc::new(std::path::PathBuf::from("<derive>")),
+        0,
+        1,
+        1,
+    );
+    RavenError::resolve(
+        ResolveError::Other(format!("derive expansion failed: {detail}")),
+        span,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Impl;
+    use std::path::PathBuf;
+
+    fn parse_src(src: &str) -> File {
+        let tokens = Lexer::new(src.to_string(), PathBuf::from("main.rv"))
+            .tokenize()
+            .expect("lex");
+        parse(&tokens).expect("parse")
+    }
+
+    /// Collect the trait impls (`impl Trait for Type`) that `expand_derives`
+    /// synthesizes for `src`.
+    fn derived_impls(src: &str) -> Vec<Impl> {
+        let file = parse_src(src);
+        let mut out = Vec::new();
+        expand_derives(&file.items, &mut out).expect("expand");
+        out.into_iter()
+            .filter_map(|d| match d.kind {
+                DeclKind::Impl(i) => Some(i),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn struct_derive_generates_one_impl_per_trait() {
+        let impls =
+            derived_impls("@derive(Eq, Hash, ToString, Debug)\nstruct Point { x: Int, y: Int }\n");
+        let traits: Vec<String> = impls
+            .iter()
+            .map(|i| i.trait_or_type.segments[0].name.clone())
+            .collect();
+        assert_eq!(traits, vec!["Eq", "Hash", "ToString", "Debug"]);
+        // Every impl targets `Point` and carries one method.
+        for i in &impls {
+            assert_eq!(i.for_type.as_ref().unwrap().segments[0].name, "Point");
+            assert_eq!(i.items.len(), 1);
+        }
+    }
+
+    #[test]
+    fn generic_derive_carries_per_param_bound() {
+        let impls = derived_impls("@derive(Eq)\nstruct Pair<A, B> { first: A, second: B }\n");
+        let eq = &impls[0];
+        // The impl is generic with the derived trait as each param's bound.
+        let bounds: Vec<(String, String)> = eq
+            .generics
+            .iter()
+            .map(|g| (g.name.clone(), g.bounds[0].segments[0].name.clone()))
+            .collect();
+        assert_eq!(
+            bounds,
+            vec![
+                ("A".to_string(), "Eq".to_string()),
+                ("B".to_string(), "Eq".to_string())
+            ]
+        );
+        // The self type is `Pair<A, B>`.
+        let for_ty = eq.for_type.as_ref().unwrap();
+        assert_eq!(for_ty.segments[0].name, "Pair");
+        assert_eq!(for_ty.segments[0].generics.len(), 2);
+    }
+
+    #[test]
+    fn enum_payload_derive_generates_eq_and_to_string() {
+        let impls = derived_impls(
+            "@derive(Eq, ToString)\nenum Shape { Dot, Circle(Int), Rect(Int, Int) }\n",
+        );
+        assert_eq!(impls.len(), 2);
+        for i in &impls {
+            assert_eq!(i.for_type.as_ref().unwrap().segments[0].name, "Shape");
+        }
+    }
+
+    #[test]
+    fn no_derive_generates_nothing() {
+        let impls = derived_impls("struct Point { x: Int }\n");
+        assert!(impls.is_empty());
+    }
+
+    #[test]
+    fn unsupported_trait_is_rejected() {
+        let file = parse_src("@derive(Ord)\nstruct Point { x: Int }\n");
+        let mut out = Vec::new();
+        let err = expand_derives(&file.items, &mut out).expect_err("Ord is not derivable");
+        assert!(format!("{err}").contains("Ord"), "got: {err}");
+    }
+
+    #[test]
+    fn struct_variant_enum_is_rejected() {
+        let file = parse_src("@derive(Eq)\nenum E { V(a: Int) }\n");
+        let mut out = Vec::new();
+        let err = expand_derives(&file.items, &mut out).expect_err("struct variant not supported");
+        assert!(
+            format!("{err}").contains("struct-style variant"),
+            "got: {err}"
+        );
+    }
+}

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -8,6 +8,7 @@
 //! See `docs/v2/specs/resolver.md` for the full design.
 
 pub mod bindings;
+pub mod derive;
 pub mod imports;
 pub mod items;
 pub mod scope;

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -240,6 +240,14 @@ pub fn expand_with_stdlib_ctx(
     wanted.insert(PRELUDE_MODULE.to_string());
     collect_std_module_imports(user, &mut wanted);
 
+    // `@derive(Debug)` synthesizes an `impl Debug`, whose trait lives in
+    // `std/fmt`. Force-merge that module so the generated impl resolves even
+    // when the user wrote no `import std/fmt` line, mirroring how the prelude
+    // is always present.
+    if super::derive::needs_fmt_module(user) {
+        wanted.insert("fmt".to_string());
+    }
+
     // Load every local `./`/`../` module reachable from the user file,
     // transitively, before computing the bundled set: a local module may
     // itself `import std/...`, and those bundled modules must merge too so
@@ -327,6 +335,15 @@ pub fn expand_with_stdlib_ctx(
     // combined file's span borrows the user's file path for diagnostics
     // that key off the top level file.
     combined_items.extend(user.items.iter().cloned());
+
+    // Synthesize trait impls for every `@derive(...)` attribute. The user's
+    // own types carry the attributes, so this runs over the full combined
+    // item list (a stdlib type never carries a derive, so scanning all of it
+    // is harmless). The generated impls append after the user items and flow
+    // through resolve, type checking, and codegen like hand written ones.
+    let mut derived_impls = Vec::new();
+    super::derive::expand_derives(&combined_items, &mut derived_impls)?;
+    combined_items.append(&mut derived_impls);
 
     Ok(File {
         items: combined_items,

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -86,6 +86,22 @@ fn enum_self_method_match_compiles_and_runs() {
 }
 
 #[test]
+fn derive_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // `@derive(Eq, Hash, ToString, Debug)` synthesizes the trait impls. The
+    // derived `Eq + Hash` let a struct key a Map and join a Set (lines 5 to
+    // 7), the enum derive compares and prints payload variants, and the
+    // generic `Pair` derive compares and prints at <Int, String>.
+    compile_link_run_and_check(
+        "use_derive.rv",
+        "true\nfalse\nPoint { x: 1, y: 2 }\nPoint { x: 1, y: 2 }\ntrue\ntrue\nfalse\ntrue\nfalse\nCircle(3)\nDot\ntrue\nfalse\nPair { first: 1, second: hi }\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn closure_value_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Adds a compile-time `@derive(...)` attribute that synthesizes the core trait impls from a struct or enum definition, so users do not hand write `equals`, `hash`, `to_string`, or `debug`.

Part of #214 (this is the first metaprogramming slice; macros and reflection are separate, later slices).

## Syntax

```raven
@derive(Eq, Hash, ToString, Debug)
struct Point { x: Int, y: Int }
```

The attribute sits on its own line before a `struct` or `enum`. The `@` lexes to the existing `At` token; the parser reads `@derive(Name, ...)` and attaches the trait list to the type. The attribute is only valid before a `struct` or `enum`, and only `derive` is a recognized attribute name (anything else is a parse error). The four supported traits are `Eq`, `Hash`, `ToString`, `Debug`; naming any other trait is a compile error.

## Expansion approach

Derive runs inside stdlib expansion (`src/resolve/derive.rs`, called from `expand_with_stdlib_ctx`), before name resolution. It generates each impl as Raven source text, re-parses it, and appends the impls to the program, mirroring how the bundled stdlib is merged. The generated impls then flow through resolve, type checking, HIR, MIR, and codegen exactly like a hand written impl, so there is no separate lowering path. `std/fmt` is force-merged when any type derives `Debug` (the `Debug` trait lives there, not in the prelude).

## Generated impl shapes

- `Eq` (`fun equals(self, other: T) -> Bool`): struct is the conjunction of `self.field.equals(other.field)`; enum matches `self` then `other` against the same variant (with `_ -> false`) and compares payload slots pairwise.
- `Hash` (`fun hash(self) -> Int`): struct folds field hashes `h = h * 31 + self.field.hash()` seeded at 17 (the String hash style); enum folds a per-variant seed then payload hashes.
- `ToString` (`fun to_string(self) -> String`): struct renders `TypeName { field: value, ... }` via each field's `to_string()`; enum renders `VariantName(p0, p1)` or the bare name for unit variants.
- `Debug` (`fun debug(self) -> String`): same shape as ToString but each member uses `debug()`, so string and char members are quoted (`User { name: "ann", age: 30 }`) while ToString is not (`User { name: ann, age: 30 }`).

The `other` parameter is annotated with the concrete self type rather than `Self`, since the type checker does not yet accept `Self` as a non-receiver parameter type.

## Generic bounds

A generic type derives a generic impl with the derived trait as a bound on every type parameter, because a field of type `A` needs `A: Eq` to call `equals`:

```raven
@derive(Eq)
struct Pair<A, B> { first: A, second: B }
// generates:
impl<A: Eq, B: Eq> Eq for Pair<A, B> { ... }
```

`Hash` emits `A: Hash`, `ToString` emits `A: ToString`, and so on.

## Verification

`examples/v2/use_derive.rv` (with a committed `.rv.out` golden baseline) compiles, links, and runs end to end:
- A non-generic `Point` with all four derives: equal/unequal compares both ways, used as a `Map` key and a `Set` element (proving derived `Eq + Hash` work with the hash-backed collections), and printed via `to_string()` and `debug()`.
- A `Shape` enum with unit and tuple payload variants and `@derive(Eq, ToString)`: same/different variant compares, payload and unit printing.
- A generic `Pair<A, B>` with `@derive(Eq, ToString)` instantiated at `<Int, String>`: compare and print, confirming the bounded generic impl.

## Follow-up sub-issues

Filed under #214, no milestone:
- #215 declarative and procedural macros
- #216 compile-time and runtime reflection
- #217 derive(ToJson/FromJson) on std/json

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all binaries pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo test --test golden` passes with no regression and the new `use_derive` example
- [x] Parser unit tests: `@derive` attaches to struct and enum, unknown attribute and derive-before-non-type are parse errors
- [x] Derive unit tests: one impl per trait, generic per-param bound, enum payload, unsupported trait and struct-variant rejection
- [x] Codegen smoke: derived type as a Map key and Set element, enum compare, generic Pair

## Limitations

- Only `Eq`, `Hash`, `ToString`, `Debug` are derivable this slice (`Ord` is not).
- Enum variants with struct-style named-field payloads are rejected with a clear error; unit and tuple variants are supported.

Spec: `docs/v2/specs/derive.md`.
