### PR TITLE
fix(mir): match String literal patterns by content, not pointer identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Raven are documented in this file.
 
 ### Fixed
 
+- `match` on `String` literal patterns now compares by content. Arms like `"yes" -> ...` previously compared heap-pointer identity, so they never matched and silently fell through to the wildcard (#265).
 - `String.len()` and `String.is_empty()` now work without an import, spelled the same as `List`/`Map`/`Set`. They previously type-checked but failed in code generation with `unresolved callee: Str$len`. A user `impl String` of either name still takes precedence (#266).
 
 ## [2.0.2] - 2026-06-02

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.0.4"
+version = "2.0.5"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/match_string.rv
+++ b/examples/v2/match_string.rv
@@ -1,0 +1,19 @@
+// match on String literal patterns compares by content. Regression for
+// issue #265, where string-literal arms compared heap-pointer identity and
+// always fell through to the wildcard. Prints:
+//   affirmative
+//   negative
+//   unknown
+fun classify(s: String) -> String {
+    return match s {
+        "yes" -> "affirmative",
+        "no" -> "negative",
+        _ -> "unknown",
+    }
+}
+
+fun main() {
+    print(classify("yes"))
+    print(classify("no"))
+    print(classify("maybe"))
+}

--- a/examples/v2/match_string.rv.out
+++ b/examples/v2/match_string.rv.out
@@ -1,0 +1,3 @@
+affirmative
+negative
+unknown

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -174,19 +174,33 @@ fn lower_fallback_match(
                 }
             }
             HirPatternKind::Literal(lit) => {
-                let cmp = literal_to_const(lit);
                 let cmp_local = cx
                     .builder
                     .fresh_temp("cmp", super::super::ty::MirType::Bool);
-                cx.builder.assign(
-                    next_test,
-                    cmp_local,
+                // A `String` literal pattern compares by content, not by
+                // heap-pointer identity: route it through the string-equality
+                // intrinsic. A plain `BinaryOp::Eq` would compare the literal
+                // constant's address against the scrutinee's and never match,
+                // silently falling through to the wildcard arm.
+                let test = if let HirLiteralPat::Str(s) = lit {
+                    MirRvalue::Call {
+                        callee: super::super::ir::MirFnRef {
+                            mangled: super::super::intrinsics::STR_EQ.into(),
+                            origin: None,
+                        },
+                        args: vec![
+                            scrut.clone(),
+                            MirOperand::Const(MirConstant::Str(s.clone())),
+                        ],
+                    }
+                } else {
                     MirRvalue::BinaryOp(
                         super::super::ir::MirBinOp::Eq,
                         scrut.clone(),
-                        MirOperand::Const(cmp),
-                    ),
-                );
+                        MirOperand::Const(literal_to_const(lit)),
+                    )
+                };
+                cx.builder.assign(next_test, cmp_local, test);
                 cx.builder.close_block(
                     next_test,
                     MirTerminator::SwitchInt {


### PR DESCRIPTION
Fixes #265.

## Summary

A `match` arm with a `String` literal pattern (`"yes" -> ...`) lowered to a plain `BinaryOp::Eq`, which compares the literal constant's heap address against the scrutinee's. They are distinct objects, so the comparison was always false: the arm never matched and execution silently fell through to the wildcard.

String literal pattern tests now lower through the `raven_string_eq` intrinsic, the same content comparison the `==` operator already uses for strings.

## Tests

- `examples/v2/match_string.rv` (+ baseline): string-literal arms select correctly and the wildcard catches the rest.
- Full lib suite (468) green; fmt and clippy clean.

Version bumped to 2.0.5 (no release).