### PR TITLE
feat(reflect): compile-time type reflection, first slice

### DIFF
--- a/docs/v2/specs/reflection.md
+++ b/docs/v2/specs/reflection.md
@@ -1,0 +1,119 @@
+# reflection
+
+Compile-time type reflection exposes a small amount of type information to
+user code, resolved while the program is compiled. This is the first slice
+of the reflection work tracked under issue #216. It ships two builtins:
+
+```raven
+type_name<T>() -> String
+field_names<T>() -> List<String>
+```
+
+Both take a single type argument and no value arguments. The type argument
+must be statically known: a concrete type (`Int`, `Point`, `Pair<Int,
+String>`) or a generic parameter `T` that is bound to a concrete type at
+each monomorphization of the enclosing generic function. There is no
+runtime reflection over a value of unknown type in this slice; that needs
+an `Any` type and is a separate follow-up (see below).
+
+## type_name
+
+`type_name<T>()` evaluates to the rendered name of the concrete type `T`,
+as a `String`.
+
+```raven
+type_name<Int>()                  // "Int"
+type_name<String>()               // "String"
+type_name<Point>()                // "Point"
+type_name<Pair<Int, String>>()    // "Pair<Int, String>"
+type_name<List<Int>>()            // "List<Int>"
+```
+
+The rendering is the language's own type spelling, the same form the type
+checker prints in diagnostics: a scalar by its keyword name (`Int`,
+`Float`, `Bool`, `Char`, `String`, `()`), a struct or enum by its name with
+its concrete type arguments in angle brackets (`Pair<Int, String>`), and
+the built-in generics by their spelling (`List<Int>`, `Option<Int>`,
+`Result<Int, String>`). `String` renders as `String` (not the internal
+`Str`).
+
+Inside a generic function, `type_name<T>()` resolves to the concrete type
+bound to `T` at each instantiation:
+
+```raven
+fun describe<T>() -> String {
+    return type_name<T>()
+}
+
+describe<Int>()      // "Int"
+describe<Point>()    // "Point"
+```
+
+This is the load-bearing property: the call is lowered once per
+monomorphization with the concrete substitution applied, so two
+instantiations of the same generic body produce two different names.
+
+## field_names
+
+`field_names<T>()` evaluates to the field names of the struct type `T`, in
+declaration order, as a `List<String>`.
+
+```raven
+struct Point { x: Int, y: Int }
+
+field_names<Point>()    // ["x", "y"]
+```
+
+`T` must be a struct. Applying `field_names` to a non-struct type (a
+scalar, an enum, a built-in generic) is a compile error. Field types,
+not just names, are a follow-up (a typed field descriptor); this slice
+returns names only.
+
+Inside a generic function, `field_names<T>()` resolves to the fields of the
+struct bound to `T` at each instantiation, the same per-monomorphization
+mechanic as `type_name`.
+
+## Model: compile-time, per-monomorphization
+
+Both builtins are resolved entirely at compile time. There is no runtime
+type tag lookup, no metadata table, and no value argument. The type must be
+statically known.
+
+The mechanic is in MIR lowering. The call carries the resolved type
+argument as an HIR type (`Ty::Param(T)` for a generic parameter, or a
+concrete `Ty` for an explicit type). Each generic function is lowered once
+per concrete instantiation under a substitution map that binds every
+generic parameter to a ground type. When the builtin is lowered, the
+substitution is applied to its type argument first, so `Ty::Param(T)`
+becomes the concrete type for that instantiation:
+
+- `type_name<T>()` lowers to a `String` constant of the grounded type's
+  rendered name.
+- `field_names<T>()` lowers to a `List<String>` literal built from the
+  grounded struct's field names, looked up from the struct declaration the
+  lowering pass already holds.
+
+Because the lowering runs per instantiation with the concrete substitution,
+a generic `type_name<T>()` produces the right name at each call, not one
+generic placeholder. A program that does not call either builtin is
+unaffected: nothing is emitted and no runtime symbol is referenced.
+
+## Recognition
+
+`type_name` and `field_names` are builtin names, recognized the same way
+the `print` builtin and the internal stdlib intrinsics are: the resolver
+allows the bare name without a binding, the type checker assigns the result
+type at the call site (and validates that `field_names` targets a struct),
+and HIR lowering rewrites the call into a dedicated reflection node carrying
+the resolved type argument. A user can shadow either name by binding it in
+scope (an import or a local), in which case the binding wins.
+
+## Deferred
+
+This slice is deliberately bounded. The following are follow-ups, each
+filed against #216:
+
+- Field types and a typed field descriptor (not just names).
+- Enum and variant introspection.
+- Runtime reflection over a value of unknown type, via an `Any` type.
+- Dynamic field get and set.

