### PR TITLE
feat(derive): @derive(ToJson, FromJson)

### DIFF
--- a/docs/v2/specs/derive.md
+++ b/docs/v2/specs/derive.md
@@ -31,8 +31,10 @@ and attaches the trait list to the following struct or enum as a
 than `derive`, is a parse error. A type with no attribute carries an empty
 derive list and is unaffected.
 
-The four supported traits in this slice are `Eq`, `Hash`, `ToString`, and
-`Debug`. Naming any other trait (for example `Ord`) is a compile error.
+The supported traits are `Eq`, `Hash`, `ToString`, `Debug`, `ToJson`, and
+`FromJson`. Naming any other trait (for example `Ord`) is a compile error.
+`ToJson` and `FromJson` provide JSON serialization on top of `std/json`; see
+their section below and the [std/json spec](std-json.md).
 
 ## Expansion
 
@@ -51,6 +53,10 @@ missing bound with its normal `trait bound ... is not satisfied` diagnostic.
 `@derive(Debug)` produces an `impl Debug`, and the `Debug` trait lives in
 `std/fmt` rather than the prelude. The expander force-merges `std/fmt` when
 any type derives `Debug`, so the user needs no explicit `import std/fmt`.
+Likewise `@derive(ToJson)` and `@derive(FromJson)` reference the `JsonValue`
+tree and the JSON traits in `std/json`, so the expander force-merges
+`std/json` (which transitively pulls in `std/error` and `std/collections`)
+when any type derives one of them.
 
 ## Generated impl shapes
 
