### PR TITLE
release: 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Raven are documented in this file.
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-06-05
+
 ### Added
 
 - Mutable module-level globals. A `let` at file scope is now a real mutable global with runtime storage: any function can read and reassign it, its initializer may be any expression (not only a constant) and runs before `main` in declaration order so a later global can read an earlier one, and a heap-valued global (`String`, `List`, struct, and so on) is registered as a permanent GC root so the collector keeps it alive for the whole program. A `const` is unchanged (an inlined compile-time constant). This completes #278.


### PR DESCRIPTION
## Release 2.3.1

Finalizes the changelog for v2.3.1. `Cargo.toml` is already at `2.3.1`.

This release bundles the work accumulated on `main` since v2.1.6, a coherent compiler-diagnostics, language, and tooling batch:

**Diagnostics**
- Type checker reports every error per compile, not just the first (#284).
- Parser reports several syntax errors per compile (item and statement recovery) (#294).

**Language**
- Mutable module-level globals: a file-scope `let` is a real mutable global with storage, declaration-order pre-`main` initialization, and GC rooting for heap values (#278).
- `const` inside a function body as an immutable local (#278).
- Module-level `const`/`let` initializers may be folded constant expressions (#278).

**Tooling**
- `rvpm fmt` now formats files that declare or use macros (#261).

After merge I will tag `v2.3.1`, which triggers the Release workflow (installers for Linux x86_64, Windows x86_64, macOS arm64, plus the install smoke-test job).
