### PR TITLE
chore(release): bump to 2.0.0 and write the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,38 @@ All notable changes to Raven are documented in this file.
 
 ## [Unreleased]
 
-### Documentation
-- Refreshed installation links (latest releases), CLI descriptions (`-c` type-check), **rvpm** (`init`, `run`, `fmt`, `fmt --check`), and optional **`[fmt]`** in `rv.toml`.
-- Added **Getting Started → rvpm and formatting** (`docs/getting-started/rvpm-and-format.md`).
-- Corrected examples README (removed obsolete `-f` flag; document `raven file.rv`).
-- **RVPM_DESIGN.md** updated for implemented commands and real module path notes.
+## [2.0.0] - 2026-06-02
+
+Raven 2.0 is a complete rewrite. Version 1 was a tree-walking interpreter; version 2 is a compiled language that emits native binaries through a Cranelift backend, with a new syntax and a real type system. This is a breaking change with no automated migration. Version 1 stays on the `v1.x-maintenance` branch, and the [migration guide](https://martian56.github.io/raven/v2/migration/) maps the differences.
+
+### Language
+
+- Native compilation through Cranelift to a single static binary. A tracing garbage collector manages the heap, so there are no manual frees and no borrow checker.
+- A static type system with generics and trait bounds, traits for polymorphism, sum types (`enum` with payloads), exhaustive `match`, and local type inference.
+- `Result<T, E>` and `Option<T>` with the `?` operator. There is no `null`.
+- String interpolation (`"${expr}"`), closures, range-based `for`, and `defer` with function-scoped semantics.
+- Enum construction with `EnumName.Variant(args)`, set literals `{a, b}`, and map literals `["k": v]`.
+- Concurrency: lightweight goroutines with `spawn` and channels in `std/sync` (cooperative single-thread scheduler in this release).
+- C FFI: `extern "C"` blocks, the numeric types `CInt`/`CLong`/`CSize`/`CFloat`/`CDouble`, `CStr` and `CPtr<T>`, raw pointer load/store/alloc, function-pointer callbacks (`CFnPtr`), and small `@repr(C)` structs passed by value.
+- Metaprogramming: `@derive` for `Eq`, `Hash`, `ToString`, `Debug`, `ToJson`, and `FromJson`; declarative macros with repetition and hygiene; and compile-time (`type_name`, `field_names`) plus runtime (`to_any`, `get_field`, `cast`) reflection.
+
+### Standard library
+
+- Bundled `std` modules: `io`, `string`, `collections` (hash-backed `Map`/`Set`), `math`, `cmp`, `hash`, `iter`, `fmt`, `encoding`, `random`, `env`, `fs`, `time`, `net`, `http`, `json`, `regex`, `process`, `ffi`, `error`, `path`, `test`, `sync`, and the always-in-scope `core` traits.
+
+### Tooling
+
+- `rvpm`: GitHub-direct packages with `rv.toml` and a content-hashed `rv.lock`, a shared cache, and `init`, `add`, `install`, `update`, `build`, `run`, and `fmt`.
+- One canonical formatter (`rvpm fmt`), an updated VS Code extension, and refreshed documentation that defaults to v2.
+- Cross-platform installers built by the release workflow: `.deb`/`.rpm`/`.tar.gz` for Linux, `.msi`/`.zip` for Windows, and `.pkg`/`.tar.gz` for macOS (Intel and Apple Silicon).
+
+### Changed
+
+- New syntax: PascalCase type names (`Int`, `String`, `Bool`, `Float`, `Char`, `Unit`), no semicolons, and programs that run from `fun main()` with no top-level statements. The `export` keyword is gone; every top-level item is importable.
+
+### Removed
+
+- The version 1 tree-walking interpreter and its REPL, and the version 1 syntax. Use the `v1.x-maintenance` branch for version 1 code.
 
 ## [1.4.0] - 2026-03-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.0.0-dev"
+version = "2.0.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.0.0-dev"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.0.0-dev"
+version = "2.0.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Stages the version and changelog for the 2.0.0 tag.

- `Cargo.toml`: workspace version `2.0.0-dev` -> `2.0.0` (so `raven --version` and the installers report `2.0.0`). `Cargo.lock` updated.
- `CHANGELOG.md`: removed the stale v1 `[Unreleased]` notes and added a `[2.0.0]` entry covering the compiled rewrite (language, standard library, tooling, the breaking-change note, and what was removed).

No em dashes. The actual tag and the v2.x to main merge remain the release step (#93).
