### PR TITLE
feat(macros): add ty, literal, pat, and block fragment specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Raven are documented in this file.
 
 ### Added
 
+- Macro fragment specifiers beyond `expr` and `ident`: `$x:ty` and `$x:pat` capture a balanced token run (a type such as `List<Int>`, a pattern such as `Some(n)`), `$x:literal` matches exactly one literal token and rejects anything else, and `$x:block` captures a brace-delimited `{ ... }` group. The names document call-site intent and, for `literal` and `block`, constrain what a rule accepts (#223).
 - Runtime reflection `set_field(a, name, value)`: write a struct field by name through an `Any`, the counterpart to `get_field`. A write whose value type does not match the field is ignored (#230).
 - Rich, colorful compiler error messages. `raven build` now prints a friendly headline, a box-drawing source pointer with an inline label at the offending span, and `help:`/`note:` lines, instead of a single terse line. Type mismatches, unknown types, missing match arms, undefined methods, and parse errors all get hand-written wording and suggestions. Color is automatic on a terminal and disabled under `NO_COLOR` or when output is piped (#283).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/macros.md
+++ b/docs/v2/specs/macros.md
@@ -79,12 +79,21 @@ This slice supports invocation in expression position only.
 ### Metavariables and fragments
 
 A matcher is a sequence of literal tokens and metavariable bindings. A
-metavariable is written `$name:fragment`. This slice supports two fragments:
+metavariable is written `$name:fragment`. The supported fragments are:
 
 * `$x:expr` captures a balanced token run up to the next literal token in
   the matcher (the delimiter), or to the end of the argument tokens when no
   delimiter follows. "Balanced" means `()`, `[]`, and `{}` nest, so a
   top-level delimiter inside parentheses does not end the capture.
+* `$x:ty` and `$x:pat` capture a balanced token run exactly like `expr`. The
+  separate names document intent at the call site (a type such as
+  `List<Int>`, or a pattern such as `Some(n)`); the matcher does not parse
+  the capture, so any balanced run is accepted.
+* `$x:literal` captures exactly one literal token: an integer, float, string,
+  block string, character, C string, or `true`/`false`. A non-literal token
+  (for example an identifier) fails the rule.
+* `$x:block` captures a brace-delimited group `{ ... }`, braces included. The
+  capture must start with `{`; the matching `}` ends it.
 * `$x:ident` captures exactly one identifier token.
 
 In a template, `$name` splices the captured token run for that
@@ -225,8 +234,9 @@ name. Definition-site resolution of free identifiers is a follow-up.
 * `macro <name> { (<matcher>) => { <template> } ... }` with one or more
   rules, first matching rule wins.
 * `name!(...)` invocation in expression position.
-* `$x:expr` (balanced capture up to the next matcher delimiter) and
-  `$x:ident` (single identifier) metavariables.
+* `$x:expr`, `$x:ty`, `$x:pat` (balanced capture up to the next matcher
+  delimiter), `$x:literal` (single literal token), `$x:block` (a `{ ... }`
+  group), and `$x:ident` (single identifier) metavariables.
 * Repetition `$( <sub> )<sep>*` and `$( <sub> )<sep>+` (one level) in both
   matchers and templates, with an optional single separator.
 * Basic hygiene: template-introduced binding-site identifiers (`let`, `const`,
@@ -240,6 +250,5 @@ name. Definition-site resolution of free identifiers is a follow-up.
 * Nested repetition (a repetition group inside another).
 * Item-position and statement-position invocations.
 * Full referential hygiene (definition-site resolution of free identifiers).
-* Additional fragment kinds (`ty`, `literal`, `pat`, `block`).
 * Procedural macros / compile-time functions (the broader procedural side).
 ```

--- a/examples/v2/macro_fragment_kinds.rv
+++ b/examples/v2/macro_fragment_kinds.rv
@@ -1,0 +1,32 @@
+// Macro fragment specifiers beyond expr and ident: ty, literal, pat, and block.
+// Each metavariable kind constrains what the matcher accepts and captures the
+// matching token run for substitution into the template.
+
+// `ty` captures a balanced type, including the angle brackets of a generic.
+macro name_of { ($t:ty) => { type_name<$t>() } }
+
+// `literal` matches exactly one literal token (here an Int), rejecting names.
+macro doubled_lit { ($x:literal) => { ($x) + ($x) } }
+
+// `pat` captures a pattern, used here in the arm of a match.
+macro matches_some { ($p:pat, $e:expr) => { match $e { $p -> true, _ -> false } } }
+
+// `block` captures a brace-delimited `{ ... }` group, braces included.
+macro run_block { ($b:block) => { $b } }
+
+fun main() {
+    print(name_of!(List<Int>))
+
+    print(doubled_lit!(21))
+
+    let v: Option<Int> = Some(5)
+    print(matches_some!(Some(n), v))
+    print(matches_some!(None, v))
+
+    let total = run_block!({
+        let a = 4
+        let b = 6
+        a + b
+    })
+    print(total)
+}

--- a/examples/v2/macro_fragment_kinds.rv.out
+++ b/examples/v2/macro_fragment_kinds.rv.out
@@ -1,0 +1,5 @@
+List<Int>
+42
+true
+false
+10

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -40,11 +40,22 @@ use crate::span::Span;
 /// bound also limits recursion depth of macros that expand to other calls.
 const EXPANSION_LIMIT: usize = 128;
 
-/// A single metavariable fragment kind supported by this slice.
+/// A single metavariable fragment kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Fragment {
+    /// A balanced expression token run, up to the next matcher delimiter.
     Expr,
+    /// A single identifier token.
     Ident,
+    /// A type, captured as a balanced token run like `expr` (so `List<Int>`
+    /// with its angle brackets is one fragment).
+    Ty,
+    /// A single literal token (number, string, char, or boolean).
+    Literal,
+    /// A pattern, captured as a balanced token run like `expr`.
+    Pat,
+    /// A brace-delimited block `{ ... }`, captured with its braces.
+    Block,
 }
 
 /// One element of a matcher: a bound metavariable, a literal token that must
@@ -384,11 +395,15 @@ fn parse_matcher(slice: &[Token], name: &str) -> Result<Vec<MatchItem>, RavenErr
                 let frag = match slice.get(i + 3).map(|t| &t.kind) {
                     Some(TokenKind::Identifier(s)) if s == "expr" => Fragment::Expr,
                     Some(TokenKind::Identifier(s)) if s == "ident" => Fragment::Ident,
+                    Some(TokenKind::Identifier(s)) if s == "ty" => Fragment::Ty,
+                    Some(TokenKind::Identifier(s)) if s == "literal" => Fragment::Literal,
+                    Some(TokenKind::Identifier(s)) if s == "pat" => Fragment::Pat,
+                    Some(TokenKind::Identifier(s)) if s == "block" => Fragment::Block,
                     other => {
                         return Err(err(
                             slice[i].span.clone(),
                             format!(
-                                "macro `{}`: unsupported fragment `{}` (this slice supports `expr` and `ident`)",
+                                "macro `{}`: unsupported fragment `{}` (supported: expr, ident, ty, literal, pat, block)",
                                 name,
                                 other.map(describe).unwrap_or_else(|| "?".into())
                             ),
@@ -620,7 +635,23 @@ fn match_seq(
                     binds.insert(name.clone(), Capture::Single(vec![tok.clone()]));
                     pos += 1;
                 }
-                Fragment::Expr => {
+                Fragment::Literal => {
+                    let tok = args.get(pos)?;
+                    if !is_literal_token(&tok.kind) {
+                        return None;
+                    }
+                    binds.insert(name.clone(), Capture::Single(vec![tok.clone()]));
+                    pos += 1;
+                }
+                Fragment::Block => {
+                    let end = capture_block(args, pos)?;
+                    binds.insert(name.clone(), Capture::Single(args[pos..end].to_vec()));
+                    pos = end;
+                }
+                // A type and a pattern capture a balanced token run, the same
+                // way an expression does: the angle brackets of `List<Int>`
+                // and the parentheses of a constructor pattern stay balanced.
+                Fragment::Expr | Fragment::Ty | Fragment::Pat => {
                     let delim = next_delim(matcher, idx + 1, outer_delim);
                     let end = capture_balanced(args, pos, delim.as_ref())?;
                     if end == pos {
@@ -767,6 +798,46 @@ fn capture_balanced(args: &[Token], start: usize, delim: Option<&TokenKind>) -> 
         return None;
     }
     Some(i)
+}
+
+/// Whether `kind` is a literal token (the `literal` fragment matches one).
+fn is_literal_token(kind: &TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::IntLit(_)
+            | TokenKind::FloatLit(_)
+            | TokenKind::StringLit(_)
+            | TokenKind::BlockStringLit(_)
+            | TokenKind::CharLit(_)
+            | TokenKind::CStringLit(_)
+            | TokenKind::True
+            | TokenKind::False
+    )
+}
+
+/// Capture a brace-delimited block `{ ... }` starting at `start`, returning
+/// the index just past its closing `}`. Returns `None` when `start` is not a
+/// `{` or the braces are unbalanced.
+fn capture_block(args: &[Token], start: usize) -> Option<usize> {
+    if !matches!(args.get(start)?.kind, TokenKind::LBrace) {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut i = start;
+    while i < args.len() {
+        match args[i].kind {
+            TokenKind::LBrace => depth += 1,
+            TokenKind::RBrace => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Instantiate a template with the given bindings. Spliced and verbatim

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -87,6 +87,42 @@ fn ident_fragment_captures_one_identifier() {
 }
 
 #[test]
+fn ty_fragment_captures_a_balanced_type() {
+    let src = "macro sizer { ($t:ty) => { size_of($t) } }\nlet n = sizer!(List<Int>)\n";
+    assert_eq!(expand_render(src), "let n = size_of ( List `<` Int > )");
+}
+
+#[test]
+fn literal_fragment_captures_one_literal() {
+    let src = "macro dbl { ($x:literal) => { ($x) + ($x) } }\nlet y = dbl!(21)\n";
+    assert_eq!(expand_render(src), "let y = ( 21 ) + ( 21 )");
+}
+
+#[test]
+fn literal_fragment_rejects_a_non_literal() {
+    let src = "macro dbl { ($x:literal) => { ($x) } }\nlet y = dbl!(n)\n";
+    let e = expand_tokens(&lex(src)).expect_err("identifier is not a literal");
+    let msg = format!("{}", e);
+    assert!(msg.contains("no rule of macro `dbl!`"), "got: {}", msg);
+}
+
+#[test]
+fn block_fragment_captures_a_brace_group() {
+    let src = "macro run { ($b:block) => { $b } }\nrun!({ let a = 1 })\n";
+    assert_eq!(expand_render(src), "{ let a = 1 }");
+}
+
+#[test]
+fn pat_fragment_captures_a_pattern() {
+    let src = "macro is { ($p:pat, $e:expr) => { match $e { $p -> true, _ -> false } } }\n\
+               let b = is!(Some(n), x)\n";
+    assert_eq!(
+        expand_render(src),
+        "let b = `match` x { Some ( n ) `->` `true` , _ `->` `false` }"
+    );
+}
+
+#[test]
 fn nested_macro_calls_expand_to_fixpoint() {
     let src = "macro twice { ($x:expr) => { ($x) + ($x) } }\nlet y = twice!(twice!(k))\n";
     assert_eq!(


### PR DESCRIPTION
## Summary

Extends declarative macro metavariables beyond `expr` and `ident` with four new fragment specifiers, closing the last open subtask on the macro epic.

- `$x:ty` and `$x:pat` capture a balanced token run, exactly like `expr`. The separate names document intent at the call site (a type such as `List<Int>`, or a pattern such as `Some(n)`). The matcher does not parse the capture, so any balanced run is accepted.
- `$x:literal` matches exactly one literal token (integer, float, string, block string, character, C string, or `true`/`false`). A non-literal token, for example an identifier, fails the rule.
- `$x:block` captures a brace-delimited group `{ ... }`, braces included. The capture must start with `{`; the matching `}` ends it.

## Testing

- New macro unit tests cover each kind, including the rejection paths for `literal` (an identifier is not a literal).
- New golden example `examples/v2/macro_fragment_kinds.rv` exercises all four kinds end to end (compiled and run): `ty` via `type_name<$t>()`, `literal` doubling, `pat` in a `match`, and `block` as a `{ ... }` expression.
- `cargo fmt --check`, `cargo clippy`, full `cargo test`, and the golden suite are green.

## Version

Patch bump to `2.1.2` (macro-epic subtask). CHANGELOG `[Unreleased]` updated; no release cut.

Fixes #223
