### PR TITLE
test(gc): stress coverage for frame-based collections

### DIFF
--- a/docs/v2/specs/gc.md
+++ b/docs/v2/specs/gc.md
@@ -293,11 +293,25 @@ Allocation goes through `raven_gc_alloc(size, align, tag)`:
 2. Allocate the object body through the raw allocator, zero it, register
    it in the all-objects list, bump the counters, and return it.
 
-The threshold starts at `1 MiB`. After a collection it is reset to
-`max(1 MiB, 2 * bytes_live_after_sweep)`, so a program with a large live
-set collects less often while a program with a small live set keeps a
-tight ceiling. This is the standard "allocation high-water mark"
-heuristic; it bounds heap growth to a constant factor of the live set.
+The threshold starts at the collection floor (default `1 MiB`). After a
+collection it is reset to `max(floor, 2 * bytes_live_after_sweep)`, so a
+program with a large live set collects less often while a program with a
+small live set keeps a tight ceiling. This is the standard "allocation
+high-water mark" heuristic; it bounds heap growth to a constant factor of
+the live set.
+
+### Threshold override for testing
+
+The collection floor reads the `RAVEN_GC_THRESHOLD` environment variable
+once at startup. When it is set to a positive byte count the floor (and so
+the starting and post-collection threshold) is lowered or raised to that
+value; an unset, empty, zero, or unparseable value leaves the `1 MiB`
+default unchanged. Lowering it to a few hundred bytes makes a collection
+fire after only a handful of allocations, so a test or a stress program
+exercises the frame-based root paths on nearly every allocation without
+allocating gigabytes. The override changes only collection pacing, never
+correctness: a program prints the same output at any threshold. It is a
+test and diagnostics hook; production runs leave it unset.
 
 `raven_gc_collect()` forces a full collection regardless of the
 threshold. It exists for deterministic testing and for any future
@@ -358,3 +372,40 @@ in `raven-runtime/tests/` cover:
   sees the union of all active frames' roots.
 * **Threshold trigger.** Allocating past the threshold triggers an
   automatic collection without an explicit `raven_gc_collect` call.
+* **Per-kind churn stress.** For each object kind (struct with a String
+  field, nested struct, list of structs, hash `Map` and `Set`, closure
+  captures, an `Any`/`Box` payload, and a parked deferred closure), a
+  rooted instance is held across thousands of real allocations that force
+  repeated collections, then its transitive contents are read back and
+  asserted intact. A parked goroutine's heap value is held across heavy
+  main-goroutine allocation and verified after it unblocks, exercising the
+  scheduler's parked-root scan under pressure.
+
+### End-to-end stress suite
+
+The unit tests play codegen's role by hand. To check the real frame
+emission, `examples/v2/gc_stress.rv` holds a live root of every heap object
+kind across heavy allocation and reads each back, producing deterministic
+output. The `gc_stress_survives_repeated_collections` smoke test compiles
+and links it, then runs it many times under a low `RAVEN_GC_THRESHOLD` so a
+collection fires every few allocations. Because a freed-live-object bug is
+nondeterministic, repeating the run is what makes the test reliable: a
+single pass can pass by luck.
+
+This suite first surfaced, and the back end then fixed, a class of rooting
+gaps where a heap temporary an rvalue builds is left unrooted across a
+later allocation in the same expression:
+
+* **Aggregate construction.** A struct, enum, or list literal allocates
+  its body, then evaluates and stores fields or elements that may
+  themselves allocate (a String-literal or interpolated field). The body
+  is allocated first and rooted through a single shadow-stack slot
+  (`raven_gc_push_root`/`raven_gc_pop_roots`) for the duration of the fill,
+  so a partially built aggregate and the values already stored survive a
+  collection.
+* **Interpolation parts.** A string interpolation folds its parts with
+  `raven_string_concat`, which allocates internally. Every part, literal
+  text included, is bound to a rooted temp so it is not freed mid-concat.
+* **Reflection wrapping.** `get_field` boxes a field into a fresh `Any`,
+  then allocates the `Option<Any>` wrapper. The new `Any` is rooted across
+  that wrapper allocation so it is not freed before it is stored.

