### PR TITLE
fix(lexer): allow nested string literals inside ${...} interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Raven are documented in this file.
 
 ### Fixed
 
+- String interpolation may now contain a nested string literal, including in a call argument: `"hello ${shout("world")}"`. The inner `"` previously ended the outer string early. Macro invocations inside `${...}` remain unsupported (tracked by #226) (#262).
 - The formatter now writes `spawn(...)` as a call, without the stray space it used to insert before the parenthesis (#263).
 - `match` on `String` literal patterns now compares by content. Arms like `"yes" -> ...` previously compared heap-pointer identity, so they never matched and silently fell through to the wildcard (#265).
 - `String.len()` and `String.is_empty()` now work without an import, spelled the same as `List`/`Map`/`Set`. They previously type-checked but failed in code generation with `unresolved callee: Str$len`. A user `impl String` of either name still takes precedence (#266).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.0.6"
+version = "2.0.7"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/interp_nested_string.rv
+++ b/examples/v2/interp_nested_string.rv
@@ -1,0 +1,15 @@
+// String interpolation may contain a nested string literal, including in a
+// call argument. Regression for issue #262, where the inner `"` ended the
+// outer string early. Prints:
+//   hello WORLD
+//   a-b
+import std/string
+
+fun shout(s: String) -> String = s.to_upper()
+
+fun join(a: String, b: String) -> String = a.concat("-").concat(b)
+
+fun main() {
+    print("hello ${shout("world")}")
+    print("${join("a", "b")}")
+}

--- a/examples/v2/interp_nested_string.rv.out
+++ b/examples/v2/interp_nested_string.rv.out
@@ -1,0 +1,2 @@
+hello WORLD
+a-b

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -549,12 +549,17 @@ impl Lexer {
         // Single line string.
         self.bump(); // opening "
         let mut out = String::new();
+        // Brace depth inside a `${...}` interpolation. While greater than 0,
+        // the bytes are an embedded expression copied verbatim (no escape
+        // decoding) for the parser's interpolation splitter to re-lex, and a
+        // `"` opens a nested string literal rather than closing this one.
+        let mut interp_depth: u32 = 0;
         loop {
             match self.peek() {
                 None => {
                     return Err(self.err(LexError::UnterminatedString, start, line, col));
                 }
-                Some('"') => {
+                Some('"') if interp_depth == 0 => {
                     self.bump();
                     let span = self.make_span(start, line, col);
                     let kind = if is_cstring {
@@ -564,10 +569,54 @@ impl Lexer {
                     };
                     return Ok(Token::new(kind, span));
                 }
+                Some('"') => {
+                    // A nested string literal inside an interpolation. Copy it
+                    // verbatim, including escapes and its closing quote, so the
+                    // splitter re-parses it as an ordinary string expression.
+                    out.push(self.bump().unwrap()); // opening "
+                    loop {
+                        match self.peek() {
+                            None | Some('\n') => {
+                                return Err(self.err(
+                                    LexError::UnterminatedString,
+                                    start,
+                                    line,
+                                    col,
+                                ));
+                            }
+                            Some('\\') => {
+                                out.push(self.bump().unwrap()); // backslash
+                                if self.peek().is_some() {
+                                    out.push(self.bump().unwrap()); // escaped char
+                                }
+                            }
+                            Some('"') => {
+                                out.push(self.bump().unwrap()); // closing "
+                                break;
+                            }
+                            Some(_) => out.push(self.bump().unwrap()),
+                        }
+                    }
+                }
                 Some('\n') => {
                     return Err(self.err(LexError::UnterminatedString, start, line, col));
                 }
-                Some('\\') => {
+                Some('$') if self.peek_at(1) == Some('{') => {
+                    out.push(self.bump().unwrap()); // $
+                    out.push(self.bump().unwrap()); // {
+                    interp_depth += 1;
+                }
+                Some('{') if interp_depth > 0 => {
+                    interp_depth += 1;
+                    out.push(self.bump().unwrap());
+                }
+                Some('}') if interp_depth > 0 => {
+                    interp_depth -= 1;
+                    out.push(self.bump().unwrap());
+                }
+                // Inside an interpolation the bytes are raw expression source,
+                // copied verbatim; escape decoding only applies to literal text.
+                Some('\\') if interp_depth == 0 => {
                     let esc_line = self.line;
                     let esc_col = self.col;
                     let esc_start = self.pos;

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -130,6 +130,22 @@ fn string_preserves_interpolation_verbatim() {
 }
 
 #[test]
+fn interpolation_may_contain_a_nested_string_literal() {
+    // A `"` inside `${...}` opens a nested string, not the end of the outer
+    // one, so the whole literal is one token. Regression for issue #262.
+    let src = r#""hello ${shout("world")}!""#;
+    let toks = lex(src);
+    match &toks[0].kind {
+        TokenKind::StringLit(s) => assert_eq!(s, r#"hello ${shout("world")}!"#),
+        other => panic!(
+            "expected one StringLit, got {:?} ({} tokens)",
+            other,
+            toks.len()
+        ),
+    }
+}
+
+#[test]
 fn string_supports_hex_and_unicode_escapes() {
     let toks = lex(r#""\x41\u{1F600}""#);
     match &toks[0].kind {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1241,6 +1241,23 @@ fn split_interpolation(decoded: &str, span: &Span) -> ParseResult<Vec<StrFragmen
             let mut j = start;
             while j < bytes.len() {
                 match bytes[j] {
+                    b'"' => {
+                        // Skip a nested string literal so braces or quotes
+                        // inside it do not affect the interpolation's brace
+                        // depth or close it early.
+                        j += 1;
+                        while j < bytes.len() {
+                            match bytes[j] {
+                                b'\\' => j += 2,
+                                b'"' => {
+                                    j += 1;
+                                    break;
+                                }
+                                _ => j += 1,
+                            }
+                        }
+                        continue;
+                    }
                     b'{' => depth += 1,
                     b'}' => {
                         depth -= 1;


### PR DESCRIPTION
Fixes #262 (the string-literal half).

## Summary

A `"` inside a `${...}` interpolation ended the outer string literal early, so `"hello ${shout("world")}"` failed to parse (`unterminated \ interpolation`). 

The single-line string lexer now tracks interpolation brace depth: while inside `${...}` a `"` opens a nested string consumed verbatim (the embedded expression is later re-lexed by the parser), and `{`/`}` balance the interpolation so it ends at the right `}`. The parser's interpolation splitter likewise skips nested string literals when scanning for the matching `}`.

Macro invocations inside `${...}` are still unsupported (they need the token-level macro pass); that is tracked separately by #226.

## Tests

- `lexer::tests::interpolation_may_contain_a_nested_string_literal`.
- `examples/v2/interp_nested_string.rv` (+ baseline) end to end.
- Full lib suite (470) green; fmt and clippy clean.

Version bumped to 2.0.7 (no release).