### PR TITLE
feat: lexicographic ordering operators on String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Raven are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Lexicographic ordering on `String` with the `<`, `<=`, `>`, `>=` operators, backed by a new `raven_string_cmp` runtime function. Previously these were a type error (#267).
+
 ### Fixed
 
 - `String.len()` and `String.is_empty()` now work without an import, spelled the same as `List`/`Map`/`Set`. They previously type-checked but failed in code generation with `unresolved callee: Str$len`. A user `impl String` of either name still takes precedence (#266).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/string_ordering.rv
+++ b/examples/v2/string_ordering.rv
@@ -1,0 +1,12 @@
+// Lexicographic ordering on String with < <= > >=. Regression for issue
+// #267 (these used to be a type error). Prints:
+//   true false true true false
+fun main() {
+    let a = "apple"
+    let b = "banana"
+    print(a < b)        // true
+    print(b < a)        // false
+    print(a <= a)       // true
+    print(b >= a)       // true
+    print(a > b)        // false
+}

--- a/examples/v2/string_ordering.rv.out
+++ b/examples/v2/string_ordering.rv.out
@@ -1,0 +1,5 @@
+true
+false
+true
+true
+false

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -29,7 +29,7 @@ pub use object::{
     raven_closure_captures, raven_closure_fn_ptr, raven_closure_new, raven_float_to_string,
     raven_int_to_string, raven_list_elements, raven_list_len, raven_list_new, raven_list_push,
     raven_map_bucket_count, raven_map_buckets, raven_map_new, raven_set_bucket_count,
-    raven_set_buckets, raven_set_new, raven_string_byte_at, raven_string_bytes,
+    raven_set_buckets, raven_set_new, raven_string_byte_at, raven_string_bytes, raven_string_cmp,
     raven_string_concat, raven_string_eq, raven_string_from_byte, raven_string_from_bytes,
     raven_string_len, raven_string_new, raven_string_substring, raven_struct_fields,
     raven_struct_new, Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap,

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -27,9 +27,9 @@ pub use map::{raven_map_bucket_count, raven_map_buckets, raven_map_new, Map, Map
 pub use set::{raven_set_bucket_count, raven_set_buckets, raven_set_new, Set, SetEntry};
 pub use string::{
     raven_bool_to_string, raven_char_to_string, raven_float_to_string, raven_int_to_string,
-    raven_string_byte_at, raven_string_bytes, raven_string_concat, raven_string_eq,
-    raven_string_from_byte, raven_string_from_bytes, raven_string_len, raven_string_new,
-    raven_string_substring, String,
+    raven_string_byte_at, raven_string_bytes, raven_string_cmp, raven_string_concat,
+    raven_string_eq, raven_string_from_byte, raven_string_from_bytes, raven_string_len,
+    raven_string_new, raven_string_substring, String,
 };
 pub use structval::{
     raven_struct_fields, raven_struct_new, STRUCT_FIELDS_OFFSET, STRUCT_FIELD_SLOT,

--- a/raven-runtime/src/object/string.rs
+++ b/raven-runtime/src/object/string.rs
@@ -213,6 +213,38 @@ pub extern "C" fn raven_string_eq(a: *const String, b: *const String) -> i8 {
     (a_slice == b_slice) as i8
 }
 
+/// Lexicographic byte comparison of two `String` values: negative when
+/// `a < b`, zero when equal, positive when `a > b`. Either pointer may be
+/// null and is treated as the empty string. Backs the `< <= > >=`
+/// operators on `String`, which compare contents lexicographically.
+#[no_mangle]
+pub extern "C" fn raven_string_cmp(a: *const String, b: *const String) -> i64 {
+    if a == b {
+        return 0;
+    }
+    let a_len = raven_string_len(a) as usize;
+    let b_len = raven_string_len(b) as usize;
+    let a_bytes = raven_string_bytes(a);
+    let b_bytes = raven_string_bytes(b);
+    let a_slice = if a_bytes.is_null() || a_len == 0 {
+        &[][..]
+    } else {
+        // SAFETY: `a_bytes` points at `a_len` valid bytes.
+        unsafe { std::slice::from_raw_parts(a_bytes, a_len) }
+    };
+    let b_slice = if b_bytes.is_null() || b_len == 0 {
+        &[][..]
+    } else {
+        // SAFETY: `b_bytes` points at `b_len` valid bytes.
+        unsafe { std::slice::from_raw_parts(b_bytes, b_len) }
+    };
+    match a_slice.cmp(b_slice) {
+        std::cmp::Ordering::Less => -1,
+        std::cmp::Ordering::Equal => 0,
+        std::cmp::Ordering::Greater => 1,
+    }
+}
+
 /// Allocate a fresh `String` holding the half-open byte range
 /// `[start, end)` of `s`. The bounds are clamped to `0..=len` and a
 /// `start` past `end` yields an empty string, so the function never
@@ -588,6 +620,30 @@ mod tests {
             drop_string_for_test(c);
             drop_string_for_test(bar);
             drop_string_for_test(abcd);
+            drop_string_for_test(empty);
+        }
+    }
+
+    #[test]
+    fn string_cmp_is_lexicographic() {
+        let apple = raven_string_from_bytes(b"apple".as_ptr(), 5);
+        let banana = raven_string_from_bytes(b"banana".as_ptr(), 6);
+        let app = raven_string_from_bytes(b"app".as_ptr(), 3);
+        let empty = raven_string_new(0);
+        // a < b, b > a, equal is 0.
+        assert!(raven_string_cmp(apple, banana) < 0);
+        assert!(raven_string_cmp(banana, apple) > 0);
+        assert_eq!(raven_string_cmp(apple, apple), 0);
+        // A prefix sorts before the longer string.
+        assert!(raven_string_cmp(app, apple) < 0);
+        assert!(raven_string_cmp(apple, app) > 0);
+        // Null is the empty string: less than any non-empty, equal to empty.
+        assert!(raven_string_cmp(std::ptr::null(), apple) < 0);
+        assert_eq!(raven_string_cmp(std::ptr::null(), empty), 0);
+        unsafe {
+            drop_string_for_test(apple);
+            drop_string_for_test(banana);
+            drop_string_for_test(app);
             drop_string_for_test(empty);
         }
     }

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -548,6 +548,10 @@ impl ModuleCx {
         sig = self.make_sig(&[ptr, ptr], &[types::I8]);
         self.declare_runtime(intrinsics::RUNTIME_STRING_EQ, &sig)?;
 
+        // raven_string_cmp(String ptr, String ptr) -> i64 (Int: -1/0/1)
+        sig = self.make_sig(&[ptr, ptr], &[i64t]);
+        self.declare_runtime(intrinsics::RUNTIME_STRING_CMP, &sig)?;
+
         // raven_int_to_string(i64) -> String ptr
         sig = self.make_sig(&[i64t], &[ptr]);
         self.declare_runtime(intrinsics::RUNTIME_INT_TO_STRING, &sig)?;

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -101,6 +101,10 @@ pub const RUNTIME_CHAR_TO_STRING: &str = "raven_char_to_string";
 /// `==`/`!=` operators on `String`.
 pub const RUNTIME_STRING_EQ: &str = "raven_string_eq";
 
+/// Runtime C symbol lexicographically comparing two `String` values,
+/// returning a negative/zero/positive `i64`. Backs `< <= > >=` on `String`.
+pub const RUNTIME_STRING_CMP: &str = "raven_string_cmp";
+
 /// Map a MIR string-runtime intrinsic mangled name to the runtime C
 /// symbol it lowers to, or `None` when `mangled` is not one of them.
 /// These intrinsics share one call shape: each operand lowers to an
@@ -110,6 +114,7 @@ pub fn string_runtime_symbol(mangled: &str) -> Option<&'static str> {
     Some(match mangled {
         mir_intr::STR_CONCAT => RUNTIME_STRING_CONCAT,
         mir_intr::STR_EQ => RUNTIME_STRING_EQ,
+        mir_intr::STR_CMP => RUNTIME_STRING_CMP,
         mir_intr::INT_TO_STRING => RUNTIME_INT_TO_STRING,
         mir_intr::BOOL_TO_STRING => RUNTIME_BOOL_TO_STRING,
         mir_intr::FLOAT_TO_STRING => RUNTIME_FLOAT_TO_STRING,

--- a/src/mir/intrinsics.rs
+++ b/src/mir/intrinsics.rs
@@ -16,6 +16,11 @@ pub const STR_CONCAT: &str = "__raven_str_concat";
 /// directly; `!=` negates it.
 pub const STR_EQ: &str = "__raven_str_eq";
 
+/// Lexicographically compare two heap `String` values, yielding an `Int`
+/// that is negative, zero, or positive. Lowers to `raven_string_cmp`. The
+/// `< <= > >=` operators compare the result against `0`.
+pub const STR_CMP: &str = "__raven_str_cmp";
+
 /// Render an `Int` as a heap `String`. Lowers to `raven_int_to_string`.
 pub const INT_TO_STRING: &str = "__raven_int_to_string";
 

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -89,6 +89,16 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             {
                 return lower_string_eq(cx, *op, lhs, rhs, ty);
             }
+            // Ordering on `String` compares contents lexicographically:
+            // `raven_string_cmp` returns -1/0/1 and the operator compares
+            // that against 0.
+            if matches!(
+                op,
+                HirBinaryOp::Lt | HirBinaryOp::Le | HirBinaryOp::Gt | HirBinaryOp::Ge
+            ) && mir_ty(&lhs.ty, cx.subst) == MirType::Str
+            {
+                return lower_string_cmp(cx, *op, lhs, rhs, ty);
+            }
             let l = lower_expr(cx, lhs);
             let r = lower_expr(cx, rhs);
             let dst = cx.builder.fresh_temp("bin", ty);
@@ -775,6 +785,43 @@ fn lower_string_eq(
             MirOperand::Copy(dst)
         }
     }
+}
+
+/// Lower an ordering comparison (`< <= > >=`) on two `String` operands.
+/// Calls the `raven_string_cmp` intrinsic, which returns a negative, zero,
+/// or positive `Int`, then applies the operator against `0`.
+fn lower_string_cmp(
+    cx: &mut LowerCx<'_>,
+    op: HirBinaryOp,
+    lhs: &HirExpr,
+    rhs: &HirExpr,
+    ty: MirType,
+) -> MirOperand {
+    let l = lower_expr(cx, lhs);
+    let r = lower_expr(cx, rhs);
+    let cmp = cx.builder.fresh_temp("strcmp", MirType::Int);
+    cx.builder.assign(
+        cx.current,
+        cmp,
+        MirRvalue::Call {
+            callee: MirFnRef {
+                mangled: super::super::intrinsics::STR_CMP.into(),
+                origin: None,
+            },
+            args: vec![l, r],
+        },
+    );
+    let dst = cx.builder.fresh_temp("strord", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::BinaryOp(
+            map_binary(op),
+            MirOperand::Copy(cmp),
+            MirOperand::Const(MirConstant::Int(0)),
+        ),
+    );
+    MirOperand::Copy(dst)
 }
 
 /// Desugar an interpolated string into a left-folded chain of runtime

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -2891,7 +2891,10 @@ pub fn check_binary(l: &Ty, r: &Ty, op: BinaryOp, span: &Span) -> Result<Ty, Rav
             }
         }
         Lt | Le | Gt | Ge => match (ls, rs) {
-            (Ty::Int, Ty::Int) | (Ty::Float, Ty::Float) | (Ty::Char, Ty::Char) => Ok(Ty::Bool),
+            (Ty::Int, Ty::Int)
+            | (Ty::Float, Ty::Float)
+            | (Ty::Char, Ty::Char)
+            | (Ty::Str, Ty::Str) => Ok(Ty::Bool),
             _ => Err(RavenError::ty(
                 TypeError::TypeMismatch {
                     expected: "orderable types".into(),


### PR DESCRIPTION
Closes #267.

## Summary

Adds `<`, `<=`, `>`, `>=` on `String` (previously a type error). The type checker accepts two `String` operands for the ordering operators, and MIR lowering routes them through a new `raven_string_cmp` runtime function: a byte-wise lexicographic comparison returning a negative/zero/positive `Int`, which the operator then compares against `0` (mirroring how `==` lowers through `raven_string_eq`). Null strings are treated as empty.

## Tests

- Runtime unit test `string_cmp_is_lexicographic` (ordering, prefix, null/empty).
- `examples/v2/string_ordering.rv` (+ baseline) covering `< <= > >=` end to end.
- Full lib (468) and runtime (110) suites green; fmt and clippy clean.

Version bumped to 2.0.4 (no release).