### PR TITLE
fix(codegen): classic linker on macOS, and Windows smoke path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,6 @@ jobs:
           $env:RAVEN_RUNTIME_LIB = "$bin\raven_runtime.lib"
           Set-Content -Path hello.rv -Value 'fun main() { print("hello") }' -Encoding ascii
           & "$bin\raven.exe" build hello.rv -o hello.exe
-          $out = (& "$bin\hello.exe")
+          $out = (& ".\hello.exe")
           Write-Host "program output: $out"
           if ($out -ne "hello") { exit 1 }

--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -291,7 +291,11 @@ fn link_unix(
     if cfg!(target_os = "linux") {
         cmd.args(["-lpthread", "-ldl", "-lm", "-lrt", "-lgcc_s", "-lutil"]);
     } else if cfg!(target_os = "macos") {
-        cmd.args(["-lpthread", "-ldl", "-lm"]);
+        // Apple's new linker (ld-prime) asserts on some relocation
+        // patterns in the Cranelift object (Relocations.cpp
+        // addFixupFromRelocations). The classic linker handles them, so
+        // select it explicitly.
+        cmd.args(["-Wl,-ld_classic", "-lpthread", "-ldl", "-lm"]);
     }
     let status = cmd
         .status()


### PR DESCRIPTION
## Summary

Two issues found by the release dry-run smoke tests (the builds all pass; these are the install-and-run checks).

### macOS linker (real fix)
Apple's new linker (ld-prime) asserts on some relocation patterns in the Cranelift-emitted object (`ld: Assertion failed: (pattern[0].addrMode == addr_other), addFixupFromRelocations, Relocations.cpp:701`), so a compiled program fails to link on macOS. Pass `-Wl,-ld_classic` on macOS so `cc` uses the classic linker, which handles these relocations. Linux and Windows linking are unchanged (separate branches).

### Windows smoke (script fix)
The Windows smoke step built `hello.exe` into the working directory (`-o hello.exe`) but ran `"$bin\hello.exe"` (the extracted artifact dir), so it never found the binary. Run `.\hello.exe` to match the working Unix smoke step. The Windows MSI/build and linking were already fine.

Verified locally: workspace builds, Windows linking still produces a working binary, clippy/fmt clean. The macOS path is verified by the next dry-run.
