### PR TITLE
fix(format): format spawn(...) as a call without a leading space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Raven are documented in this file.
 
 ### Fixed
 
+- The formatter now writes `spawn(...)` as a call, without the stray space it used to insert before the parenthesis (#263).
 - `match` on `String` literal patterns now compares by content. Arms like `"yes" -> ...` previously compared heap-pointer identity, so they never matched and silently fell through to the wildcard (#265).
 - `String.len()` and `String.is_empty()` now work without an import, spelled the same as `List`/`Map`/`Set`. They previously type-checked but failed in code generation with `unresolved callee: Str$len`. A user `impl String` of either name still takes precedence (#266).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.0.5"
+version = "2.0.6"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -632,7 +632,15 @@ impl Printer<'_> {
                 self.emit_multiline(&text);
             }
             StmtKind::Spawn(e) => {
-                let text = format!("spawn {}", self.render_expr(e));
+                // `spawn` reads as a call: no space before the argument and a
+                // single layer of parentheses. Unwrap an explicit paren so the
+                // canonical form `spawn(<closure>)` is stable under repeated
+                // formatting.
+                let inner = match &e.kind {
+                    ExprKind::Paren(inner) => inner.as_ref(),
+                    _ => e,
+                };
+                let text = format!("spawn({})", self.render_expr(inner));
                 self.emit_multiline(&text);
             }
             StmtKind::Assign { target, op, value } => {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -102,6 +102,15 @@ fn defer_stmt() {
 }
 
 #[test]
+fn spawn_stmt_formats_as_call() {
+    // `spawn` reads as a call: no space before the parenthesis, a single
+    // paren layer, and stable under re-formatting (checked by `fmt`).
+    let out = fmt("fun f(){spawn (fun()->Unit{work()})}");
+    assert!(out.contains("spawn(fun() -> Unit {"), "got: {out}");
+    assert!(!out.contains("spawn ("), "got: {out}");
+}
+
+#[test]
 fn extern_block() {
     let out = fmt("extern \"C\"{fun foo(x:Int)->Int\nfun bar()}");
     assert!(out.contains("extern \"C\" {"));


### PR DESCRIPTION
Fixes #263.

## Summary

`rvpm fmt` rendered `spawn(...)` as `spawn (...)`, inserting a space before the parenthesis as if `spawn` were a control-flow keyword. It now formats as a call. An explicit paren in the argument is unwrapped so the canonical `spawn(<closure>)` is stable under repeated formatting (idempotent).

## Tests

- `format::tests::spawn_stmt_formats_as_call` (no space, idempotent via the shared `fmt` helper that also checks AST preservation).
- Full lib suite (469) and the fmt golden suite green; fmt and clippy clean.

Version bumped to 2.0.6 (no release).