### PR TITLE
feat(tycheck): report multiple type errors per compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Raven are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- The type checker now reports multiple errors per compile instead of stopping at the first. The body pass recovers at item and statement boundaries: an error in one function, impl method, `const`, or `let` no longer hides errors in the next, and each statement in a block reports independently. Recovery binds a failed `let` to its annotated type (or `Ty::Error`) so later references do not cascade into spurious follow-on errors, and identical diagnostics are de-duplicated. Each error is rendered with the rich source-pointer format from 2.1.0, separated by a blank line. Parser-level recovery (multiple syntax errors per compile) remains a follow-up (#284).
+
 ## [2.1.6] - 2026-06-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.1.5"
+version = "2.2.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.1.5"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.1.6"
+version = "2.2.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/tycheck.md
+++ b/docs/v2/specs/tycheck.md
@@ -12,7 +12,7 @@ The type checker is total: every malformed program produces a `RavenError::Type(
 Source -> Lexer -> Parser -> Resolver -> TypeChecker -> (HIR -> MIR -> codegen)
 ```
 
-The type checker consumes nodes from `src/ast` plus the resolver's `ResolutionMap`. It does not load files or perform any I/O. The first error halts checking of the current file; multi error recovery is out of scope for this release.
+The type checker consumes nodes from `src/ast` plus the resolver's `ResolutionMap`. It does not load files or perform any I/O. The body pass recovers at item and statement boundaries so one compile reports many independent errors (see "Error recovery" below).
 
 ## The `Ty` representation
 
@@ -214,6 +214,17 @@ Member access against these types goes through a small inherent method table. No
 
 All variants reach the user via `RavenError::Type(error, span, hint)`. The renderer in `RavenError::display` is extended to handle the new arm.
 
+## Error recovery
+
+The body pass collects multiple errors per compile instead of stopping at the first one. A `Checker` holds an `errors: Vec<RavenError>` sink, and checking recovers at two boundaries:
+
+* **Item boundary.** `check_bodies` checks each top-level item (function, impl method, trait default body, `const`, `let`) independently and accumulates their errors, so a mistake in one function does not hide errors in the next.
+* **Statement boundary.** `check_block` checks each statement through `check_stmt`, which never bubbles: a failed sub-check records its error and continues. Within a single statement or expression, errors still fail fast up to the enclosing statement, which is the recovery point.
+
+Recovery uses the `Ty::Error` placeholder (which unifies with anything) to suppress cascades. A statement that introduces a binding always introduces it: a `let` with a type annotation binds the annotated type even when its initializer fails; an unannotated `let` whose initializer fails binds `Ty::Error`. Later references therefore type-check against a known (or error) type rather than spraying "undefined" follow-on errors. Identical diagnostics (same span and message) are de-duplicated before rendering.
+
+The collection pass (Pass 1) stays fail-fast: a malformed signature stops it, because later items depend on the collected signatures. `check_file_all` returns `Result<TypedFile, Vec<RavenError>>`; the driver renders each error with the #283 renderer, separated by a blank line. `check_file` remains a thin wrapper returning only the first error, for callers (tests, golden harnesses) that surface one.
+
 ## Out of scope
 
 * User defined generic functions, structs, and traits land in
@@ -226,6 +237,7 @@ All variants reach the user via `RavenError::Type(error, span, hint)`. The rende
 * End to end `?` propagation. Tracked with HIR lowering in issue #60.
 * String interpolation expansion (handled by parser side lowering later).
 * Cross module member resolution against imported modules. The type checker recognizes the import target but defers member lookups against std modules to the HIR lowering pass.
+* Parser-level error recovery (reporting several parse errors in one compile). A syntax error still stops the parser at the first one; the multi-error recovery here is for the type checker's body pass. Parser recovery is a follow-up under issue #284.
 
 ## Tests
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -23,7 +23,7 @@ use crate::lexer::Lexer;
 use crate::mir::lower_program;
 use crate::parser::parse_with_macros;
 use crate::resolve::{expand_with_stdlib_ctx, resolve_file_ctx, FsLoader, PackageContext};
-use crate::tycheck::check_file;
+use crate::tycheck::check_file_all;
 
 /// An error from the compile pipeline or the link step.
 #[derive(Debug)]
@@ -37,10 +37,10 @@ pub enum DriverError {
     RuntimeMissing,
 }
 
-/// Render a front-end [`RavenError`] into a [`DriverError::Diagnostic`],
-/// reading the offending span's file when it differs from the entry file
-/// (for example an error inside a local module or a dependency).
-fn frontend_diag(e: crate::error::RavenError, input: &Path, source: &str) -> DriverError {
+/// Render one front-end [`RavenError`], reading the offending span's file
+/// when it differs from the entry file (for example an error inside a local
+/// module or a dependency).
+fn render_one(e: &crate::error::RavenError, input: &Path, source: &str) -> String {
     let span_file = e.span().file.clone();
     let src: std::borrow::Cow<str> = if span_file.as_path() == input {
         std::borrow::Cow::Borrowed(source)
@@ -50,7 +50,26 @@ fn frontend_diag(e: crate::error::RavenError, input: &Path, source: &str) -> Dri
             Err(_) => std::borrow::Cow::Borrowed(source),
         }
     };
-    DriverError::Diagnostic(e.display(&src))
+    e.display(&src)
+}
+
+/// Render a single front-end error into a [`DriverError::Diagnostic`].
+fn frontend_diag(e: crate::error::RavenError, input: &Path, source: &str) -> DriverError {
+    DriverError::Diagnostic(render_one(&e, input, source))
+}
+
+/// Render every collected front-end error into one [`DriverError::Diagnostic`],
+/// separated by a blank line, so a compile reports all of them at once.
+fn frontend_diags(
+    errors: Vec<crate::error::RavenError>,
+    input: &Path,
+    source: &str,
+) -> DriverError {
+    let rendered: Vec<String> = errors
+        .iter()
+        .map(|e| render_one(e, input, source))
+        .collect();
+    DriverError::Diagnostic(rendered.join("\n"))
 }
 
 impl From<CodegenError> for DriverError {
@@ -123,7 +142,7 @@ pub fn compile_to_object(
     let mut loader = FsLoader;
     let resolved =
         resolve_file_ctx(&file, &mut loader, ctx).map_err(|e| frontend_diag(e, input, source))?;
-    let typed = check_file(&resolved).map_err(|e| frontend_diag(e, input, source))?;
+    let typed = check_file_all(&resolved).map_err(|es| frontend_diags(es, input, source))?;
     let hir = lower_file(&typed).map_err(|e| frontend_diag(e, input, source))?;
     if std::env::var("RAVEN_DUMP_HIR").is_ok() {
         eprintln!("{}", crate::hir::pretty_program(&hir));

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -35,11 +35,32 @@ pub fn check_bodies(
     resolved: &ResolvedFile<'_>,
     env: &TypeEnv,
     types: &mut TypeMap,
-) -> Result<(), RavenError> {
+) -> Result<(), Vec<RavenError>> {
+    // Each top-level item recovers at its own boundary, so an error in one
+    // function or impl method does not hide errors in the next.
+    let mut errors: Vec<RavenError> = Vec::new();
     for decl in &resolved.file.items {
-        check_decl_body(decl, resolved, env, types)?;
+        errors.extend(check_decl_body(decl, resolved, env, types));
     }
-    Ok(())
+    dedup_errors(&mut errors);
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// Drop duplicate diagnostics, keeping the first occurrence. Two errors at
+/// the same span with the same message are treated as duplicates, so a root
+/// cause recorded once (and recovered to `Ty::Error`) does not spray the
+/// same follow-on message from several sibling sites.
+fn dedup_errors(errors: &mut Vec<RavenError>) {
+    let mut seen: std::collections::HashSet<(std::path::PathBuf, usize, usize, String)> =
+        std::collections::HashSet::new();
+    errors.retain(|e| {
+        let s = e.span();
+        seen.insert((s.file.to_path_buf(), s.start, s.end, format!("{}", e)))
+    });
 }
 
 fn check_decl_body(
@@ -47,16 +68,11 @@ fn check_decl_body(
     resolved: &ResolvedFile<'_>,
     env: &TypeEnv,
     types: &mut TypeMap,
-) -> Result<(), RavenError> {
+) -> Vec<RavenError> {
     match &decl.kind {
         DeclKind::Function(f) => check_function(f, None, &[], resolved, env, types),
         DeclKind::Impl(i) => {
-            let impl_id_idx = resolved
-                .file
-                .items
-                .iter()
-                .position(|d| std::ptr::eq(d, decl))
-                .unwrap_or(0);
+            let mut errors: Vec<RavenError> = Vec::new();
             let impl_sig = env.impls.iter().find(|s| s.span == i.span).cloned();
             let impl_generics = impl_sig
                 .as_ref()
@@ -67,7 +83,7 @@ fn check_decl_body(
                 None => (&i.trait_or_type, None),
             };
             let scope = scope_from_params(&impl_generics);
-            let self_ty = resolve_ty(
+            let self_ty = match resolve_ty(
                 &crate::ast::Type {
                     kind: crate::ast::TypeKind::Path(impl_path.clone()),
                     span: impl_path.span.clone(),
@@ -76,25 +92,38 @@ fn check_decl_body(
                 env,
                 None,
                 &scope,
-            )?;
+            ) {
+                Ok(t) => t,
+                Err(e) => {
+                    errors.push(e);
+                    Ty::Error
+                }
+            };
             for f in &i.items {
-                check_function(f, Some(&self_ty), &impl_generics, resolved, env, types)?;
+                errors.extend(check_function(
+                    f,
+                    Some(&self_ty),
+                    &impl_generics,
+                    resolved,
+                    env,
+                    types,
+                ));
             }
-            let _ = impl_id_idx;
-            Ok(())
+            errors
         }
         DeclKind::Trait(t) => {
             // Default bodies in trait declarations: walk them without
             // a concrete Self because we treat `Self` as an error
             // marker for now; trait default bodies that reference Self
             // remain limited in this release.
+            let mut errors: Vec<RavenError> = Vec::new();
             for m in &t.members {
                 if matches!(m.body, FunctionBody::None) {
                     continue;
                 }
-                check_function(m, None, &[], resolved, env, types)?;
+                errors.extend(check_function(m, None, &[], resolved, env, types));
             }
-            Ok(())
+            errors
         }
         DeclKind::Const(c) => {
             let expected = env
@@ -103,31 +132,40 @@ fn check_decl_body(
                 .cloned()
                 .unwrap_or(Ty::Error);
             let mut cx = Checker::new(resolved, env, types, None, expected.clone());
-            let actual = cx.check_expr(&c.value)?;
+            let actual = cx.check_expr_recover(&c.value);
             if !matches!(expected, Ty::Error) {
-                cx.unify(&expected, &actual, &c.value.span)?;
+                cx.unify_recover(&expected, &actual, &c.value.span);
             }
-            cx.finalize_types()?;
-            Ok(())
+            cx.finalize_into_errors();
+            cx.take_errors()
         }
         DeclKind::Let(l) => {
             let scope = GenericScope::new();
+            let mut errors: Vec<RavenError> = Vec::new();
             let expected = match &l.ty {
-                Some(t) => resolve_ty(t, resolved, env, None, &scope)?,
+                Some(t) => match resolve_ty(t, resolved, env, None, &scope) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        errors.push(e);
+                        Ty::Error
+                    }
+                },
                 None => Ty::Error,
             };
             if let Some(init) = &l.init {
                 let mut cx = Checker::new(resolved, env, types, None, expected.clone());
-                let actual = cx.check_expr(init)?;
+                cx.errors = std::mem::take(&mut errors);
+                let actual = cx.check_expr_recover(init);
                 if !matches!(expected, Ty::Error) {
-                    cx.unify(&expected, &actual, &init.span)?;
+                    cx.unify_recover(&expected, &actual, &init.span);
                 }
-                cx.finalize_types()?;
+                cx.finalize_into_errors();
+                return cx.take_errors();
             }
-            Ok(())
+            errors
         }
         DeclKind::Struct(_) | DeclKind::Enum(_) | DeclKind::Extern(_) | DeclKind::Import(_) => {
-            Ok(())
+            Vec::new()
         }
     }
 }
@@ -149,7 +187,7 @@ fn check_function(
     resolved: &ResolvedFile<'_>,
     env: &TypeEnv,
     types: &mut TypeMap,
-) -> Result<(), RavenError> {
+) -> Vec<RavenError> {
     // Build a generic scope: enclosing impl generics, then this
     // function's own generics.
     let fn_generics = super::collect::scope_from_params(extra_generics);
@@ -158,13 +196,23 @@ fn check_function(
     let mut full_scope = fn_generics;
     super::collect::push_into_scope(&mut full_scope, &f_params);
 
+    // The return type is resolved before the body's checker exists; a
+    // failure recovers to `Ty::Error` and is seeded into the sink below.
+    let mut setup_errors: Vec<RavenError> = Vec::new();
     let ret_ty = match &f.ret {
-        Some(t) => resolve_ty(t, resolved, env, self_ty, &full_scope)?,
+        Some(t) => match resolve_ty(t, resolved, env, self_ty, &full_scope) {
+            Ok(t) => t,
+            Err(e) => {
+                setup_errors.push(e);
+                Ty::Error
+            }
+        },
         None => Ty::Unit,
     };
 
     let mut cx =
         Checker::new(resolved, env, types, self_ty.cloned(), ret_ty.clone()).with_scope(full_scope);
+    cx.errors = setup_errors;
     // Record the trait bounds of every in-scope generic parameter (the
     // enclosing impl's plus this function's own) so a method call on a
     // `Ty::Param` value can resolve through its bound.
@@ -180,16 +228,22 @@ fn check_function(
                 .map(|t| Ty::SelfTy(Box::new(t)))
                 .unwrap_or(Ty::Error)
         } else {
-            cx.resolve_ast_ty(&p.ty)?
+            match cx.resolve_ast_ty(&p.ty) {
+                Ok(t) => t,
+                Err(e) => {
+                    cx.push_error(e);
+                    Ty::Error
+                }
+            }
         };
         cx.locals.insert(BindingKey::param(&p.span), ty);
     }
 
     match &f.body {
         FunctionBody::Block(b) => {
-            let body_ty = cx.check_block(b)?;
+            let body_ty = cx.check_block(b).unwrap_or(Ty::Error);
             if b.trailing.is_some() {
-                cx.unify(&ret_ty, &body_ty, &b.span)?;
+                cx.unify_recover(&ret_ty, &body_ty, &b.span);
             } else if !matches!(ret_ty, Ty::Unit | Ty::Error) {
                 // No trailing expression and a non unit return type.
                 // Acceptable as long as the body contains explicit
@@ -197,13 +251,13 @@ fn check_function(
             }
         }
         FunctionBody::Expr(e) => {
-            let body_ty = cx.check_expr(e)?;
-            cx.unify(&ret_ty, &body_ty, &e.span)?;
+            let body_ty = cx.check_expr_recover(e);
+            cx.unify_recover(&ret_ty, &body_ty, &e.span);
         }
         FunctionBody::None => {}
     }
-    cx.finalize_types()?;
-    Ok(())
+    cx.finalize_into_errors();
+    cx.take_errors()
 }
 
 /// A local typing scope.
@@ -232,6 +286,11 @@ struct Checker<'a, 'b> {
     /// binding's declared `List<T>` type while its initializer is checked.
     /// An empty `[]` has no element to infer from, so it adopts this hint.
     array_hint: Option<Ty>,
+    /// Accumulated diagnostics for this body. Statement and item checking
+    /// recover at their boundaries (binding a failed value to `Ty::Error`)
+    /// and push the error here instead of returning it, so one compile can
+    /// report many independent errors. See `docs/v2/specs/tycheck.md`.
+    errors: Vec<RavenError>,
 }
 
 /// Keys used by the locals map. Mirrors the resolver's `Binding`
@@ -279,12 +338,44 @@ impl<'a, 'b> Checker<'a, 'b> {
             param_bounds: HashMap::new(),
             infer: InferCtx::new(),
             array_hint: None,
+            errors: Vec::new(),
         }
     }
 
     fn with_scope(mut self, scope: GenericScope) -> Self {
         self.generic_scope = scope;
         self
+    }
+
+    /// Record a diagnostic in the sink and keep going. Used at recovery
+    /// points so an error in one statement or item does not hide errors in
+    /// the next.
+    fn push_error(&mut self, e: RavenError) {
+        self.errors.push(e);
+    }
+
+    /// Take the accumulated diagnostics, leaving the sink empty.
+    fn take_errors(&mut self) -> Vec<RavenError> {
+        std::mem::take(&mut self.errors)
+    }
+
+    /// Check an expression, recovering to `Ty::Error` (and recording the
+    /// error) when it fails, so sibling statements still type-check.
+    fn check_expr_recover(&mut self, expr: &Expr) -> Ty {
+        match self.check_expr(expr) {
+            Ok(t) => t,
+            Err(e) => {
+                self.push_error(e);
+                Ty::Error
+            }
+        }
+    }
+
+    /// Unify, recording a mismatch in the sink instead of returning it.
+    fn unify_recover(&mut self, expected: &Ty, actual: &Ty, span: &Span) {
+        if let Err(e) = self.unify(expected, actual, span) {
+            self.push_error(e);
+        }
     }
 
     /// Record the trait bounds declared on a set of generic parameters so
@@ -507,6 +598,15 @@ impl<'a, 'b> Checker<'a, 'b> {
         Ok(())
     }
 
+    /// Resolve inference variables and push any failure into the sink
+    /// instead of returning it, so a body's type errors and its
+    /// inference failures are reported together.
+    fn finalize_into_errors(&mut self) {
+        if let Err(e) = self.finalize_types() {
+            self.push_error(e);
+        }
+    }
+
     /// Instantiate a function signature: substitute fresh inference
     /// variables for each declared generic parameter and record any
     /// bounds those variables carry.
@@ -583,22 +683,35 @@ impl<'a, 'b> Checker<'a, 'b> {
     }
 
     fn check_block(&mut self, block: &Block) -> Result<Ty, RavenError> {
+        // Each statement recovers at its own boundary: a failed statement
+        // records its error and the block continues, so unrelated errors in
+        // later statements are still reported in one compile.
         for stmt in &block.stmts {
-            self.check_stmt(stmt)?;
+            self.check_stmt(stmt);
         }
         let ty = match &block.trailing {
-            Some(e) => self.check_expr(e)?,
+            Some(e) => self.check_expr_recover(e),
             None => Ty::Unit,
         };
         self.record(&block.span, ty.clone());
         Ok(ty)
     }
 
-    fn check_stmt(&mut self, stmt: &Stmt) -> Result<(), RavenError> {
+    /// Check one statement, recovering at the statement boundary. A failed
+    /// sub-check records its error and the statement still introduces any
+    /// binding it declares (bound to its annotated type, or `Ty::Error`), so
+    /// later references do not cascade into spurious "undefined" errors.
+    fn check_stmt(&mut self, stmt: &Stmt) {
         match &stmt.kind {
             StmtKind::Let { name: _, ty, init } => {
                 let declared = match ty {
-                    Some(t) => Some(self.resolve_ast_ty(t)?),
+                    Some(t) => match self.resolve_ast_ty(t) {
+                        Ok(d) => Some(d),
+                        Err(e) => {
+                            self.push_error(e);
+                            Some(Ty::Error)
+                        }
+                    },
                     None => None,
                 };
                 // While checking the initializer, expose the declared
@@ -607,14 +720,11 @@ impl<'a, 'b> Checker<'a, 'b> {
                 if let Some(Ty::List(elem)) = &declared {
                     self.array_hint = Some((**elem).clone());
                 }
-                let init_ty = match init {
-                    Some(e) => Some(self.check_expr(e)?),
-                    None => None,
-                };
+                let init_ty = init.as_ref().map(|e| self.check_expr_recover(e));
                 self.array_hint = prev_hint;
                 let final_ty = match (declared, init_ty) {
                     (Some(d), Some(i)) => {
-                        self.unify(&d, &i, &init.as_ref().unwrap().span)?;
+                        self.unify_recover(&d, &i, &init.as_ref().unwrap().span);
                         d
                     }
                     (Some(d), None) => d,
@@ -631,51 +741,54 @@ impl<'a, 'b> Checker<'a, 'b> {
             }
             StmtKind::Return(e) => {
                 let actual = match e {
-                    Some(expr) => self.check_expr(expr)?,
+                    Some(expr) => self.check_expr_recover(expr),
                     None => Ty::Unit,
                 };
                 let ret = self.return_ty.clone();
-                self.unify(&ret, &actual, &stmt.span)?;
+                self.unify_recover(&ret, &actual, &stmt.span);
             }
             StmtKind::Break(e) => {
                 if let Some(expr) = e {
-                    self.check_expr(expr)?;
+                    self.check_expr_recover(expr);
                 }
             }
             StmtKind::Continue => {}
             StmtKind::Defer(e) => {
-                self.check_expr(e)?;
+                self.check_expr_recover(e);
             }
             StmtKind::Spawn(e) => {
                 // The goroutine body must be a `fun() -> Unit` closure.
-                let ty = self.check_expr(e)?;
+                let ty = self.check_expr_recover(e);
                 let expected = Ty::Function {
                     params: Vec::new(),
                     ret: Box::new(Ty::Unit),
                 };
-                self.unify(&expected, &ty, &e.span)?;
+                self.unify_recover(&expected, &ty, &e.span);
             }
             StmtKind::Assign { target, op, value } => {
-                let target_ty = self.check_expr(target)?;
-                let value_ty = self.check_expr(value)?;
+                let target_ty = self.check_expr_recover(target);
+                let value_ty = self.check_expr_recover(value);
                 match op {
                     AssignOp::Assign => {
-                        self.unify(&target_ty, &value_ty, &value.span)?;
+                        self.unify_recover(&target_ty, &value_ty, &value.span);
                     }
                     _ => {
                         // Compound: target op= value behaves like
                         // target = target op value. Reuse the binary
                         // op checker to pin the rule down.
                         let bin = compound_binary_op(*op);
-                        let _ = super::expr::check_binary(&target_ty, &value_ty, bin, &stmt.span)?;
+                        if let Err(e) =
+                            super::expr::check_binary(&target_ty, &value_ty, bin, &stmt.span)
+                        {
+                            self.push_error(e);
+                        }
                     }
                 }
             }
             StmtKind::Expr(e) => {
-                self.check_expr(e)?;
+                self.check_expr_recover(e);
             }
         }
-        Ok(())
     }
 
     fn check_expr(&mut self, expr: &Expr) -> Result<Ty, RavenError> {

--- a/src/tycheck/mod.rs
+++ b/src/tycheck/mod.rs
@@ -145,13 +145,18 @@ pub struct TypedFile<'a> {
 }
 
 /// Run the type checker on `resolved` and return either a `TypedFile`
-/// or the first [`RavenError::Type`] encountered.
+/// or every [`RavenError::Type`] the body pass recovered from.
 ///
 /// The function runs two passes: a declared type collection pass that
-/// populates `TypeEnv` and a body check pass that fills the `TypeMap`.
-pub fn check_file<'a>(resolved: &'a ResolvedFile<'a>) -> Result<TypedFile<'a>, RavenError> {
+/// populates `TypeEnv` and a body check pass that fills the `TypeMap`. The
+/// collection pass is fail-fast (a malformed signature stops it, since later
+/// items depend on collected signatures); the body pass recovers at item and
+/// statement boundaries so one compile reports many independent errors.
+pub fn check_file_all<'a>(
+    resolved: &'a ResolvedFile<'a>,
+) -> Result<TypedFile<'a>, Vec<RavenError>> {
     let mut env = TypeEnv::new();
-    collect::collect_declarations(resolved, &mut env)?;
+    collect::collect_declarations(resolved, &mut env).map_err(|e| vec![e])?;
     let mut types = TypeMap::new();
     expr::check_bodies(resolved, &env, &mut types)?;
     Ok(TypedFile {
@@ -160,4 +165,11 @@ pub fn check_file<'a>(resolved: &'a ResolvedFile<'a>) -> Result<TypedFile<'a>, R
         env,
         types,
     })
+}
+
+/// Run the type checker and return either a `TypedFile` or the first
+/// [`RavenError::Type`] encountered. A thin wrapper over [`check_file_all`]
+/// for callers that only surface one error (tests, golden harnesses).
+pub fn check_file<'a>(resolved: &'a ResolvedFile<'a>) -> Result<TypedFile<'a>, RavenError> {
+    check_file_all(resolved).map_err(|mut es| es.remove(0))
 }

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -1,6 +1,6 @@
 //! Inline unit tests for the type checker.
 
-use super::{check_file, Ty};
+use super::{check_file, check_file_all, Ty};
 use crate::error::{RavenError, TypeError};
 use crate::lexer::Lexer;
 use crate::parser::parse;
@@ -22,6 +22,21 @@ fn check(src: &str) -> Result<(), RavenError> {
     let mut loader = NoLoader;
     let resolved = resolve_file(&file, &mut loader)?;
     check_file(&resolved).map(|_| ())
+}
+
+/// Type-check `src` and return every recovered diagnostic, for tests that
+/// assert the checker reports more than one error per compile.
+fn check_all(src: &str) -> Vec<RavenError> {
+    let tokens = Lexer::new(src.to_string(), PathBuf::from("t.rv"))
+        .tokenize()
+        .expect("lex");
+    let file = parse(&tokens).expect("parse");
+    let mut loader = NoLoader;
+    let resolved = resolve_file(&file, &mut loader).expect("resolve");
+    match check_file_all(&resolved) {
+        Ok(_) => Vec::new(),
+        Err(es) => es,
+    }
 }
 
 /// Like `check`, but merges the bundled prelude first so `print` of a
@@ -821,4 +836,44 @@ fn ptr_builtin_rejects_a_non_pointer_pointee() {
         RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::Custom(_))),
         other => panic!("expected a type error, got {:?}", other),
     }
+}
+
+#[test]
+fn reports_an_error_in_each_sibling_function() {
+    // Two unrelated functions each have a return type mismatch; both are
+    // reported in one compile, not just the first.
+    let errs = check_all("fun f() -> Int = \"x\"\nfun g() -> Bool = 5\n");
+    assert_eq!(errs.len(), 2, "got: {:?}", errs);
+}
+
+#[test]
+fn reports_an_error_for_each_failed_statement() {
+    // Two `let` bindings with annotation mismatches both report; the later
+    // use does not cascade because each binding adopts its annotated `Int`.
+    let errs = check_all(
+        "fun h() -> Int {\n    let x: Int = \"a\"\n    let y: Int = true\n    return x + y\n}\n",
+    );
+    assert_eq!(errs.len(), 2, "got: {:?}", errs);
+}
+
+#[test]
+fn a_failed_unannotated_let_does_not_cascade() {
+    // `let x = <type error>` records one error and binds `x` to `Error`, so
+    // the later `x + z` use adds no diagnostic.
+    let errs = check_all(
+        "fun u() -> Int {\n    let x = 1 + \"oops\"\n    let z = 5\n    return x + z\n}\n",
+    );
+    assert_eq!(errs.len(), 1, "got: {:?}", errs);
+}
+
+#[test]
+fn a_clean_program_reports_no_errors() {
+    assert!(check_all("fun f() -> Int = 1 + 2\n").is_empty());
+}
+
+#[test]
+fn duplicate_diagnostics_are_deduplicated() {
+    // The same message at the same span is collapsed to one entry.
+    let errs = check_all("fun f() -> Int = \"x\"\n");
+    assert_eq!(errs.len(), 1, "got: {:?}", errs);
 }


### PR DESCRIPTION
## Summary

The type checker was fail-fast: one compile reported one error, so users fixed one and recompiled to see the next. The body pass now recovers and accumulates, reporting every independent type error in a single compile, the highest-value half of #284. Each is rendered with the rich source-pointer format from 2.1.0, separated by a blank line.

```
error: this should be `Int`, but it's `String`
  ┌─ main.rv:1:18
  │
1 │ fun f() -> Int = "not an int"
  │                  ^^^^^^^^^^^^ this is `String`

error: this should be `Bool`, but it's `Int`
  ┌─ main.rv:3:19
  │
3 │ fun g() -> Bool = 5
  │                   ^ this is `Int`

error: this should be `Int`, but it's `String`
  ┌─ main.rv:6:18
  │
6 │     let x: Int = "hello"
  │                  ^^^^^^^ this is `String`
```

## How recovery works

Two boundaries:
- **Item boundary** - `check_bodies` checks each top-level function, impl method, trait default body, `const`, and `let` independently and accumulates their errors.
- **Statement boundary** - `check_block` runs each statement through `check_stmt`, which never bubbles: a failed sub-check records its error and the block continues. Within a single statement, errors still fail fast up to the enclosing statement (the recovery point).

Cascades are suppressed with the existing `Ty::Error` placeholder (it unifies with anything, and `check_binary` already short-circuits on it). A statement that introduces a binding always introduces it: an annotated `let` binds its annotation even when its initializer fails; an unannotated failed `let` binds `Ty::Error`. So `print(x)` after a bad `let x = ...` does not spray a follow-on "undefined" error. Identical diagnostics (same span and message) are de-duplicated.

## API

- New `Checker.errors` sink plus `check_expr_recover` / `unify_recover` / `finalize_into_errors` helpers.
- `check_file_all` returns `Result<TypedFile, Vec<RavenError>>`; the driver renders all errors blank-line separated via the new `frontend_diags`.
- `check_file` stays a thin first-error wrapper, so the many existing callers (tests, golden harnesses) are unchanged. The collection pass stays fail-fast (later items depend on collected signatures).

## Testing

- New tycheck unit tests: errors in each sibling function, an error per failed statement, cascade suppression for an unannotated failed `let`, a clean program reporting nothing, and dedup.
- Full `cargo test` green, including the golden, tycheck-golden, hir-golden, and mir-golden suites (unchanged, since they use the single-error `check_file`). `cargo fmt --check` and `cargo clippy` clean.

## Scope

This delivers the type-checker recovery from #284 (the bulk of the value, since type errors are the common case). Parser-level recovery (multiple syntax errors per compile) is a separate, smaller follow-up; I'll file it and keep #284 open for it.

## Version

Minor bump to `2.2.0` (feature). CHANGELOG `[Unreleased]` updated; no release cut.

Part of #284