@@ -115,6 +121,61 @@ to_string -> User { name: ann, age: 30 }
 debug     -> User { name: "ann", age: 30 }
 ```
 
+### ToJson
+
+```raven
+fun to_json(self) -> JsonValue
+```
+
+* Struct: a JSON object keyed by field name, each value the field's own
+  `to_json()`. `Point { x: 1, y: 2 }` serializes to `{"x":1,"y":2}`.
+* Enum: a tagged object `{"tag": "Variant", "values": [p0, p1, ...]}`, where
+  the payload slots are each value's `to_json()` and a unit variant has an
+  empty `values` array. `Shape.Rect(2, 5)` serializes to
+  `{"tag":"Rect","values":[2,5]}`, and `Shape.Dot` to
+  `{"tag":"Dot","values":[]}`.
+
+Object key order follows the `Map` hash-bucket layout of `std/json`, not
+source order. Combine `to_json` with `stringify` to get a `String`.
+
+### FromJson
+
+```raven
+fun from_json(j: JsonValue) -> Result<Self, Error>
+```
+
+`from_json` is an associated function (it takes no `self`), so it is called
+as `Point.from_json(j)`. The `FromJson` trait declares the method with `Self`
+in the return, but the generated impl writes the concrete type, because the
+type checker does not yet accept `Self` as a non-receiver type in a method
+signature (the same limitation `Eq` works around). So `@derive(FromJson)` on
+`Point` generates `impl FromJson for Point { fun from_json(j) -> Result<Point,
+Error> { ... } }`.
+
+* Struct: read each field from the object by name, decode it to the field's
+  declared type, propagate a missing or wrong-typed field as an `Err`, then
+  construct the struct.
+* Enum: read the `tag` string, dispatch to the matching variant, decode each
+  payload slot positionally from the `values` array, and return an `Err` on an
+  unknown tag.
+
+The derived `from_json` calls a small set of helper free functions that the
+derive pass emits into the program once (a generic decode dispatcher plus
+object/array accessors). They cannot live in `std/json` because a bundled
+free function is namespaced (`std.json.f`) and so not callable by its bare
+name from generated source.
+
+### Scalar, List, and Option impls
+
+`std/json` hand-writes the `ToJson`/`FromJson` impls that field recursion
+bottoms out on: `Int`, `Float`, `Bool`, `String`, `List<T: ToJson/FromJson>`,
+and `Option<T: ToJson/FromJson>`. `Int` and `Float` both serialize to a JSON
+number; `Bool` to a JSON bool; `String` to a JSON string; `List<T>` to a JSON
+array; and `Option<T>` to `null` or the inner value. An `Int` round-trips
+through `Float` (JSON has one number type) and loses precision beyond 2^53,
+the IEEE 754 double mantissa. The derive only generates impls for user
+structs and enums; it never generates impls for the built-in types.
+
 ## Generics
 
 For a generic type the synthesized impl is generic with the derived trait as
@@ -137,20 +198,23 @@ impl<A: Eq, B: Eq> Eq for Pair<A, B> {
 
 The bound is required because `equals` on a field of type `A` needs
 `A: Eq`. The same rule applies to each trait: `Hash` emits `A: Hash`,
-`ToString` emits `A: ToString`, and so on.
+`ToString` emits `A: ToString`, `ToJson` emits `A: ToJson`, `FromJson` emits
+`A: FromJson`, and so on. So `@derive(ToJson)` on `Pair<A, B>` generates
+`impl<A: ToJson, B: ToJson> ToJson for Pair<A, B>`.
 
 ## Limitations
 
-* Only `Eq`, `Hash`, `ToString`, and `Debug` are supported. `Ord` and other
-  traits are not derivable yet.
+* Only `Eq`, `Hash`, `ToString`, `Debug`, `ToJson`, and `FromJson` are
+  supported. `Ord` and other traits are not derivable yet.
 * Enum variants with struct-style (named-field) payloads, for example
   `V(a: Int)`, are rejected with a clear error. Unit and tuple variants are
   fully supported.
 * `Debug` reuses the `ToString` field shape with `debug()` formatting rather
   than offering a separate layout.
+* A derived `FromJson` reads only the keys it declares; extra object members
+  are ignored, and a `Number` decodes to `Int` by truncation toward zero.
 
 ## Follow-ups
 
 Derive is the first metaprogramming slice. Later slices build on it:
-declarative and procedural macros, compile-time and runtime reflection, and
-a `derive(ToJson/FromJson)` slice on top of `std/json`.
+declarative and procedural macros, and compile-time and runtime reflection.

--- a/docs/v2/specs/std-json.md
+++ b/docs/v2/specs/std-json.md
@@ -120,6 +120,49 @@ payload currently corrupts the extracted value in the back end, so every
 accessor that inspects a payload goes through a free helper. The serializer
 is already a free function for the same reason.
 
+## Serialization traits
+
+`std/json` defines two traits for converting between a value and its JSON
+form, plus hand-written impls for the built-in types so field recursion
+bottoms out.
+
+```raven
+trait ToJson {
+    fun to_json(self) -> JsonValue
+}
+
+trait FromJson {
+    fun from_json(j: JsonValue) -> Result<Self, Error>
+}
+```
+
+`to_json` is an ordinary `self` method. `from_json` is an associated function
+(no `self`), called as `Point.from_json(j)`; the trait declares it with `Self`
+in the return, and an impl writes the concrete type, because the checker does
+not yet accept `Self` as a non-receiver type in a method signature.
+
+Built-in impls: `Int` and `Float` map to a JSON number, `Bool` to a JSON
+bool, `String` to a JSON string, `List<T>` to a JSON array, and `Option<T>`
+to `null` or the inner value. An `Int` round-trips through `Float` (JSON has
+one number type) and loses precision beyond 2^53, and a number decodes back
+to `Int` by truncation toward zero.
+
+User structs and enums get these traits through `@derive(ToJson, FromJson)`.
+A struct serializes to an object keyed by field name; an enum to a tagged
+object `{"tag": "Variant", "values": [...]}`. See the
+[derive spec](derive.md) for the full encoding and the helper functions the
+derive emits.
+
+| Item | Result | Notes |
+|---|---|---|
+| `Int/Float/Bool/String.to_json(self)` | `JsonValue` | scalar to its JSON kind |
+| `List<T: ToJson>.to_json(self)` | `JsonValue` | JSON array |
+| `Option<T: ToJson>.to_json(self)` | `JsonValue` | `null` or inner value |
+| `Type.from_json(j)` | `Result<Type, Error>` | decode, `Err` on shape mismatch |
+
+The `Float`-to-`Int` truncation binds the `raven_float_to_int` runtime symbol
+through an `extern "C"` block, the counterpart to `raven_int_to_float`.
+
 ## Out of scope
 
 Pretty printing (indentation), duplicate-key policy beyond last-wins (the

--- a/examples/v2/use_derive_json.rv
+++ b/examples/v2/use_derive_json.rv
@@ -1,0 +1,109 @@
+// Compile-time `@derive(ToJson, FromJson)` for JSON serialization. Each
+// type round-trips through `to_json` -> `stringify` -> `parse` -> `from_json`
+// back to a value equal to the original. The struct encoding is a JSON
+// object keyed by field name; the enum encoding is a tagged object
+// `{"tag": "Variant", "values": [...]}`. Object key order follows the Map
+// hash-bucket layout (see std/json), so the printed bytes are the
+// serializer's order, not source order.
+
+import std/json { JsonValue, stringify, parse }
+
+@derive(ToJson, FromJson, Eq, ToString)
+struct Point { x: Int, y: Int }
+
+@derive(ToJson, FromJson, Eq, ToString)
+struct Segment { start: Point, end: Point }
+
+@derive(ToJson, FromJson, Eq, ToString)
+struct Pair<A, B> { first: A, second: B }
+
+@derive(ToJson, FromJson, Eq, ToString)
+enum Shape {
+    Dot,
+    Circle(Int),
+    Rect(Int, Int),
+}
+
+// Round-trip a struct: serialize, print the bytes, parse back, decode, and
+// report whether the decoded value equals the original.
+fun roundtrip_point(p: Point) {
+    let s = stringify(p.to_json())
+    print(s)
+    match parse(s) {
+        Ok(v) -> {
+            match Point.from_json(v) {
+                Ok(p2) -> print(p.equals(p2)),
+                Err(e) -> print("decode error"),
+            }
+        },
+        Err(e) -> print("parse error"),
+    }
+}
+
+fun main() {
+    let p = Point { x: 1, y: 2 }
+    roundtrip_point(p)
+
+    let seg = Segment { start: Point { x: 0, y: 0 }, end: Point { x: 3, y: 4 } }
+    let ss = stringify(seg.to_json())
+    print(ss)
+    match parse(ss) {
+        Ok(v) -> {
+            match Segment.from_json(v) {
+                Ok(s2) -> print(seg.equals(s2)),
+                Err(e) -> print("decode error"),
+            }
+        },
+        Err(e) -> print("parse error"),
+    }
+
+    let pr = Pair { first: 7, second: true }
+    let ps = stringify(pr.to_json())
+    print(ps)
+    match parse(ps) {
+        Ok(v) -> {
+            match Pair.from_json(v) {
+                Ok(pr2) -> print(pr.equals(pr2)),
+                Err(e) -> print("decode error"),
+            }
+        },
+        Err(e) -> print("parse error"),
+    }
+
+    let c = Shape.Rect(2, 5)
+    let cs = stringify(c.to_json())
+    print(cs)
+    match parse(cs) {
+        Ok(v) -> {
+            match Shape.from_json(v) {
+                Ok(c2) -> print(c.equals(c2)),
+                Err(e) -> print("decode error"),
+            }
+        },
+        Err(e) -> print("parse error"),
+    }
+
+    let d = Shape.Dot
+    let ds = stringify(d.to_json())
+    print(ds)
+    match parse(ds) {
+        Ok(v) -> {
+            match Shape.from_json(v) {
+                Ok(d2) -> print(d.equals(d2)),
+                Err(e) -> print("decode error"),
+            }
+        },
+        Err(e) -> print("parse error"),
+    }
+
+    // A from_json failure: the object is missing the required `y` field.
+    match parse("{\"x\": 9}") {
+        Ok(v) -> {
+            match Point.from_json(v) {
+                Ok(bad) -> print("unexpected ok"),
+                Err(e) -> print(e.message),
+            }
+        },
+        Err(e) -> print("parse error"),
+    }
+}

--- a/examples/v2/use_derive_json.rv.out
+++ b/examples/v2/use_derive_json.rv.out
@@ -1,0 +1,11 @@
+{"x":1,"y":2}
+true
+{"start":{"x":0,"y":0},"end":{"x":3,"y":4}}
+true
+{"first":7,"second":true}
+true
+{"tag":"Rect","values":[2,5]}
+true
+{"tag":"Dot","values":[]}
+true
+missing field y

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -499,6 +499,18 @@ pub extern "C" fn raven_int_to_float(value: i64) -> f64 {
     value as f64
 }
 
+/// Truncate an `f64` toward zero to a signed 64-bit integer.
+///
+/// The v2 surface language has no Float-to-Int cast, so `std/json` binds
+/// this symbol through `extern "C"` to recover an `Int` field from a JSON
+/// number (which always parses to `Float`). A value outside the `i64`
+/// range saturates to `i64::MIN`/`i64::MAX`, and `NaN` maps to `0`, the
+/// usual `as` cast behavior.
+#[no_mangle]
+pub extern "C" fn raven_float_to_int(value: f64) -> i64 {
+    value as i64
+}
+
 /// Copy a Raven `String` into a freshly allocated, null-terminated byte
 /// buffer and return a `*const c_char` (`CStr`) to its first byte.
 ///

--- a/src/resolve/derive.rs
+++ b/src/resolve/derive.rs
@@ -18,23 +18,40 @@
 //! See `docs/v2/specs/derive.md` for the syntax, the generated-impl shapes,
 //! and the formatting conventions.
 
-use crate::ast::{Decl, DeclKind, Enum, EnumVariant, File, GenericParam, Struct, VariantPayload};
+use crate::ast::{
+    Decl, DeclKind, Enum, EnumVariant, File, GenericParam, Struct, Type, TypeKind, TypePath,
+    VariantPayload,
+};
 use crate::error::{RavenError, ResolveError};
 use crate::lexer::Lexer;
 use crate::parser::parse;
 
-/// The four traits this slice can derive.
-const SUPPORTED: &[&str] = &["Eq", "Hash", "ToString", "Debug"];
+/// The traits this pass can derive.
+const SUPPORTED: &[&str] = &["Eq", "Hash", "ToString", "Debug", "ToJson", "FromJson"];
+
+/// Whether a derive of `trait_name` is present on any type in `file`.
+fn any_derive(file: &File, trait_name: &str) -> bool {
+    file.items.iter().any(|d| match &d.kind {
+        DeclKind::Struct(s) => s.derives.iter().any(|t| t == trait_name),
+        DeclKind::Enum(e) => e.derives.iter().any(|t| t == trait_name),
+        _ => false,
+    })
+}
 
 /// Whether `file` requests `@derive(Debug)` on any type. The `Debug` trait
 /// lives in `std/fmt`, not the prelude, so the expander force-merges that
 /// module when a derive needs it.
 pub fn needs_fmt_module(file: &File) -> bool {
-    file.items.iter().any(|d| match &d.kind {
-        DeclKind::Struct(s) => s.derives.iter().any(|t| t == "Debug"),
-        DeclKind::Enum(e) => e.derives.iter().any(|t| t == "Debug"),
-        _ => false,
-    })
+    any_derive(file, "Debug")
+}
+
+/// Whether `file` requests `@derive(ToJson)` or `@derive(FromJson)` on any
+/// type. Those traits and the `JsonValue` tree live in `std/json` (which
+/// itself pulls in `std/error` and `std/collections`), so the expander
+/// force-merges `std/json` when a derive needs it, mirroring how `Debug`
+/// force-merges `std/fmt`.
+pub fn needs_json_module(file: &File) -> bool {
+    any_derive(file, "ToJson") || any_derive(file, "FromJson")
 }
 
 /// Append a synthesized impl for every `@derive(...)` request in `items` to
@@ -42,11 +59,15 @@ pub fn needs_fmt_module(file: &File) -> bool {
 /// type the slice cannot derive (a struct enum variant payload).
 pub fn expand_derives(items: &[Decl], combined: &mut Vec<Decl>) -> Result<(), RavenError> {
     let mut generated = String::new();
+    let mut needs_json_helpers = false;
     for decl in items {
         match &decl.kind {
             DeclKind::Struct(s) if !s.derives.is_empty() => {
                 for trait_name in &s.derives {
                     check_supported(trait_name, &decl.span)?;
+                    if trait_name == "ToJson" || trait_name == "FromJson" {
+                        needs_json_helpers = true;
+                    }
                     generated.push_str(&struct_impl(s, trait_name));
                     generated.push('\n');
                 }
@@ -54,6 +75,9 @@ pub fn expand_derives(items: &[Decl], combined: &mut Vec<Decl>) -> Result<(), Ra
             DeclKind::Enum(e) if !e.derives.is_empty() => {
                 for trait_name in &e.derives {
                     check_supported(trait_name, &decl.span)?;
+                    if trait_name == "ToJson" || trait_name == "FromJson" {
+                        needs_json_helpers = true;
+                    }
                     generated.push_str(&enum_impl(e, trait_name, &decl.span)?);
                     generated.push('\n');
                 }
@@ -63,6 +87,13 @@ pub fn expand_derives(items: &[Decl], combined: &mut Vec<Decl>) -> Result<(), Ra
     }
     if generated.is_empty() {
         return Ok(());
+    }
+    // The derived `from_json` bodies call these helpers by bare name. A
+    // bundled stdlib free function is namespaced (`std.json.f`) and so not
+    // callable by its bare name from generated source, so the helpers are
+    // emitted into the generated file itself, exactly once per program.
+    if needs_json_helpers {
+        generated.insert_str(0, JSON_HELPERS);
     }
     let path = std::path::PathBuf::from("<derive>");
     let tokens = Lexer::new(generated.clone(), path.clone())
@@ -79,7 +110,7 @@ fn check_supported(trait_name: &str, span: &crate::span::Span) -> Result<(), Rav
     } else {
         Err(RavenError::resolve(
             ResolveError::Other(format!(
-                "cannot derive `{trait_name}`: supported traits are Eq, Hash, ToString, Debug"
+                "cannot derive `{trait_name}`: supported traits are Eq, Hash, ToString, Debug, ToJson, FromJson"
             )),
             span.clone(),
         ))
@@ -111,6 +142,8 @@ fn struct_impl(s: &Struct, trait_name: &str) -> String {
         "Hash" => struct_hash_body(s),
         "ToString" => struct_to_string_body(s, "to_string"),
         "Debug" => struct_to_string_body(s, "debug"),
+        "ToJson" => struct_to_json_body(s),
+        "FromJson" => struct_from_json_body(s, &self_ty),
         _ => unreachable!("checked by check_supported"),
     };
     format!("impl{gen} {trait_name} for {self_ty} {{\n{body}}}\n")
@@ -191,6 +224,8 @@ fn enum_impl(e: &Enum, trait_name: &str, span: &crate::span::Span) -> Result<Str
         "Hash" => enum_hash_body(e),
         "ToString" => enum_to_string_body(e, "to_string"),
         "Debug" => enum_to_string_body(e, "debug"),
+        "ToJson" => enum_to_json_body(e),
+        "FromJson" => enum_from_json_body(e, &self_ty),
         _ => unreachable!("checked by check_supported"),
     };
     Ok(format!(
@@ -285,6 +320,204 @@ fn enum_to_string_body(e: &Enum, method: &str) -> String {
         }
     }
     body.push_str("        }\n    }\n");
+    body
+}
+
+// ----- ToJson / FromJson -----
+//
+// The JSON encoding: a struct becomes a JSON object keyed by field name;
+// an enum becomes a tagged object `{"tag": "Variant", "values": [...]}`,
+// where a unit variant has an empty `values` array. Each field or payload
+// slot serializes through its own type's `to_json` and decodes through its
+// `from_json`, so a member type must itself implement the trait (the type
+// checker reports a missing impl with its normal bound diagnostic).
+
+/// Helper free functions the derived `from_json` bodies call by bare name.
+/// They are emitted into the generated file (not the bundled `std/json`)
+/// because a bundled free function is namespaced and so unreachable by its
+/// bare name from generated source. The names are prefixed to avoid
+/// colliding with a user declaration.
+const JSON_HELPERS: &str = r#"fun raven_derive_json_decode<T: FromJson>(j: JsonValue) -> Result<T, Error> {
+    return T.from_json(j)
+}
+fun raven_derive_json_field(j: JsonValue, key: String) -> Result<JsonValue, Error> {
+    return match j.get(key) {
+        Some(v) -> Ok(v),
+        None -> Err(Error { kind: "json", message: "missing field ".concat(key) }),
+    }
+}
+fun raven_derive_json_index(j: JsonValue, i: Int) -> Result<JsonValue, Error> {
+    return match j.at(i) {
+        Some(v) -> Ok(v),
+        None -> Err(Error { kind: "json", message: "missing payload element" }),
+    }
+}
+fun raven_derive_json_tag(j: JsonValue) -> Result<String, Error> {
+    let t = raven_derive_json_field(j, "tag")?
+    return match t {
+        Str(s) -> Ok(s),
+        _ -> Err(Error { kind: "json", message: "enum tag is not a string" }),
+    }
+}
+fun raven_derive_tagged(tag: String, values: List<JsonValue>) -> JsonValue {
+    let m: Map<String, JsonValue> = Map.new()
+    m.set("tag", JsonValue.Str(tag))
+    m.set("values", JsonValue.Array(values))
+    return JsonValue.Object(m)
+}
+fun raven_derive_tagged_unit(tag: String) -> JsonValue {
+    let values: List<JsonValue> = []
+    return raven_derive_tagged(tag, values)
+}
+"#;
+
+/// Render a `Type` back to its source form so a derived `from_json` can
+/// annotate a decoded local with the field's exact declared type (which
+/// drives the `from_json_value` type parameter). Only the type shapes that
+/// appear in a struct field or a tuple variant are handled; an unexpected
+/// shape renders as `_` and fails the later type check rather than silently
+/// miscompiling.
+fn render_type(ty: &Type) -> String {
+    match &ty.kind {
+        TypeKind::Path(p) => render_type_path(p),
+        TypeKind::Optional(inner) => format!("Option<{}>", render_type(inner)),
+        TypeKind::Unit => "()".to_string(),
+        TypeKind::Dyn(p) => format!("dyn {}", render_type_path(p)),
+        TypeKind::Function { .. } => "_".to_string(),
+    }
+}
+
+fn render_type_path(p: &TypePath) -> String {
+    let segs: Vec<String> = p
+        .segments
+        .iter()
+        .map(|s| {
+            if s.generics.is_empty() {
+                s.name.clone()
+            } else {
+                let args: Vec<String> = s.generics.iter().map(render_type).collect();
+                format!("{}<{}>", s.name, args.join(", "))
+            }
+        })
+        .collect();
+    segs.join(".")
+}
+
+/// `to_json` for a struct: build a JSON object keyed by field name, each
+/// value the field's own `to_json()`. A field-less struct is the empty
+/// object.
+fn struct_to_json_body(s: &Struct) -> String {
+    let mut body = String::from(
+        "    fun to_json(self) -> JsonValue {\n        let m: Map<String, JsonValue> = Map.new()\n",
+    );
+    for f in &s.fields {
+        body.push_str(&format!(
+            "        m.set(\"{0}\", self.{0}.to_json())\n",
+            f.name
+        ));
+    }
+    body.push_str("        return JsonValue.Object(m)\n    }\n");
+    body
+}
+
+/// `from_json` for a struct: pull each field from the object by name and
+/// decode it to the field's declared type, propagating a missing or wrong
+/// typed field as an `Err`, then construct the struct.
+fn struct_from_json_body(s: &Struct, self_ty: &str) -> String {
+    let mut body = format!("    fun from_json(j: JsonValue) -> Result<{self_ty}, Error> {{\n");
+    for f in &s.fields {
+        body.push_str(&format!(
+            "        let f_{0}: {1} = raven_derive_json_decode(raven_derive_json_field(j, \"{0}\")?)?\n",
+            f.name,
+            render_type(&f.ty)
+        ));
+    }
+    let inits: Vec<String> = s
+        .fields
+        .iter()
+        .map(|f| format!("{0}: f_{0}", f.name))
+        .collect();
+    if inits.is_empty() {
+        body.push_str(&format!("        return Ok({} {{}})\n    }}\n", s.name));
+    } else {
+        body.push_str(&format!(
+            "        return Ok({} {{ {} }})\n    }}\n",
+            s.name,
+            inits.join(", ")
+        ));
+    }
+    body
+}
+
+/// The positional payload types of a tuple variant (empty for a unit
+/// variant). Struct-style variants are rejected before this is reached.
+fn variant_tuple_types(v: &EnumVariant) -> &[Type] {
+    match &v.payload {
+        VariantPayload::Tuple(tys) => tys,
+        _ => &[],
+    }
+}
+
+/// `to_json` for an enum: match self and emit the tagged object
+/// `{"tag": "Variant", "values": [p0, p1, ...]}`. A unit variant emits an
+/// empty `values` array.
+fn enum_to_json_body(e: &Enum) -> String {
+    let mut body =
+        String::from("    fun to_json(self) -> JsonValue {\n        return match self {\n");
+    for v in &e.variants {
+        let n = variant_arity(v);
+        if n == 0 {
+            body.push_str(&format!(
+                "            {0} -> raven_derive_tagged_unit(\"{0}\"),\n",
+                v.name
+            ));
+        } else {
+            let binds: Vec<String> = (0..n).map(|i| format!("a{i}")).collect();
+            let vals: Vec<String> = (0..n).map(|i| format!("a{i}.to_json()")).collect();
+            body.push_str(&format!(
+                "            {0}({1}) -> raven_derive_tagged(\"{0}\", [{2}]),\n",
+                v.name,
+                binds.join(", "),
+                vals.join(", ")
+            ));
+        }
+    }
+    body.push_str("        }\n    }\n");
+    body
+}
+
+/// `from_json` for an enum: read the tag, dispatch to the matching variant,
+/// decode each payload slot positionally, and error on an unknown tag.
+fn enum_from_json_body(e: &Enum, self_ty: &str) -> String {
+    let mut body = format!(
+        "    fun from_json(j: JsonValue) -> Result<{self_ty}, Error> {{\n        let tag = raven_derive_json_tag(j)?\n        let vals = raven_derive_json_field(j, \"values\")?\n"
+    );
+    for v in &e.variants {
+        body.push_str(&format!("        if tag.equals(\"{}\") {{\n", v.name));
+        let tys = variant_tuple_types(v);
+        if tys.is_empty() {
+            body.push_str(&format!("            return Ok({}.{})\n", e.name, v.name));
+        } else {
+            for (i, ty) in tys.iter().enumerate() {
+                body.push_str(&format!(
+                    "            let p{0}: {1} = raven_derive_json_decode(raven_derive_json_index(vals, {0})?)?\n",
+                    i,
+                    render_type(ty)
+                ));
+            }
+            let args: Vec<String> = (0..tys.len()).map(|i| format!("p{i}")).collect();
+            body.push_str(&format!(
+                "            return Ok({}.{}({}))\n",
+                e.name,
+                v.name,
+                args.join(", ")
+            ));
+        }
+        body.push_str("        }\n");
+    }
+    body.push_str(
+        "        return Err(Error { kind: \"json\", message: \"unknown tag \".concat(tag) })\n    }\n",
+    );
     body
 }
 
@@ -395,6 +628,93 @@ mod tests {
     #[test]
     fn struct_variant_enum_is_rejected() {
         let file = parse_src("@derive(Eq)\nenum E { V(a: Int) }\n");
+        let mut out = Vec::new();
+        let err = expand_derives(&file.items, &mut out).expect_err("struct variant not supported");
+        assert!(
+            format!("{err}").contains("struct-style variant"),
+            "got: {err}"
+        );
+    }
+
+    /// All declarations `expand_derives` synthesizes for `src`, including the
+    /// emitted JSON helper free functions.
+    fn derived_decls(src: &str) -> Vec<Decl> {
+        let file = parse_src(src);
+        let mut out = Vec::new();
+        expand_derives(&file.items, &mut out).expect("expand");
+        out
+    }
+
+    #[test]
+    fn json_derive_generates_to_and_from_json_impls() {
+        let impls = derived_impls("@derive(ToJson, FromJson)\nstruct Point { x: Int, y: Int }\n");
+        let traits: Vec<String> = impls
+            .iter()
+            .map(|i| i.trait_or_type.segments[0].name.clone())
+            .collect();
+        assert_eq!(traits, vec!["ToJson", "FromJson"]);
+        for i in &impls {
+            assert_eq!(i.for_type.as_ref().unwrap().segments[0].name, "Point");
+            assert_eq!(i.items.len(), 1);
+        }
+        let method_names: Vec<String> = impls
+            .iter()
+            .flat_map(|i| i.items.iter().map(|m| m.name.clone()))
+            .collect();
+        assert_eq!(method_names, vec!["to_json", "from_json"]);
+    }
+
+    #[test]
+    fn json_derive_emits_helper_functions_once() {
+        // Two types both derive the JSON traits; the shared helper free
+        // functions must be emitted exactly once.
+        let decls = derived_decls(
+            "@derive(ToJson)\nstruct A { x: Int }\n@derive(FromJson)\nstruct B { y: Int }\n",
+        );
+        let decode_count = decls
+            .iter()
+            .filter(|d| matches!(&d.kind, DeclKind::Function(f) if f.name == "raven_derive_json_decode"))
+            .count();
+        assert_eq!(decode_count, 1, "decode helper must be emitted once");
+        let field_count = decls
+            .iter()
+            .filter(
+                |d| matches!(&d.kind, DeclKind::Function(f) if f.name == "raven_derive_json_field"),
+            )
+            .count();
+        assert_eq!(field_count, 1);
+    }
+
+    #[test]
+    fn non_json_derive_emits_no_json_helpers() {
+        let decls = derived_decls("@derive(Eq)\nstruct Point { x: Int }\n");
+        let has_helper = decls.iter().any(
+            |d| matches!(&d.kind, DeclKind::Function(f) if f.name.starts_with("raven_derive_json")),
+        );
+        assert!(!has_helper, "no JSON helper without a JSON derive");
+    }
+
+    #[test]
+    fn json_derive_on_generic_carries_per_param_bound() {
+        let impls = derived_impls("@derive(ToJson)\nstruct Pair<A, B> { first: A, second: B }\n");
+        let to_json = &impls[0];
+        let bounds: Vec<(String, String)> = to_json
+            .generics
+            .iter()
+            .map(|g| (g.name.clone(), g.bounds[0].segments[0].name.clone()))
+            .collect();
+        assert_eq!(
+            bounds,
+            vec![
+                ("A".to_string(), "ToJson".to_string()),
+                ("B".to_string(), "ToJson".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn json_derive_rejects_struct_variant_enum() {
+        let file = parse_src("@derive(ToJson)\nenum E { V(a: Int) }\n");
         let mut out = Vec::new();
         let err = expand_derives(&file.items, &mut out).expect_err("struct variant not supported");
         assert!(

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -248,6 +248,15 @@ pub fn expand_with_stdlib_ctx(
         wanted.insert("fmt".to_string());
     }
 
+    // `@derive(ToJson)`/`@derive(FromJson)` synthesize impls that reference
+    // the `JsonValue` tree and the JSON traits in `std/json`. Force-merge
+    // that module (it transitively pulls in `std/error` and
+    // `std/collections`) so the generated impls resolve even when the user
+    // wrote no `import std/json` line.
+    if super::derive::needs_json_module(user) {
+        wanted.insert("json".to_string());
+    }
+
     // Load every local `./`/`../` module reachable from the user file,
     // transitively, before computing the bundled set: a local module may
     // itself `import std/...`, and those bundled modules must merge too so

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -2060,10 +2060,11 @@ impl<'a, 'b> Checker<'a, 'b> {
             .cloned()
             .ok_or_else(|| ty_custom("enum signature missing", span))?;
         let Some((_, variant)) = sig.variant(name) else {
-            return Err(RavenError::ty(
-                TypeError::Custom(format!("enum `{}` has no variant `{}`", sig.name, name)),
-                span.clone(),
-            ));
+            // Not a variant: this may be an associated function call on the
+            // enum (for example a derived `Shape.from_json(j)`). Fall through
+            // so associated-function resolution can try; it reports its own
+            // error if no such function exists.
+            return Ok(None);
         };
         // Fresh inference variables for the enum's generic parameters.
         let args = self.instantiate_type_args(&sig.generics, &[], span, &sig.name)?;

--- a/stdlib/std/json.rv
+++ b/stdlib/std/json.rv
@@ -10,6 +10,7 @@ import std/string
 
 extern "C" {
     fun raven_int_to_float(x: Int) -> Float
+    fun raven_float_to_int(x: Float) -> Int
 }
 
 // The JSON value tree. Construct variants with the qualified form
@@ -598,5 +599,173 @@ fun array_at(value: JsonValue, i: Int) -> Option<JsonValue> {
             }
         },
         _ -> None,
+    }
+}
+
+// ----- JSON serialization traits -----
+//
+// `ToJson` turns a value into a `JsonValue`; pair it with `stringify` for a
+// String. `FromJson` reads a `JsonValue` back, returning an `Error` when the
+// shape does not match. `from_json` is an associated function: call it as
+// `Point.from_json(j)` for a user type, or route a field through the generic
+// `from_json_value` helper so the type parameter selects the impl.
+//
+// `@derive(ToJson, FromJson)` synthesizes these for user structs and enums.
+// See docs/v2/specs/derive.md for the struct/enum JSON encodings.
+
+trait ToJson {
+    fun to_json(self) -> JsonValue
+}
+
+trait FromJson {
+    fun from_json(j: JsonValue) -> Result<Self, Error>
+}
+
+// Decode `j` as a `T`, with `T` chosen by the expected result type, so
+// scalar, List, Option, and user-type members decode uniformly through one
+// call (`T.from_json` dispatches on the type parameter). The built-in List
+// and Option impls use it; a hand-written FromJson impl can too.
+fun from_json_value<T: FromJson>(j: JsonValue) -> Result<T, Error> {
+    return T.from_json(j)
+}
+
+// Read object member `key`, or an Err when `j` is not an object or the key
+// is absent. Useful in a hand-written `from_json` to fetch a field before
+// decoding it (`@derive(FromJson)` emits its own equivalent helper).
+fun json_field(j: JsonValue, key: String) -> Result<JsonValue, Error> {
+    return match object_get(j, key) {
+        Some(v) -> Ok(v),
+        None -> Err(json_error("missing field ".concat(key))),
+    }
+}
+
+// ----- Built-in ToJson/FromJson impls -----
+//
+// These bottom out field recursion. Int and Float both serialize to a JSON
+// number; an Int round-trips through Float and loses precision beyond 2^53
+// (the IEEE 754 double mantissa). Bool maps to a JSON bool, String to a JSON
+// string, List<T> to a JSON array, and Option<T> to null or the inner value.
+
+impl ToJson for Int {
+    fun to_json(self) -> JsonValue {
+        return JsonValue.Number(raven_int_to_float(self))
+    }
+}
+
+impl FromJson for Int {
+    fun from_json(j: JsonValue) -> Result<Int, Error> {
+        return match j {
+            Number(n) -> Ok(raven_float_to_int(n)),
+            _ -> Err(json_error("expected a number")),
+        }
+    }
+}
+
+impl ToJson for Float {
+    fun to_json(self) -> JsonValue {
+        return JsonValue.Number(self)
+    }
+}
+
+impl FromJson for Float {
+    fun from_json(j: JsonValue) -> Result<Float, Error> {
+        return match j {
+            Number(n) -> Ok(n),
+            _ -> Err(json_error("expected a number")),
+        }
+    }
+}
+
+impl ToJson for Bool {
+    fun to_json(self) -> JsonValue {
+        return JsonValue.Bool(self)
+    }
+}
+
+impl FromJson for Bool {
+    fun from_json(j: JsonValue) -> Result<Bool, Error> {
+        return match j {
+            Bool(b) -> Ok(b),
+            _ -> Err(json_error("expected a bool")),
+        }
+    }
+}
+
+impl ToJson for String {
+    fun to_json(self) -> JsonValue {
+        return JsonValue.Str(self)
+    }
+}
+
+impl FromJson for String {
+    fun from_json(j: JsonValue) -> Result<String, Error> {
+        return match j {
+            Str(s) -> Ok(s),
+            _ -> Err(json_error("expected a string")),
+        }
+    }
+}
+
+impl<T: ToJson> ToJson for List<T> {
+    fun to_json(self) -> JsonValue {
+        let items: List<JsonValue> = []
+        let i = 0
+        let n = self.len()
+        while i < n {
+            items.push(self[i].to_json())
+            i = i + 1
+        }
+        return JsonValue.Array(items)
+    }
+}
+
+impl<T: FromJson> FromJson for List<T> {
+    fun from_json(j: JsonValue) -> Result<List<T>, Error> {
+        return list_from_json(j)
+    }
+}
+
+// The List FromJson body lives in a free function: matching a `self`-less
+// JsonValue payload and pushing decoded elements through the generic helper
+// keeps the element type inference straightforward.
+fun list_from_json<T: FromJson>(j: JsonValue) -> Result<List<T>, Error> {
+    return match j {
+        Array(items) -> {
+            let out: List<T> = []
+            let i = 0
+            let n = items.len()
+            while i < n {
+                let elem: T = from_json_value(items[i])?
+                out.push(elem)
+                i = i + 1
+            }
+            Ok(out)
+        },
+        _ -> Err(json_error("expected an array")),
+    }
+}
+
+impl<T: ToJson> ToJson for Option<T> {
+    fun to_json(self) -> JsonValue {
+        return match self {
+            Some(v) -> v.to_json(),
+            None -> JsonValue.Null,
+        }
+    }
+}
+
+impl<T: FromJson> FromJson for Option<T> {
+    fun from_json(j: JsonValue) -> Result<Option<T>, Error> {
+        return option_from_json(j)
+    }
+}
+
+fun option_from_json<T: FromJson>(j: JsonValue) -> Result<Option<T>, Error> {
+    return match j {
+        Null -> Ok(None),
+        _ -> {
+            let v: T = from_json_value(j)?
+            Ok(Some(v))
+        },
     }
 }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -102,6 +102,24 @@ fn derive_program_compiles_and_runs() {
 }
 
 #[test]
+fn derive_json_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // `@derive(ToJson, FromJson)` synthesizes JSON serialization for a
+    // struct, a nested struct, a generic `Pair`, and an enum (tuple and unit
+    // variants). Each value round-trips `to_json` -> `stringify` -> `parse`
+    // -> `from_json` back to an equal value (the `true` lines), and a
+    // from_json on an object missing a required field returns the
+    // missing-field error.
+    compile_link_run_and_check(
+        "use_derive_json.rv",
+        "{\"x\":1,\"y\":2}\ntrue\n{\"start\":{\"x\":0,\"y\":0},\"end\":{\"x\":3,\"y\":4}}\ntrue\n{\"first\":7,\"second\":true}\ntrue\n{\"tag\":\"Rect\",\"values\":[2,5]}\ntrue\n{\"tag\":\"Dot\",\"values\":[]}\ntrue\nmissing field y\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn closure_value_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`@derive(ToJson, FromJson)` synthesizes JSON serialization for user structs and enums on top of the `@derive` mechanism and `std/json`.

Closes #217

## Traits and derived shapes

`std/json` defines two traits:

```raven
trait ToJson { fun to_json(self) -> JsonValue }
trait FromJson { fun from_json(j: JsonValue) -> Result<Self, Error> }
```

`@derive(ToJson)` on a struct generates `to_json` building a JSON object keyed by field name, each value the field's own `to_json()`. `@derive(FromJson)` generates `from_json` reading each field by name, decoding to the field's declared type, propagating a missing or wrong-typed field as `Err`, then constructing the value. Generic types bound each parameter by the derived trait, for example `@derive(ToJson)` on `Pair<A, B>` generates `impl<A: ToJson, B: ToJson> ToJson for Pair<A, B>`.

## `Self` and the associated-function decision

`from_json` is an associated function (no `self`), called as `Point.from_json(j)`. The `FromJson` trait declares the method with `Self` in the return, but the derived impl writes the concrete type (`Result<Point, Error>`), because the checker does not yet accept `Self` as a non-receiver type in a method signature (the same limitation `Eq` works around). This compiles and is ergonomic: associated-function dispatch on user types works directly.

The derived `from_json` calls a small set of helper free functions (a generic `T.from_json` dispatcher plus object and array accessors) that the derive pass emits into the program once. They cannot live in `std/json` because a bundled stdlib free function is namespaced (`std.json.f`) and so not callable by its bare name from generated source.

## Enum tag encoding

An enum serializes to a tagged object `{"tag": "Variant", "values": [p0, p1, ...]}`, where a unit variant has an empty `values` array. `from_json` reads the tag, dispatches to the variant, decodes each payload slot positionally, and returns `Err` on an unknown tag. Struct-style (named-field) variants are rejected, matching the existing derive.

## Scalar, List, and Option impls

`std/json` hand-writes the impls field recursion bottoms out on: `Int` and `Float` to a JSON number, `Bool` to a JSON bool, `String` to a JSON string, `List<T>` to a JSON array, and `Option<T>` to `null` or the inner value. An `Int` round-trips through `Float` (JSON has one number type) and loses precision beyond 2^53; a number decodes back to `Int` by truncation toward zero (a new `raven_float_to_int` runtime symbol). The derive never generates impls for the built-in types.

## Round-trip verification

`examples/v2/use_derive_json.rv` exercises a struct, a nested struct, a generic `Pair`, and an enum (tuple and unit variants), all `@derive(ToJson, FromJson, Eq, ToString)`. Each value survives `to_json` -> `stringify` -> `parse` -> `from_json` -> `equals` back to the original, plus a `from_json` on an object missing a required field returns `Err`. Real binary output (the committed golden baseline):

```
{"x":1,"y":2}
true
{"start":{"x":0,"y":0},"end":{"x":3,"y":4}}
true
{"first":7,"second":true}
true
{"tag":"Rect","values":[2,5]}
true
{"tag":"Dot","values":[]}
true
missing field y
```

Object key order follows the `std/json` Map hash-bucket layout, documented and asserted as the serializer's actual bytes.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (416 lib + 58 codegen smoke + golden, all green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo test --test golden` (no regression; new example baseline added)
- [x] Derive unit tests for the JSON traits (impl generation, helper-emitted-once, generic bounds, struct-variant rejection)
- [x] Codegen smoke test `derive_json_program_compiles_and_runs`

Note: "Closes #217" will not auto-close on merge to `v2.x` (non-default branch); expected.
