### PR TITLE
ci(web): add manual trigger to the website deploy

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "web/**"
       - ".github/workflows/web-deploy.yml"
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to `web-deploy.yml`. The v2 merge changed `web/index.html` but the push path filter did not fire on the large merge commit, so the site was not redeployed. A manual trigger lets us deploy on demand, and merging this PR (which touches the workflow file, in the path filter) redeploys the v2 site.