### PR TITLE
docs(release): 2.0.10 docs + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Raven are documented in this file.
 
 ## [Unreleased]
 
+## [2.0.10] - 2026-06-04
+
 ### Added
 
 - Module-level constants with literal initializers now work and can be used from any function: `const MAX: Int = 100`, `let GREETING = "hello"`, `let NEG = -7`. Each reference is inlined to its literal, and an unannotated `let` infers its type from the literal. References previously mis-typed as `Unit` and failed in code generation. Mutable or computed module-level bindings remain unsupported (#278).

--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -90,8 +90,10 @@ pointer to a static null terminated buffer (see [FFI](#ffi-and-c-types)).
 
 Arithmetic: `+`, `-`, `*`, `/`, `%`.
 
-Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`. Comparisons do not chain:
-`a < b < c` is an error.
+Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`. Ordering (`<`, `<=`, `>`,
+`>=`) works on `Int`, `Float`, `Char`, and `String` (lexicographic, by
+bytes); `==`/`!=` work on any type. Comparisons do not chain: `a < b < c`
+is an error.
 
 Logical: `&&`, `||`, `!`.
 
@@ -542,6 +544,9 @@ Forms:
   methods resolve by receiver type.
 - `import std/collections` is a whole module import; `Map` and `Set` are
   reached as `Map.new()` and `Set.new()` rather than through a selector.
+- A whole module import also allows module-qualified calls: after
+  `import std/fs` you can call `fs.write(path, data)`, the same function a
+  selector import would bind as a bare `write`.
 - `import "./helpers"` loads a local module relative to the current file.
 - `import "github.com/<user>/<repo>"` resolves a dependency through the
   rvpm cache (see the [rvpm guide](rvpm.md)). Add `as name` for an alias.

--- a/docs/v2/guide/standard-library.md
+++ b/docs/v2/guide/standard-library.md
@@ -7,8 +7,9 @@ scope.
 
 Two import gotchas to keep in mind:
 
-- To use `String` methods such as `concat` or `to_upper`, a module must
-  `import std/string`, which merges the `impl String` block.
+- `String.len()` and `String.is_empty()` are built in and need no import.
+  The other `String` methods (`concat`, `to_upper`, `substring`, ...) come
+  from `import std/string`, which merges the `impl String` block.
 - `import std/collections` whole (not `{ Map }`), so the `Map.new()` and
   `Set.new()` constructors resolve.
 
@@ -46,9 +47,13 @@ A global `print` builtin is also always available and accepts any
 
 Methods on `String`, merged by a bare import.
 
-`length`, `is_empty`, `char_at`, `substring(start, end)`, `concat`,
-`to_upper`, `to_lower`, `trim`, `is_blank`, `repeat(n)`, `index_of`,
-`contains`, `starts_with`, `ends_with`, `replace(from, to)`.
+`length` (alias `len`), `is_empty`, `char_at`, `substring(start, end)`,
+`concat`, `to_upper`, `to_lower`, `trim`, `is_blank`, `repeat(n)`,
+`index_of`, `contains`, `starts_with`, `ends_with`, `replace(from, to)`.
+
+`len` and `is_empty` are built in and work without the import. `String`
+values also compare lexicographically with `<`, `<=`, `>`, `>=`, and a
+`String` literal can be a `match` pattern (compared by content).
 
 ```raven
 import std/string


### PR DESCRIPTION
Documents the new capabilities for the 2.0.10 release and finalizes the changelog. The VS Code extension needs no changes: this batch adds no new syntax (String len/ordering/match, interpolation, module-qualified calls, and module constants are existing grammar that now works), and the extension already covers v2 syntax with no outdated claims.