--- a/examples/v2/use_reflection.rv
+++ b/examples/v2/use_reflection.rv
@@ -1,0 +1,51 @@
+// Compile-time type reflection: type_name<T>() and field_names<T>().
+//
+// Both resolve at compile time. type_name renders a type's name; a generic
+// describe<T> resolves per monomorphization, so describe<Int> and
+// describe<Point> print different names from one body. field_names yields a
+// struct's field names in declaration order. See docs/v2/specs/reflection.md.
+//
+// Compiling and running this prints:
+//   Int
+//   String
+//   Point
+//   2
+//   x
+//   y
+//   Int
+//   Point
+//   introspect Point
+//   field x
+//   field y
+struct Point {
+    x: Int,
+    y: Int
+}
+
+fun describe<T>() -> String {
+    return type_name<T>()
+}
+
+fun introspect<T>() {
+    print("introspect ${type_name<T>()}")
+    let fields = field_names<T>()
+    for f in fields {
+        print("field ${f}")
+    }
+}
+
+fun main() {
+    print(type_name<Int>())       // Int
+    print(type_name<String>())    // String
+    print(type_name<Point>())     // Point
+
+    let names = field_names<Point>()
+    print(names.len())            // 2
+    print(names[0])               // x
+    print(names[1])               // y
+
+    print(describe<Int>())        // Int
+    print(describe<Point>())      // Point
+
+    introspect<Point>()           // introspect Point, field x, field y
+}

--- a/examples/v2/use_reflection.rv.out
+++ b/examples/v2/use_reflection.rv.out
@@ -1,0 +1,11 @@
+Int
+String
+Point
+2
+x
+y
+Int
+Point
+introspect Point
+field x
+field y

