### PR TITLE
docs(v2): bring the guide up to date with shipped features

### DIFF
--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -200,8 +200,11 @@ for v in xs {
 ## defer
 
 `defer` schedules an expression to run when the enclosing function
-returns. Deferred expressions run in reverse order of registration
-(last in, first out), and only those actually reached at runtime run.
+returns. This is function-scoped, like Go's `defer`, not block-scoped: a
+`defer` written inside a nested block, an `if`, or a loop still runs at
+the function's return, not when the inner block exits. Deferred
+expressions run in reverse order of registration (last in, first out),
+and only those actually reached at runtime run.
 
 ```raven
 fun demo() -> Int {
@@ -211,6 +214,27 @@ fun demo() -> Int {
 }
 // prints 2 then 1
 ```
+
+Because a defer is function-scoped, the order across nested blocks is the
+same LIFO order, measured by when each `defer` statement ran:
+
+```raven
+fun f() -> Int {
+    print(1)
+    if true {
+        defer print(2)
+        print(3)
+    }
+    print(4)
+    return 0
+}
+// prints 1 3 4 2: the nested defer fires at f's return, after 4
+```
+
+On `return e` the return value is computed first, then the deferred
+thunks run, then the function returns. A deferred expression runs for its
+side effects and cannot change the return value. Defers do not run on a
+`panic`, which aborts the process without unwinding.
 
 ## Structs
 
@@ -291,6 +315,11 @@ fun main() {
 }
 ```
 
+You construct a variant only through the qualified form. A bare `Green` or
+`Circle(2.0)` in expression position is not a constructor yet; it is read
+as a name and fails to resolve. The bare names appear only as match
+patterns.
+
 ## match
 
 `match` tests a value against patterns top to bottom and yields the
@@ -307,6 +336,42 @@ fun classify(n: Int) -> String {
     }
 }
 ```
+
+## List, set, and map literals
+
+A list literal is comma-separated values in brackets, `[1, 2, 3]`, and an
+empty list is `[]`. Lists are built in: they index, grow with `push`, and
+report `len()`.
+
+A set literal is comma-separated values in braces, `{1, 2, 3}`. A map
+literal is comma-separated `key: value` pairs in brackets, `["a": 1,
+"b": 2]`. Both come from `std/collections`, so the literals need
+`import std/collections` in scope (see the [standard library](standard-library.md#stdcollections)).
+
+```raven
+import std/collections
+
+fun main() {
+    let s = {1, 2, 2, 3}        // Set<Int>, dedups to {1, 2, 3}
+    let m = ["a": 1, "b": 2]    // Map<String, Int>
+    print(s.len())              // 3
+    print(m.len())              // 2
+}
+```
+
+The brace and bracket forms overlap with blocks and lists, so a few rules
+disambiguate them:
+
+- A set literal needs at least one comma, so a single-element set is
+  written with a trailing comma, `{x,}`. A bare `{ x }` is a block whose
+  tail expression is `x`, and `{}` is an empty block. An empty set is
+  `Set.new()`.
+- The empty map is the distinct `[:]` form, since a bare `[]` is an empty
+  list. A bracket whose first element has a top-level `:` is a map; one
+  without is a list.
+
+A set's element type and a map's key type must implement `Eq + Hash`,
+the same bound the collection types carry.
 
 ## Traits and impl
 
@@ -403,6 +468,60 @@ Use generics with a bound when the concrete type is known at the call
 site (no indirection), and `dyn Trait` when you need a single type that
 holds different implementers.
 
+## Concurrency
+
+`spawn` starts a goroutine: a lightweight green thread that runs a
+`fun() -> Unit` closure. Goroutines run on a cooperative scheduler. The
+program multiplexes many of them onto one OS thread, and exactly one runs
+at a time. A goroutine runs until it reaches a yield point, then the
+scheduler resumes another ready goroutine.
+
+```raven
+spawn(fun() -> Unit {
+    // goroutine body
+})
+```
+
+Goroutines communicate over channels from `std/sync`. `channel()` makes
+an unbuffered (rendezvous) channel, and `channel_buffered(cap)` makes a
+buffered one. `ch.send(v)` sends a value and `ch.recv()` receives one.
+A send on a full channel and a recv on an empty one block the goroutine,
+yielding to the scheduler until the counterpart operation runs.
+`yield_now()` yields explicitly. Channels carry `Int` values in this
+release.
+
+```raven
+import std/sync { channel }
+
+fun main() {
+    let ch = channel()
+    spawn(fun() -> Unit {
+        let i = 1
+        while i <= 5 {
+            ch.send(i)
+            i = i + 1
+        }
+    })
+    let sum = 0
+    let n = 0
+    while n < 5 {
+        sum = sum + ch.recv()
+        n = n + 1
+    }
+    print(sum)              // 15
+}
+```
+
+When `main` returns the program exits, and any goroutines still alive are
+abandoned. If every goroutine is blocked with none ready, the scheduler
+reports a deadlock and exits.
+
+The model is cooperative on a single OS thread in this release: there is
+no preemption and no multicore parallelism. A goroutine that blocks in a
+runtime IO call (a net read, a file read, an http request) stalls the
+whole scheduler, since those calls are synchronous. True multicore
+parallelism, `select`, and non-blocking IO are future work.
+
 ## Modules and imports
 
 `import` brings in a module. Standard library modules use the `std/...`
@@ -457,11 +576,308 @@ C types map to C as follows:
 | `CStr`  | `const char *` | pointer width |
 | `CFloat` | `float`       | 32-bit |
 | `CDouble` | `double`     | 64-bit |
+| `CPtr<T>` | `T *`        | pointer width |
+| `CFnPtr` | function pointer | pointer width |
 
 A native `Int` is accepted where an integer C type is expected, and a
 `c"..."` literal where a `CStr` is expected. A native `Float` is accepted
 where a `CFloat` or `CDouble` is expected; for `CFloat` the value is
 narrowed to f32 at the call and a `CFloat` return is widened back to a
-`Float`. To pass a runtime `String`
-to C, convert it with [`std/ffi`](standard-library.md#stdffi)'s
-`to_cstr`; a native `String` is not itself a valid `const char *`.
+`Float`. The integer and float C return types satisfy `ToString`, so a
+`CInt` or `CDouble` result prints and interpolates directly.
+
+```raven
+extern "C" {
+    fun sqrtf(x: CFloat) -> CFloat
+}
+
+fun main() {
+    print(sqrtf(16.0))           // 4
+}
+```
+
+### Strings across the boundary
+
+To pass a runtime `String` to C, convert it with
+[`std/ffi`](standard-library.md#stdffi)'s `to_cstr`; a native `String` is
+not itself a valid `const char *`. `from_cstr` reads a `CStr` back into a
+`String`. `to_cstr` copies into a buffer outside the GC and does not free
+it, so it leaks one buffer per call; hoist the conversion out of a hot
+loop.
+
+```raven
+import std/ffi { to_cstr, from_cstr }
+
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+}
+
+fun main() {
+    print(strlen(to_cstr("hello")))          // 5
+    print(from_cstr(to_cstr("roundtrip")))   // roundtrip
+}
+```
+
+### Raw pointers
+
+`CPtr<T>` is a usable raw pointer. `std/ffi` reads and writes C memory
+through it: `alloc<T>(count)` reserves a buffer, `free<T>(p)` releases it,
+`load<T>(p)` and `store<T>(p, v)` read and write the element at `p`,
+`offset<T>(p, i)` advances by `i` elements (scaled by `sizeof(T)`),
+`null_ptr<T>()` is the null pointer, and `is_null<T>(p)` tests it.
+
+```raven
+import std/ffi { alloc, free, load, store, offset, is_null, null_ptr }
+
+fun main() {
+    let buf = alloc<CInt>(4)
+    store<CInt>(buf, 10)
+    store<CInt>(offset<CInt>(buf, 1), 20)
+    print(load<CInt>(buf))                   // 10
+    print(load<CInt>(offset<CInt>(buf, 1)))  // 20
+    print(is_null<CInt>(null_ptr<CInt>()))   // true
+    free<CInt>(buf)
+}
+```
+
+This memory lives outside the garbage collector. It is never traced or
+reclaimed automatically, so the caller owns it and must `free` it. There
+are no bounds, null, or use-after-free checks: an out-of-range `offset`
+or a `load` through a freed pointer is undefined behavior, exactly as in
+C. `T` must be a C scalar (`CInt`, `CLong`, `CSize`, `CFloat`, `CDouble`,
+`CStr`) or a native `Int`/`Float`.
+
+### Callbacks
+
+`CFnPtr` is an untyped C function pointer. A C function that takes a
+callback can call back into Raven through one. Pass a non-capturing
+top-level function by naming it bare. Its parameters and return must all
+be C-FFI types so the C ABI is well defined. A capturing closure (a local
+of function type) is rejected, since C cannot supply its capture
+environment.
+
+```raven
+import std/ffi { alloc, free, load, store, offset }
+
+extern "C" {
+    fun raven_ffi_qsort_i32(p: CPtr<CInt>, n: CSize, cmp: CFnPtr)
+}
+
+fun compare(a: CPtr<CInt>, b: CPtr<CInt>) -> CInt {
+    return load<CInt>(a) - load<CInt>(b)
+}
+
+fun main() {
+    let buf = alloc<CInt>(3)
+    store<CInt>(buf, 30)
+    store<CInt>(offset<CInt>(buf, 1), 10)
+    store<CInt>(offset<CInt>(buf, 2), 20)
+    raven_ffi_qsort_i32(buf, 3, compare)
+    print(load<CInt>(buf))                   // 10
+    free<CInt>(buf)
+}
+```
+
+`CFnPtr` is untyped: the type checker does not verify the function's
+signature against what the C side expects. Matching it is your
+responsibility, as in C.
+
+### Small structs by value
+
+A small C struct can cross the boundary by value. Mark the matching Raven
+struct `@repr(C)` to give it C memory layout. The supported shape is a
+struct whose fields are all integer-class C scalars (`CInt`, `CLong`,
+`CSize`, `CStr`, `CPtr<T>`, or `CFnPtr`) and whose total size is at most
+8 bytes (one machine register). A larger struct, or one with a float
+field, is rejected; pass a `CPtr<...>` to it instead.
+
+```raven
+@repr(C)
+struct Point {
+    x: CInt
+    y: CInt
+}
+
+extern "C" {
+    fun raven_ffi_point_sum(p: Point) -> CInt
+    fun raven_ffi_translate(p: Point, dx: CInt, dy: CInt) -> Point
+}
+
+fun main() {
+    let p = Point { x: 3, y: 4 }
+    print(raven_ffi_point_sum(p))            // 7
+    let q = raven_ffi_translate(p, 1, 2)     // {4, 6}
+    print(q.x)                               // 4
+    print(q.y)                               // 6
+}
+```
+
+The fields stay readable on the Raven side (`q.x`); only the call
+boundary marshals the struct by value.
+
+## Metaprogramming
+
+Raven has three metaprogramming tools: `@derive` to synthesize trait
+impls, declarative macros to rewrite call sites, and reflection to read
+type information.
+
+### @derive
+
+`@derive(...)` sits on its own line before a `struct` or `enum` and
+synthesizes trait impls from the type definition, so you do not hand write
+`equals`, `hash`, `to_string`, or `debug`. The derivable traits are `Eq`,
+`Hash`, `ToString`, `Debug`, `ToJson`, and `FromJson`. A field or payload
+type must itself implement the trait being derived.
+
+```raven
+import std/collections { Map, Set }
+
+@derive(Eq, Hash, ToString, Debug)
+struct Point { x: Int, y: Int }
+
+fun main() {
+    let p = Point { x: 1, y: 2 }
+    let q = Point { x: 1, y: 2 }
+    print(p.equals(q))          // true
+    print(p.to_string())        // Point { x: 1, y: 2 }
+
+    // Derived Eq + Hash let the struct key a Map or join a Set.
+    let m: Map<Point, Int> = Map.new()
+    m.set(p, 100)
+    print(m.has(q))             // true
+    let s: Set<Point> = Set.new()
+    s.add(p)
+    print(s.contains(q))        // true
+}
+```
+
+`@derive(ToJson, FromJson)` adds JSON serialization built on `std/json`.
+`to_json` produces a `JsonValue`, and `from_json` is an associated
+function that decodes one back, returning a `Result`. Combine `to_json`
+with `stringify`, and `parse` with `from_json`, for a round trip.
+
+```raven
+import std/json { JsonValue, stringify, parse }
+
+@derive(ToJson, FromJson, Eq)
+struct User { id: Int, name: String }
+
+fun main() {
+    let u = User { id: 7, name: "ada" }
+    let text = stringify(u.to_json())
+    print(text)                          // {"id":7,"name":"ada"} (key order is the map layout)
+    match parse(text) {
+        Ok(v) -> {
+            match User.from_json(v) {
+                Ok(u2) -> print(u.equals(u2)),   // true
+                Err(e) -> print("decode error"),
+            }
+        },
+        Err(e) -> print("parse error"),
+    }
+}
+```
+
+Object key order follows the map hash-bucket layout, not source order.
+Enum variants with named-field payloads are not derivable yet; unit and
+tuple variants are. `Ord` is not derivable yet.
+
+### Declarative macros
+
+A `macro` definition lists one or more rules, each a token matcher and a
+template, and a `name!(...)` call is rewritten by matching the argument
+tokens against the first matching rule and splicing the captures into the
+template. Macros expand before parsing, in expression position.
+
+A matcher binds metavariables: `$x:expr` captures a balanced expression
+and `$x:ident` captures one identifier. The template splices `$x` back in.
+Wrap each splice in parentheses where precedence matters.
+
+```raven
+macro twice { ($x:expr) => { ($x) + ($x) } }
+
+fun main() {
+    let n = 3
+    print(twice!(n + 1))        // 8
+}
+```
+
+A repetition group `$(...)*` (zero or more) or `$(...)+` (one or more)
+matches a sub-pattern several times, with an optional separator between
+the closing `)` and the marker. In the template it expands once per
+capture.
+
+```raven
+macro sum_all { ($($x:expr),*) => { (0 $(+ ($x))*) } }
+
+fun main() {
+    print(sum_all!(1, 2, 3))    // 6
+    print(sum_all!())           // 0
+    print(sum_all!(10))         // 10
+}
+```
+
+A name a template introduces at a `let`, `const`, or `for` binding is
+renamed to a fresh name, so a template temporary cannot collide with or
+capture a caller's variable of the same spelling.
+
+### Reflection
+
+Compile-time reflection reads type information resolved while the program
+compiles. `type_name<T>()` returns the rendered name of a type, and
+`field_names<T>()` returns a struct's field names in declaration order.
+Inside a generic function each resolves to the concrete type bound to `T`
+at that instantiation.
+
+```raven
+struct Point { x: Int, y: Int }
+
+fun introspect<T>() {
+    print("type ${type_name<T>()}")
+    for f in field_names<T>() {
+        print("field ${f}")
+    }
+}
+
+fun main() {
+    print(type_name<Int>())     // Int
+    introspect<Point>()         // type Point, field x, field y
+}
+```
+
+Runtime reflection works over a value whose type is not known statically.
+`to_any<T>(v)` boxes a value into an `Any`. Over an `Any`,
+`type_name_of(a)` reads its runtime type name, `field_names_of(a)` lists
+its struct fields, `get_field(a, name)` reads one field back as an
+`Option<Any>`, and `cast<T>(a)` recovers a concrete value as an
+`Option<T>` (`None` for the wrong `T`).
+
+```raven
+struct User { id: Int, name: String }
+
+fun describe(a: Any) {
+    print("type: ${type_name_of(a)}")
+    for f in field_names_of(a) {
+        match get_field(a, f) {
+            Some(v) -> {
+                match cast<Int>(v) {
+                    Some(n) -> print("field ${f} = ${n}"),
+                    None -> {
+                        match cast<String>(v) {
+                            Some(s) -> print("field ${f} = ${s}"),
+                            None -> print("field ${f} = ?"),
+                        }
+                    },
+                }
+            },
+            None -> print("field ${f}: missing"),
+        }
+    }
+}
+
+fun main() {
+    let u = User { id: 7, name: "ada" }
+    describe(to_any<User>(u))
+    // type: User, field id = 7, field name = ada
+}
+```

--- a/docs/v2/guide/standard-library.md
+++ b/docs/v2/guide/standard-library.md
@@ -63,24 +63,54 @@ fun main() {
 ## std/collections
 
 Generic hash-backed `Set<T: Eq + Hash>` and `Map<K: Eq + Hash, V>`, built
-with `Set.new()` and `Map.new()`. Operations are O(1) average. Import the
-whole module. Keys must implement `Eq + Hash` (`Int`, `Bool`, `String`, or
-a user type with both impls; `Char` and `Float` are not yet hashable).
+with `Set.new()` and `Map.new()`. Storage is a hash-bucket layout, so
+lookup, insert, and remove are O(1) average. Import the whole module. Keys
+must implement `Eq + Hash` (`Int`, `Bool`, `String`, or a user type with
+both impls; `Char` and `Float` are not yet hashable).
 
 - `Set`: `add`, `remove`, `contains`, `len`, `is_empty`.
 - `Map`: `set(k, v)`, `get(k) -> Option<V>`, `has(k)`, `remove(k)`,
   `keys()`, `values()`, `len`, `is_empty`.
 
+Set and map literals build these types: `{1, 2, 3}` is a set, `["a": 1]`
+is a map, and `[:]` is an empty map. See the [language reference](language-reference.md#list-set-and-map-literals)
+for the literal grammar.
+
 ```raven
 import std/collections
 
 fun main() {
-    let m = Map.new()
-    m.set("a", 10)
+    let m = ["a": 10, "b": 20]
     match m.get("a") {
-        Some(v) -> print(v),
+        Some(v) -> print(v),            // 10
         None -> print(0),
     }
+    let s = {1, 2, 3}
+    print(s.contains(2))                // true
+}
+```
+
+## std/sync
+
+Goroutine-style concurrency: channels and the scheduler helpers used with
+the `spawn` keyword (see the [language reference](language-reference.md#concurrency)).
+Channels carry `Int` values in this release.
+
+- `channel() -> Channel`: an unbuffered (rendezvous) channel.
+- `channel_buffered(cap) -> Channel`: a buffered channel of capacity `cap`.
+- `Channel`: `send(v)` and `recv() -> Int`, each blocking by yielding to
+  the scheduler when the channel is full or empty.
+- `yield_now()`: yield control to the scheduler.
+
+```raven
+import std/sync { channel }
+
+fun main() {
+    let ch = channel()
+    spawn(fun() -> Unit {
+        ch.send(42)
+    })
+    print(ch.recv())                    // 42
 }
 ```
 
@@ -363,9 +393,15 @@ fun main() {
 
 ## std/ffi
 
-Bridge runtime `String` values to C strings for FFI calls.
+Bridge runtime values to C and access raw memory for FFI calls. See the
+[FFI section](language-reference.md#ffi-and-c-types) of the language
+reference for the full picture.
 
-- `to_cstr(s) -> CStr`, `from_cstr(p) -> String`.
+- Strings: `to_cstr(s) -> CStr`, `from_cstr(p) -> String`.
+- Raw pointers over `CPtr<T>`: `alloc<T>(count)`, `free<T>(p)`,
+  `load<T>(p)`, `store<T>(p, v)`, `offset<T>(p, i)`, `is_null<T>(p)`,
+  `null_ptr<T>()`. This memory lives outside the GC, so you must `free`
+  it.
 
 ```raven
 import std/ffi { to_cstr, from_cstr }


### PR DESCRIPTION
Bring the v2 user-facing guide up to date with features that shipped after the docs were first written.

## Sections added

- **Concurrency** (`spawn`, the cooperative scheduler, `std/sync` channels, `send`/`recv`/`yield_now`, deadlock, and the single-thread-this-release note).
- **Metaprogramming**: `@derive` (Eq, Hash, ToString, Debug, ToJson, FromJson) with a Map-key and JSON round-trip example, declarative macros (metavariables, repetition, hygiene), and compile-time plus runtime reflection.
- **List, set, and map literals**: `{1, 2, 3}`, `["a": 1]`, `[:]`, the block versus set and list versus map disambiguation, and the `Eq + Hash` bound.
- **Enum construction**: clarified that variants construct only through the qualified `EnumName.Variant` form and bare-name construction is not supported yet.
- **Expanded FFI**: `CPtr<T>` raw pointers (`alloc`/`free`/`load`/`store`/`offset`/`is_null`/`null_ptr`, non-GC manual memory), `CFnPtr` callbacks, and small `@repr(C)` structs by value, plus `CFloat`/`CDouble`.

## Stale sections fixed

- **defer** is now documented as function-scoped (Go style), with the nested example that prints `1 3 4 2`.
- **std/sync** added to the standard library page; the collections entry notes the hash-backed O(1) `Map`/`Set` and the literal forms.

Every code block was checked against the real `examples/v2/` programs, and the newest snippets (concurrency, derive JSON, macros, compile-time and runtime reflection, raw pointers, callbacks, by-value structs, set and map literals) were compiled and run with the real binary to confirm the documented output.

`mkdocs build` succeeds with no broken links. The only remaining warnings are pre-existing (spec pages not in nav, the README/index conflict). No em dashes or en dashes in the changed docs.

Docs only, so Rust CI does not trigger.
