### PR TITLE
feat(reflection): add enum variant introspection builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Raven are documented in this file.
 
 ### Added
 
+- Compile-time enum reflection `variant_names<T>()` and `variant_field_types<T>()`: `variant_names` returns an enum's variant names in declaration order as a `List<String>`; `variant_field_types` returns a `List<List<String>>` with one inner list per variant of its payload field type names (empty for a unit variant, so the inner length is the payload arity). For a generic enum each payload type renders at its concrete instantiation. A non-enum type argument is rejected (#228).
 - Compile-time reflection `field_types<T>()`: the positional counterpart to `field_names<T>()`, returning each struct field's type name in declaration order as a `List<String>`. For a generic struct each field renders its concrete type per instantiation, so `field_types<Box<Int>>()` yields `["Int"]`. A non-struct type argument is rejected, matching `field_names` (#227).
 - Macro fragment specifiers beyond `expr` and `ident`: `$x:ty` and `$x:pat` capture a balanced token run (a type such as `List<Int>`, a pattern such as `Some(n)`), `$x:literal` matches exactly one literal token and rejects anything else, and `$x:block` captures a brace-delimited `{ ... }` group. The names document call-site intent and, for `literal` and `block`, constrain what a rule accepts (#223).
 - Runtime reflection `set_field(a, name, value)`: write a struct field by name through an `Any`, the counterpart to `get_field`. A write whose value type does not match the field is ignored (#230).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.1.3"
+version = "2.1.4"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -855,6 +855,18 @@ fun main() {
 }
 ```
 
+For enums, `variant_names<T>()` lists the variant names in declaration order
+and `variant_field_types<T>()` gives each variant's payload type names as an
+inner list (empty for a unit variant), so the inner length is the variant's
+payload arity.
+
+```raven
+enum Shape { Circle(radius: Float) Rectangle(w: Float, h: Float) Dot }
+
+variant_names<Shape>()        // ["Circle", "Rectangle", "Dot"]
+variant_field_types<Shape>()  // [["Float"], ["Float", "Float"], []]
+```
+
 Runtime reflection works over a value whose type is not known statically.
 `to_any<T>(v)` boxes a value into an `Any`. Over an `Any`,
 `type_name_of(a)` reads its runtime type name, `field_names_of(a)` lists

--- a/docs/v2/specs/reflection.md
+++ b/docs/v2/specs/reflection.md
@@ -2,12 +2,14 @@
 
 Compile-time type reflection exposes a small amount of type information to
 user code, resolved while the program is compiled. This is the first slice
-of the reflection work tracked under issue #216. It ships three builtins:
+of the reflection work tracked under issue #216. It ships these builtins:
 
 ```raven
 type_name<T>() -> String
 field_names<T>() -> List<String>
 field_types<T>() -> List<String>
+variant_names<T>() -> List<String>
+variant_field_types<T>() -> List<List<String>>
 ```
 
 Both take a single type argument and no value arguments. The type argument
@@ -101,6 +103,48 @@ A typed descriptor object (a struct the user can read, rather than parallel
 string lists) remains a possible future surface; this slice pairs
 `field_names` and `field_types` by position.
 
+## variant_names
+
+`variant_names<T>()` evaluates to the variant names of the enum type `T`, in
+declaration order, as a `List<String>`. It is the enum counterpart to
+`field_names`.
+
+```raven
+enum Shape { Circle(radius: Float) Rectangle(width: Float, height: Float) Dot }
+
+variant_names<Shape>()    // ["Circle", "Rectangle", "Dot"]
+```
+
+`T` must be an enum. Applying `variant_names` to a non-enum type (a struct, a
+scalar, a built-in generic) is a compile error. The built-in `Option` and
+`Result` are not user enums and are not accepted in this slice.
+
+## variant_field_types
+
+`variant_field_types<T>()` describes each variant's payload, as a
+`List<List<String>>`: one inner list per variant in declaration order,
+holding that variant's payload field type names. A unit variant has an empty
+inner list, so the inner list's length is the variant's payload arity.
+
+```raven
+enum Shape { Circle(radius: Float) Rectangle(width: Float, height: Float) Dot }
+
+variant_names<Shape>()        // ["Circle", "Rectangle", "Dot"]
+variant_field_types<Shape>()  // [["Float"], ["Float", "Float"], []]
+```
+
+For a generic enum each payload type is rendered at its concrete
+instantiation, the same per-monomorphization mechanic as `field_types`:
+
+```raven
+enum Tree<T> { Leaf(value: T) Branch(left: T, right: T) Empty }
+
+variant_field_types<Tree<Int>>()    // [["Int"], ["Int", "Int"], []]
+```
+
+The unit / tuple / named-field distinction beyond payload types and arity is
+not exposed in this slice.
+
 ## Model: compile-time, per-monomorphization
 
 Both builtins are resolved entirely at compile time. There is no runtime
@@ -124,6 +168,11 @@ becomes the concrete type for that instantiation:
   struct's field type names. A per-instantiation substitution built from the
   concrete type arguments grounds each declared field type first, so a
   generic field renders its concrete type.
+- `variant_names<T>()` lowers to a `List<String>` literal of the grounded
+  enum's variant names.
+- `variant_field_types<T>()` lowers to a `List<List<String>>` literal, one
+  inner list per variant, built from the grounded enum's variant payload
+  types under the same per-instantiation substitution as `field_types`.
 
 Because the lowering runs per instantiation with the concrete substitution,
 a generic `type_name<T>()` produces the right name at each call, not one
@@ -132,14 +181,15 @@ unaffected: nothing is emitted and no runtime symbol is referenced.
 
 ## Recognition
 
-`type_name`, `field_names`, and `field_types` are builtin names, recognized
-the same way the `print` builtin and the internal stdlib intrinsics are: the
-resolver allows the bare name without a binding, the type checker assigns the
-result type at the call site (and validates that `field_names`/`field_types`
-target a struct),
-and HIR lowering rewrites the call into a dedicated reflection node carrying
-the resolved type argument. A user can shadow either name by binding it in
-scope (an import or a local), in which case the binding wins.
+`type_name`, `field_names`, `field_types`, `variant_names`, and
+`variant_field_types` are builtin names, recognized the same way the `print`
+builtin and the internal stdlib intrinsics are: the resolver allows the bare
+name without a binding, the type checker assigns the result type at the call
+site (and validates that `field_names`/`field_types` target a struct and
+`variant_names`/`variant_field_types` target an enum), and HIR lowering
+rewrites the call into a dedicated reflection node carrying the resolved type
+argument. A user can shadow any of these names by binding it in scope (an
+import or a local), in which case the binding wins.
 
 ## Deferred
 
@@ -147,5 +197,8 @@ This slice is deliberately bounded. The following are follow-ups, each
 filed against #216:
 
 - A typed field descriptor object (a readable struct, not parallel string
-  lists); `field_types` covers the field-type information for now.
-- Enum and variant introspection.
+  lists); `field_types` and `variant_field_types` cover the type information
+  for now.
+- The unit / tuple / named-field distinction for enum variants, beyond
+  payload arity and types.
+- Variant introspection over the built-in `Option` and `Result` enums.

--- a/examples/v2/use_variant_reflection.rv
+++ b/examples/v2/use_variant_reflection.rv
@@ -1,0 +1,67 @@
+// Compile-time enum reflection: variant_names<T>() and
+// variant_field_types<T>().
+//
+// variant_names yields an enum's variant names in declaration order.
+// variant_field_types yields, per variant (same order), the payload field
+// type names as an inner list: empty for a unit variant, one entry per
+// payload field otherwise. Both resolve at compile time per monomorphization,
+// so a generic enum renders its concrete payload types. See
+// docs/v2/specs/reflection.md.
+//
+// Compiling and running this prints:
+//   Circle
+//   Rectangle
+//   Dot
+//   --
+//   Circle: Float
+//   Rectangle: Float, Float
+//   Dot
+//   == generic ==
+//   Leaf: Int
+//   Branch: Int, Int
+//   Empty
+enum Shape {
+    Circle(radius: Float)
+    Rectangle(width: Float, height: Float)
+    Dot
+}
+
+enum Tree<T> {
+    Leaf(value: T)
+    Branch(left: T, right: T)
+    Empty
+}
+
+fun describe<T>() {
+    let names = variant_names<T>()
+    let payloads = variant_field_types<T>()
+    let i = 0
+    while i < names.len() {
+        let types = payloads[i]
+        let joined = ""
+        let j = 0
+        while j < types.len() {
+            if j > 0 {
+                joined = "${joined}, "
+            }
+            joined = "${joined}${types[j]}"
+            j += 1
+        }
+        if types.len() > 0 {
+            print("${names[i]}: ${joined}")
+        } else {
+            print(names[i])
+        }
+        i += 1
+    }
+}
+
+fun main() {
+    for n in variant_names<Shape>() {
+        print(n)
+    }
+    print("--")
+    describe<Shape>()
+    print("== generic ==")
+    describe<Tree<Int>>()
+}

--- a/examples/v2/use_variant_reflection.rv.out
+++ b/examples/v2/use_variant_reflection.rv.out
@@ -1,0 +1,11 @@
+Circle
+Rectangle
+Dot
+--
+Circle: Float
+Rectangle: Float, Float
+Dot
+== generic ==
+Leaf: Int
+Branch: Int, Int
+Empty

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -275,6 +275,15 @@ pub enum HirExprKind {
     /// name in declaration order, grounded per monomorphization so a generic
     /// field renders its concrete type.
     FieldTypes(HirTy),
+    /// `variant_names<T>()` compile-time reflection builtin. Carries the
+    /// resolved enum type argument, lowered to a `List<String>` of the
+    /// enum's variant names in declaration order.
+    VariantNames(HirTy),
+    /// `variant_field_types<T>()` compile-time reflection builtin. Lowered
+    /// to a `List<List<String>>`: one inner list per variant (declaration
+    /// order) of that variant's payload field type names (empty for a unit
+    /// variant), grounded per monomorphization.
+    VariantFieldTypes(HirTy),
 
     /// A raw-pointer FFI builtin (`__ptr_load`, `__ptr_store`,
     /// `__ptr_offset`, `__ptr_is_null`, `__ptr_null`, `__ptr_alloc`,

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -206,6 +206,14 @@ pub(crate) fn lower_expr(
                         let arg_ty = cx.ty_at(&callee.span);
                         return Ok(make_expr(HirExprKind::FieldTypes(arg_ty), ty, span));
                     }
+                    if name == "variant_names" {
+                        let arg_ty = cx.ty_at(&callee.span);
+                        return Ok(make_expr(HirExprKind::VariantNames(arg_ty), ty, span));
+                    }
+                    if name == "variant_field_types" {
+                        let arg_ty = cx.ty_at(&callee.span);
+                        return Ok(make_expr(HirExprKind::VariantFieldTypes(arg_ty), ty, span));
+                    }
                     if let Some(op) = ptr_builtin_op(name) {
                         let pointee = cx.ty_at(&callee.span);
                         let mut lowered = Vec::with_capacity(args.len());

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -493,6 +493,12 @@ fn pretty_expr(buf: &mut String, expr: &HirExpr, depth: usize) {
         HirExprKind::FieldTypes(arg) => {
             writeln!(buf, "(field-types arg={} ty={})", arg, expr.ty).unwrap()
         }
+        HirExprKind::VariantNames(arg) => {
+            writeln!(buf, "(variant-names arg={} ty={})", arg, expr.ty).unwrap()
+        }
+        HirExprKind::VariantFieldTypes(arg) => {
+            writeln!(buf, "(variant-field-types arg={} ty={})", arg, expr.ty).unwrap()
+        }
         HirExprKind::PtrBuiltin { op, pointee, args } => {
             writeln!(
                 buf,

--- a/src/mir/lower/closure.rs
+++ b/src/mir/lower/closure.rs
@@ -320,6 +320,8 @@ fn collect_free_expr(
         | HirExprKind::TypeName(_)
         | HirExprKind::FieldNames(_)
         | HirExprKind::FieldTypes(_)
+        | HirExprKind::VariantNames(_)
+        | HirExprKind::VariantFieldTypes(_)
         | HirExprKind::Continue => {}
         HirExprKind::Ident(name) => record_use(name, bound, seen, out),
         HirExprKind::Array(items) => {

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -354,6 +354,8 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
         HirExprKind::TypeName(arg) => lower_type_name(cx, arg, ty),
         HirExprKind::FieldNames(arg) => lower_field_names(cx, arg, ty),
         HirExprKind::FieldTypes(arg) => lower_field_types(cx, arg, ty),
+        HirExprKind::VariantNames(arg) => lower_variant_names(cx, arg, ty),
+        HirExprKind::VariantFieldTypes(arg) => lower_variant_field_types(cx, arg, ty),
         HirExprKind::PtrBuiltin { op, pointee, args } => {
             lower_ptr_builtin(cx, *op, pointee, args, ty)
         }
@@ -595,6 +597,111 @@ fn lower_field_types(cx: &mut LowerCx<'_>, arg: &crate::tycheck::Ty, ty: MirType
         MirRvalue::ArrayLit {
             ty: list_ty,
             elements,
+        },
+    );
+    MirOperand::Copy(dst)
+}
+
+/// Lower `variant_names<T>()`. The carried type argument is grounded under
+/// the current substitution; when it is a known enum, the variant names in
+/// declaration order become a `List<String>` literal. A grounded non-enum
+/// type yields an empty list.
+fn lower_variant_names(cx: &mut LowerCx<'_>, arg: &crate::tycheck::Ty, ty: MirType) -> MirOperand {
+    use crate::tycheck::Ty;
+    let concrete = super::substitute(arg, cx.subst);
+    let names: Vec<String> = match concrete.strip_self() {
+        Ty::Enum { name, .. } => cx
+            .decls
+            .enums
+            .get(name.as_str())
+            .map(|e| e.variants.iter().map(|v| v.name.clone()).collect())
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    let elements: Vec<MirOperand> = names
+        .into_iter()
+        .map(|n| MirOperand::Const(MirConstant::Str(n)))
+        .collect();
+    let list_ty = MirType::List(Box::new(MirType::Str));
+    let dst = cx.builder.fresh_temp("variantnames", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::ArrayLit {
+            ty: list_ty,
+            elements,
+        },
+    );
+    MirOperand::Copy(dst)
+}
+
+/// Lower `variant_field_types<T>()` to a `List<List<String>>`: one inner list
+/// per variant (declaration order) of that variant's payload field type
+/// names, empty for a unit variant. Each declared field type is grounded
+/// under a per-instantiation substitution from the enum's generic parameters
+/// to the concrete type arguments, so a generic payload renders its concrete
+/// type. A grounded non-enum type yields an empty outer list.
+fn lower_variant_field_types(
+    cx: &mut LowerCx<'_>,
+    arg: &crate::tycheck::Ty,
+    ty: MirType,
+) -> MirOperand {
+    use crate::tycheck::Ty;
+    let str_list_ty = MirType::List(Box::new(MirType::Str));
+    let concrete = super::substitute(arg, cx.subst);
+    // Render each variant's payload types into a vector of strings, in
+    // declaration order, before touching the builder.
+    let per_variant: Vec<Vec<String>> = match concrete.strip_self() {
+        Ty::Enum { name, args, .. } => cx
+            .decls
+            .enums
+            .get(name.as_str())
+            .map(|e| {
+                let mut subst: super::SubstMap = super::SubstMap::new();
+                for (p, a) in enum_generic_params(e).iter().zip(args.iter()) {
+                    subst.insert(p.clone(), a.clone());
+                }
+                e.variants
+                    .iter()
+                    .map(|v| {
+                        v.fields
+                            .iter()
+                            .map(|(_, fty, _)| {
+                                format!("{}", super::substitute(fty, &subst).strip_self())
+                            })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    // Build each inner `List<String>` into its own temp, then collect those
+    // temps as the outer list's elements.
+    let mut outer: Vec<MirOperand> = Vec::with_capacity(per_variant.len());
+    for variant in per_variant {
+        let inner_elements: Vec<MirOperand> = variant
+            .into_iter()
+            .map(|n| MirOperand::Const(MirConstant::Str(n)))
+            .collect();
+        let inner = cx.builder.fresh_temp("variantfields", str_list_ty.clone());
+        cx.builder.assign(
+            cx.current,
+            inner,
+            MirRvalue::ArrayLit {
+                ty: str_list_ty.clone(),
+                elements: inner_elements,
+            },
+        );
+        outer.push(MirOperand::Copy(inner));
+    }
+    let dst = cx.builder.fresh_temp("variantfieldtypes", ty);
+    cx.builder.assign(
+        cx.current,
+        dst,
+        MirRvalue::ArrayLit {
+            ty: MirType::List(Box::new(str_list_ty)),
+            elements: outer,
         },
     );
     MirOperand::Copy(dst)
@@ -1200,6 +1307,21 @@ fn struct_generic_params(s: &crate::hir::HirStruct) -> Vec<crate::tycheck::ty::P
     let mut found: Vec<crate::tycheck::ty::ParamId> = Vec::new();
     for (_, ty, _) in &s.fields {
         collect_ty_params(ty, &mut found);
+    }
+    found.sort_by_key(|p| p.index);
+    found.dedup();
+    found
+}
+
+/// The generic parameters of an enum declaration, in `ParamId` order. Like
+/// `struct_generic_params` but gathered across every variant's payload field
+/// types, so an enum's instantiation can ground its variant payloads.
+fn enum_generic_params(e: &crate::hir::HirEnum) -> Vec<crate::tycheck::ty::ParamId> {
+    let mut found: Vec<crate::tycheck::ty::ParamId> = Vec::new();
+    for v in &e.variants {
+        for (_, ty, _) in &v.fields {
+            collect_ty_params(ty, &mut found);
+        }
     }
     found.sort_by_key(|p| p.index);
     found.dedup();

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -668,6 +668,8 @@ fn is_builtin_ctor_name(name: &str) -> bool {
             | "type_name"
             | "field_names"
             | "field_types"
+            | "variant_names"
+            | "variant_field_types"
             | "to_any"
             | "cast"
             | "type_name_of"

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1353,9 +1353,13 @@ impl<'a, 'b> Checker<'a, 'b> {
         span: &Span,
     ) -> Result<Ty, RavenError> {
         match name {
-            "type_name" => self.check_reflection_builtin(name, generics, callee_span, args, span),
-            "field_names" => self.check_reflection_builtin(name, generics, callee_span, args, span),
-            "field_types" => self.check_reflection_builtin(name, generics, callee_span, args, span),
+            "type_name"
+            | "field_names"
+            | "field_types"
+            | "variant_names"
+            | "variant_field_types" => {
+                self.check_reflection_builtin(name, generics, callee_span, args, span)
+            }
             "__ptr_alloc" | "__ptr_free" | "__ptr_load" | "__ptr_store" | "__ptr_offset"
             | "__ptr_is_null" | "__ptr_null" => {
                 self.check_ptr_builtin(name, generics, callee_span, args, span)
@@ -1522,7 +1526,8 @@ impl<'a, 'b> Checker<'a, 'b> {
     }
 
     /// Check a compile-time reflection builtin (`type_name<T>()`,
-    /// `field_names<T>()`, or `field_types<T>()`). Each takes exactly one
+    /// `field_names<T>()`, `field_types<T>()`, `variant_names<T>()`, or
+    /// `variant_field_types<T>()`). Each takes exactly one
     /// type argument and no value
     /// arguments. The resolved type argument is recorded under the callee
     /// span so HIR lowering can carry it (a generic parameter `T` resolves
@@ -1568,12 +1573,25 @@ impl<'a, 'b> Checker<'a, 'b> {
                 span.clone(),
             ));
         }
+        if (name == "variant_names" || name == "variant_field_types")
+            && !matches!(arg_ty.strip_self(), Ty::Enum { .. } | Ty::Param(_))
+        {
+            return Err(RavenError::ty(
+                TypeError::Custom(format!(
+                    "`{}` requires an enum type, got `{}`",
+                    name, arg_ty
+                )),
+                span.clone(),
+            ));
+        }
         // Record the resolved type argument at the callee span. HIR lowering
         // reads it to build the reflection node; the call's own result span
-        // keeps the result type (`String` or `List<String>`).
+        // keeps the result type (`String`, `List<String>`, or
+        // `List<List<String>>`).
         self.record(callee_span, arg_ty);
         Ok(match name {
-            "field_names" | "field_types" => Ty::List(Box::new(Ty::Str)),
+            "field_names" | "field_types" | "variant_names" => Ty::List(Box::new(Ty::Str)),
+            "variant_field_types" => Ty::List(Box::new(Ty::List(Box::new(Ty::Str)))),
             _ => Ty::Str,
         })
     }

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -744,6 +744,39 @@ fn field_types_on_scalar_is_rejected() {
 }
 
 #[test]
+fn variant_names_yields_list_of_string() {
+    check(
+        "enum Shape {\n    Circle(r: Int)\n    Dot\n}\n\
+         fun a() -> List<String> = variant_names<Shape>()\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn variant_field_types_yields_nested_list() {
+    check(
+        "enum Shape {\n    Circle(r: Int)\n    Dot\n}\n\
+         fun a() -> List<List<String>> = variant_field_types<Shape>()\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn variant_names_on_struct_is_rejected() {
+    let err = check(
+        r#"
+        struct P { x: Int }
+        fun a() -> List<String> = variant_names<P>()
+    "#,
+    )
+    .unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::Custom(_))),
+        other => panic!("expected a type error, got {:?}", other),
+    }
+}
+
+#[test]
 fn ptr_builtins_typecheck_for_c_scalars() {
     // load returns the pointee, store/free/offset/is_null/null/alloc all
     // accept and yield the documented types for a C scalar pointee.

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -150,6 +150,22 @@ fn field_types_program_compiles_and_runs() {
 }
 
 #[test]
+fn variant_reflection_program_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // `variant_names<T>()` lists an enum's variants and
+    // `variant_field_types<T>()` gives each variant's payload types (empty for
+    // a unit variant). The generic `describe<T>` resolves per monomorphization,
+    // so `Tree<Int>` renders `Int` payloads.
+    compile_link_run_and_check(
+        "use_variant_reflection.rv",
+        "Circle\nRectangle\nDot\n--\nCircle: Float\nRectangle: Float, Float\nDot\n== generic ==\nLeaf: Int\nBranch: Int, Int\nEmpty\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn derive_json_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
## Summary

Extends compile-time reflection to enums, the counterpart to the struct builtins `field_names`/`field_types`. Closes #228.

- `variant_names<T>() -> List<String>`: an enum's variant names in declaration order.
- `variant_field_types<T>() -> List<List<String>>`: one inner list per variant (declaration order) of that variant's payload field type names. A unit variant has an empty inner list, so the inner length is the variant's payload arity.

```raven
enum Shape { Circle(radius: Float) Rectangle(width: Float, height: Float) Dot }

variant_names<Shape>()        // ["Circle", "Rectangle", "Dot"]
variant_field_types<Shape>()  // [["Float"], ["Float", "Float"], []]
```

Both resolve per monomorphization. For a generic enum each payload type is grounded under a per-instantiation substitution from the enum's generic parameters to the concrete type arguments:

```raven
enum Tree<T> { Leaf(value: T) Branch(left: T, right: T) Empty }

variant_field_types<Tree<Int>>()    // [["Int"], ["Int", "Int"], []]
```

A non-enum type argument is rejected. The built-in `Option`/`Result` are not user enums and are out of scope for this slice (noted in the spec deferred list, along with the unit/tuple/named-field distinction beyond payload types).

## Implementation

Mirrors the struct builtins: resolver allowlist, type checker (`check_reflection_builtin` with an enum guard and the nested-list result type), dedicated `HirExprKind::VariantNames` / `VariantFieldTypes` nodes, and MIR lowering. `variant_field_types` builds each inner `List<String>` into its own temp and collects them into the outer list. A new `enum_generic_params` helper mirrors `struct_generic_params` to build the payload substitution.

## Testing

- Type checker unit tests: both builtins yield the right list types; a struct argument to `variant_names` is rejected.
- Codegen smoke test plus a golden example `examples/v2/use_variant_reflection.rv` exercising tuple, named-field, and unit variants and a generic enum instantiation, all compiled and run.
- `cargo fmt --check`, `cargo clippy`, full `cargo test`, and the golden suite are green.

## Version

Patch bump to `2.1.4` (reflection-epic subtask). CHANGELOG `[Unreleased]` updated; no release cut.

Fixes #228