--- a/src/hir/decl.rs
+++ b/src/hir/decl.rs
@@ -72,6 +72,12 @@ pub struct HirFn {
     pub name: String,
     pub params: Vec<(String, HirTy, Span)>,
     pub ret: HirTy,
+    /// The function's generic parameters in declaration order (impl/trait
+    /// owner parameters first, then the function's own). Monomorphization
+    /// uses this so a parameter that appears only in the body, for example
+    /// the `T` of `fun describe<T>() -> String { type_name<T>() }`, still
+    /// drives specialization even though no signature type mentions it.
+    pub generics: Vec<crate::tycheck::ty::ParamId>,
     /// `None` for trait members without a default body.
     pub body: Option<HirBlock>,
     pub span: Span,

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -137,6 +137,11 @@ pub enum HirExprKind {
     Call {
         callee: Box<HirExpr>,
         args: Vec<HirExpr>,
+        /// Resolved explicit type arguments written at the call site
+        /// (`f<Int>()`), in declaration order. Carried so MIR can bind a
+        /// callee's generic parameters that the value arguments do not pin
+        /// down. Empty when the call wrote no type arguments.
+        type_args: Vec<super::ty::HirTy>,
     },
     MethodCall {
         receiver: Box<HirExpr>,
@@ -218,6 +223,16 @@ pub enum HirExprKind {
         variant: usize,
         args: Vec<HirExpr>,
     },
+
+    /// `type_name<T>()` compile-time reflection builtin. Carries the
+    /// resolved type argument (a `Ty::Param` for a generic parameter, or a
+    /// concrete type), grounded per monomorphization in MIR and rendered to
+    /// a `String` constant. See `docs/v2/specs/reflection.md`.
+    TypeName(HirTy),
+    /// `field_names<T>()` compile-time reflection builtin. Carries the
+    /// resolved struct type argument, grounded per monomorphization in MIR
+    /// and lowered to a `List<String>` of the struct's field names.
+    FieldNames(HirTy),
 
     // ----- lambda -----
     Lambda {

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -178,6 +178,22 @@ pub(crate) fn lower_expr(
                     ));
                 }
             }
+            // Compile-time reflection builtins. The callee is an unbound
+            // identifier with a single type argument; the type checker
+            // recorded the resolved type argument at the callee span. Carry
+            // it into a dedicated node so MIR grounds it per monomorphization.
+            if let ExprKind::Ident { name, .. } = &callee.kind {
+                if cx.is_unbound_builtin(&callee.span) {
+                    if name == "type_name" {
+                        let arg_ty = cx.ty_at(&callee.span);
+                        return Ok(make_expr(HirExprKind::TypeName(arg_ty), ty, span));
+                    }
+                    if name == "field_names" {
+                        let arg_ty = cx.ty_at(&callee.span);
+                        return Ok(make_expr(HirExprKind::FieldNames(arg_ty), ty, span));
+                    }
+                }
+            }
             // Recognize the built in enum constructors `Some(x)`, `Ok(x)`,
             // and `Err(x)` so they lower to typed constructor nodes (and
             // then to `EnumCreate` in MIR) rather than ordinary calls.
@@ -238,6 +254,7 @@ pub(crate) fn lower_expr(
             HirExprKind::Call {
                 callee: Box::new(c),
                 args: lowered,
+                type_args: cx.type_args_at(&callee.span),
             }
         }
         ExprKind::MethodCall {

--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -85,6 +85,25 @@ impl<'a> LowerCtx<'a> {
         self.typed.types.lookup(span).cloned().unwrap_or(Ty::Error)
     }
 
+    /// Resolved explicit type arguments recorded at a call's callee span,
+    /// or an empty vector when the call wrote none.
+    pub(crate) fn type_args_at(&self, span: &Span) -> Vec<Ty> {
+        self.typed
+            .types
+            .lookup_type_args(span)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// True when the use site at `span` has no resolver binding. The
+    /// reflection builtins (`type_name`, `field_names`) and `print` reach
+    /// HIR as unbound identifiers; a user binding (an import or a local)
+    /// would record a binding here, in which case the call is an ordinary
+    /// one.
+    pub(crate) fn is_unbound_builtin(&self, span: &Span) -> bool {
+        self.resolved.map.lookup(span).is_none()
+    }
+
     /// Resolve an identifier use site to the declared name of the
     /// top level function it binds to, if any.
     ///
@@ -347,6 +366,7 @@ fn lower_function(
         name: f.name.clone(),
         params,
         ret,
+        generics: sigs.iter().map(|s| s.id.clone()).collect(),
         body,
         span: f.span.clone(),
     })

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -301,7 +301,7 @@ fn pretty_expr(buf: &mut String, expr: &HirExpr, depth: usize) {
             indent(buf, depth);
             buf.push_str(")\n");
         }
-        HirExprKind::Call { callee, args } => {
+        HirExprKind::Call { callee, args, .. } => {
             writeln!(buf, "(call ty={}", expr.ty).unwrap();
             pretty_expr(buf, callee, depth + 1);
             for a in args {
@@ -477,6 +477,12 @@ fn pretty_expr(buf: &mut String, expr: &HirExpr, depth: usize) {
             }
             indent(buf, depth);
             buf.push_str(")\n");
+        }
+        HirExprKind::TypeName(arg) => {
+            writeln!(buf, "(type-name arg={} ty={})", arg, expr.ty).unwrap()
+        }
+        HirExprKind::FieldNames(arg) => {
+            writeln!(buf, "(field-names arg={} ty={})", arg, expr.ty).unwrap()
         }
         HirExprKind::Lambda { params, ret, body } => {
             write!(buf, "(lambda ret={} params=(", ret).unwrap();

--- a/src/mir/lower/closure.rs
+++ b/src/mir/lower/closure.rs
@@ -311,6 +311,8 @@ fn collect_free_expr(
         | HirExprKind::Unit
         | HirExprKind::SelfValue
         | HirExprKind::NoneCtor
+        | HirExprKind::TypeName(_)
+        | HirExprKind::FieldNames(_)
         | HirExprKind::Continue => {}
         HirExprKind::Ident(name) => record_use(name, bound, seen, out),
         HirExprKind::Array(items) => {
@@ -335,7 +337,7 @@ fn collect_free_expr(
             collect_free_expr(lhs, bound, seen, out);
             collect_free_expr(rhs, bound, seen, out);
         }
-        HirExprKind::Call { callee, args } => {
+        HirExprKind::Call { callee, args, .. } => {
             collect_free_expr(callee, bound, seen, out);
             for a in args {
                 collect_free_expr(a, bound, seen, out);

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -76,14 +76,18 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             MirOperand::Copy(dst)
         }
         HirExprKind::StructLit { name, fields } => lower_struct_lit(cx, name, fields, &expr.ty, ty),
-        HirExprKind::Call { callee, args } => {
+        HirExprKind::Call {
+            callee,
+            args,
+            type_args,
+        } => {
             // A callee that is an in-scope local of function type is a
             // closure value: dispatch indirectly through its Closure
             // object. Any other callee is a direct call by symbol.
             if is_closure_value_callee(cx, callee) {
                 return lower_closure_call(cx, callee, args, ty);
             }
-            let callee_ref = call_ref_from_callee(cx, callee, args, &expr.ty);
+            let callee_ref = call_ref_from_callee(cx, callee, args, type_args, &expr.ty);
             let arg_ops: Vec<MirOperand> = args.iter().map(|a| lower_expr(cx, a)).collect();
             let dst = cx.builder.fresh_temp("call", ty);
             cx.builder.assign(
@@ -309,7 +313,59 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             cx.builder.assign(cx.current, dst, rvalue);
             MirOperand::Copy(dst)
         }
+        HirExprKind::TypeName(arg) => lower_type_name(cx, arg, ty),
+        HirExprKind::FieldNames(arg) => lower_field_names(cx, arg, ty),
     }
+}
+
+/// Lower `type_name<T>()`. The carried type argument is grounded under the
+/// current substitution (so a generic parameter becomes the concrete type
+/// for this monomorphization), then rendered to its source spelling as a
+/// `String` constant. See `docs/v2/specs/reflection.md`.
+fn lower_type_name(cx: &mut LowerCx<'_>, arg: &crate::tycheck::Ty, ty: MirType) -> MirOperand {
+    let concrete = super::substitute(arg, cx.subst);
+    let rendered = format!("{}", concrete.strip_self());
+    let dst = cx.builder.fresh_temp("typename", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::Use(MirOperand::Const(MirConstant::Str(rendered))),
+    );
+    MirOperand::Copy(dst)
+}
+
+/// Lower `field_names<T>()`. The carried type argument is grounded under the
+/// current substitution; when it is a known struct, the field names in
+/// declaration order become a `List<String>` literal. A grounded non-struct
+/// type yields an empty list (a generic parameter bound to a non-struct at
+/// some instantiation cannot be rejected at the call site in this slice).
+fn lower_field_names(cx: &mut LowerCx<'_>, arg: &crate::tycheck::Ty, ty: MirType) -> MirOperand {
+    use crate::tycheck::Ty;
+    let concrete = super::substitute(arg, cx.subst);
+    let names: Vec<String> = match concrete.strip_self() {
+        Ty::Struct { name, .. } => cx
+            .decls
+            .structs
+            .get(name.as_str())
+            .map(|s| s.fields.iter().map(|(n, _, _)| n.clone()).collect())
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    let elements: Vec<MirOperand> = names
+        .into_iter()
+        .map(|n| MirOperand::Const(MirConstant::Str(n)))
+        .collect();
+    let list_ty = MirType::List(Box::new(MirType::Str));
+    let dst = cx.builder.fresh_temp("fieldnames", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::ArrayLit {
+            ty: list_ty,
+            elements,
+        },
+    );
+    MirOperand::Copy(dst)
 }
 
 /// Lower a block to a single result operand. Statements are emitted as
@@ -713,6 +769,7 @@ fn call_ref_from_callee(
     cx: &mut LowerCx<'_>,
     callee: &HirExpr,
     args: &[HirExpr],
+    type_args: &[crate::tycheck::Ty],
     result_ty: &crate::tycheck::Ty,
 ) -> MirFnRef {
     let HirExprKind::Ident(name) = &callee.kind else {
@@ -743,6 +800,16 @@ fn call_ref_from_callee(
     // can bind them. The two parameter spaces never collide because a
     // `ParamId` carries its owner span.
     let mut subst: super::SubstMap = super::SubstMap::new();
+    // Explicit type arguments bind the callee's generic parameters in
+    // declaration order. Each is grounded under the enclosing function's
+    // substitution first, so a `T` argument inside a generic body resolves
+    // to the concrete type for this monomorphization. This is what lets a
+    // call carrying `T` only as a type argument (no value argument pins it)
+    // specialize correctly, for example `type_name<T>()` and `describe<T>()`.
+    for (param, arg) in entry.generic_params.iter().zip(type_args.iter()) {
+        let got = super::substitute(arg, cx.subst);
+        subst.entry(param.clone()).or_insert(got);
+    }
     for (decl_ty, arg) in entry.params.iter().zip(args.iter()) {
         let got = super::substitute(&arg.ty, cx.subst);
         match_param(decl_ty, &got, &mut subst);

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -344,13 +344,17 @@ fn collect_roots(
     )
 }
 
-/// Collect a function's generic parameters in declaration order. The
-/// HIR does not carry an explicit parameter list, so the parameters are
-/// recovered by scanning the parameter and return types for `Ty::Param`
-/// occurrences and ordering them by their declaration index. The index
-/// on a `ParamId` is its position in the original `<...>` list, which is
-/// the order both the call site and the mangled name rely on.
+/// Collect a function's generic parameters in declaration order. The HIR
+/// carries the declared parameter list (`HirFn::generics`); it is the
+/// authoritative source because a parameter may appear only in the body
+/// (for example the `T` of `type_name<T>()`) and so be invisible to a scan
+/// of the signature types. The list is already in declaration order, the
+/// order both the call site and the mangled name rely on. The signature
+/// scan is kept as a fallback for any HIR built without the field set.
 fn generic_params_of(f: &HirFn) -> Vec<ParamId> {
+    if !f.generics.is_empty() {
+        return f.generics.clone();
+    }
     let mut found: Vec<ParamId> = Vec::new();
     let mut collect = |t: &Ty| collect_params(t, &mut found);
     for (_, ty, _) in &f.params {

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -630,3 +630,97 @@ fn gc_pointer_captures_are_ordered_first() {
         _ => unreachable!(),
     }
 }
+
+// ----- Compile-time reflection -----
+
+/// Collect every `String` constant assigned anywhere in a function, in
+/// statement order. Reflection builtins lower to such constants.
+fn str_constants(f: &MirFunction) -> Vec<String> {
+    let mut out = Vec::new();
+    for block in &f.blocks {
+        for stmt in &block.statements {
+            if let MirStatement::Assign { rvalue, .. } = stmt {
+                match rvalue {
+                    MirRvalue::Use(MirOperand::Const(MirConstant::Str(s))) => out.push(s.clone()),
+                    MirRvalue::ArrayLit { elements, .. } => {
+                        for e in elements {
+                            if let MirOperand::Const(MirConstant::Str(s)) = e {
+                                out.push(s.clone());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn type_name_on_scalar_lowers_to_name_constant() {
+    let prog = compile("fun f() -> String = type_name<Int>()\n");
+    let f = find_fn(&prog, "f");
+    assert!(
+        str_constants(f).contains(&"Int".to_string()),
+        "type_name<Int>() should lower to the constant \"Int\""
+    );
+}
+
+#[test]
+fn type_name_on_struct_lowers_to_name_constant() {
+    let prog = compile(
+        r#"
+        struct Point { x: Int, y: Int }
+        fun f() -> String = type_name<Point>()
+    "#,
+    );
+    let f = find_fn(&prog, "f");
+    assert!(str_constants(f).contains(&"Point".to_string()));
+}
+
+#[test]
+fn field_names_on_struct_lowers_to_field_constants() {
+    let prog = compile(
+        r#"
+        struct Point { x: Int, y: Int }
+        fun f() -> List<String> = field_names<Point>()
+    "#,
+    );
+    let f = find_fn(&prog, "f");
+    let consts = str_constants(f);
+    assert_eq!(consts, vec!["x".to_string(), "y".to_string()]);
+}
+
+#[test]
+fn type_name_on_generic_param_resolves_per_monomorphization() {
+    // `describe<T>` is instantiated at two concrete types. Each
+    // monomorphization grounds the body's `type_name<T>()` to the concrete
+    // name, so the two specialized functions carry different constants.
+    let prog = compile(
+        r#"
+        struct Point { x: Int, y: Int }
+        fun describe<T>() -> String = type_name<T>()
+        fun main() {
+            let a = describe<Int>()
+            let b = describe<Point>()
+        }
+    "#,
+    );
+    let names: Vec<String> = prog
+        .functions
+        .iter()
+        .filter(|f| f.origin == "describe")
+        .flat_map(str_constants)
+        .collect();
+    assert!(
+        names.contains(&"Int".to_string()),
+        "an instantiation should render Int, got {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"Point".to_string()),
+        "the other instantiation should render Point, got {:?}",
+        names
+    );
+}

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -662,6 +662,8 @@ fn is_builtin_ctor_name(name: &str) -> bool {
             | "Ok"
             | "Err"
             | "print"
+            | "type_name"
+            | "field_names"
             | "__io_print_str"
             | "__io_println_str"
             | "__io_read_line"

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -861,6 +861,14 @@ impl<'a, 'b> Checker<'a, 'b> {
             for g in generics {
                 explicit_args.push(self.resolve_ast_ty(g)?);
             }
+            // Record the resolved explicit type arguments at the use site so
+            // MIR can bind a callee's generic parameters that the value
+            // arguments do not pin down (a `f<T>()` with no argument carrying
+            // `T`). Resolved here under the enclosing generic scope, so a
+            // `T` argument stays a `Ty::Param` and grounds per monomorphization.
+            if !explicit_args.is_empty() {
+                self.record_type_args(span, explicit_args.clone());
+            }
             self.type_of_binding(&binding, span, &explicit_args)
         } else {
             Err(RavenError::ty(
@@ -1169,9 +1177,15 @@ impl<'a, 'b> Checker<'a, 'b> {
         // only call form we recognize for variants is `Some(x)`,
         // `Ok(x)`, `Err(x)` which arrive as `Call { callee: Ident, .. }`
         // without a resolver binding.
-        if let ExprKind::Ident { name, .. } = &callee.kind {
+        if let ExprKind::Ident { name, generics } = &callee.kind {
             if self.resolved.map.lookup(&callee.span).is_none() {
-                return self.check_builtin_constructor_call(name, args, span);
+                return self.check_builtin_constructor_call(
+                    name,
+                    generics,
+                    &callee.span,
+                    args,
+                    span,
+                );
             }
         }
 
@@ -1228,10 +1242,14 @@ impl<'a, 'b> Checker<'a, 'b> {
     fn check_builtin_constructor_call(
         &mut self,
         name: &str,
+        generics: &[crate::ast::Type],
+        callee_span: &Span,
         args: &[Expr],
         span: &Span,
     ) -> Result<Ty, RavenError> {
         match name {
+            "type_name" => self.check_reflection_builtin(name, generics, callee_span, args, span),
+            "field_names" => self.check_reflection_builtin(name, generics, callee_span, args, span),
             "Some" => {
                 if args.len() != 1 {
                     return Err(RavenError::ty(
@@ -1388,6 +1406,61 @@ impl<'a, 'b> Checker<'a, 'b> {
                 span.clone(),
             )),
         }
+    }
+
+    /// Check a compile-time reflection builtin (`type_name<T>()` or
+    /// `field_names<T>()`). Both take exactly one type argument and no value
+    /// arguments. The resolved type argument is recorded under the callee
+    /// span so HIR lowering can carry it (a generic parameter `T` resolves
+    /// to `Ty::Param`, grounded per monomorphization in MIR). See
+    /// `docs/v2/specs/reflection.md`.
+    fn check_reflection_builtin(
+        &mut self,
+        name: &str,
+        generics: &[crate::ast::Type],
+        callee_span: &Span,
+        args: &[Expr],
+        span: &Span,
+    ) -> Result<Ty, RavenError> {
+        if !args.is_empty() {
+            return Err(RavenError::ty(
+                TypeError::WrongArity {
+                    func: name.to_string(),
+                    expected: 0,
+                    actual: args.len(),
+                },
+                span.clone(),
+            ));
+        }
+        if generics.len() != 1 {
+            return Err(RavenError::ty(
+                TypeError::GenericArityMismatch {
+                    decl: name.to_string(),
+                    expected: 1,
+                    actual: generics.len(),
+                },
+                span.clone(),
+            ));
+        }
+        let arg_ty = self.resolve_ast_ty(&generics[0])?;
+        if name == "field_names" && !matches!(arg_ty.strip_self(), Ty::Struct { .. } | Ty::Param(_))
+        {
+            return Err(RavenError::ty(
+                TypeError::Custom(format!(
+                    "`field_names` requires a struct type, got `{}`",
+                    arg_ty
+                )),
+                span.clone(),
+            ));
+        }
+        // Record the resolved type argument at the callee span. HIR lowering
+        // reads it to build the reflection node; the call's own result span
+        // keeps the result type (`String` or `List<String>`).
+        self.record(callee_span, arg_ty);
+        Ok(match name {
+            "field_names" => Ty::List(Box::new(Ty::Str)),
+            _ => Ty::Str,
+        })
     }
 
     /// Reject a stdlib intrinsic call whose argument count differs from
@@ -2342,6 +2415,10 @@ impl<'a, 'b> Checker<'a, 'b> {
 
     fn record(&mut self, span: &Span, ty: Ty) {
         self.types.types.insert(UseKey::from_span(span), ty);
+    }
+
+    fn record_type_args(&mut self, span: &Span, args: Vec<Ty>) {
+        self.types.record_type_args(span, args);
     }
 
     /// Type an interpolated string literal. The whole literal has type

--- a/src/tycheck/mod.rs
+++ b/src/tycheck/mod.rs
@@ -76,6 +76,13 @@ pub struct TypeMap {
     pub types: HashMap<UseKey, Ty>,
     /// `dyn Trait` coercions keyed by the coerced expression's span.
     pub coercions: HashMap<UseKey, DynCoercion>,
+    /// Resolved explicit type arguments of a generic call, keyed by the
+    /// callee's span. Recorded only when a call writes them (`f<Int>()`).
+    /// MIR uses them to bind a callee's generic parameters that the value
+    /// arguments and result type do not pin down (for example a
+    /// `type_name<T>()` inside a generic body, or any `f<T>()` with no
+    /// argument carrying `T`).
+    pub type_args: HashMap<UseKey, Vec<Ty>>,
 }
 
 impl TypeMap {
@@ -92,6 +99,17 @@ impl TypeMap {
     /// Look up the type recorded at `span`, if any.
     pub fn lookup(&self, span: &Span) -> Option<&Ty> {
         self.types.get(&UseKey::from_span(span))
+    }
+
+    /// Record the resolved explicit type arguments of a call at the
+    /// callee's `span`.
+    pub fn record_type_args(&mut self, span: &Span, args: Vec<Ty>) {
+        self.type_args.insert(UseKey::from_span(span), args);
+    }
+
+    /// Look up the explicit type arguments recorded at `span`, if any.
+    pub fn lookup_type_args(&self, span: &Span) -> Option<&Vec<Ty>> {
+        self.type_args.get(&UseKey::from_span(span))
     }
 
     /// Record a `dyn Trait` coercion at `span` (the coerced expression).

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -592,3 +592,40 @@ fn map_literal_requires_collections_import() {
     let err = check_with_prelude("fun main() {\n    let m = [\"a\": 1]\n}\n").unwrap_err();
     assert!(matches!(err, RavenError::Type(_, _, _)), "got: {}", err);
 }
+
+#[test]
+fn type_name_accepts_scalar_and_struct() {
+    check(
+        r#"
+        struct Point { x: Int, y: Int }
+        fun a() -> String = type_name<Int>()
+        fun b() -> String = type_name<Point>()
+    "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn field_names_yields_list_of_string() {
+    check(
+        r#"
+        struct Point { x: Int, y: Int }
+        fun a() -> List<String> = field_names<Point>()
+    "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn type_name_resolves_a_generic_parameter() {
+    check("fun describe<T>() -> String = type_name<T>()\n").unwrap();
+}
+
+#[test]
+fn field_names_on_scalar_is_rejected() {
+    let err = check("fun a() -> List<String> = field_names<Int>()\n").unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::Custom(_))),
+        other => panic!("expected a type error, got {:?}", other),
+    }
+}

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -114,6 +114,21 @@ fn derive_program_compiles_and_runs() {
 }
 
 #[test]
+fn reflection_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // `type_name<T>()` renders a type's name and `field_names<T>()` yields a
+    // struct's fields. The generic `describe<T>` and `introspect<T>` resolve
+    // per monomorphization, so the same body prints `Int` then `Point`.
+    compile_link_run_and_check(
+        "use_reflection.rv",
+        "Int\nString\nPoint\n2\nx\ny\nInt\nPoint\nintrospect Point\nfield x\nfield y\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn derive_json_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
The first slice of compile-time type reflection: two builtins that expose a type's name and a struct's field names, resolved at compile time per monomorphization.

Part of #216.

## Design

See the new spec at `docs/v2/specs/reflection.md`. Reflection here is compile-time only: the type must be statically known, either a concrete type or a generic parameter that monomorphizes to one. There is no runtime reflection over a value of unknown type in this slice.

## Builtins

```raven
type_name<T>() -> String
field_names<T>() -> List<String>
```

- `type_name<T>()` renders the concrete type's name (`"Int"`, `"Point"`, `"Pair<Int, String>"`), using the language's own type spelling.
- `field_names<T>()` returns a struct's field names in declaration order. A non-struct argument is a compile error.

Both take a single type argument and no value arguments. They are recognized the same way the `print` builtin and the stdlib intrinsics are (resolver allowlist, tycheck signatures, HIR lowering to dedicated nodes). A user binding of either name shadows the builtin.

## Compile-time, per-monomorphization model

The mechanic is in MIR lowering. The call carries the resolved type argument as an HIR type (`Ty::Param(T)` for a generic parameter). Each generic function is lowered once per concrete instantiation under a substitution map; applying it to the type argument grounds `T` to the concrete type for that instantiation. So `type_name<T>()` inside a generic body renders the right name at each call, not one placeholder.

To make this work for a generic function whose parameter appears only in the body (for example `describe<T>` calling `type_name<T>()`, where no value argument or return type pins `T`), the change also records each function's declared generic parameters (`HirFn::generics`) and each call's explicit type arguments, so monomorphization can specialize on a parameter the signature does not mention.

A program that does not use reflection is unaffected: nothing is emitted and no runtime symbol is referenced.

## Deferred (filed as sub-issues, assigned martian56)

- #227 Field types and a typed field descriptor (not just names)
- #228 Enum and variant introspection
- #229 Runtime reflection over a value via an Any type
- #230 Dynamic field get and set

## Verification

`examples/v2/use_reflection.rv`, compiled and run with the real binary, prints:

```
Int
String
Point
2
x
y
Int
Point
introspect Point
field x
field y
```

This shows `type_name` on a scalar and a struct, `field_names` on `Point` yielding `["x", "y"]`, the generic `describe<T>` at `Int` and `Point` (proving per-monomorphization resolution), and an `introspect<T>` serializer skeleton combining both.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (435 lib + 60 codegen smoke + golden suites, no regression)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] tycheck unit tests: `type_name` on scalar/struct/generic-param, `field_names` yields `List<String>`, `field_names` on a scalar rejected
- [x] MIR unit tests: `type_name` on scalar/struct lowers to the name constant, `field_names` lowers to the field constants, `type_name<T>()` resolves per monomorphization (different constants from one body)
- [x] codegen smoke test runs the example and checks stdout
- [x] golden baseline `examples/v2/use_reflection.rv.out`
- [x] non-reflection programs unaffected (full golden suite passes)
