### PR TITLE
ci(release): fix MSI packaging, drop Intel macOS, improve release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,43 @@
+# Categorizes the automatically generated release notes (the "What's
+# Changed" section) by pull request label. The release workflow turns
+# this on with generate_release_notes. A pull request lands in the first
+# category whose labels it carries; "New Contributors" is added by GitHub.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - duplicate
+      - invalid
+  categories:
+    - title: Bug Fixes
+      labels:
+        - type/bug
+        - bug
+    - title: Language and Compiler
+      labels:
+        - area/lexer
+        - area/parser
+        - area/ast
+        - area/resolver
+        - area/tycheck
+        - area/hir-mir
+        - area/codegen
+        - area/runtime
+        - area/gc
+    - title: Standard Library
+      labels:
+        - area/stdlib
+        - area/ffi
+    - title: Tooling and Packaging
+      labels:
+        - area/rvpm
+        - area/formatter
+        - area/tooling
+        - area/ci
+    - title: Other Features
+      labels:
+        - type/feature
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,6 @@ jobs:
           - name: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
-          - name: macos-x86_64
-            os: macos-13
-            target: x86_64-apple-darwin
           - name: macos-arm64
             os: macos-14
             target: aarch64-apple-darwin
@@ -232,8 +229,6 @@ jobs:
             os: ubuntu-latest
           - name: windows-x86_64
             os: windows-latest
-          - name: macos-x86_64
-            os: macos-13
           - name: macos-arm64
             os: macos-14
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,23 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: Raven ${{ github.ref_name }}
+          # The categorized "What's Changed" and "New Contributors"
+          # sections are appended below this body. Categories come from
+          # .github/release.yml.
+          body: |
+            Raven ${{ github.ref_name }}, a statically typed, compiled language with a Cranelift backend, a tracing garbage collector, generics and traits, sum types, goroutines, a C FFI, and a package manager.
+
+            ## Install
+
+            Download the installer or archive for your platform from the assets below:
+
+            - Linux: `.deb`, `.rpm`, or `.tar.gz`
+            - Windows: `.msi` or `.zip`
+            - macOS (Apple Silicon): `.pkg` or `.tar.gz`
+
+            Each one installs the `raven` compiler and the `rvpm` package manager. Compiling a program also needs a C linker (the MSVC build tools on Windows, `cc` or `clang` on Linux and macOS).
+
+            The full changelog is in [CHANGELOG.md](https://github.com/martian56/raven/blob/main/CHANGELOG.md), and the docs are at [martian56.github.io/raven](https://martian56.github.io/raven/).
           generate_release_notes: true
           files: dist/*
           fail_on_unmatched_files: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,10 @@ jobs:
           $v = "${{ steps.version.outputs.value }}"
           # cargo-wix derives the installer version from Cargo.toml; pass the
           # release version explicitly so the MSI matches the tag.
-          cargo wix --no-build --nocapture --target ${{ matrix.target }} `
+          # The workspace has more than one package, so name the one to
+          # package (the `raven` binary crate); cargo-wix otherwise errors
+          # with "Workspace detected. Please pass a package name."
+          cargo wix -p raven --no-build --nocapture --target ${{ matrix.target }} `
             --install-version $v --output "target/wix/raven-$v-${{ matrix.target }}.msi"
 
       - name: Sign Windows MSI (optional)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Download the installer or archive for your platform from the [releases page](htt
 
 - Linux: `.deb`, `.rpm`, or `.tar.gz`
 - Windows: `.msi` or `.zip`
-- macOS: `.pkg` or `.tar.gz` (Intel and Apple Silicon)
+- macOS: `.pkg` or `.tar.gz` (Apple Silicon)
 
 This installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker on your machine (the MSVC build tools on Windows, `cc`/`clang` on Linux and macOS).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ fun main() {
 
 ## Install
 
-Download the installer or archive for your platform from the [releases page](https://github.com/martian56/raven/releases): `.deb`/`.rpm`/`.tar.gz` for Linux, `.msi`/`.zip` for Windows, and `.pkg`/`.tar.gz` for macOS (Intel and Apple Silicon). Each one installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker (the MSVC build tools on Windows, `cc` or `clang` on Linux and macOS).
+Download the installer or archive for your platform from the [releases page](https://github.com/martian56/raven/releases): `.deb`/`.rpm`/`.tar.gz` for Linux, `.msi`/`.zip` for Windows, and `.pkg`/`.tar.gz` for macOS (Apple Silicon). Each one installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker (the MSVC build tools on Windows, `cc` or `clang` on Linux and macOS).
 
 If you would rather build from source, or want to track the latest commit:
 

--- a/docs/v2/guide/getting-started.md
+++ b/docs/v2/guide/getting-started.md
@@ -12,7 +12,7 @@ to a managed project with `rvpm`.
 Download the installer or archive for your platform from the
 [releases page](https://github.com/martian56/raven/releases): `.deb`,
 `.rpm`, or `.tar.gz` for Linux, `.msi` or `.zip` for Windows, and `.pkg`
-or `.tar.gz` for macOS (Intel and Apple Silicon). Each installs the
+or `.tar.gz` for macOS (Apple Silicon). Each installs the
 `raven` compiler and the `rvpm` package manager and adds them to your
 `PATH`.
 

--- a/docs/v2/specs/release.md
+++ b/docs/v2/specs/release.md
@@ -8,15 +8,17 @@ Release.
 
 ## Artifacts per platform
 
-The build matrix covers four targets. Each target produces a portable archive
+The build matrix covers three targets. Each target produces a portable archive
 and the platform native installer.
 
 | Target | Archive | Installer |
 |--------|---------|-----------|
 | Linux x86_64 (`x86_64-unknown-linux-gnu`) | `.tar.gz` | `.deb`, `.rpm` |
 | Windows x86_64 (`x86_64-pc-windows-msvc`) | `.zip` | `.msi` |
-| macOS x86_64 (`x86_64-apple-darwin`) | `.tar.gz` | `.pkg` |
 | macOS arm64 (`aarch64-apple-darwin`) | `.tar.gz` | `.pkg` |
+
+macOS Intel (`x86_64-apple-darwin`) is not built: the `macos-13` runner is
+unreliable to schedule. It can be re-added to the matrix when needed.
 
 Every artifact bundles two binaries, `raven` (the compiler and build driver)
 and `rvpm` (the package manager), plus the `raven_runtime` static library.

--- a/docs/v2/specs/release.md
+++ b/docs/v2/specs/release.md
@@ -17,9 +17,6 @@ and the platform native installer.
 | Windows x86_64 (`x86_64-pc-windows-msvc`) | `.zip` | `.msi` |
 | macOS arm64 (`aarch64-apple-darwin`) | `.tar.gz` | `.pkg` |
 
-macOS Intel (`x86_64-apple-darwin`) is not built: the `macos-13` runner is
-unreliable to schedule. It can be re-added to the matrix when needed.
-
 Every artifact bundles two binaries, `raven` (the compiler and build driver)
 and `rvpm` (the package manager), plus the `raven_runtime` static library.
 


### PR DESCRIPTION
## Summary

The Windows MSI step in the release workflow ran `cargo wix` at the workspace root without naming a package, so cargo-wix failed with `Workspace detected. Please pass a package name.` (the workspace has both `raven` and `raven-runtime`).

Fix: pass `-p raven` so cargo-wix packages the `raven` binary crate.

Found by the release dry-run (workflow_dispatch). In that run, Linux (.deb/.rpm/.tar.gz) and macOS-arm64 built and smoke-tested green; only the Windows MSI step failed, and this is the cause.
