### PR TITLE
feat(reflection): add field_types<T>() compile-time builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Raven are documented in this file.
 
 ### Added
 
+- Compile-time reflection `field_types<T>()`: the positional counterpart to `field_names<T>()`, returning each struct field's type name in declaration order as a `List<String>`. For a generic struct each field renders its concrete type per instantiation, so `field_types<Box<Int>>()` yields `["Int"]`. A non-struct type argument is rejected, matching `field_names` (#227).
 - Macro fragment specifiers beyond `expr` and `ident`: `$x:ty` and `$x:pat` capture a balanced token run (a type such as `List<Int>`, a pattern such as `Some(n)`), `$x:literal` matches exactly one literal token and rejects anything else, and `$x:block` captures a brace-delimited `{ ... }` group. The names document call-site intent and, for `literal` and `block`, constrain what a rule accepts (#223).
 - Runtime reflection `set_field(a, name, value)`: write a struct field by name through an `Any`, the counterpart to `get_field`. A write whose value type does not match the field is ignored (#230).
 - Rich, colorful compiler error messages. `raven build` now prints a friendly headline, a box-drawing source pointer with an inline label at the offending span, and `help:`/`note:` lines, instead of a single terse line. Type mismatches, unknown types, missing match arms, undefined methods, and parse errors all get hand-written wording and suggestions. Color is automatic on a terminal and disabled under `NO_COLOR` or when output is piped (#283).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.1.2"
+version = "2.1.3"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -829,24 +829,29 @@ capture a caller's variable of the same spelling.
 ### Reflection
 
 Compile-time reflection reads type information resolved while the program
-compiles. `type_name<T>()` returns the rendered name of a type, and
-`field_names<T>()` returns a struct's field names in declaration order.
-Inside a generic function each resolves to the concrete type bound to `T`
-at that instantiation.
+compiles. `type_name<T>()` returns the rendered name of a type,
+`field_names<T>()` returns a struct's field names in declaration order, and
+`field_types<T>()` returns the matching field type names by position. Inside
+a generic function each resolves to the concrete type bound to `T` at that
+instantiation.
 
 ```raven
 struct Point { x: Int, y: Int }
 
 fun introspect<T>() {
     print("type ${type_name<T>()}")
-    for f in field_names<T>() {
-        print("field ${f}")
+    let names = field_names<T>()
+    let types = field_types<T>()
+    let i = 0
+    while i < names.len() {
+        print("field ${names[i]}: ${types[i]}")
+        i += 1
     }
 }
 
 fun main() {
     print(type_name<Int>())     // Int
-    introspect<Point>()         // type Point, field x, field y
+    introspect<Point>()         // type Point, field x: Int, field y: Int
 }
 ```
 

--- a/docs/v2/specs/reflection.md
+++ b/docs/v2/specs/reflection.md
@@ -2,11 +2,12 @@
 
 Compile-time type reflection exposes a small amount of type information to
 user code, resolved while the program is compiled. This is the first slice
-of the reflection work tracked under issue #216. It ships two builtins:
+of the reflection work tracked under issue #216. It ships three builtins:
 
 ```raven
 type_name<T>() -> String
 field_names<T>() -> List<String>
+field_types<T>() -> List<String>
 ```
 
 Both take a single type argument and no value arguments. The type argument
@@ -65,13 +66,40 @@ field_names<Point>()    // ["x", "y"]
 ```
 
 `T` must be a struct. Applying `field_names` to a non-struct type (a
-scalar, an enum, a built-in generic) is a compile error. Field types,
-not just names, are a follow-up (a typed field descriptor); this slice
-returns names only.
+scalar, an enum, a built-in generic) is a compile error.
 
 Inside a generic function, `field_names<T>()` resolves to the fields of the
 struct bound to `T` at each instantiation, the same per-monomorphization
 mechanic as `type_name`.
+
+## field_types
+
+`field_types<T>()` evaluates to the field types of the struct type `T`, in
+declaration order, as a `List<String>` of rendered type names. It is the
+positional counterpart to `field_names`: index `i` of one lines up with
+index `i` of the other, so the two together describe each field.
+
+```raven
+struct User { id: Int, name: String, active: Bool }
+
+field_names<User>()    // ["id", "name", "active"]
+field_types<User>()    // ["Int", "String", "Bool"]
+```
+
+`T` must be a struct, with the same non-struct rejection as `field_names`.
+For a generic struct, each field type is rendered at its concrete
+instantiation, so a generic field reads as the type it is bound to:
+
+```raven
+struct Box<T> { value: T }
+
+field_types<Box<Int>>()       // ["Int"]
+field_types<Box<String>>()    // ["String"]
+```
+
+A typed descriptor object (a struct the user can read, rather than parallel
+string lists) remains a possible future surface; this slice pairs
+`field_names` and `field_types` by position.
 
 ## Model: compile-time, per-monomorphization
 
@@ -92,6 +120,10 @@ becomes the concrete type for that instantiation:
 - `field_names<T>()` lowers to a `List<String>` literal built from the
   grounded struct's field names, looked up from the struct declaration the
   lowering pass already holds.
+- `field_types<T>()` lowers to a `List<String>` literal of the grounded
+  struct's field type names. A per-instantiation substitution built from the
+  concrete type arguments grounds each declared field type first, so a
+  generic field renders its concrete type.
 
 Because the lowering runs per instantiation with the concrete substitution,
 a generic `type_name<T>()` produces the right name at each call, not one
@@ -100,10 +132,11 @@ unaffected: nothing is emitted and no runtime symbol is referenced.
 
 ## Recognition
 
-`type_name` and `field_names` are builtin names, recognized the same way
-the `print` builtin and the internal stdlib intrinsics are: the resolver
-allows the bare name without a binding, the type checker assigns the result
-type at the call site (and validates that `field_names` targets a struct),
+`type_name`, `field_names`, and `field_types` are builtin names, recognized
+the same way the `print` builtin and the internal stdlib intrinsics are: the
+resolver allows the bare name without a binding, the type checker assigns the
+result type at the call site (and validates that `field_names`/`field_types`
+target a struct),
 and HIR lowering rewrites the call into a dedicated reflection node carrying
 the resolved type argument. A user can shadow either name by binding it in
 scope (an import or a local), in which case the binding wins.
@@ -113,7 +146,6 @@ scope (an import or a local), in which case the binding wins.
 This slice is deliberately bounded. The following are follow-ups, each
 filed against #216:
 
-- Field types and a typed field descriptor (not just names).
+- A typed field descriptor object (a readable struct, not parallel string
+  lists); `field_types` covers the field-type information for now.
 - Enum and variant introspection.
-- Runtime reflection over a value of unknown type, via an `Any` type.
-- Dynamic field get and set.

--- a/examples/v2/use_field_types.rv
+++ b/examples/v2/use_field_types.rv
@@ -1,0 +1,52 @@
+// Compile-time field reflection: field_types<T>() pairs with field_names<T>().
+//
+// field_types yields a struct's field type names in declaration order, the
+// counterpart to field_names. Both resolve at compile time per
+// monomorphization, so a generic struct renders its concrete field types and a
+// generic describe<T> resolves to a different struct from one body. See
+// docs/v2/specs/reflection.md.
+//
+// Compiling and running this prints:
+//   id: Int
+//   name: String
+//   active: Bool
+//   --
+//   Int
+//   String
+//   --
+//   value: Int
+struct User {
+    id: Int,
+    name: String,
+    active: Bool
+}
+
+struct Box<T> {
+    value: T
+}
+
+fun describe<T>() {
+    let names = field_names<T>()
+    let types = field_types<T>()
+    let i = 0
+    while i < names.len() {
+        print("${names[i]}: ${types[i]}")
+        i += 1
+    }
+}
+
+fun main() {
+    describe<User>()
+
+    print("--")
+    // A generic struct renders its concrete field type per instantiation.
+    for t in field_types<Box<Int>>() {
+        print(t)
+    }
+    for t in field_types<Box<String>>() {
+        print(t)
+    }
+
+    print("--")
+    describe<Box<Int>>()
+}

--- a/examples/v2/use_field_types.rv.out
+++ b/examples/v2/use_field_types.rv.out
@@ -1,0 +1,8 @@
+id: Int
+name: String
+active: Bool
+--
+Int
+String
+--
+value: Int

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -270,6 +270,11 @@ pub enum HirExprKind {
     /// resolved struct type argument, grounded per monomorphization in MIR
     /// and lowered to a `List<String>` of the struct's field names.
     FieldNames(HirTy),
+    /// `field_types<T>()` compile-time reflection builtin. Like
+    /// `FieldNames`, but lowered to a `List<String>` of each field's type
+    /// name in declaration order, grounded per monomorphization so a generic
+    /// field renders its concrete type.
+    FieldTypes(HirTy),
 
     /// A raw-pointer FFI builtin (`__ptr_load`, `__ptr_store`,
     /// `__ptr_offset`, `__ptr_is_null`, `__ptr_null`, `__ptr_alloc`,

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -202,6 +202,10 @@ pub(crate) fn lower_expr(
                         let arg_ty = cx.ty_at(&callee.span);
                         return Ok(make_expr(HirExprKind::FieldNames(arg_ty), ty, span));
                     }
+                    if name == "field_types" {
+                        let arg_ty = cx.ty_at(&callee.span);
+                        return Ok(make_expr(HirExprKind::FieldTypes(arg_ty), ty, span));
+                    }
                     if let Some(op) = ptr_builtin_op(name) {
                         let pointee = cx.ty_at(&callee.span);
                         let mut lowered = Vec::with_capacity(args.len());

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -490,6 +490,9 @@ fn pretty_expr(buf: &mut String, expr: &HirExpr, depth: usize) {
         HirExprKind::FieldNames(arg) => {
             writeln!(buf, "(field-names arg={} ty={})", arg, expr.ty).unwrap()
         }
+        HirExprKind::FieldTypes(arg) => {
+            writeln!(buf, "(field-types arg={} ty={})", arg, expr.ty).unwrap()
+        }
         HirExprKind::PtrBuiltin { op, pointee, args } => {
             writeln!(
                 buf,

--- a/src/mir/lower/closure.rs
+++ b/src/mir/lower/closure.rs
@@ -319,6 +319,7 @@ fn collect_free_expr(
         | HirExprKind::NoneCtor
         | HirExprKind::TypeName(_)
         | HirExprKind::FieldNames(_)
+        | HirExprKind::FieldTypes(_)
         | HirExprKind::Continue => {}
         HirExprKind::Ident(name) => record_use(name, bound, seen, out),
         HirExprKind::Array(items) => {

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -353,6 +353,7 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
         }
         HirExprKind::TypeName(arg) => lower_type_name(cx, arg, ty),
         HirExprKind::FieldNames(arg) => lower_field_names(cx, arg, ty),
+        HirExprKind::FieldTypes(arg) => lower_field_types(cx, arg, ty),
         HirExprKind::PtrBuiltin { op, pointee, args } => {
             lower_ptr_builtin(cx, *op, pointee, args, ty)
         }
@@ -544,6 +545,50 @@ fn lower_field_names(cx: &mut LowerCx<'_>, arg: &crate::tycheck::Ty, ty: MirType
         .collect();
     let list_ty = MirType::List(Box::new(MirType::Str));
     let dst = cx.builder.fresh_temp("fieldnames", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::ArrayLit {
+            ty: list_ty,
+            elements,
+        },
+    );
+    MirOperand::Copy(dst)
+}
+
+/// Lower `field_types<T>()`. Mirrors `field_names`, but renders each field's
+/// type name in declaration order instead of its name. For a generic struct
+/// the declared field types carry the struct's own `Ty::Param`s; a
+/// per-instantiation substitution built from the concrete type arguments
+/// grounds them, so `field_types<Box<Int>>()` yields `["Int"]`. A grounded
+/// non-struct type yields an empty list, matching `field_names`.
+fn lower_field_types(cx: &mut LowerCx<'_>, arg: &crate::tycheck::Ty, ty: MirType) -> MirOperand {
+    use crate::tycheck::Ty;
+    let concrete = super::substitute(arg, cx.subst);
+    let type_names: Vec<String> = match concrete.strip_self() {
+        Ty::Struct { name, args, .. } => cx
+            .decls
+            .structs
+            .get(name.as_str())
+            .map(|s| {
+                let mut subst: super::SubstMap = super::SubstMap::new();
+                for (p, a) in struct_generic_params(s).iter().zip(args.iter()) {
+                    subst.insert(p.clone(), a.clone());
+                }
+                s.fields
+                    .iter()
+                    .map(|(_, fty, _)| format!("{}", super::substitute(fty, &subst).strip_self()))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    let elements: Vec<MirOperand> = type_names
+        .into_iter()
+        .map(|n| MirOperand::Const(MirConstant::Str(n)))
+        .collect();
+    let list_ty = MirType::List(Box::new(MirType::Str));
+    let dst = cx.builder.fresh_temp("fieldtypes", ty);
     cx.builder.assign(
         cx.current,
         dst,

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -667,6 +667,7 @@ fn is_builtin_ctor_name(name: &str) -> bool {
             | "print"
             | "type_name"
             | "field_names"
+            | "field_types"
             | "to_any"
             | "cast"
             | "type_name_of"

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1355,6 +1355,7 @@ impl<'a, 'b> Checker<'a, 'b> {
         match name {
             "type_name" => self.check_reflection_builtin(name, generics, callee_span, args, span),
             "field_names" => self.check_reflection_builtin(name, generics, callee_span, args, span),
+            "field_types" => self.check_reflection_builtin(name, generics, callee_span, args, span),
             "__ptr_alloc" | "__ptr_free" | "__ptr_load" | "__ptr_store" | "__ptr_offset"
             | "__ptr_is_null" | "__ptr_null" => {
                 self.check_ptr_builtin(name, generics, callee_span, args, span)
@@ -1520,8 +1521,9 @@ impl<'a, 'b> Checker<'a, 'b> {
         }
     }
 
-    /// Check a compile-time reflection builtin (`type_name<T>()` or
-    /// `field_names<T>()`). Both take exactly one type argument and no value
+    /// Check a compile-time reflection builtin (`type_name<T>()`,
+    /// `field_names<T>()`, or `field_types<T>()`). Each takes exactly one
+    /// type argument and no value
     /// arguments. The resolved type argument is recorded under the callee
     /// span so HIR lowering can carry it (a generic parameter `T` resolves
     /// to `Ty::Param`, grounded per monomorphization in MIR). See
@@ -1555,12 +1557,13 @@ impl<'a, 'b> Checker<'a, 'b> {
             ));
         }
         let arg_ty = self.resolve_ast_ty(&generics[0])?;
-        if name == "field_names" && !matches!(arg_ty.strip_self(), Ty::Struct { .. } | Ty::Param(_))
+        if (name == "field_names" || name == "field_types")
+            && !matches!(arg_ty.strip_self(), Ty::Struct { .. } | Ty::Param(_))
         {
             return Err(RavenError::ty(
                 TypeError::Custom(format!(
-                    "`field_names` requires a struct type, got `{}`",
-                    arg_ty
+                    "`{}` requires a struct type, got `{}`",
+                    name, arg_ty
                 )),
                 span.clone(),
             ));
@@ -1570,7 +1573,7 @@ impl<'a, 'b> Checker<'a, 'b> {
         // keeps the result type (`String` or `List<String>`).
         self.record(callee_span, arg_ty);
         Ok(match name {
-            "field_names" => Ty::List(Box::new(Ty::Str)),
+            "field_names" | "field_types" => Ty::List(Box::new(Ty::Str)),
             _ => Ty::Str,
         })
     }

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -715,8 +715,28 @@ fn type_name_resolves_a_generic_parameter() {
 }
 
 #[test]
+fn field_types_yields_list_of_string() {
+    check(
+        r#"
+        struct Point { x: Int, y: Int }
+        fun a() -> List<String> = field_types<Point>()
+    "#,
+    )
+    .unwrap();
+}
+
+#[test]
 fn field_names_on_scalar_is_rejected() {
     let err = check("fun a() -> List<String> = field_names<Int>()\n").unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::Custom(_))),
+        other => panic!("expected a type error, got {:?}", other),
+    }
+}
+
+#[test]
+fn field_types_on_scalar_is_rejected() {
+    let err = check("fun a() -> List<String> = field_types<Int>()\n").unwrap_err();
     match err {
         RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::Custom(_))),
         other => panic!("expected a type error, got {:?}", other),

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -134,6 +134,22 @@ fn reflection_program_compiles_and_runs() {
 }
 
 #[test]
+fn field_types_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // `field_types<T>()` pairs with `field_names<T>()`, rendering each field's
+    // type by position. A generic struct (`Box<T>`) renders its concrete field
+    // type per instantiation, so `Box<Int>` reads `Int` and `Box<String>`
+    // reads `String`.
+    compile_link_run_and_check(
+        "use_field_types.rv",
+        "id: Int\nname: String\nactive: Bool\n--\nInt\nString\n--\nvalue: Int\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn derive_json_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
## Summary

Adds `field_types<T>()`, the positional counterpart to `field_names<T>()`. It returns a struct's field type names in declaration order as a `List<String>`, so index `i` of one lines up with index `i` of the other and the two together describe each field.

```raven
struct User { id: Int, name: String, active: Bool }

field_names<User>()    // ["id", "name", "active"]
field_types<User>()    // ["Int", "String", "Bool"]
```

Like the other compile-time reflection builtins it resolves per monomorphization. For a generic struct the declared field types carry the struct's own `Ty::Param`s; a per-instantiation substitution built from the concrete type arguments grounds them, so a generic field renders its concrete type:

```raven
struct Box<T> { value: T }

field_types<Box<Int>>()       // ["Int"]
field_types<Box<String>>()    // ["String"]
```

A non-struct type argument is rejected with the same wording as `field_names`.

This closes #227. Per the issue's "decide the descriptor's surface shape (a struct the user can read, or a pair list)", this ships the parallel-list shape: `field_names` + `field_types` paired by position. A typed descriptor object remains a possible future surface and is noted as such in the spec.

## Implementation

Wires the builtin through the same path as `field_names`: resolver allowlist, type checker (`check_reflection_builtin`, struct guard, `List<String>` result), a dedicated `HirExprKind::FieldTypes` node, and MIR lowering (`lower_field_types`, reusing the existing `struct_generic_params` substitution machinery).

## Testing

- Type checker unit tests: `field_types` yields `List<String>`; a scalar argument is rejected.
- Codegen smoke test plus a golden example `examples/v2/use_field_types.rv` exercising plain structs, generic struct instantiations, and the names/types pairing, all compiled and run.
- `cargo fmt --check`, `cargo clippy`, full `cargo test`, and the golden suite are green.

## Version

Patch bump to `2.1.3` (reflection-epic subtask). CHANGELOG `[Unreleased]` updated; no release cut.

Fixes #227
