### PR TITLE
release: 2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Raven are documented in this file.
 
 ## [Unreleased]
 
+## [2.1.6] - 2026-06-04
+
 ### Added
 
 - Documented and locked in macro calls in statement position and item (top-level) position, not only expression position. The token-level pre-pass already splices a template wherever the call appears, so a template that parses as one or more items or statements (a `struct`/`fun` declaration, a `let` binding) is valid there. Added tests and a golden example covering both positions (#221).


### PR DESCRIPTION
## Release 2.1.6

Finalizes the changelog for v2.1.6. `Cargo.toml` is already at `2.1.6` (bumped incrementally across the merged PRs).

This release is a coherent developer-experience, reflection, and macros milestone, accumulated since v2.0.10:

**Developer experience**
- Rich, colorful compiler error messages with a box-drawing source pointer, inline label, and help/note lines (#283).

**Reflection (declarative slice now complete)**
- Runtime `set_field(a, name, value)` (#230).
- Compile-time `field_types<T>()` (#227).
- Compile-time enum `variant_names<T>()` and `variant_field_types<T>()` (#228).

**Macros (declarative slice now complete)**
- New fragment specifiers `ty`, `literal`, `pat`, `block` (#223).
- Macro calls expand inside `"${...}"` interpolation fragments (#226).
- Macro calls in statement and item (top-level) position (#221).

After merge I will tag `v2.1.6`, which triggers the Release workflow (installers for Linux x86_64, Windows x86_64, macOS arm64, plus the install smoke-test job).
