### PR TITLE
docs: install from the releases page, not from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,34 +48,44 @@ let u: User = User { name: "Raven", age: 1 };
 greet(u);
 ```
 
+## Install
+
+Download the installer or archive for your platform from the [releases page](https://github.com/martian56/raven/releases):
+
+- Linux: `.deb`, `.rpm`, or `.tar.gz`
+- Windows: `.msi` or `.zip`
+- macOS: `.pkg` or `.tar.gz` (Intel and Apple Silicon)
+
+This installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker on your machine (the MSVC build tools on Windows, `cc`/`clang` on Linux and macOS).
+
 ## Quick Start
 
 ```bash
-# Build from source
+# Compile a source file to a native binary
+raven build hello.rv -o hello
+./hello
+```
+
+Project workflow with `rvpm`:
+
+```bash
+rvpm init my_app
+cd my_app
+rvpm run          # builds and runs src/main.rv
+rvpm fmt          # format the .rv sources
+```
+
+### Build from source
+
+For contributors, or to track the latest commit:
+
+```bash
 git clone https://github.com/martian56/raven.git
 cd raven
 cargo build --release
-
-# Run a file
-./target/release/raven hello.rv
-
-# Type-check only (no run)
-./target/release/raven hello.rv -c
-
-# REPL
-./target/release/raven
 ```
 
-**Project workflow** (optional `rv.toml`):
-
-```bash
-./target/release/rvpm init my_app
-cd my_app
-./target/release/rvpm run          # runs src/main.rv
-./target/release/rvpm fmt          # format .rv sources (see [fmt] in rv.toml)
-```
-
-Or get the installer for your OS from the [releases](https://github.com/martian56/raven/releases) page.
+The `raven` and `rvpm` binaries land in `target/release/`.
 
 ## Learn More
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,9 @@ fun main() {
 
 ## Install
 
-The fastest path today is building from source:
+Download the installer or archive for your platform from the [releases page](https://github.com/martian56/raven/releases): `.deb`/`.rpm`/`.tar.gz` for Linux, `.msi`/`.zip` for Windows, and `.pkg`/`.tar.gz` for macOS (Intel and Apple Silicon). Each one installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker (the MSVC build tools on Windows, `cc` or `clang` on Linux and macOS).
+
+If you would rather build from source, or want to track the latest commit:
 
 ```bash
 git clone https://github.com/martian56/raven.git
@@ -96,7 +98,7 @@ cd raven
 cargo build --release
 ```
 
-The `raven` and `rvpm` binaries land in `target/release/`. Add that directory to your `PATH`. Signed installers for Linux, Windows, and macOS are produced by the release workflow and attached to each tagged release on [GitHub](https://github.com/martian56/raven/releases).
+The `raven` and `rvpm` binaries land in `target/release/`.
 
 The [VS Code extension](https://marketplace.visualstudio.com/items?itemName=martian56.raven-language) adds syntax highlighting and snippets.
 

--- a/docs/v2/guide/getting-started.md
+++ b/docs/v2/guide/getting-started.md
@@ -7,9 +7,21 @@ through Cranelift, linking against the Raven runtime.
 This page takes you from a single source file to a compiled binary, then
 to a managed project with `rvpm`.
 
-## Build the toolchain
+## Install
 
-Build the `raven` and `rvpm` binaries from source:
+Download the installer or archive for your platform from the
+[releases page](https://github.com/martian56/raven/releases): `.deb`,
+`.rpm`, or `.tar.gz` for Linux, `.msi` or `.zip` for Windows, and `.pkg`
+or `.tar.gz` for macOS (Intel and Apple Silicon). Each installs the
+`raven` compiler and the `rvpm` package manager and adds them to your
+`PATH`.
+
+Compiling a program also needs a C linker on your machine: the MSVC build
+tools on Windows, or `cc`/`clang` on Linux and macOS. The compiler uses it
+to link the final binary.
+
+To build from source instead (for contributors, or to track the latest
+commit):
 
 ```bash
 git clone https://github.com/martian56/raven.git


### PR DESCRIPTION
## Summary

Install instructions now lead with downloading a prebuilt installer/archive from the [releases page](https://github.com/martian56/raven/releases) for the user's platform. Building from source is kept as a secondary option for contributors.

## Changes

- `README.md`: replaced the "build from source" Quick Start with an Install section (download the per-platform installer) and v2 usage (`raven build`, `rvpm`); build-from-source moved to its own subsection.
- `docs/index.md`: Install section leads with the releases page.
- `docs/v2/guide/getting-started.md`: "Build the toolchain" becomes "Install", leading with the releases page; from-source kept below.

Each spot lists the artifact types (deb/rpm/tar.gz, msi/zip, pkg) and notes that compiling needs a C linker. `mkdocs build` succeeds, no em dashes. Docs-only, so the Rust CI jobs do not trigger.
