### PR TITLE
feat(parser): item-level error recovery for multiple syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Raven are documented in this file.
 
 ### Added
 
+- The parser now recovers at item boundaries, so one compile reports several syntax errors instead of only the first. On a failed top-level item the error is recorded and the parser skips to the next item-starting keyword (`fun`, `struct`, `enum`, `trait`, `impl`, `extern`, `import`, or `@`), tracking bracket depth so it steps over a broken function body. A compile with parse errors reports them all (de-duplicated) and stops before resolve and type checking. Statement-level recovery within one body remains a follow-up (#294).
 - The type checker now reports multiple errors per compile instead of stopping at the first. The body pass recovers at item and statement boundaries: an error in one function, impl method, `const`, or `let` no longer hides errors in the next, and each statement in a block reports independently. Recovery binds a failed `let` to its annotated type (or `Ty::Error`) so later references do not cascade into spurious follow-on errors, and identical diagnostics are de-duplicated. Each error is rendered with the rich source-pointer format from 2.1.0, separated by a blank line. Parser-level recovery (multiple syntax errors per compile) remains a follow-up (#284).
 
 ## [2.1.6] - 2026-06-04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/parser.md
+++ b/docs/v2/specs/parser.md
@@ -4,7 +4,15 @@
 
 Consume the lexer's `Vec<Token>` and produce an Abstract Syntax Tree (AST) for the full Raven v2 grammar. The parser is a hand written recursive descent implementation with operator precedence climbing for expressions. Every AST node carries a `Span` so downstream passes (name resolution, type checking, code generation) can produce errors anchored at the source.
 
-The parser is total: it never panics on user input. Every malformed program produces a `RavenError::Parse(ParseError, Span, Option<String>)` and the parser does not attempt aggressive recovery in this release (one error, stop). Recovery is tracked separately and is out of scope for this PR.
+The parser is total: it never panics on user input. Every malformed program produces a `RavenError::Parse(ParseError, Span, Option<String>)`.
+
+Two entry points exist. `parse_file` stops at the first error (used by tests and golden harnesses, which expect a single error). `parse_file_recover` (used by the compile driver via `parse_with_macros_all`) recovers at item boundaries so one compile can report several syntax errors: on a failed `parse_decl`, the error is recorded and the parser skips forward to the next item-starting keyword before continuing.
+
+### Error recovery
+
+`recover_to_next_item` consumes at least one token (guaranteeing progress) and then skips tokens, tracking bracket depth, until the next unambiguous top-level item keyword at depth zero or below: `fun`, `struct`, `enum`, `trait`, `impl`, `extern`, `import`, or a `@` attribute. `let` and `const` are not synchronization points because they also appear as statements inside a body, so syncing on them could stop recovery inside the broken item. The depth counter lets recovery skip a broken function body (its inner braces and its closing `}`) and resume at the next item.
+
+When any item failed, `parse_file_recover` returns every collected error (de-duplicated by span and message) and discards the partial item list: a damaged AST would only produce cascade errors in resolve and type checking, so a compile with parse errors stops after parsing and reports them all. A clean parse returns the full `File` exactly as `parse_file` would. Statement-level recovery within a single body (reporting more than one error per item) is a follow-up under issue #294.
 
 ## Pipeline position
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -21,7 +21,7 @@ use crate::codegen::{self, CodegenError};
 use crate::hir::lower_file;
 use crate::lexer::Lexer;
 use crate::mir::lower_program;
-use crate::parser::parse_with_macros;
+use crate::parser::parse_with_macros_all;
 use crate::resolve::{expand_with_stdlib_ctx, resolve_file_ctx, FsLoader, PackageContext};
 use crate::tycheck::check_file_all;
 
@@ -136,8 +136,8 @@ pub fn compile_to_object(
         crate::macros::collect_macro_table(&tokens).map_err(|e| frontend_diag(e, input, source))?;
     let tokens =
         crate::macros::expand_tokens(&tokens).map_err(|e| frontend_diag(e, input, source))?;
-    let file =
-        parse_with_macros(&tokens, macro_table).map_err(|e| frontend_diag(e, input, source))?;
+    let file = parse_with_macros_all(&tokens, macro_table)
+        .map_err(|es| frontend_diags(es, input, source))?;
     let file = expand_with_stdlib_ctx(&file, ctx).map_err(|e| frontend_diag(e, input, source))?;
     let mut loader = FsLoader;
     let resolved =

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,8 +1,9 @@
 //! Recursive descent parser for the v2 grammar.
 //!
 //! The parser consumes a token slice produced by `crate::lexer` and
-//! emits an AST (`crate::ast::File`). It is hand written, single pass,
-//! and non recovering: the first error stops parsing.
+//! emits an AST (`crate::ast::File`). It is hand written and single pass.
+//! `parse_file` stops at the first error; `parse_file_recover` recovers at
+//! item boundaries to report several syntax errors per compile.
 //!
 //! Internally the implementation is split by grammar category:
 //!
@@ -100,6 +101,66 @@ impl Parser {
             items,
             span: merge_spans(&start_span, &end_span),
         })
+    }
+
+    /// Parse the entire token stream, recovering at item boundaries so a
+    /// syntax error in one top-level item does not hide errors in the next.
+    /// On a failed `parse_decl`, the error is recorded and the parser skips
+    /// to the next item-starting keyword before continuing. Returns every
+    /// collected parse error when any occurred (the partial item list is
+    /// discarded, since a damaged AST would only produce cascade errors
+    /// downstream).
+    pub fn parse_file_recover(&mut self) -> Result<File, Vec<RavenError>> {
+        let start_span = self.peek().span.clone();
+        let mut items = Vec::new();
+        let mut errors: Vec<RavenError> = Vec::new();
+        self.skip_separators();
+        while !self.is_at_end() {
+            match self.parse_decl() {
+                Ok(item) => items.push(item),
+                Err(e) => {
+                    errors.push(e);
+                    self.recover_to_next_item();
+                }
+            }
+            self.skip_separators();
+        }
+        dedup_parse_errors(&mut errors);
+        if errors.is_empty() {
+            let end_span = self.peek().span.clone();
+            Ok(File {
+                items,
+                span: merge_spans(&start_span, &end_span),
+            })
+        } else {
+            Err(errors)
+        }
+    }
+
+    /// Skip tokens after a failed item parse until the next item-starting
+    /// keyword at the top level. Always consumes at least one token so
+    /// recovery makes progress, then tracks bracket depth and stops at the
+    /// first unambiguous top-level item keyword (`fun`, `struct`, `enum`,
+    /// `trait`, `impl`, `extern`, `import`, or a `@` attribute). `let` and
+    /// `const` are not sync points because they double as statements inside a
+    /// body.
+    fn recover_to_next_item(&mut self) {
+        if !self.is_at_end() {
+            self.advance();
+        }
+        let mut depth: i32 = 0;
+        while !self.is_at_end() {
+            let k = self.peek_kind();
+            if depth <= 0 && is_item_start(k) {
+                break;
+            }
+            match k {
+                TokenKind::LBrace | TokenKind::LParen | TokenKind::LBracket => depth += 1,
+                TokenKind::RBrace | TokenKind::RParen | TokenKind::RBracket => depth -= 1,
+                _ => {}
+            }
+            self.advance();
+        }
     }
 
     // ----- token cursor primitives -----
@@ -232,6 +293,45 @@ pub fn parse(tokens: &[Token]) -> ParseResult<File> {
 pub fn parse_with_macros(tokens: &[Token], macros: crate::macros::MacroTable) -> ParseResult<File> {
     let mut p = Parser::new_with_macros(tokens, macros);
     p.parse_file()
+}
+
+/// Parse a complete source file with item-level error recovery, carrying the
+/// file's macro definitions. Returns every collected parse error when any
+/// occurred, so one compile reports several syntax errors.
+pub fn parse_with_macros_all(
+    tokens: &[Token],
+    macros: crate::macros::MacroTable,
+) -> Result<File, Vec<RavenError>> {
+    let mut p = Parser::new_with_macros(tokens, macros);
+    p.parse_file_recover()
+}
+
+/// Whether `k` begins an unambiguous top-level item, used as a parser
+/// synchronization point during error recovery. `let` and `const` are
+/// excluded because they also appear as statements inside a body.
+fn is_item_start(k: &TokenKind) -> bool {
+    matches!(
+        k,
+        TokenKind::Fun
+            | TokenKind::Struct
+            | TokenKind::Enum
+            | TokenKind::Trait
+            | TokenKind::Impl
+            | TokenKind::Extern
+            | TokenKind::Import
+            | TokenKind::At
+    )
+}
+
+/// Drop duplicate parse diagnostics, keeping the first occurrence. Two errors
+/// at the same span with the same message are duplicates.
+fn dedup_parse_errors(errors: &mut Vec<RavenError>) {
+    let mut seen: std::collections::HashSet<(std::path::PathBuf, usize, usize, String)> =
+        std::collections::HashSet::new();
+    errors.retain(|e| {
+        let s = e.span();
+        seen.insert((s.file.to_path_buf(), s.start, s.end, format!("{}", e)))
+    });
 }
 
 /// Merge two spans into one covering both. Both must come from the same

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -12,10 +12,20 @@ use crate::ast::{
 use crate::error::{ParseError, RavenError};
 use crate::lexer::Lexer;
 
-use super::parse;
+use super::{parse, parse_with_macros_all};
 
 fn tokens(src: &str) -> Vec<crate::lexer::Token> {
     Lexer::new(src, "test.rv").tokenize().expect("lex ok")
+}
+
+/// Parse with item-level recovery and return every collected error (empty
+/// when the source parses cleanly).
+fn parse_all_errors(src: &str) -> Vec<RavenError> {
+    let toks = tokens(src);
+    match parse_with_macros_all(&toks, crate::macros::MacroTable::default()) {
+        Ok(_) => Vec::new(),
+        Err(es) => es,
+    }
 }
 
 fn parse_ok(src: &str) -> crate::ast::File {
@@ -871,4 +881,33 @@ fn unexpected_eof_reports_eof() {
 fn invalid_import_path_for_bare_path() {
     let err = parse_err("import 42\n");
     assert!(matches!(err, RavenError::Parse(_, _, _)));
+}
+
+// ----- item-level error recovery -----
+
+#[test]
+fn recovery_reports_an_error_in_each_broken_item() {
+    // Two functions have a broken body; both errors are reported, and the
+    // valid functions between and after them do not add noise.
+    let errs = parse_all_errors(
+        "fun a() -> Int {\n    let x = @\n    return x\n}\nfun b() -> Int { return 2 }\nfun c() -> Int {\n    let y = )\n    return y\n}\nfun d() -> Int { return 4 }\n",
+    );
+    assert_eq!(errs.len(), 2, "got: {:?}", errs);
+}
+
+#[test]
+fn recovery_resyncs_at_a_struct_after_a_broken_function() {
+    // A broken function followed by a valid struct and function: one error,
+    // and recovery finds the next item.
+    let errs = parse_all_errors(
+        "fun a() -> Int {\n    return @\n}\nstruct P { x: Int }\nfun b() -> Int { return 1 }\n",
+    );
+    assert_eq!(errs.len(), 1, "got: {:?}", errs);
+}
+
+#[test]
+fn recovery_on_a_clean_file_reports_nothing() {
+    assert!(
+        parse_all_errors("fun a() -> Int { return 1 }\nfun b() -> Int { return 2 }\n").is_empty()
+    );
 }


### PR DESCRIPTION
## Summary

Continues the multi-error work (#284 shipped the type-checker half; this is the parser half, #294). The parser was fail-fast, so one compile reported one syntax error. It now recovers at item boundaries, reporting several syntax errors in a single compile.

```
error: expected expression, found `@`
  ┌─ main.rv:2:13
  │
2 │     let x = @
  │             ^

error: expected expression, found `)`
   ┌─ main.rv:13:13
   │
13 │     let y = )
   │             ^
```

## How it works

`parse_file_recover` (used by the driver via the new `parse_with_macros_all`) checks each top-level item; on a failed `parse_decl` it records the error and calls `recover_to_next_item`, which consumes at least one token (guaranteeing progress) then tracks bracket depth and skips to the next unambiguous top-level item keyword at depth zero: `fun`, `struct`, `enum`, `trait`, `impl`, `extern`, `import`, or `@`. `let` and `const` are deliberately not synchronization points, since they also appear as statements inside a body. The depth counter lets recovery step over a broken function body (its inner braces and closing `}`) and resume at the next item.

A compile with parse errors returns them all (de-duplicated by span and message) and discards the partial AST, stopping before resolve and type checking, since a damaged tree would only produce cascade errors. The driver renders each error with the rich renderer from 2.1.0, blank-line separated, reusing the multi-error path added with the type-checker recovery.

`parse_file` stays fail-fast (single error) for the test and golden harnesses that expect one error.

## Testing

- New parser unit tests: an error in each of two broken functions is reported; recovery resyncs at a struct after a broken function; a clean file reports nothing.
- Full `cargo test` green, including the golden suite (unchanged, since it uses the single-error `parse`). `cargo fmt --check` and `cargo clippy` (with tests) clean.

## Scope

Item-level recovery: at most one error per top-level item, but every broken item across the file is reported. Statement-level recovery within a single body (more than one error per item) remains a follow-up, tracked in #294.

## Version

Patch bump to `2.2.1` (follow-up subtask of the multi-error effort). CHANGELOG `[Unreleased]` updated; no release cut.

Part of #294
