### PR TITLE
fix(format): format macro definitions and calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to Raven are documented in this file.
 - The parser now recovers at item and statement boundaries, so one compile reports several syntax errors instead of only the first. On a failed top-level item the parser skips to the next item-starting keyword (`fun`, `struct`, `enum`, `trait`, `impl`, `extern`, `import`, or `@`); on a failed statement inside a block it skips to the next statement boundary and keeps parsing the body, so more than one error per function is reported too. Both track bracket depth to step over nested groups, and a compile with parse errors reports them all (de-duplicated) and stops before resolve and type checking. Recovery is opt-in, so a valid program parses unchanged (#294).
 - The type checker now reports multiple errors per compile instead of stopping at the first. The body pass recovers at item and statement boundaries: an error in one function, impl method, `const`, or `let` no longer hides errors in the next, and each statement in a block reports independently. Recovery binds a failed `let` to its annotated type (or `Ty::Error`) so later references do not cascade into spurious follow-on errors, and identical diagnostics are de-duplicated. Each error is rendered with the rich source-pointer format from 2.1.0, separated by a blank line. Parser-level recovery (multiple syntax errors per compile) remains a follow-up (#284).
 
+### Fixed
+
+- `rvpm fmt` now formats files that declare or use macros instead of leaving them untouched. A `macro name { (matcher) => { template } ... }` definition and a `name!(...)` invocation are parsed into dedicated AST nodes (the formatter parses un-expanded source) and rendered canonically: one rule per line for multi-rule macros, with metavariables (`$x:expr`) and the repetition sigil kept tight. The surrounding code in a macro-using file is now formatted normally rather than passed through verbatim (#261).
+
 ## [2.1.6] - 2026-06-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/formatter.md
+++ b/docs/v2/specs/formatter.md
@@ -104,6 +104,19 @@ Removed from every line.
   recurses into them.
 * Float literals always show a decimal point (`3` written where a float
   is expected renders as `3.0`).
+* Macros. A `macro name { (matcher) => { template } ... }` definition and a
+  `name!(...)` / `name![...]` / `name!{...}` invocation are parsed into
+  dedicated AST nodes (the formatter parses un-expanded source, unlike the
+  compile pipeline, which expands macros at the token level before parsing).
+  A definition with one rule renders on a single line; with several rules
+  each gets its own indented line. The matcher, template, and call arguments
+  are rendered token by token with canonical spacing: metavariables
+  (`$x`, `$x:expr`) and the repetition sigil `$(` stay tight, brackets and
+  punctuation follow the same rules as expressions. The result re-lexes to
+  the same tokens, so macro formatting is idempotent. Because the rendering
+  is token-level (a macro body is not a normal expression), a few constructs
+  such as generic angle brackets inside a template may keep surrounding
+  spaces; the output stays parseable and stable.
 
 There is no line length limit and no expression wrapping: an expression
 renders on one line unless it contains a block bearing sub expression

--- a/src/ast/decl.rs
+++ b/src/ast/decl.rs
@@ -3,6 +3,7 @@
 //! Items appear at the module level: functions, types, traits, impls,
 //! enums, extern blocks, imports, constants, and module level lets.
 
+use crate::lexer::Token;
 use crate::span::Span;
 
 use super::expr::{Block, Expr};
@@ -37,6 +38,21 @@ pub enum DeclKind {
     Const(Const),
     /// Module level `let name [: T] [= expr]`. Mutable module global.
     Let(LetDecl),
+    /// `macro name { (matcher) => { template } ... }`. Macros are expanded by
+    /// a token-level pre-pass before the compiler parses, so this node is
+    /// produced only by the formatter (which parses un-expanded source); the
+    /// compile pipeline never sees it.
+    Macro(MacroDef),
+}
+
+/// A declarative macro definition, kept as raw tokens for the formatter to
+/// render. `body` is every token between the outer braces of
+/// `macro name { ... }`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MacroDef {
+    pub name: String,
+    pub body: Vec<Token>,
+    pub span: Span,
 }
 
 /// A function declaration.

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -5,6 +5,7 @@
 //! lambdas, struct literals. The variants below mirror the grammar in
 //! `docs/v2/specs/parser.md` closely.
 
+use crate::lexer::Token;
 use crate::span::Span;
 
 use super::pattern::Pattern;
@@ -52,6 +53,10 @@ pub enum ExprKind {
     /// A bare identifier, optionally with generic arguments
     /// `name<T1, T2>`.
     Ident { name: String, generics: Vec<Type> },
+    /// A macro invocation `name!(...)`, `name![...]`, or `name!{...}`, kept as
+    /// raw argument tokens for the formatter. Macros are expanded before the
+    /// compiler parses, so this node is produced only by the formatter.
+    MacroCall(MacroCall),
     /// A struct literal: `Point { x: 1, y: 2 }`. The `name` is the type
     /// path source spelling, recorded as identifier segments. Generic
     /// arguments on the path live on the leading `Ident` if any.
@@ -174,6 +179,24 @@ pub enum UnaryOp {
     Not,
     /// `&x` reference. Semantics deferred to the type checker.
     Ref,
+}
+
+/// A macro invocation, kept as raw argument tokens for the formatter.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MacroCall {
+    pub name: String,
+    /// The bracket the call uses: `(`, `[`, or `{`.
+    pub delim: MacroDelim,
+    /// The tokens between the brackets, excluding the brackets themselves.
+    pub tokens: Vec<Token>,
+}
+
+/// The bracket style of a macro invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacroDelim {
+    Paren,
+    Bracket,
+    Brace,
 }
 
 /// Binary infix operators.

--- a/src/ast/pretty.rs
+++ b/src/ast/pretty.rs
@@ -35,6 +35,9 @@ fn indent(buf: &mut String, depth: usize) {
 fn pretty_decl(buf: &mut String, decl: &Decl, depth: usize) {
     indent(buf, depth);
     match &decl.kind {
+        DeclKind::Macro(m) => {
+            writeln!(buf, "(macro {})", quote(&m.name)).unwrap();
+        }
         DeclKind::Function(f) => {
             write!(buf, "(fn {}", quote(&f.name)).unwrap();
             if !f.generics.is_empty() {
@@ -326,6 +329,7 @@ fn pretty_stmt(buf: &mut String, stmt: &Stmt, depth: usize) {
 fn pretty_expr(buf: &mut String, expr: &Expr, depth: usize) {
     indent(buf, depth);
     match &expr.kind {
+        ExprKind::MacroCall(m) => writeln!(buf, "(macro-call {})", quote(&m.name)).unwrap(),
         ExprKind::Int(n) => writeln!(buf, "(int {})", n).unwrap(),
         ExprKind::Float(v) => writeln!(buf, "(float {})", v).unwrap(),
         ExprKind::Bool(b) => writeln!(buf, "(bool {})", b).unwrap(),

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -14,10 +14,11 @@ use std::fmt::Write as _;
 use crate::ast::{
     AssignOp, BinaryOp, Block, Const, Decl, DeclKind, ElseBranch, Enum, Expr, ExprKind, Extern,
     ExternFn, File, Function, FunctionBody, GenericParam, Impl, Import, ImportSource, LambdaBody,
-    LambdaParam, LetDecl, LiteralPattern, MatchArm, Param, Pattern, PatternKind, Stmt, StmtKind,
-    StrFragment, Struct, StructField, Trait, Type, TypeKind, TypePath, UnaryOp, VariantPayload,
+    LambdaParam, LetDecl, LiteralPattern, MacroDef, MacroDelim, MatchArm, Param, Pattern,
+    PatternKind, Stmt, StmtKind, StrFragment, Struct, StructField, Trait, Type, TypeKind, TypePath,
+    UnaryOp, VariantPayload,
 };
-use crate::lexer::Lexer;
+use crate::lexer::{Lexer, Token, TokenKind};
 use crate::parser::parse;
 
 mod comments;
@@ -51,14 +52,11 @@ pub fn format_source(src: &str) -> Result<String, FormatError> {
     let tokens = Lexer::new(src, "<fmt>")
         .tokenize()
         .map_err(|e| FormatError::Parse(e.to_string()))?;
-    // Macro definitions and `name!(...)` invocations have no AST node (they
-    // are expanded at the token level before parsing in the compile
-    // pipeline), so the AST-based formatter cannot represent them. Rather
-    // than fail, leave a file that uses macros unchanged. Reformatting macro
-    // internals is tracked as a follow-up.
-    if crate::macros::contains_macros(&tokens) {
-        return Ok(src.to_string());
-    }
+    // Macro definitions (`macro name { ... }`) and invocations (`name!(...)`)
+    // are parsed into dedicated AST nodes here (the formatter parses
+    // un-expanded source, unlike the compile pipeline, which expands macros
+    // at the token level first) and rendered by `macro_decl` / the
+    // `MacroCall` expression arm.
     let file = parse(&tokens).map_err(|e| FormatError::Parse(e.to_string()))?;
     let comments = comments::scan(src);
     let mut p = Printer::new(src, comments);
@@ -241,6 +239,7 @@ impl Printer<'_> {
     /// line, if one was found.
     fn decl(&mut self, decl: &Decl) -> Option<String> {
         match &decl.kind {
+            DeclKind::Macro(m) => self.macro_decl(m),
             DeclKind::Function(f) => self.function(f, ""),
             DeclKind::Struct(s) => self.struct_decl(s),
             DeclKind::Trait(t) => self.trait_decl(t),
@@ -251,6 +250,103 @@ impl Printer<'_> {
             DeclKind::Const(c) => self.const_decl(c),
             DeclKind::Let(l) => self.let_decl(l),
         }
+    }
+
+    /// Emit a `macro name { (matcher) => { template } ... }` definition. One
+    /// rule renders on a single line; several rules each get their own
+    /// indented line. The matcher and template token runs are rendered with
+    /// canonical spacing.
+    fn macro_decl(&mut self, m: &MacroDef) -> Option<String> {
+        let rules = split_macro_rules(&m.body);
+        if rules.is_empty() {
+            // The body did not match the expected rule shape; render its
+            // tokens inline so the output still round-trips and re-parses.
+            let body = self.render_macro_tokens(&m.body);
+            self.line(&format!("macro {} {{ {} }}", m.name, body));
+        } else if rules.len() == 1 {
+            let mt = self.render_macro_tokens(&rules[0].0);
+            let tp = self.render_macro_tokens(&rules[0].1);
+            self.line(&format!("macro {} {{ ({}) => {{ {} }} }}", m.name, mt, tp));
+        } else {
+            self.line(&format!("macro {} {{", m.name));
+            self.indent += 1;
+            for (matcher, template) in &rules {
+                let mt = self.render_macro_tokens(matcher);
+                let tp = self.render_macro_tokens(template);
+                self.line(&format!("({}) => {{ {} }}", mt, tp));
+            }
+            self.indent -= 1;
+            self.line("}");
+        }
+        self.take_trailing_comment(self.line_of(m.span.end))
+    }
+
+    /// The exact source text of a token.
+    fn tok_src(&self, t: &Token) -> &str {
+        self.src.get(t.span.start..t.span.end).unwrap_or("")
+    }
+
+    /// Render a macro matcher, template, or call-argument token run with
+    /// canonical spacing. Metavariables (`$x`, `$x:expr`) and the repetition
+    /// sigil `$(` are kept tight; other tokens use expression-like spacing.
+    /// Layout tokens (newlines) are dropped. The result re-lexes to the same
+    /// tokens, so formatting is idempotent.
+    fn render_macro_tokens(&self, raw: &[Token]) -> String {
+        let toks: Vec<&Token> = raw
+            .iter()
+            .filter(|t| !matches!(t.kind, TokenKind::Newline | TokenKind::Eof))
+            .collect();
+        let mut out = String::new();
+        let mut prev: Option<TokenKind> = None;
+        let mut i = 0;
+        while i < toks.len() {
+            let t = toks[i];
+            if matches!(t.kind, TokenKind::Dollar) {
+                if let Some(p) = &prev {
+                    if macro_space_before(p, &TokenKind::Dollar) {
+                        out.push(' ');
+                    }
+                }
+                out.push('$');
+                i += 1;
+                // `$(` repetition group: keep the bracket tight.
+                if i < toks.len() && matches!(toks[i].kind, TokenKind::LParen) {
+                    out.push('(');
+                    prev = Some(TokenKind::LParen);
+                    i += 1;
+                    continue;
+                }
+                // `$name`, optionally with a `:fragment` annotation.
+                if i < toks.len() {
+                    if let TokenKind::Identifier(_) = toks[i].kind {
+                        out.push_str(self.tok_src(toks[i]));
+                        i += 1;
+                        if i + 1 < toks.len()
+                            && matches!(toks[i].kind, TokenKind::Colon)
+                            && matches!(toks[i + 1].kind, TokenKind::Identifier(_))
+                        {
+                            out.push(':');
+                            out.push_str(self.tok_src(toks[i + 1]));
+                            i += 2;
+                        }
+                        // A metavariable behaves like an atom for spacing.
+                        prev = Some(TokenKind::Identifier(String::new()));
+                        continue;
+                    }
+                }
+                prev = Some(TokenKind::Dollar);
+                continue;
+            }
+            if let Some(p) = &prev {
+                if macro_space_before(p, &t.kind) {
+                    out.push(' ');
+                }
+            }
+            out.push_str(self.tok_src(t));
+            prev = Some(t.kind.clone());
+            i += 1;
+        }
+        out
     }
 
     fn function(&mut self, f: &Function, prefix: &str) -> Option<String> {
@@ -727,6 +823,16 @@ impl Printer<'_> {
     /// are woven in from the shared cursor as the block renders.
     fn expr_at(&mut self, e: &Expr, base: usize) -> String {
         match &e.kind {
+            ExprKind::MacroCall(m) => {
+                let (open, close) = macro_delim_chars(m.delim);
+                format!(
+                    "{}!{}{}{}",
+                    m.name,
+                    open,
+                    self.render_macro_tokens(&m.tokens),
+                    close
+                )
+            }
             ExprKind::Int(n) => n.to_string(),
             ExprKind::Float(v) => render_float(*v),
             ExprKind::Bool(b) => b.to_string(),
@@ -1144,6 +1250,112 @@ fn render_param(p: &Param) -> String {
         }
     }
     format!("{}: {}", p.name, render_type(&p.ty))
+}
+
+/// The opening and closing bracket characters for a macro call delimiter.
+fn macro_delim_chars(d: MacroDelim) -> (char, char) {
+    match d {
+        MacroDelim::Paren => ('(', ')'),
+        MacroDelim::Bracket => ('[', ']'),
+        MacroDelim::Brace => ('{', '}'),
+    }
+}
+
+/// Split a macro body (the tokens between the outer braces) into its rules,
+/// each a `(matcher, template)` pair of inner token runs. Returns an empty
+/// vector when the body does not match the `(...) => { ... } ...` shape, so
+/// the caller can fall back to rendering the body inline.
+fn split_macro_rules(body: &[Token]) -> Vec<(Vec<Token>, Vec<Token>)> {
+    let toks: Vec<&Token> = body
+        .iter()
+        .filter(|t| !matches!(t.kind, TokenKind::Newline | TokenKind::Eof))
+        .collect();
+    let mut rules = Vec::new();
+    let mut i = 0;
+    while i < toks.len() {
+        let Some((matcher, after_m)) =
+            capture_macro_group(&toks, i, &TokenKind::LParen, &TokenKind::RParen)
+        else {
+            return Vec::new();
+        };
+        i = after_m;
+        if i >= toks.len() || !matches!(toks[i].kind, TokenKind::FatArrow) {
+            return Vec::new();
+        }
+        i += 1;
+        let Some((template, after_t)) =
+            capture_macro_group(&toks, i, &TokenKind::LBrace, &TokenKind::RBrace)
+        else {
+            return Vec::new();
+        };
+        i = after_t;
+        rules.push((matcher, template));
+    }
+    rules
+}
+
+/// Capture the tokens inside a bracket group that begins at `start` (which
+/// must be `open`), tracking nesting of the same bracket pair. Returns the
+/// inner tokens (cloned, brackets excluded) and the index just past the
+/// closing bracket, or `None` when `start` is not `open` or the group never
+/// closes.
+fn capture_macro_group(
+    toks: &[&Token],
+    start: usize,
+    open: &TokenKind,
+    close: &TokenKind,
+) -> Option<(Vec<Token>, usize)> {
+    if start >= toks.len() || &toks[start].kind != open {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut inner = Vec::new();
+    let mut i = start;
+    while i < toks.len() {
+        let k = &toks[i].kind;
+        if k == open {
+            depth += 1;
+            if depth > 1 {
+                inner.push(toks[i].clone());
+            }
+        } else if k == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some((inner, i + 1));
+            }
+            inner.push(toks[i].clone());
+        } else {
+            inner.push(toks[i].clone());
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Whether a space goes between two macro tokens. Default is a space, with
+/// the usual tight cases: no space inside call/index brackets, before
+/// punctuation, or after `.`/`$`/`!`.
+fn macro_space_before(prev: &TokenKind, cur: &TokenKind) -> bool {
+    use TokenKind::*;
+    if matches!(
+        cur,
+        Comma | Semi | RParen | RBracket | RBrace | Dot | ColonColon | Question | Colon | Bang
+    ) {
+        return false;
+    }
+    if matches!(prev, LParen | LBracket | Dot | ColonColon | Dollar | Bang) {
+        return false;
+    }
+    // `name(` / `name[` / `)(` stay tight (call or index).
+    if matches!(cur, LParen | LBracket)
+        && matches!(
+            prev,
+            Identifier(_) | RParen | RBracket | SelfLower | SelfUpper
+        )
+    {
+        return false;
+    }
+    true
 }
 
 fn render_type(ty: &Type) -> String {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -102,14 +102,39 @@ fn defer_stmt() {
 }
 
 #[test]
-fn macro_file_is_left_unchanged() {
-    // Macro definitions and `name!(...)` invocations have no AST node, so the
-    // formatter passes a macro-using file through unchanged rather than
-    // failing to parse it.
-    let src =
-        "macro square { ($x:expr) => { ($x) * ($x) } }\nfun main() {\n    print(square!(5))\n}\n";
+fn macro_definition_and_call_are_formatted() {
+    // A cramped macro definition and the function that uses it both
+    // canonicalize: the rule gets spacing, the metavariable stays tight, and
+    // the `name!(...)` call is laid out like any other expression.
+    let src = "macro square{($x:expr)=>{($x)*($x)}}\nfun main(){\nlet n=square!(5)\nprint(n)\n}\n";
     let out = format_source(src).expect("formatting a macro file must not error");
-    assert_eq!(out, src);
+    let expected = "macro square { ($x:expr) => { ($x) * ($x) } }\nfun main() {\n    let n = square!(5)\n    print(n)\n}\n";
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn multi_rule_macro_splits_onto_lines() {
+    let src = "macro pick{($a:expr,$b:expr)=>{two}($a:expr)=>{one}}\n";
+    let out = format_source(src).expect("format ok");
+    let expected = "macro pick {\n    ($a:expr, $b:expr) => { two }\n    ($a:expr) => { one }\n}\n";
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn macro_formatting_is_idempotent() {
+    let src = "macro twice{($x:expr)=>{($x)+($x)}}\nfun main(){print(twice!(3))}\n";
+    let once = format_source(src).expect("format ok");
+    let twice = format_source(&once).expect("format ok");
+    assert_eq!(
+        once, twice,
+        "formatting an already-formatted macro file is a no-op"
+    );
+}
+
+#[test]
+fn macro_call_with_bracket_delimiter() {
+    let out = fmt("fun f(){let a=make![1,2,3]\n a}");
+    assert!(out.contains("make![1, 2, 3]"), "got: {out}");
 }
 
 #[test]

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -65,6 +65,15 @@ pub(crate) fn lower_expr(
     let ty = cx.ty_at(&expr.span);
     let span = expr.span.clone();
     let kind = match &expr.kind {
+        // A macro call should have been expanded before HIR lowering; reaching
+        // here means the token pre-pass was skipped (only the formatter parses
+        // un-expanded source, and it never lowers to HIR).
+        ExprKind::MacroCall(_) => {
+            return Err(super::ty_error(
+                "internal error: macro call reached HIR lowering without expansion",
+                &span,
+            ))
+        }
         ExprKind::Int(i) => HirExprKind::Int(*i),
         ExprKind::Float(f) => HirExprKind::Float(*f),
         ExprKind::Bool(b) => HirExprKind::Bool(*b),

--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -359,6 +359,9 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
             span: decl.span.clone(),
             kind: HirItemKind::Opaque("import".into()),
         })),
+        // Macros are expanded before the compiler parses; only the formatter
+        // produces this node, so it lowers to nothing.
+        DeclKind::Macro(_) => Ok(None),
         DeclKind::Extern(ext) => {
             // Resolve each foreign signature's parameter and return types
             // so codegen can declare the symbol with its C ABI shape.

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -2,7 +2,7 @@
 
 use crate::ast::{
     Const, Decl, DeclKind, Enum, EnumVariant, Extern, ExternFn, Function, FunctionBody,
-    GenericParam, Impl, Import, ImportSource, LetDecl, Param, Struct, StructField, Trait,
+    GenericParam, Impl, Import, ImportSource, LetDecl, MacroDef, Param, Struct, StructField, Trait,
     VariantPayload,
 };
 use crate::error::{ParseError, RavenError};
@@ -21,6 +21,14 @@ impl Parser {
         while matches!(self.peek_kind(), TokenKind::At) {
             self.parse_item_attr(&mut derives, &mut repr_c)?;
             self.skip_separators();
+        }
+        // `macro name { ... }`. `macro` is a contextual identifier (not a
+        // keyword), so match it by spelling. Only the formatter reaches this:
+        // the compile pipeline expands and strips macros before parsing.
+        if matches!(self.peek_kind(), TokenKind::Identifier(n) if n == "macro")
+            && matches!(self.peek_kind_at(1), TokenKind::Identifier(_))
+        {
+            return self.parse_macro_def();
         }
         match self.peek_kind() {
             TokenKind::Struct => self.parse_struct_decl(derives, repr_c),
@@ -84,6 +92,24 @@ impl Parser {
                 name_span,
             )),
         }
+    }
+
+    /// Parse `macro name { (matcher) => { template } ... }`, capturing the
+    /// body tokens raw. The leading `macro` identifier is at the cursor.
+    fn parse_macro_def(&mut self) -> ParseResult<Decl> {
+        let start = self.advance().span; // `macro`
+        let (name, _) = self.expect_ident("macro name")?;
+        self.expect(&TokenKind::LBrace, "`{`")?;
+        let (body, close_span) = self.capture_balanced(&TokenKind::LBrace, &TokenKind::RBrace)?;
+        let span = merge_spans(&start, &close_span);
+        Ok(Decl {
+            kind: DeclKind::Macro(MacroDef {
+                name,
+                body,
+                span: span.clone(),
+            }),
+            span,
+        })
     }
 
     fn parse_function_decl(&mut self) -> ParseResult<Decl> {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -4,11 +4,11 @@
 //! level. The level order from lowest to highest matches the spec.
 
 use crate::ast::{
-    BinaryOp, Block, ElseBranch, Expr, ExprKind, FieldInit, LambdaBody, LambdaParam, MatchArm,
-    StrFragment, Type, UnaryOp,
+    BinaryOp, Block, ElseBranch, Expr, ExprKind, FieldInit, LambdaBody, LambdaParam, MacroCall,
+    MacroDelim, MatchArm, StrFragment, Type, UnaryOp,
 };
 use crate::error::{ParseError, RavenError};
-use crate::lexer::{Lexer, TokenKind, ESCAPED_DOLLAR_SENTINEL};
+use crate::lexer::{Lexer, Token, TokenKind, ESCAPED_DOLLAR_SENTINEL};
 use crate::span::Span;
 
 use super::{merge_spans, ParseResult, Parser};
@@ -827,8 +827,69 @@ impl Parser {
         })
     }
 
+    /// Parse a macro invocation `name!(...)` / `name![...]` / `name!{...}`
+    /// after the name has been consumed. The `!` is at the cursor. The
+    /// argument tokens are captured raw for the formatter to render.
+    fn parse_macro_call(&mut self, name: String, name_span: Span) -> ParseResult<Expr> {
+        self.expect(&TokenKind::Bang, "`!`")?;
+        let (delim, open, close) = match self.peek_kind() {
+            TokenKind::LParen => (MacroDelim::Paren, TokenKind::LParen, TokenKind::RParen),
+            TokenKind::LBracket => (
+                MacroDelim::Bracket,
+                TokenKind::LBracket,
+                TokenKind::RBracket,
+            ),
+            TokenKind::LBrace => (MacroDelim::Brace, TokenKind::LBrace, TokenKind::RBrace),
+            _ => return Err(self.unexpected("`(`, `[`, or `{` after a macro name")),
+        };
+        self.advance(); // opening delimiter
+        let (tokens, close_span) = self.capture_balanced(&open, &close)?;
+        let span = merge_spans(&name_span, &close_span);
+        Ok(Expr {
+            kind: ExprKind::MacroCall(MacroCall {
+                name,
+                delim,
+                tokens,
+            }),
+            span,
+        })
+    }
+
+    /// Collect tokens up to the delimiter that closes an already-consumed
+    /// `open`, tracking nesting of the same delimiter pair. Consumes the
+    /// closing delimiter and returns the inner tokens plus the close span.
+    pub(crate) fn capture_balanced(
+        &mut self,
+        open: &TokenKind,
+        close: &TokenKind,
+    ) -> ParseResult<(Vec<Token>, Span)> {
+        let mut depth = 1usize;
+        let mut toks: Vec<Token> = Vec::new();
+        loop {
+            if matches!(self.peek_kind(), TokenKind::Eof) {
+                return Err(self.unexpected("a matching closing delimiter"));
+            }
+            if self.peek_kind() == open {
+                depth += 1;
+            } else if self.peek_kind() == close {
+                depth -= 1;
+                if depth == 0 {
+                    let closing = self.advance();
+                    return Ok((toks, closing.span));
+                }
+            }
+            toks.push(self.advance());
+        }
+    }
+
     fn parse_ident_primary(&mut self) -> ParseResult<Expr> {
         let (name, name_span) = self.expect_ident("identifier")?;
+        // Macro invocation `name!(...)`. The compile pipeline expands macros
+        // before parsing, so this is reached only by the formatter parsing
+        // un-expanded source.
+        if matches!(self.peek_kind(), TokenKind::Bang) {
+            return self.parse_macro_call(name, name_span);
+        }
         // Optional generics, only when the trial succeeds.
         let mut generics = Vec::new();
         if matches!(self.peek_kind(), TokenKind::Lt) {

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -315,7 +315,9 @@ fn resolve_local_import(
                     module_names.push(it.name.clone());
                 }
             }
-            DeclKind::Impl(_) | DeclKind::Import(_) => {}
+            // A macro exports no importable module name, and only appears in
+            // formatter-parsed source anyway.
+            DeclKind::Impl(_) | DeclKind::Import(_) | DeclKind::Macro(_) => {}
         }
     }
 

--- a/src/resolve/items.rs
+++ b/src/resolve/items.rs
@@ -74,6 +74,9 @@ fn collect_decl(decl: &Decl, id: DeclId, scope: &mut ScopeStack) -> Result<(), R
         DeclKind::Import(_) => {
             // Handled by `imports::resolve_imports`.
         }
+        // Macros are expanded before the compiler parses; this node only
+        // appears in the formatter, so it declares no resolvable name.
+        DeclKind::Macro(_) => {}
     }
     Ok(())
 }

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -904,6 +904,9 @@ fn rewrite_expr(expr: &mut Expr, rename: &HashMap<String, String>) {
         | ExprKind::Char(_)
         | ExprKind::CStr(_)
         | ExprKind::SelfLower
+        // A macro call only appears in formatter-parsed source; the stdlib
+        // rename pass runs after expansion, so it never sees one.
+        | ExprKind::MacroCall(_)
         | ExprKind::SelfUpper => {}
     }
 }

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -82,6 +82,10 @@ fn walk_decl(
         DeclKind::Import(_) => {
             // Already resolved by the imports pass.
         }
+        DeclKind::Macro(_) => {
+            // Macros are expanded before the compiler parses; only the
+            // formatter produces this node, so resolution has nothing to do.
+        }
     }
     Ok(())
 }
@@ -298,6 +302,9 @@ fn walk_expr(
         | ExprKind::Str(_)
         | ExprKind::BlockStr(_)
         | ExprKind::Char(_)
+        // A macro call only appears in formatter-parsed source (the compile
+        // pipeline expands macros first), so there are no names to resolve.
+        | ExprKind::MacroCall(_)
         | ExprKind::CStr(_) => {}
         ExprKind::SelfLower => {
             if !scope.in_impl() {

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -175,6 +175,9 @@ pub fn collect_declarations(
                 env.statics.insert(id, ty);
             }
             DeclKind::Import(_) => {}
+            // Macros are expanded before the compiler parses; only the
+            // formatter produces this node, so there is no type to collect.
+            DeclKind::Macro(_) => {}
         }
     }
 

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -164,9 +164,13 @@ fn check_decl_body(
             }
             errors
         }
-        DeclKind::Struct(_) | DeclKind::Enum(_) | DeclKind::Extern(_) | DeclKind::Import(_) => {
-            Vec::new()
-        }
+        DeclKind::Struct(_)
+        | DeclKind::Enum(_)
+        | DeclKind::Extern(_)
+        | DeclKind::Import(_)
+        // Macros are expanded before the compiler parses; only the formatter
+        // produces this node, so there is no body to check.
+        | DeclKind::Macro(_) => Vec::new(),
     }
 }
 
@@ -831,6 +835,9 @@ impl<'a, 'b> Checker<'a, 'b> {
 
     fn check_expr_inner(&mut self, expr: &Expr) -> Result<Ty, RavenError> {
         match &expr.kind {
+            // A macro call only appears in formatter-parsed source; the
+            // compile pipeline expands macros before type checking.
+            ExprKind::MacroCall(_) => Ok(Ty::Error),
             ExprKind::Int(_) => Ok(Ty::Int),
             ExprKind::Float(_) => Ok(Ty::Float),
             ExprKind::Bool(_) => Ok(Ty::Bool),

--- a/tests/fmt_corpus/macros.rv
+++ b/tests/fmt_corpus/macros.rv
@@ -1,0 +1,10 @@
+macro square{($x:expr)=>{($x)*($x)}}
+
+macro pick{($a:expr,$b:expr)=>{($a)+($b)}($a:expr)=>{($a)}}
+
+fun main(){
+let n=square!(5)
+print(n)
+print(pick!(1,2))
+print(pick!(9))
+}

--- a/tests/fmt_corpus/macros.rv.fmt
+++ b/tests/fmt_corpus/macros.rv.fmt
@@ -1,0 +1,13 @@
+macro square { ($x:expr) => { ($x) * ($x) } }
+
+macro pick {
+    ($a:expr, $b:expr) => { ($a) + ($b) }
+    ($a:expr) => { ($a) }
+}
+
+fun main() {
+    let n = square!(5)
+    print(n)
+    print(pick!(1, 2))
+    print(pick!(9))
+}


### PR DESCRIPTION
## Summary

Closes #261. `rvpm fmt` left any file containing a macro untouched, because macro definitions (`macro name { ... }`) and invocations (`name!(...)`) had no AST node: the compile pipeline expands macros at the token level before parsing, so the AST never represented them. The formatter, which parses un-expanded source, now does.

```
# before:  rvpm fmt left this file completely unchanged
# after:
macro square{($x:expr)=>{($x)*($x)}}       ->  macro square { ($x:expr) => { ($x) * ($x) } }
fun main(){let n=square!(5)                ->  fun main() {
print(n)}                                  ->      let n = square!(5)
                                           ->      print(n)
                                           ->  }
```

## How it works

- Adds `DeclKind::Macro` and `ExprKind::MacroCall`, each carrying the raw tokens, and teaches the parser to recognize `macro name { ... }` items and `name!(...)` / `name![...]` / `name!{...}` calls (capturing balanced token ranges).
- These nodes are produced **only by the formatter**. The compile pipeline expands macros before parsing (the only non-test caller of the bare `parse` is the formatter), so the compiler passes treat them as unreachable: resolve / tycheck / type-collection no-op, HIR lowering returns a clear internal error.
- The formatter renders a definition with one rule on a single line, several rules each on their own indented line, and a call as `name!(args)`. Matcher, template, and argument token runs render with canonical spacing: metavariables (`$x`, `$x:expr`) and the repetition sigil `$(` stay tight, other tokens use expression-like spacing. The output re-lexes to the same tokens, so formatting is idempotent.

## Testing

- New fmt-corpus golden case `tests/fmt_corpus/macros.rv` (also compiled and run-verified: prints `25`, `3`, `9`), which the harness checks for the golden baseline, idempotency, and AST preservation.
- Formatter unit tests: definition + call formatting, multi-rule split, idempotency, and a bracket-delimited call.
- Full `cargo test` green (510 lib + fmt_golden + golden); `cargo fmt --check` and `cargo clippy` clean.

## Limitation

Rendering is token-level (a macro body is not a normal expression), so a few constructs such as generic angle brackets or a repetition separator inside a template may keep surrounding spaces. The output stays parseable and idempotent. Documented in the formatter spec.

## Version

Patch bump to `2.3.1` (bug fix). CHANGELOG `[Unreleased]` updated; no release cut.

Closes #261