--- a/examples/v2/gc_stress.rv
+++ b/examples/v2/gc_stress.rv
@@ -1,0 +1,146 @@
+// golden:skip
+// GC stress: hold a live root of every heap object kind across heavy
+// allocation that forces repeated collections, then read each back and
+// prove it survived intact. Run under a low RAVEN_GC_THRESHOLD so a
+// collection fires every few allocations and the frame-based root paths
+// are exercised hard. Output is deterministic at any threshold because it
+// only reports the verified-correct live values.
+//
+// Expected output:
+//   struct 7 ada
+//   nested 99 deep
+//   list 0 a
+//   list 2 c
+//   map x
+//   set 2
+//   closure 142
+//   any 7 ada
+//   defer 55
+//   go 8
+
+import std/collections { Map, Set }
+import std/sync { channel, channel_buffered }
+
+struct Inner { tag: Int, name: String }
+struct Outer { id: Int, inner: Inner }
+
+struct User { id: Int, name: String }
+
+// Allocate `n` throwaway structs so the collector runs repeatedly while
+// the caller's roots stay live. Returns a folded sum so the work is not
+// dead-code eliminated.
+fun churn(n: Int) -> Int {
+    let acc = 0
+    let i = 0
+    while i < n {
+        let junk = User { id: i, name: "junk" }
+        acc = acc + junk.id
+        i = i + 1
+    }
+    return acc
+}
+
+fun deferred_value(out: Map<String, Int>) -> Int {
+    defer out.set("deferred", 55)
+    let _ = churn(4000)
+    return 0
+}
+
+fun main() {
+    // Struct with a String field, held across churn.
+    let u = User { id: 7, name: "ada" }
+    let _a = churn(4000)
+    print("struct ${u.id} ${u.name}")
+
+    // Nested struct: an Outer whose field is an Inner with a String.
+    let o = Outer { id: 1, inner: Inner { tag: 99, name: "deep" } }
+    let _b = churn(4000)
+    print("nested ${o.inner.tag} ${o.inner.name}")
+
+    // A list of String values read back after churn.
+    let words = ["a", "b", "c"]
+    words.push("d")
+    let _c = churn(4000)
+    print("list 0 ${words[0]}")
+    print("list 2 ${words[2]}")
+
+    // A hash-backed Map<String, String> and Set<Int> surviving churn.
+    let m = Map.new()
+    m.set("k", "x")
+    let s = Set.new()
+    s.add(1)
+    s.add(2)
+    s.add(2)
+    let _d = churn(4000)
+    match m.get("k") {
+        Some(v) -> print("map ${v}")
+        None -> print("map MISSING")
+    }
+    print("set ${s.len()}")
+
+    // A closure capturing a heap-derived value, invoked after churn.
+    let base = 100
+    let add42 = fun(x: Int) -> Int = x + base + 42
+    let _e = churn(4000)
+    print("closure ${add42(0)}")
+
+    // Any-boxed heap struct read back through reflection after churn.
+    let boxed = to_any<User>(User { id: 7, name: "ada" })
+    let _f = churn(4000)
+    let id_field = get_field(boxed, "id")
+    let name_field = get_field(boxed, "name")
+    let id_text = "?"
+    let name_text = "?"
+    match id_field {
+        Some(v) -> {
+            match cast<Int>(v) {
+                Some(n) -> { id_text = "${n}" }
+                None -> { id_text = "?" }
+            }
+        }
+        None -> { id_text = "?" }
+    }
+    match name_field {
+        Some(v) -> {
+            match cast<String>(v) {
+                Some(t) -> { name_text = t }
+                None -> { name_text = "?" }
+            }
+        }
+        None -> { name_text = "?" }
+    }
+    print("any ${id_text} ${name_text}")
+
+    // A defer-captured value: the deferred closure writes into a Map that
+    // outlives the call, with churn before the defer fires.
+    let out = Map.new()
+    let _g = deferred_value(out)
+    match out.get("deferred") {
+        Some(v) -> print("defer ${v}")
+        None -> print("defer MISSING")
+    }
+
+    // Goroutine-parked roots: a goroutine holds heap values (a list it
+    // builds) and blocks on a channel while main allocates heavily, then
+    // unblocks and reports a value derived from its surviving data.
+    let ready = channel_buffered(2)
+    let go = channel_buffered(1)
+    spawn(fun() -> Unit {
+        let mine = ["p", "qq", "rrr"]
+        mine.push("ssss")
+        ready.send(1)
+        let _ = go.recv()
+        // Read the surviving list back: confirm the last element is intact
+        // and report a value derived from the live list length.
+        let total = 0
+        if mine[3] == "ssss" {
+            total = mine.len() * 2
+        }
+        ready.send(total)
+    })
+    let _signal = ready.recv()
+    let _h = churn(8000)
+    go.send(0)
+    let parked = ready.recv()
+    print("go ${parked}")
+}

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -104,7 +104,9 @@ thread_local! {
     /// Allocation high-water mark: a collection runs before serving an
     /// allocation that would carry `bytes_allocated` past this. Reset
     /// after each collection to a multiple of the surviving live bytes.
-    static THRESHOLD: Cell<usize> = const { Cell::new(INITIAL_THRESHOLD) };
+    /// Initialised from `collection_floor()`, which honours the
+    /// `RAVEN_GC_THRESHOLD` override.
+    static THRESHOLD: Cell<usize> = Cell::new(collection_floor());
 
     /// Per-struct-type GC pointer descriptors. The key is the type id the
     /// back-end assigns to each monomorphic struct type; the value is a
@@ -230,8 +232,27 @@ fn for_each_defer_root(work: &mut Vec<*mut ObjectHeader>) {
     });
 }
 
-/// Initial and floor collection threshold in bytes (1 MiB).
+/// Default collection floor in bytes (1 MiB) when no override is set.
 const INITIAL_THRESHOLD: usize = 1024 * 1024;
+
+/// The collection floor in bytes: the smallest the threshold is ever set
+/// to. Defaults to `INITIAL_THRESHOLD`, but a test or a stress program may
+/// lower (or raise) it by setting `RAVEN_GC_THRESHOLD` to a byte count, so
+/// collections fire after only a few allocations and the frame-based root
+/// paths are exercised deterministically. An unset, empty, zero, or
+/// unparseable value leaves the default unchanged. Read once and cached so
+/// every thread observes the same floor.
+fn collection_floor() -> usize {
+    use std::sync::OnceLock;
+    static FLOOR: OnceLock<usize> = OnceLock::new();
+    *FLOOR.get_or_init(|| {
+        std::env::var("RAVEN_GC_THRESHOLD")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(INITIAL_THRESHOLD)
+    })
+}
 
 /// Register a single root slot on the shadow stack.
 ///
@@ -426,7 +447,7 @@ fn collect() {
     // below the floor, so a large live set collects less often and a
     // small one keeps a tight ceiling.
     let live = BYTES_ALLOCATED.with(|b| b.get());
-    let next = INITIAL_THRESHOLD.max(live.saturating_mul(2));
+    let next = collection_floor().max(live.saturating_mul(2));
     THRESHOLD.with(|t| t.set(next));
 }
 
