### PR TITLE
ci(release): expire build artifacts after 7 days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,7 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: dist/*
+          retention-days: 7
 
       - name: Upload to release
         if: github.ref_type == 'tag'


### PR DESCRIPTION
Set `retention-days: 7` on the release workflow's `upload-artifact` step. These artifacts are the hand-off from the build jobs to the smoke jobs and the only way to retrieve a dry-run build, so they do not need the 90-day default. Published GitHub Release assets are stored separately and are unaffected.