### PR TITLE
fix(format): stop rvpm fmt from failing on files that use macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Raven are documented in this file.
 
 ### Fixed
 
+- `rvpm fmt` and `rvpm fmt --check` no longer fail on a file that declares or uses a macro. Such a file is left unchanged for now (macro definitions and `name!(...)` invocations have no AST node to format); reformatting them is a follow-up (#261).
 - String interpolation may now contain a nested string literal, including in a call argument: `"hello ${shout("world")}"`. The inner `"` previously ended the outer string early. Macro invocations inside `${...}` remain unsupported (tracked by #226) (#262).
 - The formatter now writes `spawn(...)` as a call, without the stray space it used to insert before the parenthesis (#263).
 - `match` on `String` literal patterns now compares by content. Arms like `"yes" -> ...` previously compared heap-pointer identity, so they never matched and silently fell through to the wildcard (#265).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.0.9"
+version = "2.0.10"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.0.9"
+version = "2.0.10"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.0.9"
+version = "2.0.10"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -51,6 +51,14 @@ pub fn format_source(src: &str) -> Result<String, FormatError> {
     let tokens = Lexer::new(src, "<fmt>")
         .tokenize()
         .map_err(|e| FormatError::Parse(e.to_string()))?;
+    // Macro definitions and `name!(...)` invocations have no AST node (they
+    // are expanded at the token level before parsing in the compile
+    // pipeline), so the AST-based formatter cannot represent them. Rather
+    // than fail, leave a file that uses macros unchanged. Reformatting macro
+    // internals is tracked as a follow-up.
+    if crate::macros::contains_macros(&tokens) {
+        return Ok(src.to_string());
+    }
     let file = parse(&tokens).map_err(|e| FormatError::Parse(e.to_string()))?;
     let comments = comments::scan(src);
     let mut p = Printer::new(src, comments);

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -102,6 +102,17 @@ fn defer_stmt() {
 }
 
 #[test]
+fn macro_file_is_left_unchanged() {
+    // Macro definitions and `name!(...)` invocations have no AST node, so the
+    // formatter passes a macro-using file through unchanged rather than
+    // failing to parse it.
+    let src =
+        "macro square { ($x:expr) => { ($x) * ($x) } }\nfun main() {\n    print(square!(5))\n}\n";
+    let out = format_source(src).expect("formatting a macro file must not error");
+    assert_eq!(out, src);
+}
+
+#[test]
 fn spawn_stmt_formats_as_call() {
     // `spawn` reads as a call: no space before the parenthesis, a single
     // paren layer, and stable under re-formatting (checked by `fmt`).

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -174,6 +174,15 @@ impl SpanGen {
 /// True when an item-position `macro` keyword appears. `macro` is a
 /// contextual identifier, so we only treat it as the keyword when it begins
 /// a definition shape (`macro <ident> {`).
+/// Whether `tokens` declare any macro. Because macros are file-local (a
+/// `name!(...)` call requires its `macro name { ... }` definition in the
+/// same file), this also tells whether the file uses macros at all. The
+/// formatter uses it to leave macro-using files untouched, since macro
+/// definitions and invocations have no AST representation to format.
+pub fn contains_macros(tokens: &[Token]) -> bool {
+    has_macro_keyword(tokens)
+}
+
 fn has_macro_keyword(tokens: &[Token]) -> bool {
     tokens.windows(3).any(|w| {
         is_macro_kw(&w[0].kind)


### PR DESCRIPTION
Addresses #261 (the crash).

## Summary

The formatter is AST-based, but macro definitions (`macro name { ... }`) and `name!(...)` invocations have no AST node: macros are expanded at the token level before parsing in the compile pipeline, so the parser never represents them. As a result `rvpm fmt` and `rvpm fmt --check` errored on any file that declares a macro (`expected top level item, found identifier macro`), which can block a project-wide format check.

This detects macro presence (a new public `macros::contains_macros`, true when the file declares any macro, which is also when it uses one, since macros are file-local) and returns the source unchanged in that case, so the tool no longer fails on macro files. Non-macro files format exactly as before.

The file is left unmodified rather than reformatted; full formatting of macro definitions and invocations needs an AST representation for them and is tracked as the remaining work on #261.

## Tests

- `format::tests::macro_file_is_left_unchanged`.
- Verified: `rvpm fmt` / `rvpm fmt --check` on a macro file now exit 0; the file still compiles and runs.
- Full lib suite (471) and the rvpm_fmt suite green; fmt and clippy clean.

Version bumped to 2.0.10 (no release).