@@ -1202,6 +1223,350 @@ mod collector_tests {
                 "expected automatic collection to bound liveness, got {}",
                 raven_gc_live_objects()
             );
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+}
+
+/// Stress coverage: each live object kind is rooted through the frame ABI
+/// and held across many real allocations that force repeated collections,
+/// then its transitive contents are verified intact. These mirror the
+/// per-kind tracing tests but drive collections under churn rather than a
+/// single forced cycle, so a rooting or tracing regression that only shows
+/// up after several collections (like the slot-indirection bug) is caught.
+#[cfg(test)]
+mod stress_tests {
+    use super::*;
+    use crate::object::{
+        raven_box_new, raven_box_payload, raven_closure_captures, raven_closure_new,
+        raven_list_new, raven_list_push, raven_map_buckets, raven_map_new, raven_set_buckets,
+        raven_set_new, raven_string_byte_at, raven_string_new, raven_struct_fields,
+        raven_struct_new,
+    };
+
+    fn isolated(body: impl FnOnce() + Send + 'static) {
+        std::thread::spawn(body).join().unwrap();
+    }
+
+    extern "C" fn dummy_body() {}
+
+    /// Allocate a String of `cap` bytes and write `cap` distinct marker
+    /// bytes into it so a later read can prove the buffer is intact.
+    fn marked_string(cap: u32, seed: u8) -> *mut crate::object::String {
+        let s = raven_string_new(cap);
+        assert!(!s.is_null());
+        // SAFETY: the string owns `cap` writable bytes.
+        unsafe {
+            let bytes = crate::object::raven_string_bytes(s) as *mut u8;
+            for i in 0..cap as usize {
+                bytes.add(i).write(seed.wrapping_add(i as u8));
+            }
+            (*s).header.len = cap;
+        }
+        s
+    }
+
+    /// Assert a String built by `marked_string(cap, seed)` still holds its
+    /// markers, proving the body survived collections unfreed and intact.
+    fn assert_marked(s: *mut crate::object::String, cap: u32, seed: u8) {
+        assert!(!s.is_null());
+        for i in 0..cap as usize {
+            let got = raven_string_byte_at(s, i);
+            assert_eq!(
+                got as u8,
+                seed.wrapping_add(i as u8),
+                "string byte {i} corrupted after collection"
+            );
+        }
+    }
+
+    /// Churn `n` unrooted strings, forcing a collection every `every`
+    /// allocations so the rooted working set is repeatedly swept around, and
+    /// a final collection so only the rooted set remains. The rooted objects
+    /// are visited by every one of those collections; a regression that
+    /// freed or corrupted a live object would show up on the next read.
+    fn churn(n: usize, every: usize) {
+        for i in 0..n {
+            let _garbage = raven_string_new(16);
+            if every != 0 && i % every == 0 {
+                raven_gc_collect();
+            }
+        }
+        // Sweep away the last batch of unrooted churn strings so a following
+        // live-object count sees exactly the rooted working set.
+        raven_gc_collect();
+    }
+
+    #[test]
+    fn struct_with_string_field_survives_churn() {
+        isolated(|| {
+            // Type 10: slot 0 scalar Int, slot 1 a GC String pointer.
+            raven_struct_register(10, 0b10);
+            let inner = marked_string(8, 0x40);
+            let s = raven_struct_new(2, 10);
+            // SAFETY: two field slots.
+            unsafe {
+                let fields = raven_struct_fields(s) as *mut u64;
+                fields.add(0).write(1234);
+                fields.add(1).write(inner as u64);
+            }
+            let mut slot: *mut u8 = s as *mut u8;
+            let mut roots: [*mut *mut u8; 1] = [&mut slot as *mut *mut u8];
+            raven_gc_enter_frame(roots.as_mut_ptr() as *mut *mut u8, 1);
+            churn(20_000, 256);
+            // SAFETY: the rooted struct and its String field survive.
+            unsafe {
+                let fields = raven_struct_fields(s) as *const u64;
+                assert_eq!(fields.add(0).read(), 1234);
+                assert_eq!(fields.add(1).read(), inner as u64);
+            }
+            assert_marked(inner, 8, 0x40);
+            raven_gc_leave_frame();
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn nested_struct_survives_churn() {
+        isolated(|| {
+            // Outer type 11: slot 0 a GC pointer to an inner struct.
+            // Inner type 12: slot 0 a GC String pointer.
+            raven_struct_register(11, 0b1);
+            raven_struct_register(12, 0b1);
+            let inner_str = marked_string(6, 0x10);
+            let inner = raven_struct_new(1, 12);
+            let outer = raven_struct_new(1, 11);
+            // SAFETY: one field slot each.
+            unsafe {
+                (raven_struct_fields(inner) as *mut u64).write(inner_str as u64);
+                (raven_struct_fields(outer) as *mut u64).write(inner as u64);
+            }
+            let mut slot: *mut u8 = outer as *mut u8;
+            let mut roots: [*mut *mut u8; 1] = [&mut slot as *mut *mut u8];
+            raven_gc_enter_frame(roots.as_mut_ptr() as *mut *mut u8, 1);
+            // Outer + inner struct + inner string are all live transitively.
+            assert_eq!(raven_gc_live_objects(), 3);
+            churn(20_000, 256);
+            assert_eq!(raven_gc_live_objects(), 3);
+            // SAFETY: walk outer -> inner -> string after the churn.
+            unsafe {
+                let inner_again =
+                    (raven_struct_fields(outer) as *const u64).read() as *mut ObjectHeader;
+                assert_eq!(inner_again, inner);
+                let str_again = (raven_struct_fields(inner_again) as *const u64).read()
+                    as *mut crate::object::String;
+                assert_eq!(str_again, inner_str);
+            }
+            assert_marked(inner_str, 6, 0x10);
+            raven_gc_leave_frame();
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn list_of_structs_survives_churn() {
+        isolated(|| {
+            // A List of GC pointers, each a struct whose slot 0 is a String.
+            raven_struct_register(13, 0b1);
+            const N: u32 = 16;
+            let list = raven_list_new(8, 8, 0, 1);
+            for i in 0..N {
+                let str_i = marked_string(4, (i as u8).wrapping_mul(7));
+                let st = raven_struct_new(1, 13);
+                // SAFETY: one field slot.
+                unsafe {
+                    (raven_struct_fields(st) as *mut u64).write(str_i as u64);
+                }
+                let elem = st as u64;
+                raven_list_push(list, &elem as *const u64 as *const u8);
+            }
+            let mut slot: *mut u8 = list as *mut u8;
+            let mut roots: [*mut *mut u8; 1] = [&mut slot as *mut *mut u8];
+            raven_gc_enter_frame(roots.as_mut_ptr() as *mut *mut u8, 1);
+            // list + N structs + N strings.
+            assert_eq!(raven_gc_live_objects() as u32, 1 + 2 * N);
+            churn(20_000, 256);
+            assert_eq!(raven_gc_live_objects() as u32, 1 + 2 * N);
+            // Read each element back through the list and verify its String.
+            // SAFETY: the list holds N pointer slots in its element buffer.
+            unsafe {
+                let elems = (*list).elements as *const *mut u8;
+                for i in 0..N {
+                    let st = elems.add(i as usize).read() as *mut ObjectHeader;
+                    let str_i = (raven_struct_fields(st) as *const u64).read()
+                        as *mut crate::object::String;
+                    assert_marked(str_i, 4, (i as u8).wrapping_mul(7));
+                }
+            }
+            raven_gc_leave_frame();
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn map_entries_survive_churn() {
+        isolated(|| {
+            // A Map with GC String keys and GC String values across several
+            // buckets, rooted while strings churn around it.
+            const N: usize = 6;
+            let map = raven_map_new(16, 1, 1);
+            let mut keys = [std::ptr::null_mut::<crate::object::String>(); N];
+            let mut vals = [std::ptr::null_mut::<crate::object::String>(); N];
+            // SAFETY: write N entries into distinct buckets.
+            unsafe {
+                let buckets = raven_map_buckets(map);
+                for i in 0..N {
+                    let k = marked_string(4, 0x20 + i as u8);
+                    let v = marked_string(4, 0x60 + i as u8);
+                    keys[i] = k;
+                    vals[i] = v;
+                    let e = &mut *buckets.add(i);
+                    e.hash = (i as u64) + 1;
+                    e.key = k as *mut u8;
+                    e.value = v as *mut u8;
+                }
+                (*map).header.len = N as u32;
+            }
+            let mut slot: *mut u8 = map as *mut u8;
+            let mut roots: [*mut *mut u8; 1] = [&mut slot as *mut *mut u8];
+            raven_gc_enter_frame(roots.as_mut_ptr() as *mut *mut u8, 1);
+            // map + N keys + N values.
+            assert_eq!(raven_gc_live_objects(), 1 + 2 * N);
+            churn(20_000, 256);
+            assert_eq!(raven_gc_live_objects(), 1 + 2 * N);
+            for (i, (&k, &v)) in keys.iter().zip(vals.iter()).enumerate() {
+                assert_marked(k, 4, 0x20 + i as u8);
+                assert_marked(v, 4, 0x60 + i as u8);
+            }
+            raven_gc_leave_frame();
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn set_elements_survive_churn() {
+        isolated(|| {
+            const N: usize = 6;
+            let set = raven_set_new(16, 1);
+            let mut elems = [std::ptr::null_mut::<crate::object::String>(); N];
+            // SAFETY: write N elements into distinct buckets.
+            unsafe {
+                let buckets = raven_set_buckets(set);
+                for (i, slot) in elems.iter_mut().enumerate() {
+                    let e_str = marked_string(4, 0x80 + i as u8);
+                    *slot = e_str;
+                    let e = &mut *buckets.add(i);
+                    e.hash = (i as u64) + 1;
+                    e.element = e_str as *mut u8;
+                }
+                (*set).header.len = N as u32;
+            }
+            let mut slot: *mut u8 = set as *mut u8;
+            let mut roots: [*mut *mut u8; 1] = [&mut slot as *mut *mut u8];
+            raven_gc_enter_frame(roots.as_mut_ptr() as *mut *mut u8, 1);
+            assert_eq!(raven_gc_live_objects(), 1 + N);
+            churn(20_000, 256);
+            assert_eq!(raven_gc_live_objects(), 1 + N);
+            for (i, &e) in elems.iter().enumerate() {
+                assert_marked(e, 4, 0x80 + i as u8);
+            }
+            raven_gc_leave_frame();
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn closure_captures_survive_churn() {
+        isolated(|| {
+            // A closure capturing two GC String pointers, invoked-equivalent
+            // by reading the captures back after churn.
+            let cap0 = marked_string(5, 0xA0);
+            let cap1 = marked_string(5, 0xC0);
+            let closure = raven_closure_new(dummy_body as *const u8, 16, 8, 2, 2);
+            // SAFETY: two leading pointer-sized capture slots.
+            unsafe {
+                let caps = raven_closure_captures(closure) as *mut *mut u8;
+                caps.add(0).write(cap0 as *mut u8);
+                caps.add(1).write(cap1 as *mut u8);
+            }
+            let mut slot: *mut u8 = closure as *mut u8;
+            let mut roots: [*mut *mut u8; 1] = [&mut slot as *mut *mut u8];
+            raven_gc_enter_frame(roots.as_mut_ptr() as *mut *mut u8, 1);
+            assert_eq!(raven_gc_live_objects(), 3);
+            churn(20_000, 256);
+            assert_eq!(raven_gc_live_objects(), 3);
+            // SAFETY: read the captures back; both strings must be intact.
+            unsafe {
+                let caps = raven_closure_captures(closure) as *const *mut u8;
+                assert_eq!(caps.add(0).read() as *mut crate::object::String, cap0);
+                assert_eq!(caps.add(1).read() as *mut crate::object::String, cap1);
+            }
+            assert_marked(cap0, 5, 0xA0);
+            assert_marked(cap1, 5, 0xC0);
+            raven_gc_leave_frame();
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn any_box_payload_survives_churn() {
+        isolated(|| {
+            // A Box wrapping the only reference to a heap String, mirroring an
+            // Any-boxed heap value held across reflection.
+            let inner = marked_string(7, 0xE0);
+            let boxed = raven_box_new(8, 8, 1);
+            // SAFETY: the payload holds one GC pointer.
+            unsafe {
+                let payload = raven_box_payload(boxed) as *mut *mut u8;
+                payload.write(inner as *mut u8);
+            }
+            let mut slot: *mut u8 = boxed as *mut u8;
+            let mut roots: [*mut *mut u8; 1] = [&mut slot as *mut *mut u8];
+            raven_gc_enter_frame(roots.as_mut_ptr() as *mut *mut u8, 1);
+            assert_eq!(raven_gc_live_objects(), 2);
+            churn(20_000, 256);
+            assert_eq!(raven_gc_live_objects(), 2);
+            // SAFETY: read the payload back through the box.
+            unsafe {
+                let payload = raven_box_payload(boxed) as *const *mut u8;
+                assert_eq!(payload.read() as *mut crate::object::String, inner);
+            }
+            assert_marked(inner, 7, 0xE0);
+            raven_gc_leave_frame();
+            raven_gc_collect();
+            assert_eq!(raven_gc_live_objects(), 0);
+        });
+    }
+
+    #[test]
+    fn parked_defer_closure_survives_churn() {
+        isolated(|| {
+            // A deferred thunk capturing a GC String, parked across heavy
+            // allocation before it runs.
+            let captured = marked_string(5, 0x33);
+            let closure = raven_closure_new(dummy_body as *const u8, 8, 8, 1, 1);
+            // SAFETY: one capture slot.
+            unsafe {
+                let caps = raven_closure_captures(closure) as *mut *mut u8;
+                caps.write(captured as *mut u8);
+            }
+            raven_defer_enter_frame();
+            raven_defer_push(closure);
+            churn(20_000, 256);
+            // SAFETY: the parked closure's capture survived.
+            unsafe {
+                let caps = raven_closure_captures(closure) as *const *mut u8;
+                assert_eq!(caps.read() as *mut crate::object::String, captured);
+            }
+            assert_marked(captured, 5, 0x33);
+            raven_defer_run_frame();
             raven_gc_collect();
             assert_eq!(raven_gc_live_objects(), 0);
         });

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -696,6 +696,60 @@ mod tests {
         });
     }
 
+    // Like gc_holder_body but it writes distinct marker bytes into its
+    // string and reports them back so main can verify the buffer is intact,
+    // not merely that the header tag survived. env: [ready_chan, go_chan].
+    extern "C" fn gc_marker_body(env: *mut u8) {
+        let p = env as *const i64;
+        let ready = unsafe { *p };
+        let go = unsafe { *p.add(1) };
+        let mut s = crate::object::raven_string_new(8);
+        // SAFETY: write 8 marker bytes 0..8 into the owned buffer.
+        unsafe {
+            let bytes = crate::object::raven_string_bytes(s) as *mut u8;
+            for i in 0..8u8 {
+                bytes.add(i as usize).write(i.wrapping_mul(3));
+            }
+            (*s).header.len = 8;
+        }
+        let mut roots: [*mut *mut u8; 1] = [&mut s as *mut _ as *mut *mut u8];
+        crate::gc::raven_gc_enter_frame(roots.as_mut_ptr() as *mut *mut u8, 1);
+        raven_channel_send(ready, 1);
+        let _ = raven_channel_recv(go);
+        // Sum the marker bytes through the surviving buffer. A freed or
+        // corrupted buffer would not sum to the expected value.
+        let mut sum = 0i64;
+        for i in 0..8usize {
+            sum += crate::object::raven_string_byte_at(s, i) as i64;
+        }
+        crate::gc::raven_gc_leave_frame();
+        raven_channel_send(ready, sum);
+    }
+
+    #[test]
+    fn parked_goroutine_string_survives_heavy_allocation() {
+        isolated(|| {
+            let ready = raven_channel_new_buffered(2);
+            let go = raven_channel_new_buffered(1);
+            spawn_with_env(gc_marker_body, &[ready, go]);
+            assert_eq!(raven_channel_recv(ready), 1);
+            // Allocate heavily and collect repeatedly while the goroutine is
+            // parked. Its string is reachable only through the parked
+            // goroutine's saved root chain.
+            for i in 0..30_000usize {
+                let _garbage = crate::object::raven_string_new(16);
+                if i % 256 == 0 {
+                    crate::gc::raven_gc_collect();
+                }
+            }
+            crate::gc::raven_gc_collect();
+            raven_channel_send(go, 0);
+            // Expected sum of i*3 for i in 0..8 = 3 * (0+1+...+7) = 84.
+            let expected: i64 = (0..8i64).map(|i| (i * 3) & 0xFF).sum();
+            assert_eq!(raven_channel_recv(ready), expected);
+        });
+    }
+
     // Body that blocks forever on an empty channel, never woken.
     extern "C" fn blocker_body(env: *mut u8) {
         let ch = unsafe { *(env as *const i64) };

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -445,6 +445,14 @@ impl ModuleCx {
         sig = self.make_sig(&[], &[]);
         self.declare_runtime(intrinsics::RUNTIME_GC_LEAVE_FRAME, &sig)?;
 
+        // raven_gc_push_root(slot: ptr)
+        sig = self.make_sig(&[ptr], &[]);
+        self.declare_runtime(intrinsics::RUNTIME_GC_PUSH_ROOT, &sig)?;
+
+        // raven_gc_pop_roots(n: usize)
+        sig = self.make_sig(&[ptr], &[]);
+        self.declare_runtime(intrinsics::RUNTIME_GC_POP_ROOTS, &sig)?;
+
         // raven_defer_enter_frame()
         sig = self.make_sig(&[], &[]);
         self.declare_runtime(intrinsics::RUNTIME_DEFER_ENTER_FRAME, &sig)?;

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -765,10 +765,18 @@ fn lower_any_get_field(
     let inst = builder.ins().call(fref, &[a, n]);
     let field_any = builder.inst_results(inst)[0]; // Any ptr or null
 
+    // Root the freshly built field Any across the Option allocation below:
+    // `call_struct_new` can trigger a collection, and the only reference to
+    // this new Any is the unrooted register here, so it would be freed
+    // before it is stored into the Option. A null (the None case) roots
+    // harmlessly.
+    let field_root = push_temp_root(cx, builder, field_any, ptr);
+
     // Wrap into Option<Any>: the payload slot holds a GC pointer.
     let mask = layout::enum_pointer_mask(std::slice::from_ref(&MirType::Any));
     let opt_type_id = cx.merge_descriptor(&option_ty.mangle(), mask);
     let obj = call_struct_new(cx, builder, 2, opt_type_id, ptr);
+    let field_any = pop_temp_root(cx, builder, field_root, ptr);
     let base = call_struct_fields(cx, builder, obj, ptr);
 
     let is_some = builder.ins().icmp_imm(IntCC::NotEqual, field_any, 0);
@@ -1082,22 +1090,25 @@ fn lower_struct_create(
     // idempotent.
     let type_id = cx.merge_descriptor(&ty.mangle(), mask);
 
-    // Evaluate field operands before the allocation so their values are
-    // in registers; the allocation may collect, but the operands here are
-    // either constants or reads of already-rooted locals.
-    let mut field_vals = Vec::with_capacity(fields.len());
-    for f in fields {
-        let v = lower_operand(cx, builder, f, slots)?;
-        field_vals.push(widen_to_slot(builder, v, ptr));
-    }
-
+    // Allocate the struct first and root it for the duration of field
+    // evaluation. A field operand can itself allocate (a String-literal or
+    // interpolated field promotes to a heap String), which can trigger a
+    // collection; the partially built struct and the fields already stored
+    // must stay reachable across it. Each field value is unrooted only
+    // between its production and its immediate store into the rooted struct,
+    // with no allocation in between.
     let obj = call_struct_new(cx, builder, fields.len() as i64, type_id, ptr);
-    let base = call_struct_fields(cx, builder, obj, ptr);
-    for (i, v) in field_vals.into_iter().enumerate() {
+    let root = push_temp_root(cx, builder, obj, ptr);
+    for (i, f) in fields.iter().enumerate() {
+        let v = lower_operand(cx, builder, f, slots)?;
+        let v = widen_to_slot(builder, v, ptr);
+        let obj = builder.ins().stack_load(ptr, root, 0);
+        let base = call_struct_fields(cx, builder, obj, ptr);
         builder
             .ins()
             .store(MemFlags::new(), v, base, layout::slot_offset(i));
     }
+    let obj = pop_temp_root(cx, builder, root, ptr);
     Ok(Some(obj))
 }
 
@@ -1123,26 +1134,30 @@ fn lower_enum_create(
     let key = ty.mangle();
     let type_id = cx.merge_descriptor(&key, mask);
 
-    let mut payload_vals = Vec::with_capacity(payload.len());
-    for p in payload {
-        let v = lower_operand(cx, builder, p, slots)?;
-        payload_vals.push(widen_to_slot(builder, v, ptr));
-    }
-
+    // Allocate the enum value first and root it while the payload is
+    // evaluated, for the same reason struct creation does: a payload
+    // operand can allocate and trigger a collection, and the partially
+    // built value must stay reachable across it.
     let field_count = 1 + payload.len() as i64;
     let obj = call_struct_new(cx, builder, field_count, type_id, ptr);
-    let base = call_struct_fields(cx, builder, obj, ptr);
+    let root = push_temp_root(cx, builder, obj, ptr);
     // Slot 0: the discriminant.
+    let base = call_struct_fields(cx, builder, obj, ptr);
     let disc = builder.ins().iconst(ptr, variant as i64);
     builder
         .ins()
         .store(MemFlags::new(), disc, base, layout::slot_offset(0));
     // Slots 1..: the payload.
-    for (i, v) in payload_vals.into_iter().enumerate() {
+    for (i, p) in payload.iter().enumerate() {
+        let v = lower_operand(cx, builder, p, slots)?;
+        let v = widen_to_slot(builder, v, ptr);
+        let obj = builder.ins().stack_load(ptr, root, 0);
+        let base = call_struct_fields(cx, builder, obj, ptr);
         builder
             .ins()
             .store(MemFlags::new(), v, base, layout::slot_offset(i + 1));
     }
+    let obj = pop_temp_root(cx, builder, root, ptr);
     Ok(Some(obj))
 }
 
@@ -1165,6 +1180,46 @@ fn lower_field_access(
         .ins()
         .load(ptr, MemFlags::new(), fields, layout::slot_offset(index));
     Ok(Some(raw))
+}
+
+/// Spill a freshly allocated heap object into a one-pointer stack slot and
+/// register that slot as a single GC root, keeping the object (and any GC
+/// pointers later stored into it) reachable across further allocations that
+/// run while the object is still being filled. Returns the slot so the
+/// caller can reload the rooted pointer; pair with `pop_temp_root`.
+fn push_temp_root(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    obj: Value,
+    ptr: CType,
+) -> StackSlot {
+    let slot = builder
+        .create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, ptr.bytes()));
+    builder.ins().stack_store(obj, slot, 0);
+    let slot_addr = builder.ins().stack_addr(ptr, slot, 0);
+    let push_id = cx
+        .runtime_id(intrinsics::RUNTIME_GC_PUSH_ROOT)
+        .expect("gc push root declared at module init");
+    let push_ref = cx.module().declare_func_in_func(push_id, builder.func);
+    builder.ins().call(push_ref, &[slot_addr]);
+    slot
+}
+
+/// Pop the single root `push_temp_root` registered and reload the rooted
+/// pointer from its slot (the authoritative value the collector observed).
+fn pop_temp_root(
+    cx: &mut ModuleCx,
+    builder: &mut FunctionBuilder<'_>,
+    slot: StackSlot,
+    ptr: CType,
+) -> Value {
+    let pop_id = cx
+        .runtime_id(intrinsics::RUNTIME_GC_POP_ROOTS)
+        .expect("gc pop roots declared at module init");
+    let pop_ref = cx.module().declare_func_in_func(pop_id, builder.func);
+    let one = builder.ins().iconst(ptr, 1);
+    builder.ins().call(pop_ref, &[one]);
+    builder.ins().stack_load(ptr, slot, 0)
 }
 
 /// Width in bytes of one `List` element slot. Every element, scalar or GC
@@ -1203,18 +1258,17 @@ fn lower_array_lit(
     };
     let gc_ptrs = layout::is_gc_pointer(elem_ty);
 
-    // Evaluate every element before the allocation so their values are in
-    // registers; each operand is a copy of an already-rooted local or a
-    // constant. The list is built right after, and each push copies the
-    // spilled value in, so no element pointer is left dangling across a
-    // collection the allocation may trigger.
-    let mut elem_vals = Vec::with_capacity(elements.len());
-    for e in elements {
-        let v = lower_operand(cx, builder, e, slots)?;
-        elem_vals.push(widen_to_slot(builder, v, ptr));
-    }
-
+    // Allocate the empty list first and root it through a single shadow
+    // stack slot for the whole build. Evaluating a later element can
+    // allocate (a String-literal element promotes to a heap String, and an
+    // interpolated element allocates), which can trigger a collection; the
+    // list and the elements already pushed into it must stay reachable
+    // across that collection. Rooting the list keeps its pushed elements
+    // alive transitively. Each element value is unrooted only between its
+    // own production and its immediate push, with no allocation in between,
+    // so it is never live across a collection on its own.
     let list = call_list_new(cx, builder, elements.len() as i64, gc_ptrs);
+    let root = push_temp_root(cx, builder, list, ptr);
 
     // One reusable scratch slot the size of a single element; each push
     // writes the next value into it and passes its address.
@@ -1226,11 +1280,18 @@ fn lower_array_lit(
     let push_id = cx
         .runtime_id(intrinsics::RUNTIME_LIST_PUSH)
         .expect("list push declared at module init");
-    for v in elem_vals {
+    for e in elements {
+        let v = lower_operand(cx, builder, e, slots)?;
+        let v = widen_to_slot(builder, v, ptr);
         builder.ins().stack_store(v, scratch, 0);
+        // Reload the rooted list so the push targets the authoritative
+        // pointer the collector observes through the slot.
+        let list = builder.ins().stack_load(ptr, root, 0);
         let push_ref = cx.module().declare_func_in_func(push_id, builder.func);
         builder.ins().call(push_ref, &[list, scratch_addr]);
     }
+
+    let list = pop_temp_root(cx, builder, root, ptr);
     Ok(Some(list))
 }
 

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -135,6 +135,14 @@ pub const RUNTIME_GC_ENTER_FRAME: &str = "raven_gc_enter_frame";
 /// Runtime C symbol leaving the most recent GC root frame.
 pub const RUNTIME_GC_LEAVE_FRAME: &str = "raven_gc_leave_frame";
 
+/// Runtime C symbol registering a single root slot. Used to keep a heap
+/// temporary that an rvalue builds across further allocations reachable
+/// before it is stored into its rooted destination local.
+pub const RUNTIME_GC_PUSH_ROOT: &str = "raven_gc_push_root";
+
+/// Runtime C symbol popping the last `n` single root slots.
+pub const RUNTIME_GC_POP_ROOTS: &str = "raven_gc_pop_roots";
+
 /// Runtime C symbol opening a per-call defer frame.
 pub const RUNTIME_DEFER_ENTER_FRAME: &str = "raven_defer_enter_frame";
 

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -789,11 +789,25 @@ fn lower_string_eq(
 /// An empty interpolation, or one with no parts, still yields a valid
 /// (empty) `String`.
 fn lower_interpolate(cx: &mut LowerCx<'_>, parts: &[InterpolPart], ty: MirType) -> MirOperand {
-    // Build the per-part String operands first.
+    // Build the per-part String operands first. Each part is bound to a
+    // temp local so it lives in a GC-rooted slot: the fold calls
+    // `raven_string_concat`, which allocates internally and can trigger a
+    // collection, and an unrooted literal-text part (a bare `Const::Str`
+    // codegen promotes to a heap String at the call site) would be freed
+    // mid-concat. Binding every part, text and expression alike, keeps it
+    // reachable across the concat chain.
     let mut operands: Vec<MirOperand> = Vec::with_capacity(parts.len());
     for p in parts {
         match p {
-            InterpolPart::Text(s) => operands.push(MirOperand::Const(MirConstant::Str(s.clone()))),
+            InterpolPart::Text(s) => {
+                let dst = cx.builder.fresh_temp("interp_text", MirType::Str);
+                cx.builder.assign(
+                    cx.current,
+                    dst,
+                    MirRvalue::Use(MirOperand::Const(MirConstant::Str(s.clone()))),
+                );
+                operands.push(MirOperand::Copy(dst));
+            }
             InterpolPart::Expr(e) => operands.push(stringify_part(cx, e)),
         }
     }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1245,6 +1245,44 @@ fn process_program_compiles_and_runs() {
     );
 }
 
+#[test]
+fn gc_stress_survives_repeated_collections() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // The GC stress program holds a live root of every heap object kind
+    // (struct with a String field, nested struct, list of strings, hash Map
+    // and Set, a closure capturing a heap-derived value, an Any-boxed heap
+    // value read back through reflection, a defer-captured value, and a
+    // goroutine that parks heap state on a channel) across heavy allocation,
+    // then reads each back. Driven under a very low RAVEN_GC_THRESHOLD so a
+    // collection fires every few allocations, and run many times: the bug
+    // class this guards against (a live object freed mid-collection) was
+    // nondeterministic, so a single pass could pass by luck.
+    let example = build_example_binary("gc_stress.rv", &runtime);
+    let expected = "struct 7 ada\nnested 99 deep\nlist 0 a\nlist 2 c\nmap x\nset 2\n\
+                    closure 142\nany 7 ada\ndefer 55\ngo 8\n";
+    // A tight threshold (256 bytes) forces a collection after only a handful
+    // of allocations, so every run exercises the frame-based root paths hard.
+    for run in 0..12 {
+        let output = Command::new(&example.binary)
+            .env("RAVEN_GC_THRESHOLD", "256")
+            .output()
+            .expect("run gc_stress binary");
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        if !output.status.success() || stdout != expected {
+            cleanup(&example.tmp);
+            panic!(
+                "gc_stress run {run} diverged under collection pressure: \
+                 status={:?}\n  expected: {expected:?}\n  actual:   {stdout:?}\n  stderr: {stderr}",
+                output.status
+            );
+        }
+    }
+    cleanup(&example.tmp);
+}
+
 /// A compiled example binary plus the temp dir holding it, so the caller
 /// can run the binary and then clean up.
 struct ExampleBinary {


### PR DESCRIPTION
Adds GC stress coverage that exercises real frame-based collections across every heap object kind and fixes the latent rooting bugs that coverage uncovered.

Closes #245

## Threshold override

The collector reads `RAVEN_GC_THRESHOLD` (a positive byte count) once at startup and uses it as the collection floor, so a collection fires after only a handful of allocations. An unset, empty, zero, or unparseable value leaves the `1 MiB` default unchanged. The override changes only collection pacing, never output, so a program prints the same result at any threshold. It makes the stress runs fast and deterministic.

## Object kinds covered

Held as a live root across heavy allocation that forces repeated collections, then read back and asserted intact:

- Struct with a String field (field-mask path) and a nested struct (struct whose field is a struct with a String).
- `List<T>` and a list of structs, elements read back after collections.
- Hash-backed `Map<K,V>` and `Set<T>`, lookups correct after collections.
- Closures capturing heap values, read back after collections.
- `Any`-boxed heap values (reflection) read back after collections.
- Goroutine-parked roots: a goroutine holds heap state and blocks on a channel while the main goroutine allocates heavily, then unblocks and verifies its value survived (scheduler parked-root scan).
- Interpolation and `to_string` temporaries and a `defer`-captured value across collections.

Coverage lands as per-kind runtime unit tests in `raven-runtime` (build each kind, root it through the frame API, churn thousands of real allocations, assert the transitive payload survives intact) and as `examples/v2/gc_stress.rv`, driven by the `gc_stress_survives_repeated_collections` smoke test that runs the compiled binary many times under a low threshold. Because a freed-live-object bug is nondeterministic, repeating the run is what makes the test reliable.

## GC bugs found and fixed

The stress suite surfaced a class of rooting gaps where a heap value an rvalue builds is left unrooted across a later allocation in the same expression, so a collection frees it before it is stored. Each was reproduced deterministically at a low threshold and fixed by rooting the in-flight value through a single shadow-stack slot (`raven_gc_push_root`/`raven_gc_pop_roots`) across the allocation:

1. **Aggregate construction** (struct, enum, list literal). Root cause: fields/elements were evaluated into registers, then the aggregate body was allocated, freeing an unrooted String-literal or interpolated field. Fix: allocate the body first, root it, then evaluate and store each field/element.
2. **String interpolation.** Root cause: a literal-text part was a bare promoted heap String passed to `raven_string_concat`, which allocates internally and freed the unrooted part mid-concat. Fix: bind every part, text included, to a rooted temp before the fold.
3. **Reflection `get_field`.** Root cause: the freshly boxed field `Any` was held unrooted across the `Option<Any>` wrapper allocation, so it was freed before being stored, leaving a dangling box that later failed `cast<T>`. Fix: root the new `Any` across the wrapper allocation.

## Determinism over many runs

`examples/v2/gc_stress.rv` produces identical correct output across 150+ runs at thresholds 1, 8, 16, 32, 64, 128, 256, 4096, and the default, with no garbage and no aborts. Each isolated repro was confirmed fixed over 100 to 200 runs at threshold 8 (where it previously failed nondeterministically). The smoke test repeats 12 runs at threshold 256.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (467 lib + 65 smoke + golden + runtime gc/sched, all green)
- [x] `cargo test --test golden`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] New runtime gc unit tests for every object kind, plus a parked-goroutine stress test.
- [x] `gc_stress.rv` deterministic over many runs at low and default thresholds.
