### PR TITLE
fix(codegen): link CoreFoundation framework on macOS

### DIFF
--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -295,7 +295,21 @@ fn link_unix(
         // patterns in the Cranelift object (Relocations.cpp
         // addFixupFromRelocations). The classic linker handles them, so
         // select it explicitly.
-        cmd.args(["-Wl,-ld_classic", "-lpthread", "-ldl", "-lm"]);
+        //
+        // CoreFoundation is required by a runtime dependency
+        // (iana_time_zone, reached through the time stdlib). Rust's
+        // `#[link(kind = "framework")]` directives are not applied when
+        // the staticlib is handed to `cc` directly, so name the
+        // framework explicitly, the same way the MSVC path names its
+        // native libs.
+        cmd.args([
+            "-Wl,-ld_classic",
+            "-lpthread",
+            "-ldl",
+            "-lm",
+            "-framework",
+            "CoreFoundation",
+        ]);
     }
     let status = cmd
         .status()


### PR DESCRIPTION
## Summary

The previous fix (classic linker) cleared the linker assertion on macOS, and the dry-run smoke test surfaced the next issue: the runtime staticlib pulls in `iana_time_zone` (via the time stdlib), which references CoreFoundation framework symbols (`_CFRelease`, `_CFStringGetBytes`, `_CFStringGetCStringPtr`, `_CFStringGetLength`, `_CFTimeZoneCopySystem`, `_CFTimeZoneGetName`, `_CFTimeZoneResetSystem`). Every compiled program failed to link with `Undefined symbols for architecture arm64`.

Rust's `#[link(kind = "framework")]` directives are not applied when we hand the staticlib to `cc` directly (the same reason the Windows path hardcodes its native libs), so name `-framework CoreFoundation` explicitly on the macOS link line.

Verified locally: builds, fmt and clippy clean (the `cfg!` branch body type-checks on all hosts). The macOS link itself is verified by the next dry-run.