### PR TITLE
docs(v2): expand standard library reference and add tutorials

### DIFF
--- a/docs/v2/guide/standard-library.md
+++ b/docs/v2/guide/standard-library.md
@@ -1,479 +1,138 @@
-# Standard library (v2)
+# Standard library
 
-The standard library ships as bundled `std/...` modules. Import a module
-with a selective import for its free functions, or a bare import for a
-module that adds methods or constructors. The core traits are always in
-scope.
+Raven ships a batteries-included standard library. Every module is bundled
+into the compiler, so there is nothing to install: just `import` what you
+need. This page explains how imports work and the conventions shared across
+modules, then links to a reference page for each one.
 
-Two import gotchas to keep in mind:
+## How modules are imported
 
-- `String.len()` and `String.is_empty()` are built in and need no import.
-  The other `String` methods (`concat`, `to_upper`, `substring`, ...) come
-  from `import std/string`, which merges the `impl String` block.
-- `import std/collections` whole (not `{ Map }`), so the `Map.new()` and
-  `Set.new()` constructors resolve.
+A module is imported by name. There are two import styles, and which one you
+use depends on what the module provides.
 
-## Core traits
-
-`std/core` defines `ToString`, `Eq`, `Ord`, `Hash`, and `Iterator<T>`,
-and implements them for the primitive types. These are auto imported, so
-no `import std/core` line is needed.
-
-```raven
-fun describe<T: ToString>(x: T) -> String = x.to_string()
-```
-
-## std/io
-
-Console input and output.
-
-- `print(s: String)`: write without a trailing newline.
-- `println(s: String)`: write with a trailing newline.
-- `input(prompt: String) -> String`: print the prompt, read one line.
-- `read_line() -> String`: read one line from standard input.
-
-```raven
-import std/io { println }
-
-fun main() {
-    println("${40 + 2}")        // 42
-}
-```
-
-A global `print` builtin is also always available and accepts any
-`ToString` value (it appends a newline).
-
-## std/string
-
-Methods on `String`, merged by a bare import.
-
-`length` (alias `len`), `is_empty`, `char_at`, `substring(start, end)`,
-`concat`, `to_upper`, `to_lower`, `trim`, `is_blank`, `repeat(n)`,
-`index_of`, `contains`, `starts_with`, `ends_with`, `replace(from, to)`.
-
-`len` and `is_empty` are built in and work without the import. `String`
-values also compare lexicographically with `<`, `<=`, `>`, `>=`, and a
-`String` literal can be a `match` pattern (compared by content).
-
-```raven
-import std/string
-
-fun main() {
-    print("hello".to_upper())            // HELLO
-    print("a-b".replace("-", "+"))       // a+b
-    print("raven".substring(1, 4))       // ave
-}
-```
-
-## std/collections
-
-Generic hash-backed `Set<T: Eq + Hash>` and `Map<K: Eq + Hash, V>`, built
-with `Set.new()` and `Map.new()`. Storage is a hash-bucket layout, so
-lookup, insert, and remove are O(1) average. Import the whole module. Keys
-must implement `Eq + Hash` (`Int`, `Bool`, `String`, or a user type with
-both impls; `Char` and `Float` are not yet hashable).
-
-- `Set`: `add`, `remove`, `contains`, `len`, `is_empty`.
-- `Map`: `set(k, v)`, `get(k) -> Option<V>`, `has(k)`, `remove(k)`,
-  `keys()`, `values()`, `len`, `is_empty`.
-
-Set and map literals build these types: `{1, 2, 3}` is a set, `["a": 1]`
-is a map, and `[:]` is an empty map. See the [language reference](language-reference.md#list-set-and-map-literals)
-for the literal grammar.
-
-```raven
-import std/collections
-
-fun main() {
-    let m = ["a": 10, "b": 20]
-    match m.get("a") {
-        Some(v) -> print(v),            // 10
-        None -> print(0),
-    }
-    let s = {1, 2, 3}
-    print(s.contains(2))                // true
-}
-```
-
-## std/sync
-
-Goroutine-style concurrency: channels and the scheduler helpers used with
-the `spawn` keyword (see the [language reference](language-reference.md#concurrency)).
-Channels carry `Int` values in this release.
-
-- `channel() -> Channel`: an unbuffered (rendezvous) channel.
-- `channel_buffered(cap) -> Channel`: a buffered channel of capacity `cap`.
-- `Channel`: `send(v)` and `recv() -> Int`, each blocking by yielding to
-  the scheduler when the channel is full or empty.
-- `yield_now()`: yield control to the scheduler.
-
-```raven
-import std/sync { channel }
-
-fun main() {
-    let ch = channel()
-    spawn(fun() -> Unit {
-        ch.send(42)
-    })
-    print(ch.recv())                    // 42
-}
-```
-
-## std/math
-
-Float and integer math.
-
-- Integer: `abs_int`, `min_int`, `max_int`, `clamp_int`, `pow_int`.
-- Float: `sqrt`, `pow`, `exp`, `ln`, `abs`, `min`, `max`, `clamp`,
-  `floor`, `ceil`, `round`, `trunc`, `sin`, `cos`.
-- Constants: `pi()`, `e()`, `tau()`.
+**Selective import** brings named free functions into scope:
 
 ```raven
 import std/math { sqrt, pow_int }
 
 fun main() {
-    print(sqrt(16.0))           // 4
-    print(pow_int(2, 10))       // 1024
+    print(sqrt(16.0))       // 4
 }
 ```
 
-## std/cmp
-
-Comparison helpers generic over `T: Ord`.
-
-- `min(a, b)`, `max(a, b)`, `clamp(x, lo, hi)`.
-- `sort(xs) -> List<T>`, `sorted_by(xs, cmp)`.
-- `max_of(xs) -> Option<T>`, `min_of(xs) -> Option<T>`.
+**Bare import** brings in a module that adds methods or constructors to a
+type (it merges an `impl` block or registers a type):
 
 ```raven
-import std/cmp { sort, max_of }
+import std/string                  // adds methods to String
+import std/collections             // registers Map.new() / Set.new()
 
 fun main() {
-    let s = sort([5, 2, 8, 1])
-    print(s[0])                 // 1
+    print("hi".to_upper())         // HI
+    let m: Map<String, Int> = Map.new()
+    m.set("a", 1)
 }
 ```
 
-## std/hash
+Two rules are worth memorizing up front:
 
-Non cryptographic hashing.
+- Import `std/string` and `std/collections` **whole** (bare), not with a
+  `{ ... }` list. Their methods and constructors come from `impl` blocks
+  that only the bare form merges.
+- `String.len()` and `String.is_empty()` are built into the compiler and
+  work with no import at all. The richer string methods need
+  `import std/string`.
 
-- `fnv1a(s)`, `djb2(s)`, `checksum(s)` over strings.
-- `hash_int(n)`, `combine(seed, value)` for mixing.
+## Core traits are always in scope
+
+`std/core` defines the foundational traits (`ToString`, `Eq`, `Ord`,
+`Hash`, `Iterator<T>`) and implements them for the primitive types. It is
+auto-imported, so you never write `import std/core`:
 
 ```raven
-import std/hash { fnv1a }
-
-fun main() {
-    print(fnv1a("abc") == fnv1a("abc"))     // true
-}
+fun describe<T: ToString>(x: T) -> String = x.to_string()
 ```
 
-## std/iter
+See [core traits](stdlib/core.md) for the full set.
 
-Lazy iterators. `xs.iter()` bridges a `List<T>` into an iterator. The
-adapters `map`, `filter`, `take`, `skip`, and `enumerate` are lazy. The
-consumers `collect`, `count`, `fold`, `any`, `all`, `find`, and
-`for_each` drive the pipeline.
+## Errors use Result and Option
+
+Anything that can fail returns `Result<T, Error>`; anything that can be
+absent returns `Option<T>`. There are no exceptions and no `null`. Handle a
+`Result` with `match`, or propagate it with the `?` operator inside a
+function that itself returns `Result`:
 
 ```raven
-import std/iter { collect, fold, count }
+import std/fs { read }
 
-fun main() {
-    let xs = [1, 2, 3, 4, 5, 6]
-    let kept = collect(xs.iter().map(fun(x: Int) -> Int = x * 10).filter(fun(y: Int) -> Bool = y > 20))
-    print(kept.len())
-    print(count(xs.iter().filter(fun(y: Int) -> Bool = y > 3)))
+fun load(path: String) -> Result<String, Error> {
+    let text = read(path)?          // returns early on Err
+    return Ok(text.trim())
 }
-```
-
-## std/fmt
-
-String formatting helpers and a `Debug` trait.
-
-- `repeat`, `pad_left`, `pad_right`, `center`, `join(parts, sep)`.
-- `to_binary`, `to_octal`, `to_hex`, `to_radix(n, base)`, `pad_int`.
-- `Debug` for the primitives, used through `.debug()`.
-
-```raven
-import std/fmt { pad_left, to_hex, join }
 
 fun main() {
-    print(pad_left("7", 3, "0"))            // 007
-    print(to_hex(255))                      // ff
-    print(join(["a", "b", "c"], ", "))      // a, b, c
-}
-```
-
-## std/encoding
-
-Hex and base64.
-
-- `hex_encode(s)`, `hex_decode(s)`.
-- `base64_encode(s)`, `base64_decode(s)`.
-
-```raven
-import std/encoding { base64_encode, base64_decode }
-
-fun main() {
-    print(base64_decode(base64_encode("hi")) == "hi")   // true
-}
-```
-
-## std/random
-
-A seeded random number generator `Rng`, built with `Rng.new(seed)` or
-`Rng.from_entropy()`.
-
-- `next_int`, `gen_range(lo, hi)`, `next_float`, `next_bool`.
-- `choice(xs) -> Option<T>`, `shuffle(xs)`.
-
-```raven
-import std/random
-
-fun main() {
-    let r = Rng.new(42)
-    print(r.gen_range(0, 10) < 10)          // true
-}
-```
-
-## std/env
-
-Process environment, arguments, and platform.
-
-- `get_env(name)`, `get_env_or(name, default)`, `has_env(name)`.
-- `arg_count`, `arg_at(i)`, `args() -> List<String>`.
-- `exit(code)`, `os_name()`, `arch()`.
-
-```raven
-import std/env { os_name, get_env_or }
-
-fun main() {
-    print(os_name())
-    print(get_env_or("HOME", "unknown"))
-}
-```
-
-## std/fs
-
-Filesystem access. The IO operations return `Result<_, Error>`.
-
-- `read(path)`, `write(path, contents)`, `append(path, contents)`.
-- `remove_file`, `create_dir`, `remove_dir`, `list_dir`, `size`.
-- `exists`, `is_file`, `is_dir` return `Bool` directly.
-- Path helpers: `join`, `basename`, `dirname`, `split`.
-
-```raven
-import std/fs { write, read }
-
-fun main() {
-    match write("note.txt", "hello") {
-        Ok(_) -> {},
-        Err(e) -> print("write failed"),
-    }
-    match read("note.txt") {
+    match load("note.txt") {
         Ok(s) -> print(s),
-        Err(e) -> print("read failed"),
+        Err(e) -> print("could not load"),
     }
 }
 ```
 
-## std/time
+See [std/error](stdlib/error.md) for `Error`, `?`, and the `Result`/`Option`
+helpers.
 
-Timestamps and calendar conversions.
+## The modules
 
-- `now() -> Int`, `now_millis()`, `sleep_millis(ms)`.
-- `from_timestamp(ts) -> DateTime`, `weekday(ts)`.
-- `format_timestamp(ts, pattern)`, `parse_timestamp(text, pattern) -> Result<Int, Error>`.
+### Text and formatting
 
-```raven
-import std/time { format_timestamp, now }
+| Module | What it is for |
+|--------|----------------|
+| [std/string](stdlib/string.md) | methods on `String`: slicing, case, search, replace |
+| [std/fmt](stdlib/fmt.md) | padding, joining, number bases, the `Debug` trait |
+| [std/regex](stdlib/regex.md) | regular expressions |
+| [std/encoding](stdlib/encoding.md) | hex and base64 |
 
-fun main() {
-    print(format_timestamp(0, "%Y-%m-%d"))
-    print(now() > 0)
-}
-```
+### Data structures and iteration
 
-## std/net
+| Module | What it is for |
+|--------|----------------|
+| [std/collections](stdlib/collections.md) | hash-backed `Map` and `Set` |
+| [std/iter](stdlib/iter.md) | lazy iterator adapters and consumers |
+| [std/cmp](stdlib/cmp.md) | sorting and comparison helpers |
+| [std/hash](stdlib/hash.md) | non-cryptographic hashing |
 
-TCP sockets.
+### Numbers
 
-- `connect(addr) -> Result<TcpStream, Error>`, `listen(addr) -> Result<TcpListener, Error>`.
-- `TcpListener.accept`, `TcpStream` `read(max)`, `write(data)`,
-  `set_read_timeout_ms(ms)`, `close`.
-- `dns_lookup(host)`, `reachable(addr)`.
+| Module | What it is for |
+|--------|----------------|
+| [std/math](stdlib/math.md) | float and integer math, constants |
+| [std/random](stdlib/random.md) | a seeded random number generator |
 
-```raven
-import std/net { connect }
+### Input, output, and the system
 
-fun main() {
-    match connect("example.com:80") {
-        Ok(s) -> s.close(),
-        Err(e) -> print("connect failed"),
-    }
-}
-```
+| Module | What it is for |
+|--------|----------------|
+| [std/io](stdlib/io.md) | console input and output |
+| [std/fs](stdlib/fs.md) | files and directories |
+| [std/path](stdlib/path.md) | path string manipulation (no IO) |
+| [std/env](stdlib/env.md) | environment, arguments, platform |
+| [std/process](stdlib/process.md) | run external programs |
+| [std/time](stdlib/time.md) | timestamps and calendar conversions |
 
-## std/http
+### Networking
 
-HTTP client built on `std/net`.
+| Module | What it is for |
+|--------|----------------|
+| [std/net](stdlib/net.md) | TCP sockets |
+| [std/http](stdlib/http.md) | an HTTP client |
+| [std/json](stdlib/json.md) | JSON parse and stringify |
 
-- `get(url)`, `post(url, body)`, `put(url, body)`, `delete(url)`.
-- `request(method, url, body, headers)`.
-- All return `Result<HttpResponse, Error>`; the response carries
-  `status_code` and `body`.
+### Concurrency, errors, FFI, testing
 
-```raven
-import std/http { get }
-
-fun main() {
-    match get("http://example.com") {
-        Ok(resp) -> print(resp.status_code),
-        Err(e) -> print("request failed"),
-    }
-}
-```
-
-## std/json
-
-JSON parsing and serialization.
-
-- `parse(text) -> Result<JsonValue, Error>`, `stringify(value) -> String`.
-- `JsonValue` accessors: `is_null`, `as_bool`, `as_number`, `as_string`,
-  `get(key)`, `at(i)`.
-
-```raven
-import std/json { parse, stringify }
-
-fun main() {
-    match parse("{\"a\": 1}") {
-        Ok(v) -> print(stringify(v)),
-        Err(e) -> print("parse failed"),
-    }
-}
-```
-
-## std/regex
-
-Regular expressions. `compile` returns `Result<Regex, Error>`. Free a
-compiled pattern with `free` when done.
-
-- `is_match(text)`, `find(text) -> Option<String>`, `find_all(text)`.
-- `captures(text)`, `replace_all(text, repl)`, `split(text)`.
-
-```raven
-import std/regex { compile }
-
-fun main() {
-    match compile("a+") {
-        Ok(re) -> {
-            print(re.is_match("xaaay"))     // true
-            re.free()
-        },
-        Err(e) -> print("compile failed"),
-    }
-}
-```
-
-## std/process
-
-Run external programs.
-
-- `run(program, args) -> Result<Output, Error>`.
-- `run_with_input(program, args, input)`.
-- `Output` carries `code`, `stdout`, `stderr`, and `success()`.
-
-```raven
-import std/process { run }
-
-fun main() {
-    let no_args: List<String> = []
-    match run("echo", no_args) {
-        Ok(out) -> print(out.code),
-        Err(e) -> print("run failed"),
-    }
-}
-```
-
-## std/ffi
-
-Bridge runtime values to C and access raw memory for FFI calls. See the
-[FFI section](language-reference.md#ffi-and-c-types) of the language
-reference for the full picture.
-
-- Strings: `to_cstr(s) -> CStr`, `from_cstr(p) -> String`.
-- Raw pointers over `CPtr<T>`: `alloc<T>(count)`, `free<T>(p)`,
-  `load<T>(p)`, `store<T>(p, v)`, `offset<T>(p, i)`, `is_null<T>(p)`,
-  `null_ptr<T>()`. This memory lives outside the GC, so you must `free`
-  it.
-
-```raven
-import std/ffi { to_cstr, from_cstr }
-
-extern "C" {
-    fun strlen(s: CStr) -> CSize
-}
-
-fun main() {
-    print(strlen(to_cstr("hello")))         // 5
-}
-```
-
-## std/error
-
-The `Error` type and `Result` helpers.
-
-- `error(msg) -> Error`, `error_kind(kind, msg)`.
-- `Error` methods: `message`, `kind`, `with_context(ctx)`, `to_string`.
-- `is_ok(r)`, `is_err(r)`, `unwrap_or(r, default)`, `ok(r) -> Option<T>`,
-  `err(r) -> Option<E>`.
-
-```raven
-import std/error { error, unwrap_or }
-
-fun divide(a: Int, b: Int) -> Result<Int, Error> {
-    if b == 0 {
-        return Err(error("divide by zero"))
-    }
-    return Ok(a / b)
-}
-
-fun main() {
-    print(unwrap_or(divide(1, 0), -1))      // -1
-}
-```
-
-## std/path
-
-Pure path string manipulation (no filesystem access).
-
-- `join(a, b)`, `basename(p)`, `dirname(p)`, `extension(p)`, `stem(p)`,
-  `is_absolute(p)`.
-
-```raven
-import std/path { join, basename, extension }
-
-fun main() {
-    print(join("a/b", "c.txt"))             // a/b/c.txt
-    print(extension("a/b/c.txt"))           // txt
-}
-```
-
-## std/test
-
-Assertions for test programs. A failing assertion panics and aborts with
-a non-zero exit.
-
-- `assert(cond)`, `assert_msg(cond, msg)`.
-- `assert_true`, `assert_false`.
-- `assert_eq_int(a, b)`, `assert_eq_str(a, b)`.
-
-```raven
-import std/test { assert, assert_eq_int }
-
-fun main() {
-    assert(1 + 1 == 2)
-    assert_eq_int(6 * 7, 42)
-}
-```
+| Module | What it is for |
+|--------|----------------|
+| [std/sync](stdlib/sync.md) | channels for goroutines |
+| [std/error](stdlib/error.md) | the `Error` type and `Result` helpers |
+| [std/ffi](stdlib/ffi.md) | bridge values to C and access raw memory |
+| [std/test](stdlib/test.md) | assertions for test programs |
+| [std/core](stdlib/core.md) | the always-in-scope core traits |

--- a/docs/v2/guide/stdlib/cmp.md
+++ b/docs/v2/guide/stdlib/cmp.md
@@ -1,0 +1,188 @@
+# std/cmp
+
+Free generic functions for ordering and sorting. They build on the prelude
+`Ord` trait, so any type that implements `compare` works with them, including
+your own structs.
+
+```raven
+import std/cmp { min, max, sort }
+
+fun main() {
+    print(min(3, 7))            // 3
+    print(max(3, 7))            // 7
+    for x in sort([5, 2, 8, 1]) {
+        print(x)                // 1, then 2, 5, 8
+    }
+}
+```
+
+## Importing
+
+These functions have no natural single receiver, so they come in through a
+selective import: list the names you want inside `{ ... }`.
+
+```raven
+import std/cmp { sort, sorted_by, min, max, clamp, max_of, min_of }
+```
+
+`List<T>` is built into the language and needs no import.
+
+## The `Ord` bound
+
+Most functions here are bound by `T: Ord`. The prelude `Ord` trait is one
+method:
+
+```raven
+fun compare(self, other: Self) -> Int
+```
+
+`compare` returns a negative `Int` when `self < other`, zero when they are
+equal, and a positive `Int` when `self > other`. Built-in types like `Int`
+and `String` already satisfy `Ord`, and any struct that implements `compare`
+becomes usable with every `Ord`-bound function below.
+
+The one exception is `sorted_by`, which takes the comparator as a value
+instead of relying on the bound (see below).
+
+## Comparing two values
+
+### `min<T: Ord>(a: T, b: T) -> T`
+
+The lesser of `a` and `b`. On a tie (`a` and `b` compare equal) it returns
+`a`.
+
+### `max<T: Ord>(a: T, b: T) -> T`
+
+The greater of `a` and `b`. On a tie it returns `a`.
+
+```raven
+import std/cmp { min, max }
+
+fun main() {
+    print(min(10, 4))       // 4
+    print(max("apple", "pear"))   // pear
+}
+```
+
+### `clamp<T: Ord>(x: T, lo: T, hi: T) -> T`
+
+Constrain `x` to the range `[lo, hi]`: returns `lo` when `x < lo`, `hi` when
+`x > hi`, and `x` otherwise.
+
+```raven
+import std/cmp { clamp }
+
+fun main() {
+    print(clamp(15, 0, 10))     // 10
+    print(clamp(-3, 0, 10))     // 0
+    print(clamp(7, 0, 10))      // 7
+}
+```
+
+## Sorting
+
+### `sort<T: Ord>(xs: List<T>) -> List<T>`
+
+A new list with the elements of `xs` in ascending order. The input is not
+mutated. `sort` delegates to `sorted_by` using `a.compare(b)` as the
+comparator.
+
+```raven
+import std/cmp { sort }
+
+fun main() {
+    let xs = [5, 2, 8, 1]
+    for x in sort(xs) {
+        print(x)        // 1, 2, 5, 8
+    }
+    print(xs[0])        // 5 (the original list is unchanged)
+}
+```
+
+### `sorted_by<T>(xs: List<T>, cmp: fun(T, T) -> Int) -> List<T>`
+
+Sort `xs` by an explicit comparator, returning a new list. There is no `Ord`
+bound here: because the comparator is passed in as a value, `sorted_by` can
+order types that have no single natural ordering, or order an `Ord` type in a
+different way.
+
+The comparator follows the same convention as `compare`: given two elements
+`a` and `b`, return a negative `Int` when `a` should come before `b`, zero
+when their order does not matter, and a positive `Int` when `a` should come
+after `b`. To sort descending, flip the comparison.
+
+```raven
+import std/cmp { sorted_by }
+
+fun main() {
+    let xs = [5, 2, 8, 1]
+    let desc = sorted_by(xs, fun(a: Int, b: Int) -> Int = b - a)
+    for x in desc {
+        print(x)    // 8, 5, 2, 1
+    }
+}
+```
+
+Both `sort` and `sorted_by` use selection sort, which is O(n^2) comparisons
+and is not stable: the relative order of elements that compare equal is
+unspecified.
+
+## Reducing a list
+
+### `max_of<T: Ord>(xs: List<T>) -> Option<T>`
+
+The largest element of `xs`, or `None` when the list is empty. Wrapping the
+result in `Option` is what lets the empty case be represented without a
+sentinel value.
+
+### `min_of<T: Ord>(xs: List<T>) -> Option<T>`
+
+The smallest element of `xs`, or `None` when the list is empty.
+
+Because both return an `Option<T>`, you match on the result to handle the
+empty list:
+
+```raven
+import std/cmp { max_of, min_of }
+
+fun main() {
+    let scores = [42, 17, 99, 8]
+    match max_of(scores) {
+        Some(best) -> print(best),      // 99
+        None -> print("no scores"),
+    }
+
+    let empty: List<Int> = []
+    match min_of(empty) {
+        Some(lo) -> print(lo),
+        None -> print("empty"),         // empty
+    }
+}
+```
+
+## Worked example: sort and pick the top
+
+```raven
+import std/cmp { sort, max_of }
+
+fun main() {
+    let scores = [42, 17, 99, 8, 56]
+
+    let ranked = sort(scores)
+    for s in ranked {
+        print(s)        // 8, 17, 42, 56, 99
+    }
+
+    match max_of(scores) {
+        Some(best) -> print("top score: ${best}"),   // top score: 99
+        None -> print("no scores yet"),
+    }
+}
+```
+
+## See also
+
+- [std/string](string.md) for text, whose `String` values are `Ord` and so
+  work with every function here.
+- The [language reference](../language-reference.md) for generics, trait
+  bounds, closures, and `Option`.

--- a/docs/v2/guide/stdlib/collections.md
+++ b/docs/v2/guide/stdlib/collections.md
@@ -1,0 +1,277 @@
+# std/collections
+
+Hash-backed `Set<T>` and `Map<K, V>` over keys that implement the prelude
+`Eq + Hash` traits. Storage is a hash-bucket layout, so lookup, insert, and
+remove are O(1) average. `List<T>` is built into the language (literals,
+indexing, `len`, `push`, `pop`, `get`) and needs no import.
+
+```raven
+import std/collections
+
+fun main() {
+    let seen = Set.new()
+    seen.add("ada")
+    print(seen.contains("ada"))     // true
+
+    let counts = Map.new()
+    counts.set("x", 1)
+    print(counts.len())             // 1
+}
+```
+
+## Importing
+
+```raven
+import std/collections
+```
+
+Import the whole module (not a selective `{ ... }` list). The idiomatic
+constructor is the associated function `new()` on each type, called as
+`Type.new()`. A bare `import std/collections` merges the `Set` and `Map`
+`impl` blocks, so both the constructors and the instance methods resolve by
+type. A selective import would bring in named functions but not the type
+`impl` blocks, so `Set.new()` and the methods below would fail to resolve.
+
+Element and key/value types are inferred from the first use: `s.add(1)`
+fixes `s` as `Set<Int>`. Where no later use pins them, write the type
+arguments on the call:
+
+```raven
+import std/collections
+
+fun main() {
+    let s = Set<Int>.new()
+    let m = Map<String, Int>.new()
+}
+```
+
+## Supported key types
+
+`Hash` is implemented for `Int`, `Bool`, and `String`, and any user type
+that implements both `Eq` and `Hash` works as an element or key. `Char` and
+`Float` do not yet implement `Hash`, so `Set<Char>`, `Set<Float>`, and maps
+keyed on them do not satisfy the bound.
+
+| Key type | Usable as `Set<T>` / `Map<K, _>` |
+|----------|----------------------------------|
+| `Int` | yes |
+| `Bool` | yes |
+| `String` | yes |
+| user type with `Eq + Hash` | yes |
+| `Char` | no (not hashable) |
+| `Float` | no (not hashable) |
+
+## Set and map literals
+
+Set and map values have literal syntax. Both lower to the constructors
+above, so they need the same `import std/collections` in scope.
+
+```raven
+import std/collections
+
+fun main() {
+    let s = {1, 2, 2, 3}            // Set<Int>, dedups to {1, 2, 3}
+    let m = ["a": 1, "b": 2]        // Map<String, Int>
+    let flags = ["x": true]         // Map<String, Bool>
+    let empty: Map<String, Int> = [:]
+}
+```
+
+Grammar and disambiguation:
+
+- A set literal is `{ e1, e2, ... }`: braces around one or more
+  comma-separated expressions. It must carry at least one comma, so a
+  single-element set is written `{x,}`. A bare `{ x }` stays a block whose
+  tail expression is `x`, and `{}` is an empty block. An empty set is written
+  `Set.new()`.
+- A map literal is `[ k1: v1, k2: v2, ... ]`: brackets around one or more
+  comma-separated `key: value` pairs. The empty map is the distinct `[:]`
+  form, so the bare `[]` stays an empty list. A bracket whose first element
+  has no top-level `:` is a list (`[1, 2, 3]`); a `:` after the first element
+  makes it a map.
+
+Element, key, and value types are inferred from the literal contents:
+`{1, 2}` is `Set<Int>`, and `["x": true]` is `Map<String, Bool>`. The set's
+`T` and the map's `K` must implement `Eq + Hash`, the same bound the types
+carry. `{a, b}` desugars to `Set.new()` then `add(a); add(b)`, and `[k: v]`
+desugars to `Map.new()` then `set(k, v)`.
+
+## Set<T: Eq + Hash>
+
+A set of distinct elements. Construct with a set literal `{1, 2}` or with
+`Set.new()`.
+
+### `new() -> Set<T>`
+
+A new empty set. Called on the type: `Set.new()`.
+
+### `len(self) -> Int`
+
+The number of elements in the set.
+
+### `is_empty(self) -> Bool`
+
+True when the set has no elements.
+
+### `contains(self, x: T) -> Bool`
+
+True when `x` is in the set. Hashes `x` to a bucket and scans that bucket
+with `Eq`.
+
+### `add(self, x: T)`
+
+Add `x` to the set. Does nothing if `x` is already present, so the set never
+holds duplicates.
+
+### `remove(self, x: T) -> Bool`
+
+Remove `x` if present, returning whether it was. Order within a bucket is not
+preserved.
+
+```raven
+import std/collections
+
+fun main() {
+    let s = Set.new()
+    s.add("a")
+    s.add("b")
+    s.add("a")                  // already present, no-op
+
+    print(s.len())              // 2
+    print(s.contains("b"))      // true
+    print(s.remove("b"))        // true
+    print(s.remove("z"))        // false
+    print(s.is_empty())         // false
+}
+```
+
+## Map<K: Eq + Hash, V>
+
+A map from keys to values. Construct with a map literal `["a": 1]` (or `[:]`
+for an empty map) or with `Map.new()`.
+
+### `new() -> Map<K, V>`
+
+A new empty map. Called on the type: `Map.new()`.
+
+### `len(self) -> Int`
+
+The number of entries in the map.
+
+### `is_empty(self) -> Bool`
+
+True when the map has no entries.
+
+### `has(self, k: K) -> Bool`
+
+True when `k` has an entry in the map.
+
+### `get(self, k: K) -> Option<V>`
+
+`Some(v)` when `k` is present, otherwise `None`. Handle it with `match`:
+
+```raven
+import std/collections
+
+fun main() {
+    let m = Map.new()
+    m.set("ada", 1815)
+
+    match m.get("ada") {
+        Some(year) -> print(year),      // 1815
+        None -> print("missing"),
+    }
+
+    match m.get("grace") {
+        Some(year) -> print(year),
+        None -> print("missing"),       // missing
+    }
+}
+```
+
+### `set(self, k: K, v: V)`
+
+Insert `k` with value `v`, or overwrite the existing value when `k` is
+already present.
+
+### `keys(self) -> List<K>`
+
+Every key in the map, in hash-bucket order (not insertion order).
+
+### `values(self) -> List<V>`
+
+Every value in the map, aligned with `keys()`: the value at index `i` in
+`values()` belongs to the key at index `i` in `keys()`.
+
+### `remove(self, k: K) -> Bool`
+
+Remove the entry for `k` if present, returning whether it was. Order within a
+bucket is not preserved.
+
+```raven
+import std/collections
+
+fun main() {
+    let m = Map.new()
+    m.set("a", 1)
+    m.set("b", 2)
+    m.set("a", 10)              // overwrites
+
+    print(m.len())              // 2
+    print(m.has("a"))           // true
+    print(m.remove("b"))        // true
+    print(m.remove("z"))        // false
+}
+```
+
+## Iteration order
+
+Both types store entries in an array of buckets. The table starts with 8
+buckets and doubles, rehashing every entry, once the load factor
+(`count / bucket_count`) passes 0.75. Because of this, `keys()` and
+`values()` follow the current bucket layout, not the order entries were
+inserted. Do not rely on iteration order being stable across inserts or
+across runs.
+
+## Worked example: word frequencies
+
+```raven
+import std/collections
+import std/string
+
+fun main() {
+    let words = ["red", "blue", "red", "green", "blue", "red"]
+
+    let counts: Map<String, Int> = Map.new()
+    let i = 0
+    while i < words.len() {
+        let w = words[i]
+        match counts.get(w) {
+            Some(n) -> counts.set(w, n + 1),
+            None -> counts.set(w, 1),
+        }
+        i = i + 1
+    }
+
+    let ks = counts.keys()
+    let j = 0
+    while j < ks.len() {
+        let k = ks[j]
+        match counts.get(k) {
+            Some(n) -> print("${k}: ${n}"),
+            None -> print("${k}: 0"),
+        }
+        j = j + 1
+    }
+}
+```
+
+## See also
+
+- The [core traits spec](../../specs/core-traits.md) for the `Eq` and `Hash`
+  traits these types build on.
+- The [std/hash spec](../../specs/std-hash.md) for hashing helpers.
+- The [std/iter spec](../../specs/std-iter.md) for working with the lists
+  returned by `keys()` and `values()`.
+- The [language reference](../language-reference.md) for `Option`, `match`,
+  and list literals.

--- a/docs/v2/guide/stdlib/core.md
+++ b/docs/v2/guide/stdlib/core.md
@@ -1,0 +1,250 @@
+# std/core
+
+The foundational traits every Raven program builds on. `std/core` is the
+prelude: the compiler merges it into every program before name resolution, so
+its traits and impls are always in scope. You never write `import std/core`,
+and there is nothing to import selectively.
+
+```raven
+fun main() {
+    print(42.to_string())           // 42
+    print(3.compare(7) < 0)         // true (3 sorts before 7)
+}
+```
+
+These traits make the rest of the standard library polymorphic. A function
+bounded by one of them, for example `fun f<T: ToString>(x: T)`, works for any
+type that implements it, including your own.
+
+## The traits
+
+| Trait | Method | Purpose |
+|-------|--------|---------|
+| `ToString` | `to_string(self) -> String` | Generic textual rendering. The basis of generic printing and of string interpolation for user types. |
+| `Eq` | `equals(self, other: Self) -> Bool` | Structural equality. Reflexive, symmetric, and transitive for the built-in impls. |
+| `Ord` | `compare(self, other: Self) -> Int` | Total ordering. Negative when `self` sorts first, zero when equal, positive otherwise. |
+| `Hash` | `hash(self) -> Int` | Stable hash for hash maps and sets. A `Hash` type should also be `Eq` so equal values hash equally. |
+| `Iterator<T>` | `next(self) -> Option<T>` | A sequence producing values one at a time. The element type `T` is a parameter on the trait. |
+
+`Self` in a signature means the implementing type, so `Eq for Int` reads as
+`equals(self, other: Int) -> Bool`.
+
+## ToString
+
+```raven
+trait ToString {
+    fun to_string(self) -> String
+}
+```
+
+Renders a value as text. `print` and string interpolation both render any
+value whose type implements `ToString`, so implementing it is what lets a type
+print.
+
+Built in for `Int`, `Float`, `Bool`, `Char`, and `String`. The scalar impls
+render through interpolation (`"${self}"`); `ToString for String` returns the
+string unchanged.
+
+```raven
+fun main() {
+    print(42.to_string())           // 42
+    print(true.to_string())         // true
+    print(3.14.to_string())         // 3.14
+
+    let count = 3
+    print("count = ${count}")       // count = 3 (interpolation uses ToString)
+}
+```
+
+## Eq
+
+```raven
+trait Eq {
+    fun equals(self, other: Self) -> Bool
+}
+```
+
+Structural equality. Built in for `Int`, `Float`, `Bool`, `Char`, and
+`String`. The scalar impls compare with `==`; `String` compares byte by byte.
+
+```raven
+fun main() {
+    print(2.equals(2))              // true
+    print("ab".equals("ab"))        // true
+    print("ab".equals("ba"))        // false
+}
+```
+
+## Ord
+
+```raven
+trait Ord {
+    fun compare(self, other: Self) -> Int
+}
+```
+
+Total ordering. `compare` returns a negative `Int` when `self` sorts before
+`other`, zero when they are equal, and a positive `Int` when `self` sorts
+after. Built in for `Int`, `Float`, `Char`, `Bool` (`false` sorts before
+`true`), and `String` (lexicographic over bytes).
+
+```raven
+fun main() {
+    print(3.compare(7))             // -1
+    print(7.compare(3))             //  1
+    print(5.compare(5))             //  0
+    print("apple".compare("apply")) // -1
+}
+```
+
+Use the sign of the result rather than the exact magnitude: only `< 0`,
+`== 0`, and `> 0` are guaranteed.
+
+```raven
+fun max<T: Ord>(a: T, b: T) -> T {
+    if a.compare(b) >= 0 {
+        return a
+    }
+    return b
+}
+
+fun main() {
+    print(max(3, 7))                // 7
+    print(max("cat", "ant"))        // cat
+}
+```
+
+## Hash
+
+```raven
+trait Hash {
+    fun hash(self) -> Int
+}
+```
+
+A stable hash for keying hash maps and sets. Built in for `Int` (identity),
+`Bool` (`0` or `1`), and `String` (a multiplier-31 rolling hash over the
+bytes). A `Hash` type should also be `Eq`, so that equal values produce equal
+hashes.
+
+`Hash for Char` and `Hash for Float` are not provided yet.
+
+```raven
+fun main() {
+    print(7.hash())                 // 7
+    print(true.hash())              // 1
+}
+```
+
+## Iterator&lt;T&gt;
+
+```raven
+trait Iterator<T> {
+    fun next(self) -> Option<T>
+}
+```
+
+A sequence that yields values one at a time. `next` returns `Some(value)`
+while elements remain and `None` when the sequence is exhausted. The element
+type `T` is a generic parameter on the trait (Raven has no associated types
+yet). The lazy adapter pipeline that builds on this lives in
+[std/iter](iter.md).
+
+## Using traits as generic bounds
+
+Write a trait after a type parameter to require that the argument implements
+it. Inside the function you can then call the trait's methods on that
+parameter. Dispatch is resolved statically at each call site, so there is no
+runtime overhead.
+
+```raven
+fun describe<T: ToString>(x: T) -> String {
+    return "value: ${x.to_string()}"
+}
+
+fun main() {
+    print(describe(42))             // value: 42
+    print(describe(true))           // value: true
+    print(describe("hi"))           // value: hi
+}
+```
+
+A type participates in a bound by implementing the trait. Implement it for your
+own struct or enum and that type becomes usable everywhere the bound appears:
+
+```raven
+struct Point {
+    x: Int,
+    y: Int,
+}
+
+impl ToString for Point {
+    fun to_string(self) -> String = "(${self.x}, ${self.y})"
+}
+
+fun describe<T: ToString>(x: T) -> String {
+    return "value: ${x.to_string()}"
+}
+
+fun main() {
+    print(describe(Point { x: 1, y: 2 }))   // value: (1, 2)
+}
+```
+
+## Deriving for user types
+
+Most of the time you do not hand-write these impls. `@derive(...)` on a struct
+or enum generates them from the fields:
+
+```raven
+@derive(Eq, Hash, ToString, Debug)
+struct User {
+    id: Int,
+    name: String,
+}
+```
+
+`Eq`, `Hash`, `ToString`, and `Debug` are derivable; `Ord` is not derivable
+yet and must be written by hand. Every field must already implement the trait
+being derived. See the `@derive` section of the
+[language reference](../language-reference.md) for the full list and rules.
+
+## Worked example: generic comparison and sorting key
+
+```raven
+struct Score {
+    name: String,
+    points: Int,
+}
+
+impl Ord for Score {
+    fun compare(self, other: Score) -> Int = self.points.compare(other.points)
+}
+
+impl ToString for Score {
+    fun to_string(self) -> String = "${self.name}: ${self.points}"
+}
+
+// Works for Int, String, Score, or anything else that is Ord.
+fun higher<T: Ord + ToString>(a: T, b: T) -> String {
+    if a.compare(b) >= 0 {
+        return a.to_string()
+    }
+    return b.to_string()
+}
+
+fun main() {
+    let ada = Score { name: "Ada", points: 90 }
+    let bob = Score { name: "Bob", points: 75 }
+    print(higher(ada, bob))         // Ada: 90
+    print(higher(3, 8))             // 8
+}
+```
+
+## See also
+
+- [std/cmp](cmp.md) for comparison helpers built on `Ord`.
+- [std/collections](collections.md) for maps and sets that key on `Eq` and `Hash`.
+- [std/iter](iter.md) for the lazy adapter pipeline over `Iterator<T>`.
+- The [language reference](../language-reference.md) for traits, generics,
+  bounds, and `@derive`.

--- a/docs/v2/guide/stdlib/encoding.md
+++ b/docs/v2/guide/stdlib/encoding.md
@@ -1,0 +1,168 @@
+# std/encoding
+
+Hex and standard base64 over the bytes of a `String`. These are free
+functions that turn a `String`'s raw bytes into encoded text and decode the
+inverse.
+
+```raven
+import std/encoding { hex_encode, base64_encode, base64_decode }
+
+fun main() {
+    print(hex_encode("abc"))        // 616263
+    print(base64_encode("abc"))     // YWJj
+    print(base64_decode("YWJj"))    // abc
+}
+```
+
+## Importing
+
+Every entry is a free function, so bind the ones you need with a selective
+import:
+
+```raven
+import std/encoding { hex_encode, hex_decode, base64_encode, base64_decode }
+```
+
+Unlike [std/string](string.md) (which merges an `impl String` block on a bare
+import), these are plain functions you call as `hex_encode(s)`, not methods on
+`String`.
+
+## A note on bytes
+
+A Raven `String` is a byte buffer. Every function here reads byte values
+`0..255` straight out of the input, so they work on arbitrary binary data
+carried in a `String`, not only valid UTF-8 text. A decoder likewise returns
+the decoded bytes as a `String`. None of these functions return a `Result`:
+they each return a `String`, and the decoders map anything unexpected to a
+defined value rather than failing (see [Invalid input](#invalid-input)).
+
+## Hex
+
+### `hex_encode(s: String) -> String`
+
+Encode each input byte as two lowercase hex digits. The result is twice as
+long as the input.
+
+```raven
+import std/encoding { hex_encode }
+
+fun main() {
+    print(hex_encode("abc"))        // 616263
+    print(hex_encode(""))           // (empty)
+}
+```
+
+### `hex_decode(s: String) -> String`
+
+The inverse of `hex_encode`. Reads the input two digits at a time, accepting
+lowercase, uppercase, or mixed hex (`0-9`, `a-f`, `A-F`).
+
+```raven
+import std/encoding { hex_decode }
+
+fun main() {
+    print(hex_decode("616263"))     // abc
+    print(hex_decode("4D61"))       // Ma  (uppercase digits)
+}
+```
+
+Round-tripping is exact for any input:
+
+```raven
+import std/encoding { hex_encode, hex_decode }
+
+fun main() {
+    let s = "raven"
+    print(hex_decode(hex_encode(s)) == s)   // true
+}
+```
+
+## Base64
+
+### `base64_encode(s: String) -> String`
+
+Encode the input bytes with the standard base64 alphabet (`A-Z`, `a-z`,
+`0-9`, `+`, `/`) and `=` padding. Every three input bytes become four output
+characters; one or two trailing bytes are padded with `=`.
+
+```raven
+import std/encoding { base64_encode }
+
+fun main() {
+    print(base64_encode("abc"))     // YWJj
+    print(base64_encode("Man"))     // TWFu
+    print(base64_encode("Ma"))      // TWE=   (one byte of padding)
+    print(base64_encode("M"))       // TQ==   (two bytes of padding)
+}
+```
+
+### `base64_decode(s: String) -> String`
+
+The inverse of `base64_encode`. Honors trailing `=` padding to recover how
+many bytes the final group yields.
+
+```raven
+import std/encoding { base64_decode }
+
+fun main() {
+    print(base64_decode("YWJj"))    // abc
+    print(base64_decode("TWE="))    // Ma
+    print(base64_decode("TQ=="))    // M
+}
+```
+
+Encode then decode round-trips for any input:
+
+```raven
+import std/encoding { base64_encode, base64_decode }
+
+fun main() {
+    let s = "Hello, Raven"
+    print(base64_decode(base64_encode(s)) == s)   // true
+}
+```
+
+## Invalid input
+
+The decoders favor a simple, total mapping over rejecting input, so they
+never fail. Pass well-formed text from the matching encoder and you always
+get the original bytes back.
+
+- `hex_decode`: any byte outside `0-9 a-f A-F` maps to nibble `0`. A lone
+  final digit (odd input length) is read as the high nibble of a zero-padded
+  byte.
+- `base64_decode`: any byte outside the alphabet, other than `=` padding,
+  maps to sextet `0`. Trailing `=` padding sets how many bytes the final
+  group yields. Input whose length is not a multiple of four decodes the
+  leading whole groups and drops a trailing partial group.
+
+## Out of scope
+
+URL-safe base64 (the `-_` alphabet) and base64 line wrapping are not provided.
+Both can be added later without changing the existing functions.
+
+## Worked example: a hex dump round trip
+
+```raven
+import std/encoding { hex_encode, hex_decode }
+
+fun main() {
+    let payload = "Raven 1.0"
+
+    // Encode to a hex string you could log or store.
+    let dumped = hex_encode(payload)
+    print(dumped)                       // 526176656e20312e30
+
+    // Decode it back to the original bytes.
+    let restored = hex_decode(dumped)
+    print(restored)                     // Raven 1.0
+    print(restored == payload)          // true
+}
+```
+
+## See also
+
+- [std/string](string.md) for inspecting, slicing, and transforming the
+  `String` values these functions read and produce.
+- [std/json](json.md) for structured serialization rather than raw byte
+  encoding.

--- a/docs/v2/guide/stdlib/env.md
+++ b/docs/v2/guide/stdlib/env.md
@@ -1,0 +1,150 @@
+# std/env
+
+Access to the process environment: environment variables, command-line
+arguments, process exit, and platform info. The primitives bind the
+raven-runtime C ABI; the convenience functions are pure Raven on top of them.
+
+```raven
+import std/env { get_env_or, os_name }
+
+fun main() {
+    let level = get_env_or("LOG_LEVEL", "info")
+    print(level)            // info, unless LOG_LEVEL is set
+    print(os_name())        // windows, linux, or macos
+}
+```
+
+## Importing
+
+```raven
+import std/env { get_env, has_env, get_env_or, args, arg_count, arg_at, exit, os_name, arch }
+```
+
+Pull in just the functions you use, or list all of them as above.
+
+## Environment variables
+
+### `get_env(name: String) -> String`
+
+The value of the environment variable `name`, or `""` when it is unset.
+A variable set to the empty string and a variable that is not set both
+yield `""`, so `get_env` alone cannot tell them apart: use `has_env` to
+distinguish unset from empty.
+
+```raven
+import std/env { get_env }
+
+fun main() {
+    print(get_env("HOME"))      // the value, or "" when unset
+}
+```
+
+### `has_env(name: String) -> Bool`
+
+True when `name` is set in the environment, regardless of its value
+(including the empty string).
+
+### `get_env_or(name: String, default: String) -> String`
+
+The value of `name`, or `default` when `name` is unset. This is the usual
+way to read configuration with a fallback.
+
+```raven
+import std/env { get_env_or }
+
+fun main() {
+    let port = get_env_or("PORT", "8080")
+    print(port)         // 8080, unless PORT is set
+}
+```
+
+## Command-line arguments
+
+### `arg_count() -> Int`
+
+The number of process arguments, always at least 1. Index 0 is the program
+path; user-supplied arguments start at index 1.
+
+### `arg_at(i: Int) -> String`
+
+The argument at index `i` (index 0 is the program path), or `""` when `i`
+is out of range.
+
+### `args() -> List<String>`
+
+All process arguments as a list, with index 0 being the program path.
+This is pure Raven: it loops `arg_at` over `0..arg_count()`.
+
+```raven
+import std/env { args }
+
+fun main() {
+    let all = args()
+    let i = 1
+    while i < all.len() {
+        print(all[i])       // each user-supplied argument
+        i = i + 1
+    }
+}
+```
+
+## Process exit
+
+### `exit(code: Int)`
+
+Terminate the process with status `code`. It does not return; any code
+after a call to `exit` is unreachable.
+
+```raven
+import std/env { arg_count, exit }
+
+fun main() {
+    if arg_count() < 2 {
+        print("usage: tool <name>")
+        exit(1)
+    }
+    print("ok")
+}
+```
+
+## Platform info
+
+### `os_name() -> String`
+
+The target operating system: `"windows"`, `"linux"`, or `"macos"`.
+
+### `arch() -> String`
+
+The target CPU architecture, for example `"x86_64"` or `"aarch64"`.
+
+```raven
+import std/env { os_name, arch }
+
+fun main() {
+    print(os_name())        // linux
+    print(arch())           // x86_64
+}
+```
+
+## Worked example: a small greeting tool
+
+```raven
+import std/env { args, get_env_or, os_name, exit }
+
+fun main() {
+    let argv = args()
+    if argv.len() < 2 {
+        print("usage: greet <name>")
+        exit(1)
+    }
+    let name = argv[1]
+    let greeting = get_env_or("GREETING", "Hello")
+    print("${greeting}, ${name}! Running on ${os_name()}.")
+}
+```
+
+## See also
+
+- [std/io](io.md) for reading from standard input and writing to standard
+  output and error.
+- [std/fs](fs.md) for working with files and paths.

--- a/docs/v2/guide/stdlib/error.md
+++ b/docs/v2/guide/stdlib/error.md
@@ -1,0 +1,305 @@
+# std/error
+
+An `Error` value type plus a few helpers over the built-in `Result<T, E>`.
+The language already gives you `Result`, `Option`, and the `?` operator, so
+this module does not invent an error system. It adds a carryable error with a
+message and an optional kind, context chaining as an error propagates, and a
+small set of free functions for the cases where matching a `Result` by hand
+gets verbose.
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    print(unwrap_or(divide(10, 2), -1))   // 5
+    print(is_ok(divide(1, 0)))            // false
+}
+```
+
+## Importing
+
+Import the free functions you use by name:
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+```
+
+`error`, `error_kind`, and the Result helpers (`is_ok`, `is_err`, `unwrap_or`,
+`ok`, `err`) are free functions, so list the ones you call. The `Error` methods
+(`message`, `kind`, `with_context`, `to_string`) come from the module's `impl`
+block, which the import merges, so `e.message()` and `print(e)` work once you
+import the module.
+
+## Result, Option, and the `?` operator
+
+`Result<T, E>`, `Option<T>`, and their variants `Ok`, `Err`, `Some`, and `None`
+are built into the language. They need no import. The convention this module
+leans on is simple:
+
+- A function that can fail returns `Result<T, Error>`. Success is `Ok(value)`,
+  failure is `Err(error("..."))`.
+- A function that can be absent returns `Option<T>`: `Some(value)` or `None`.
+
+The `?` operator is the primary way to propagate failures. When applied to a
+`Result`, `?` unwraps an `Ok` to its value or returns the `Err` from the
+enclosing function early. It works the same on `Option`, unwrapping `Some` or
+returning `None`. Because `?` returns early, it can only appear in a function
+whose return type matches (a `Result` for `?` on a `Result`, an `Option` for
+`?` on an `Option`).
+
+A function that uses `?` to chain failing steps:
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun positive(n: Int) -> Result<Int, Error> {
+    if n <= 0 {
+        return Err(error("must be positive"))
+    }
+    return Ok(n)
+}
+
+fun add_positive(a: Int, b: Int) -> Result<Int, Error> {
+    let x = positive(a)?    // returns Err early if `a` is not positive
+    let y = positive(b)?
+    return Ok(x + y)
+}
+```
+
+Each `?` keeps the happy path flat: if `positive` returns an `Err`,
+`add_positive` returns that same `Err` without running the rest of the body.
+
+A caller handles the result with `match`:
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun positive(n: Int) -> Result<Int, Error> {
+    if n <= 0 {
+        return Err(error("must be positive"))
+    }
+    return Ok(n)
+}
+
+fun main() {
+    match positive(5) {
+        Ok(n) -> print("ok: ${n}"),         // ok: 5
+        Err(e) -> print("failed: ${e.to_string()}"),
+    }
+}
+```
+
+`match` forces you to handle both arms, so a failure cannot be ignored by
+accident. When you do not need the full match, the Result helpers below cover
+the common shortcuts.
+
+Errors here are values, never control flow. `panic(msg)` aborts the process and
+is a separate runtime facility, not part of this module. Reach for `Result` and
+`Error` when a failure is expected and recoverable, and for `panic` only when a
+bug has made the program unable to continue.
+
+## Constructors
+
+### `error(msg: String) -> Error`
+
+Build an `Error` with the given message and an empty kind. This is the usual
+constructor for an ad hoc failure.
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun check_age(age: Int) -> Result<Int, Error> {
+    if age < 0 {
+        return Err(error("age cannot be negative"))
+    }
+    return Ok(age)
+}
+```
+
+### `error_kind(kind: String, msg: String) -> Error`
+
+Build an `Error` tagged with a kind, for example `"io"` or `"parse"`. The kind
+is a free-form `String`; callers can branch on it with `e.kind()`.
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun open_config(path: String) -> Result<String, Error> {
+    return Err(error_kind("io", "no such file: ${path}"))
+}
+```
+
+## Error methods
+
+`Error` is a struct holding a `kind` and a `message`, both `String`. These
+methods come from the merged `impl` blocks.
+
+### `message(self) -> String`
+
+The message text.
+
+### `kind(self) -> String`
+
+The kind tag, or `""` when the error was built with `error`.
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun main() {
+    let e = error_kind("parse", "unexpected token")
+    print(e.kind())       // parse
+    print(e.message())    // unexpected token
+}
+```
+
+### `with_context(self, ctx: String) -> Error`
+
+A new `Error` whose message is `ctx + ": " + message`, preserving the kind. Use
+it to add a higher-level explanation to a lower-level failure as it propagates.
+It returns a new `Error` and does not mutate the receiver.
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun load_settings(path: String) -> Result<String, Error> {
+    return match read_raw(path) {
+        Ok(text) -> Ok(text),
+        Err(e) -> Err(e.with_context("load settings")),
+    }
+}
+```
+
+If the inner error was `no such file`, the caller now sees
+`load settings: no such file`, with the original kind intact.
+
+### `to_string(self) -> String`
+
+The display form: the bare `message` when the kind is empty, otherwise
+`kind + ": " + message`. This comes from the `ToString` impl, so `print(e)`
+uses it too.
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun main() {
+    print(error("disk full").to_string())            // disk full
+    print(error_kind("io", "disk full").to_string()) // io: disk full
+}
+```
+
+## Result helpers
+
+Free functions generic over `Result<T, E>`. They work with any error type in
+the `E` slot, not only this module's `Error`. Each one matches the Result
+internally, so you can avoid writing a `match` for the simple cases.
+
+### `is_ok<T, E>(r: Result<T, E>) -> Bool`
+
+True when `r` is `Ok`.
+
+### `is_err<T, E>(r: Result<T, E>) -> Bool`
+
+True when `r` is `Err`.
+
+### `unwrap_or<T, E>(r: Result<T, E>, default: T) -> T`
+
+The `Ok` value, or `default` when `r` is an `Err`.
+
+```raven
+import std/error { error, unwrap_or, is_err }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    print(unwrap_or(divide(10, 2), -1))   // 5
+    print(unwrap_or(divide(1, 0), -1))    // -1
+    print(is_err(divide(1, 0)))           // true
+}
+```
+
+### `ok<T, E>(r: Result<T, E>) -> Option<T>`
+
+Discard the error: map `Ok(v)` to `Some(v)` and `Err(e)` to `None`. Useful when
+you care whether a value is present but not why it failed.
+
+### `err<T, E>(r: Result<T, E>) -> Option<E>`
+
+Keep the error: map `Err(e)` to `Some(e)` and `Ok(v)` to `None`.
+
+```raven
+import std/error { error, ok }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    match ok(divide(10, 2)) {
+        Some(n) -> print("got ${n}"),    // got 5
+        None -> print("no value"),
+    }
+}
+```
+
+## Worked example: a small config loader
+
+This ties the pieces together: failing steps return `Result<T, Error>`, `?`
+propagates failures, `with_context` annotates them as they rise, and the caller
+recovers with `unwrap_or`.
+
+```raven
+import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
+
+fun check_port(port: Int) -> Result<Int, Error> {
+    if port < 1 {
+        return Err(error_kind("config", "port must be positive"))
+    }
+    return Ok(port)
+}
+
+fun read_port(port: Int) -> Result<Int, Error> {
+    let checked = check_port(port)?
+    return Ok(checked)
+}
+
+fun with_label(port: Int) -> Result<Int, Error> {
+    return match read_port(port) {
+        Ok(p) -> Ok(p),
+        Err(e) -> Err(e.with_context("read port")),
+    }
+}
+
+fun main() {
+    print(unwrap_or(with_label(8080), 80))    // 8080
+    print(unwrap_or(with_label(0), 80))       // 80
+
+    match with_label(-1) {
+        Ok(p) -> print("port ${p}"),
+        Err(e) -> print(e.to_string()),       // read port: port must be positive
+    }
+}
+```
+
+## See also
+
+- [std/io](io.md) for `print` and `println`, which render an `Error` through its
+  `ToString` impl.
+- [std/string](string.md) for `concat`, `trim`, and the other text methods used
+  alongside error messages.
+- The [language reference](../language-reference.md) for `Result`, `Option`,
+  pattern matching, and the `?` operator.

--- a/docs/v2/guide/stdlib/ffi.md
+++ b/docs/v2/guide/stdlib/ffi.md
@@ -1,0 +1,182 @@
+# std/ffi
+
+Bridges for the C foreign-function interface. `std/ffi` converts a Raven
+`String` to and from a C `CStr`, and gives you a raw pointer API over
+`CPtr<T>` for allocating, reading, and writing C memory. Use it alongside an
+`extern "C"` block to call C functions with runtime values.
+
+```raven
+import std/ffi { to_cstr, from_cstr }
+
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+}
+
+fun main() {
+    let s = "hello"
+    print(strlen(to_cstr(s)))     // 5
+}
+```
+
+The C type set (`CInt`, `CLong`, `CSize`, `CStr`, `CPtr<T>`, `CFloat`,
+`CDouble`) is built into the type checker. A `c"..."` literal already yields a
+`CStr` at compile time; `to_cstr` covers the case of a `String` value computed
+at runtime, which has no compile-time form.
+
+## Importing
+
+Bring in just the helpers you use:
+
+```raven
+import std/ffi { to_cstr, from_cstr }
+import std/ffi { alloc, free, load, store, offset, is_null, null_ptr }
+```
+
+## Memory lives outside the GC
+
+Read this before using `to_cstr` or `alloc`.
+
+Both `to_cstr` and `alloc` hand back memory that the garbage collector does
+**not** trace and will **never** reclaim. The lifetime is manual:
+
+- `alloc<T>(...)` memory is yours to `free`. You **must** call `free` on it, or
+  it leaks for the rest of the program run.
+- `to_cstr(...)` copies into a fresh buffer that is valid for the rest of the
+  run. There is no `free` helper for it in this release: each call leaks one
+  buffer, so hoist the conversion out of hot loops.
+
+The raw pointer access is unchecked, exactly like C. There are no bounds
+checks and no use-after-free protection. An out-of-range `offset`, or a
+`load`/`store` through a null or freed pointer, is undefined behavior. Use
+`is_null` to guard a pointer a C API may return null, and keep the pointee
+type `T` consistent with how the C side allocated the memory.
+
+## String bridges
+
+### `to_cstr(s: String) -> CStr`
+
+Copy `s` into a fresh, null-terminated C string and return a `CStr` pointing
+at the first byte. The result is a standalone copy (not the String's own
+length-prefixed buffer), so it is a valid `const char *` that a C function may
+read or retain after the call returns. Embedded NUL bytes are kept up to the
+first one, at which a C reader stops.
+
+### `from_cstr(p: CStr) -> String`
+
+Read the null-terminated bytes at `p`, stopping at the first NUL, and build an
+ordinary GC-managed Raven `String` (the terminator is dropped). The resulting
+`String` is traced and reclaimed like any other.
+
+```raven
+import std/ffi { to_cstr, from_cstr }
+
+fun main() {
+    print(from_cstr(to_cstr("roundtrip")))    // roundtrip
+}
+```
+
+Plain UTF-8 text without interior NUL bytes round-trips exactly. A `String`
+with an embedded NUL truncates at that NUL on a round trip, since the C reader
+stops there.
+
+## Raw pointer and buffer access
+
+`CPtr<T>` is a usable raw pointer. The following generic functions allocate,
+release, and read or write C memory through it. The pointee type `T` must be a
+C scalar (`CInt`, `CLong`, `CSize`, `CFloat`, `CDouble`, `CStr`) or a native
+`Int`/`Float`; its width drives the load/store size and the element stride for
+`offset`.
+
+### `alloc<T>(count: Int) -> CPtr<T>`
+
+Reserve room for `count` elements of type `T` and return a `CPtr<T>` to the
+buffer. The memory is uninitialized. Returns the null pointer on a zero count
+or allocation failure. The caller must `free` it.
+
+### `free<T>(p: CPtr<T>)`
+
+Release a buffer obtained from `alloc`. A null pointer is a no-op.
+
+### `load<T>(p: CPtr<T>) -> T`
+
+Read the element of type `T` at `p`.
+
+### `store<T>(p: CPtr<T>, value: T)`
+
+Write `value` to the element of type `T` at `p`.
+
+### `offset<T>(p: CPtr<T>, count: Int) -> CPtr<T>`
+
+Advance `p` by `count` elements, scaled by the size of `T`
+(`p + count * sizeof(T)`). There is no indexed load in this release; compose
+`load(offset(p, i))` to read element `i`.
+
+### `is_null<T>(p: CPtr<T>) -> Bool`
+
+True exactly when `p` is the null pointer. Many C APIs return null on failure,
+so check before dereferencing.
+
+### `null_ptr<T>() -> CPtr<T>`
+
+The null `CPtr<T>`.
+
+### Example: a buffer of `CInt`
+
+```raven
+import std/ffi { alloc, free, load, store, offset, is_null, null_ptr }
+
+fun main() {
+    let n = 3
+    let buf = alloc<CInt>(n)
+    if is_null<CInt>(buf) {
+        return
+    }
+
+    // Store 10, 20, 30 at successive offsets.
+    store<CInt>(buf, 10)
+    store<CInt>(offset<CInt>(buf, 1), 20)
+    store<CInt>(offset<CInt>(buf, 2), 30)
+
+    // Read them back.
+    print(load<CInt>(buf))                    // 10
+    print(load<CInt>(offset<CInt>(buf, 1)))   // 20
+    print(load<CInt>(offset<CInt>(buf, 2)))   // 30
+
+    print(is_null<CInt>(null_ptr<CInt>()))    // true
+    print(is_null<CInt>(buf))                 // false
+
+    free<CInt>(buf)
+}
+```
+
+## Calling a C function with a runtime String
+
+Declare the C function in an `extern "C"` block, then pass a `to_cstr`
+conversion of a runtime `String` where the signature expects a `CStr`:
+
+```raven
+import std/ffi { to_cstr, from_cstr }
+
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+    fun strcmp(a: CStr, b: CStr) -> CInt
+}
+
+fun main() {
+    let s = "hello"
+    print(strlen(to_cstr(s)))                     // 5
+    print(strcmp(to_cstr("abc"), to_cstr("abc"))) // 0
+    print(strcmp(to_cstr("abc"), to_cstr("abd"))) // -1
+}
+```
+
+The integer FFI types print directly: `CInt`, `CLong`, and `CSize` satisfy
+`ToString` by widening to `Int`, so a `CSize` or `CInt` result can be printed
+or interpolated into a `"${...}"` string.
+
+## See also
+
+- The [language reference](../language-reference.md) for the FFI section:
+  `extern "C"` blocks, the C type set, `c"..."` literals, `@repr(C)` structs by
+  value, and `CFnPtr` callbacks.
+- [std/string](string.md) for working with the `String` values you convert.

--- a/docs/v2/guide/stdlib/fmt.md
+++ b/docs/v2/guide/stdlib/fmt.md
@@ -1,0 +1,226 @@
+# std/fmt
+
+String formatting helpers and a `Debug` trait. These are the building blocks
+that compose with string interpolation: pad and align fields, repeat and join
+strings, render integers in a base, and produce quoted debug output.
+
+```raven
+import std/fmt { pad_left, to_hex }
+import std/io { println }
+
+fun main() {
+    println(pad_left("7", 3, "0"))      // 007
+    println(to_hex(255))                // ff
+}
+```
+
+## No printf
+
+There is no `format("{}", a, b)` function. The v2 surface language has no
+varargs and no format-placeholder runtime, so string interpolation `"${expr}"`
+is the placeholder mechanism. std/fmt provides the helpers that compose with
+it, not a printf replacement.
+
+## Importing
+
+The formatting helpers are free functions, bound with a selective import:
+
+```raven
+import std/fmt { repeat, pad_left, pad_right, center, join, to_radix, to_binary, to_octal, to_hex, pad_int }
+```
+
+The `Debug` trait is brought in by the same `import std/fmt` (its impls merge
+into scope like `std/string`'s methods). Once the module is imported, the
+`debug` method dispatches on the receiver's type and needs no explicit
+selector:
+
+```raven
+import std/fmt
+
+fun main() {
+    print("hi".debug())     // "hi"
+    print(true.debug())     // true
+}
+```
+
+## A note on bytes
+
+A Raven `String` is a byte buffer. Padding widths and `to_radix` digit counts
+are measured in **UTF-8 bytes**, not code points. For ASCII text a byte equals
+a displayed character; for multi-byte text the width is the encoded byte
+length. The `fill` argument to the padding functions is assumed to be a
+single-byte string; a multi-byte `fill` can overshoot the target width by up
+to its length minus one. See [std/string](string.md) for the same byte model.
+
+## String helpers
+
+### `repeat(s: String, n: Int) -> String`
+
+`s` concatenated `n` times. A non-positive `n` yields the empty string.
+
+```raven
+import std/fmt { repeat }
+
+fun main() {
+    print(repeat("ab", 3))      // ababab
+    print(repeat("x", 0))       // (empty)
+}
+```
+
+### `pad_left(s: String, width: Int, fill: String) -> String`
+
+Left-pad `s` with `fill` until its byte length is at least `width`. A `width`
+that does not exceed the current length returns `s` unchanged.
+
+### `pad_right(s: String, width: Int, fill: String) -> String`
+
+Right-pad `s` with `fill` until its byte length is at least `width`.
+
+```raven
+import std/fmt { pad_left, pad_right }
+
+fun main() {
+    print(pad_left("42", 5, "0"))       // 00042
+    print(pad_right("id", 5, "."))      // id...
+}
+```
+
+### `center(s: String, width: Int, fill: String) -> String`
+
+Center `s` in a field of byte width `width`, padding with `fill`. An odd
+amount of padding puts the extra byte on the right.
+
+```raven
+import std/fmt { center }
+
+fun main() {
+    print(center("hi", 6, "-"))     // --hi--
+    print(center("hi", 7, "-"))     // --hi---
+}
+```
+
+### `join(parts: List<String>, sep: String) -> String`
+
+Join `parts` with `sep` between adjacent elements.
+
+```raven
+import std/fmt { join }
+
+fun main() {
+    print(join(["a", "b", "c"], ", "))      // a, b, c
+}
+```
+
+## Number-base formatting
+
+### `to_radix(n: Int, base: Int) -> String`
+
+`n` written in `base`, with a single leading `-` for negatives. `base` must be
+in `2..=16`; a `base` outside that range returns the empty string. Zero
+renders as `"0"`. Digits are `0-9` then lowercase `a-f`. The conversion works
+in the negative domain (accumulating the negative magnitude), so the most
+negative i64 has no overflowing negation.
+
+```raven
+import std/fmt { to_radix }
+
+fun main() {
+    print(to_radix(255, 16))    // ff
+    print(to_radix(-42, 16))    // -2a
+    print(to_radix(5, 2))       // 101
+}
+```
+
+### `to_binary(n: Int) -> String`, `to_octal(n: Int) -> String`, `to_hex(n: Int) -> String`
+
+Thin wrappers over `to_radix` for base 2, 8, and 16.
+
+```raven
+import std/fmt { to_binary, to_octal, to_hex }
+
+fun main() {
+    print(to_binary(6))     // 110
+    print(to_octal(64))     // 100
+    print(to_hex(3735928559))   // deadbeef
+}
+```
+
+### `pad_int(n: Int, width: Int) -> String`
+
+Decimal `n` zero-padded to byte width `width`. For a negative `n` the `-`
+stays leftmost and the zero fill goes between the sign and the digits, so
+`pad_int(-7, 4)` is `"-007"`. A `width` that does not exceed the rendered
+length returns the value unchanged.
+
+```raven
+import std/fmt { pad_int }
+
+fun main() {
+    print(pad_int(7, 4))        // 0007
+    print(pad_int(-7, 4))       // -007
+    print(pad_int(12345, 3))    // 12345 (already wider than width)
+}
+```
+
+## The `Debug` trait
+
+```raven
+trait Debug {
+    fun debug(self) -> String
+}
+```
+
+`Debug` is a separate trait from `ToString`. The module ships impls for the
+built-in scalar types:
+
+| Receiver | `debug(self)` result |
+|----------|----------------------|
+| `Int` | delegates to `to_string` |
+| `Float` | delegates to `to_string` |
+| `Bool` | delegates to `to_string` |
+| `Char` | the value wrapped in single quotes |
+| `String` | the value wrapped in double quotes |
+
+Char and String quoting does not escape inner quotes: a String containing a
+`"` reproduces it literally inside the surrounding quotes. So `"hi".debug()` is
+the 4-character string `"hi"`.
+
+```raven
+import std/fmt
+
+fun main() {
+    print(42.debug())       // 42
+    print(true.debug())     // true
+    print('x'.debug())      // 'x'
+    print("hi".debug())     // "hi"
+}
+```
+
+## Worked example: a fixed-width table row
+
+```raven
+import std/fmt { pad_right, pad_int, join, to_hex }
+import std/io { println }
+
+fun row(name: String, count: Int, color: Int) -> String {
+    let cells = [
+        pad_right(name, 8, " "),
+        pad_int(count, 4),
+        to_hex(color),
+    ]
+    return join(cells, " | ")
+}
+
+fun main() {
+    println(row("red", 7, 16711680))        // red      | 0007 | ff0000
+    println(row("green", 128, 65280))       // green    | 0128 | ff00
+}
+```
+
+## See also
+
+- [std/string](string.md) for the methods on `String` values and the same
+  byte model.
+- [std/io](io.md) for `print` and `println`.
+- The [language reference](../language-reference.md) for string literals and
+  interpolation.

--- a/docs/v2/guide/stdlib/fs.md
+++ b/docs/v2/guide/stdlib/fs.md
@@ -1,0 +1,322 @@
+# std/fs
+
+Filesystem access: read and write files, create and remove directories,
+list and size entries, query existence, and manipulate path strings. The
+fallible operations return `Result<T, Error>`; the queries return a plain
+`Bool`; the path helpers are pure string work with no runtime call.
+
+```raven
+import std/fs { write, read }
+
+fun main() {
+    match write("greeting.txt", "hello") {
+        Ok(_) -> print("wrote it"),
+        Err(e) -> print(e.message()),
+    }
+}
+```
+
+## Importing
+
+```raven
+import std/fs { read, write, append, remove_file, create_dir, remove_dir, list_dir, size, exists, is_file, is_dir, join, dirname, basename, split }
+```
+
+`std/fs` is a set of free functions, so use a selective import and list the
+names you want. A bare `import std/fs` does not bring the functions into
+scope. Import only what a given file uses:
+
+```raven
+import std/fs { read, exists }
+```
+
+## The error model
+
+Fallible operations return `Result<T, Error>`. On failure the `Error` is an
+std/error value tagged with kind `"io"`. Its message is a short context
+prefix (the operation name) joined to the operating system error text, for
+example `read: No such file or directory`.
+
+There are no sentinel return values: a missing file does not come back as an
+empty string or a `-1`, it comes back as an `Err`. The two ways to consume a
+`Result` are a `match` and the `?` operator.
+
+Handle each arm explicitly with `match`:
+
+```raven
+import std/fs { read }
+
+fun main() {
+    match read("config.txt") {
+        Ok(text) -> print(text),
+        Err(e) -> print(e.message()),
+    }
+}
+```
+
+Or propagate the error to the caller with `?`, which unwraps `Ok` and
+returns early on `Err`:
+
+```raven
+import std/fs { read, write }
+
+fun copy(src: String, dst: String) -> Result<Bool, Error> {
+    let text = read(src)?
+    return write(dst, text)
+}
+```
+
+## Reading and writing
+
+### `read(path: String) -> Result<String, Error>`
+
+Read the whole file at `path` and return it as a single `String`.
+
+```raven
+import std/fs { read }
+
+fun main() {
+    match read("notes.txt") {
+        Ok(text) -> print(text),
+        Err(e) -> print(e.message()),
+    }
+}
+```
+
+### `write(path: String, contents: String) -> Result<Bool, Error>`
+
+Create or truncate `path`, then write `contents`. Returns `Ok(true)` on
+success. The `Bool` payload is always `true`; it exists only so the success
+arm carries a value (the surface uses `Result<Bool, Error>` rather than a
+unit payload).
+
+```raven
+import std/fs { write }
+
+fun main() {
+    match write("out.txt", "first line\n") {
+        Ok(_) -> print("ok"),
+        Err(e) -> print(e.message()),
+    }
+}
+```
+
+### `append(path: String, contents: String) -> Result<Bool, Error>`
+
+Write `contents` to the end of `path`, creating the file when it is absent.
+Returns `Ok(true)` on success.
+
+```raven
+import std/fs { append }
+
+fun log_line(line: String) -> Result<Bool, Error> {
+    return append("app.log", line.concat("\n"))
+}
+```
+
+## Directory and file operations
+
+### `remove_file(path: String) -> Result<Bool, Error>`
+
+Remove the file at `path`. Returns `Ok(true)` on success.
+
+### `create_dir(path: String) -> Result<Bool, Error>`
+
+Create the directory at `path`, including any missing parent directories, so
+creating a nested path in one call succeeds. Returns `Ok(true)` on success.
+
+```raven
+import std/fs { create_dir }
+
+fun main() {
+    match create_dir("build/cache/tmp") {
+        Ok(_) -> print("created"),
+        Err(e) -> print(e.message()),
+    }
+}
+```
+
+### `remove_dir(path: String) -> Result<Bool, Error>`
+
+Remove the directory at `path` and all of its contents recursively. Returns
+`Ok(true)` on success.
+
+### `list_dir(path: String) -> Result<List<String>, Error>`
+
+Return the entry names (not full paths) of the directory at `path`. An empty
+directory yields an empty list, not a one-element list containing `""`.
+
+```raven
+import std/fs { list_dir }
+
+fun main() {
+    match list_dir(".") {
+        Ok(names) -> {
+            for name in names {
+                print(name)
+            }
+        }
+        Err(e) -> print(e.message()),
+    }
+}
+```
+
+### `size(path: String) -> Result<Int, Error>`
+
+Return the file size at `path` in bytes.
+
+```raven
+import std/fs { size }
+
+fun main() {
+    match size("out.txt") {
+        Ok(n) -> print(n),
+        Err(e) -> print("could not stat the file"),
+    }
+}
+```
+
+The `?` operator is the shorter form, but it only works inside a function that
+itself returns `Result`, not in `main`:
+
+```raven
+import std/fs { size }
+
+fun total(a: String, b: String) -> Result<Int, Error> {
+    return Ok(size(a)? + size(b)?)
+}
+```
+
+## Boolean checks
+
+```raven
+fun exists(path: String) -> Bool
+fun is_file(path: String) -> Bool
+fun is_dir(path: String) -> Bool
+```
+
+These return a plain `Bool`, never a `Result`. A missing path is a normal
+`false`, not an `Err`. `is_file` is `false` for a path that exists but is not
+a regular file (a directory, say), and `is_dir` is `false` for anything that
+is not a directory.
+
+```raven
+import std/fs { exists, is_dir, read }
+
+fun main() {
+    if exists("config.txt") {
+        match read("config.txt") {
+            Ok(text) -> print(text),
+            Err(e) -> print(e.message()),
+        }
+    }
+    print(is_dir("build"))
+}
+```
+
+## Path helpers
+
+```raven
+fun join(a: String, b: String) -> String
+fun basename(p: String) -> String
+fun dirname(p: String) -> String
+fun split(p: String) -> List<String>
+```
+
+These are pure string operations with no runtime call and no `Result`. They
+use `/` as the separator. Forward slash works on Windows for these std ops,
+so the operating system separator is not detected. They overlap with
+[std/path](../../specs/std-path.md); std/fs duplicates them so the module is
+usable without a second import.
+
+### `join(a: String, b: String) -> String`
+
+Join two path segments with a single `/`, collapsing a trailing slash on `a`
+or a leading slash on `b` so the result never doubles the separator. An empty
+segment returns the other unchanged.
+
+```raven
+import std/fs { join }
+
+fun main() {
+    print(join("build", "out.txt"))     // build/out.txt
+    print(join("build/", "/out.txt"))   // build/out.txt
+}
+```
+
+### `basename(p: String) -> String`
+
+The final component of `p` (everything after the last `/`). A path with no
+slash returns unchanged.
+
+```raven
+import std/fs { basename }
+
+fun main() {
+    print(basename("a/b/c.txt"))    // c.txt
+    print(basename("c.txt"))        // c.txt
+}
+```
+
+### `dirname(p: String) -> String`
+
+Everything before the last `/`. A path with no slash returns `"."`; a path
+whose only slash is at the front returns `"/"`.
+
+```raven
+import std/fs { dirname }
+
+fun main() {
+    print(dirname("a/b/c.txt"))     // a/b
+    print(dirname("c.txt"))         // .
+}
+```
+
+### `split(p: String) -> List<String>`
+
+Split `p` on `/` into its components, dropping empty pieces produced by
+leading, trailing, or repeated separators.
+
+```raven
+import std/fs { split }
+
+fun main() {
+    let parts = split("/a//b/c/")   // ["a", "b", "c"]
+    for part in parts {
+        print(part)
+    }
+}
+```
+
+## Worked example: write then read a file
+
+Write a file, confirm it exists, then read it back. Each fallible step uses
+`?` to bail out on the first error, and the caller decides what to do with it.
+
+```raven
+import std/fs { write, read, exists }
+import std/error { error_kind }
+
+fun round_trip() -> Result<String, Error> {
+    write("scratch.txt", "saved value")?
+    if !exists("scratch.txt") {
+        return Err(error_kind("io", "file vanished after write"))
+    }
+    return read("scratch.txt")
+}
+
+fun main() {
+    match round_trip() {
+        Ok(text) -> print(text),       // saved value
+        Err(e) -> print(e.message()),
+    }
+}
+```
+
+## See also
+
+- [std/path](../../specs/std-path.md) for the same `join`, `dirname`, and
+  `basename` helpers when you do not also need filesystem access.
+- [std/error](../../specs/std-error.md) for `Error`, `error_kind`, and reading
+  the `kind` and `message` of an `Err`.
+- [std/io](io.md) for reading from and writing to the console instead of files.

--- a/docs/v2/guide/stdlib/hash.md
+++ b/docs/v2/guide/stdlib/hash.md
@@ -1,0 +1,191 @@
+# std/hash
+
+Non-cryptographic hashing building blocks: free functions that hash the bytes
+of a `String` or mix an `Int`. They are fast, well-known mixing functions meant
+for hash tables, checksums, and folding several values into one composite hash.
+
+```raven
+import std/hash { fnv1a }
+
+fun main() {
+    print(fnv1a("abc"))     // a 64-bit FNV-1a hash, may be negative
+}
+```
+
+## Not cryptographic
+
+These functions are **not** cryptographic. Do not use them for passwords,
+signatures, integrity against an adversary, or any security purpose. They make
+no collision-resistance or preimage guarantees. Cryptographic hashes (SHA-2,
+BLAKE3, and similar) are out of scope for the standard library and belong in a
+package.
+
+What they are good for: keys in a hash table, quick change detection, and
+combining the hashes of a struct's fields.
+
+## Importing
+
+Every entry is a free function, so bring in the ones you need with a selective
+import:
+
+```raven
+import std/hash { fnv1a, djb2, hash_int, combine, checksum }
+```
+
+## A note on integers
+
+Raven `Int` is i64 and arithmetic wraps in two's complement. That wrapping is
+the intended behavior here: the FNV multiply, the djb2 multiply, and the
+integer mixes all rely on it. Returned hashes use the full i64 range and may be
+negative.
+
+`fnv1a` uses the standard FNV-64 offset basis (`14695981039346656037`, written
+as its i64 two's-complement value) and prime (`1099511628211`), so it
+reproduces the canonical FNV-1a 64-bit vectors (for example `fnv1a("abc")` is
+`0xe71fa2190541574b`).
+
+`>>` is an arithmetic (sign-propagating) shift. The integer mixes stay
+deterministic under it; the values differ from an unsigned-shift reference, but
+that does not matter for a non-cryptographic hash.
+
+## Surface
+
+| Function | Result | Notes |
+|---|---|---|
+| `fnv1a(s: String)` | `Int` | FNV-1a over the bytes of `s`, 64-bit variant |
+| `djb2(s: String)` | `Int` | classic djb2 string hash (`hash * 33 + byte`, seed 5381) |
+| `hash_int(n: Int)` | `Int` | splitmix64-style bit-mix so sequential ints scatter |
+| `combine(seed: Int, value: Int)` | `Int` | fold two hashes into one (boost `hash_combine`) |
+| `checksum(s: String)` | `Int` | additive byte checksum; cheap and weak, change detection only |
+
+## Hashing strings
+
+### `fnv1a(s: String) -> Int`
+
+FNV-1a over the bytes of `s`, the 64-bit variant. A good general-purpose string
+hash with strong avalanche behavior for short keys. Prefer this when you want
+one string hash and are unsure which to pick.
+
+```raven
+import std/hash { fnv1a }
+
+fun main() {
+    print(fnv1a("abc"))     // 0xe71fa2190541574b as a signed i64
+    print(fnv1a(""))        // the offset basis, for the empty string
+}
+```
+
+### `djb2(s: String) -> Int`
+
+The classic djb2 hash: start at `5381`, then `hash = hash * 33 + byte` for each
+byte. Simple and fast; included as a well-known alternative to `fnv1a`.
+
+```raven
+import std/hash { djb2 }
+
+fun main() {
+    print(djb2("raven"))
+}
+```
+
+### `checksum(s: String) -> Int`
+
+A plain additive checksum: the sum of the byte values in `s`. Cheaper and
+weaker than the hashes above, so use it only for quick change detection (did
+this string change?), not for distributing keys across buckets.
+
+```raven
+import std/hash { checksum }
+
+fun main() {
+    print(checksum("abc"))      // 97 + 98 + 99 = 294
+}
+```
+
+## Mixing integers
+
+### `hash_int(n: Int) -> Int`
+
+A splitmix64-style bit-mix. Sequential integers (`0, 1, 2, ...`) hash to
+scattered, well-spread values, which is what you want before using them as
+table indices.
+
+```raven
+import std/hash { hash_int }
+
+fun main() {
+    print(hash_int(0))
+    print(hash_int(1))      // far from hash_int(0)
+}
+```
+
+### `combine(seed: Int, value: Int) -> Int`
+
+Fold `value` into `seed` and return the mixed result (the boost `hash_combine`
+recipe, using the 32-bit golden ratio constant). Chain it to hash a sequence of
+values into a single hash:
+
+```raven
+import std/hash { hash_int, combine }
+
+fun main() {
+    let h = hash_int(1)
+    h = combine(h, hash_int(2))
+    h = combine(h, hash_int(3))
+    print(h)        // one hash that depends on all three values, in order
+}
+```
+
+Order matters: `combine` is not commutative, so `[1, 2]` and `[2, 1]` produce
+different hashes.
+
+## Relationship to the Hash trait
+
+The prelude defines `trait Hash { fun hash(self) -> Int }` with built-in impls
+for `Int`, `Bool`, and `String`, which is what [std/collections](collections.md)
+uses to key its hash-based containers. These functions are the building blocks
+a user's own `Hash` impl can call: hash each field, then fold the results with
+`combine`.
+
+```raven
+import std/hash { hash_int, combine }
+
+struct Point { x: Int, y: Int }
+
+impl Hash for Point {
+    fun hash(self) -> Int {
+        let h = hash_int(self.x)
+        combine(h, hash_int(self.y))
+    }
+}
+```
+
+## Worked example: hashing a record
+
+Hash a small struct by mixing a string field and an integer field into one
+value, suitable for use as a key.
+
+```raven
+import std/hash { fnv1a, hash_int, combine }
+
+struct User { name: String, id: Int }
+
+fun hash_user(u: User) -> Int {
+    let h = fnv1a(u.name)
+    return combine(h, hash_int(u.id))
+}
+
+fun main() {
+    let a = User { name: "ada", id: 1 }
+    let b = User { name: "ada", id: 2 }
+
+    print(hash_user(a) == hash_user(a))     // true, hashing is deterministic
+    print(hash_user(a) == hash_user(b))     // false, the id differs
+}
+```
+
+## See also
+
+- [std/collections](collections.md) for the hash-based containers that build on
+  the `Hash` trait.
+- [std/string](string.md) for the string methods you may call before hashing.

--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -1,0 +1,173 @@
+# std/http
+
+A small HTTP/1.1 client built on [std/net](net.md). It sends `GET`, `POST`,
+`PUT`, and `DELETE` requests and hands back a captured response. Every call
+returns `Result<HttpResponse, Error>`, so transport failures (DNS, connect,
+timeout) come back as an [std/error](error.md) `Error` you handle with
+`match`.
+
+```raven
+import std/http { get }
+
+fun main() {
+    match get("https://example.com") {
+        Ok(resp) -> print(resp.status_code),    // 200
+        Err(e) -> print("request failed"),
+    }
+}
+```
+
+## Importing
+
+```raven
+import std/http { get, post, put, delete, request }
+```
+
+Select the functions you use. The `HttpResponse` type comes in with the
+module and needs no separate selector.
+
+## The response type
+
+### `struct HttpResponse`
+
+```raven
+struct HttpResponse {
+    status_code: Int,
+    status_text: String,
+    headers: String,
+    body: String,
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `status_code` | The HTTP status as an `Int`, for example `200` or `404`. |
+| `status_text` | The reason phrase, for example `"OK"` or `"Not Found"`. |
+| `headers` | Response headers as `Key: Value` lines joined by `\n`. |
+| `body` | The full response body as a `String`. |
+
+Read the fields directly off the struct once you have unwrapped the `Ok`
+case.
+
+## A 404 is not an error
+
+A non-2xx HTTP status (404, 500, and the like) is a successful request that
+returned a response, so it takes the `Ok` path with `status_code` set to the
+server's value. Only transport failures (DNS, connect, timeout, malformed
+response) take the `Err` path. Inspect `status_code` yourself to tell a 200
+from a 404:
+
+```raven
+import std/http { get }
+
+fun main() {
+    match get("https://example.com/missing") {
+        Ok(resp) -> {
+            if resp.status_code == 200 {
+                print(resp.body)
+            } else {
+                print("server returned ${resp.status_code}")
+            }
+        },
+        Err(e) -> print("could not reach server"),
+    }
+}
+```
+
+## Requests
+
+### `get(url: String) -> Result<HttpResponse, Error>`
+
+Send a `GET` to `url`. No request body.
+
+```raven
+import std/http { get }
+
+fun main() {
+    match get("https://example.com") {
+        Ok(resp) -> {
+            print(resp.status_code)     // 200
+            print(resp.body)
+        },
+        Err(e) -> print("request failed"),
+    }
+}
+```
+
+### `post(url: String, body: String) -> Result<HttpResponse, Error>`
+
+Send `body` to `url` with a `POST`.
+
+```raven
+import std/http { post }
+
+fun main() {
+    match post("https://example.com/items", "{\"name\":\"raven\"}") {
+        Ok(resp) -> print(resp.status_code),
+        Err(e) -> print("request failed"),
+    }
+}
+```
+
+### `put(url: String, body: String) -> Result<HttpResponse, Error>`
+
+Send `body` to `url` with a `PUT`.
+
+### `delete(url: String) -> Result<HttpResponse, Error>`
+
+Send a `DELETE` to `url`. No request body.
+
+### `request(method: String, url: String, body: String, headers: String) -> Result<HttpResponse, Error>`
+
+The general form the others delegate to. `method` is the HTTP verb
+(`"GET"`, `"POST"`, and so on), `body` is the request body (pass `""` for
+none), and `headers` is a String of `Key: Value` lines separated by `\n`
+(pass `""` for none). Use `request` when you need a custom method or
+request headers.
+
+```raven
+import std/http { request }
+
+fun main() {
+    let headers = "Accept: application/json\nX-Token: secret"
+    match request("GET", "https://example.com/api", "", headers) {
+        Ok(resp) -> print(resp.body),
+        Err(e) -> print("request failed"),
+    }
+}
+```
+
+`get`, `post`, `put`, and `delete` are thin wrappers: `get` and `delete`
+pass `""` for both body and headers, while `post` and `put` pass your body
+and `""` for headers.
+
+## Worked example: fetch and report
+
+This GETs a URL, reports the status, and prints the body only on a 200.
+
+```raven
+import std/http { get }
+
+fun fetch(url: String) {
+    match get(url) {
+        Ok(resp) -> {
+            print("status: ${resp.status_code} ${resp.status_text}")
+            if resp.status_code == 200 {
+                print(resp.body)
+            }
+        },
+        Err(e) -> print("error reaching ${url}"),
+    }
+}
+
+fun main() {
+    fetch("https://example.com")
+}
+```
+
+## See also
+
+- [std/net](net.md) for the TCP sockets this client is built on.
+- [std/json](json.md) for parsing and building request and response bodies.
+- [std/error](error.md) for the `Error` type returned on transport failure
+  (the errors here are tagged with kind `"http"`).

--- a/docs/v2/guide/stdlib/io.md
+++ b/docs/v2/guide/stdlib/io.md
@@ -1,0 +1,136 @@
+# std/io
+
+Console input and output: write lines to standard output and read lines from
+standard input. The functions here are free functions, so you import the ones
+you need by name.
+
+```raven
+import std/io { println, input }
+
+fun main() {
+    let name = input("Your name: ")
+    println("Hello, ${name}")
+}
+```
+
+## Importing
+
+```raven
+import std/io { print, println, input, read_line }
+```
+
+`std/io` is a set of free functions, so use a selective import and list the
+names you want. A bare `import std/io` does not bring the functions into
+scope.
+
+### The global `print` builtin
+
+You do not need `std/io` to print. The `print` builtin is always in scope and
+accepts any value whose type implements `ToString`, so it works on numbers,
+booleans, and your own types without conversion:
+
+```raven
+fun main() {
+    print(42)               // 42
+    print(true)             // true
+    print(3.14)             // 3.14
+}
+```
+
+The `print` function from `std/io` is the `String`-only form below. The
+always-available builtin is the more convenient choice for most output; reach
+for `std/io` when you want `println`, `input`, or `read_line`.
+
+## Output
+
+### `print(s: String)`
+
+Write `s` to standard output with no trailing newline. The argument must be a
+`String`; build one with interpolation or [std/string](string.md) methods if
+you have other values to include.
+
+```raven
+import std/io { print }
+
+fun main() {
+    print("no newline here")
+    print(" and more on the same line")
+}
+```
+
+### `println(s: String)`
+
+Write `s` to standard output followed by a newline.
+
+```raven
+import std/io { println }
+
+fun main() {
+    println("first line")
+    println("second line")
+}
+```
+
+## Input
+
+### `input(prompt: String) -> String`
+
+Write `prompt` to standard output with no trailing newline, then read one line
+from standard input and return it without its trailing newline. At end of
+input the returned string is empty.
+
+```raven
+import std/io { input }
+
+fun main() {
+    let answer = input("Continue? (y/n) ")
+    if answer == "y" {
+        print("ok")
+    }
+}
+```
+
+### `read_line() -> String`
+
+Read one line from standard input and return it without its trailing newline,
+printing no prompt. At end of input the returned string is empty, which is how
+you detect that the stream is exhausted.
+
+```raven
+import std/io { read_line }
+import std/string
+
+fun main() {
+    let line = read_line()
+    print(line.trim().to_upper())
+}
+```
+
+## Worked example: echo non-empty lines
+
+Read lines until the input ends, skipping blank ones. The empty string from
+`read_line` at end of input ends the loop.
+
+```raven
+import std/io { read_line, println }
+import std/string
+
+fun main() {
+    let line = read_line()
+    while !line.is_blank() {
+        println(line.trim())
+        line = read_line()
+    }
+}
+```
+
+## See also
+
+- [std/string](string.md) for building and trimming the strings you read and
+  print.
+- [std/fmt](fmt.md) for padding, joining, and number formatting before
+  output.
+- [std/fs](fs.md) when you want to read from and write to files instead of the
+  console.
+</content>
+</invoke>

--- a/docs/v2/guide/stdlib/iter.md
+++ b/docs/v2/guide/stdlib/iter.md
@@ -1,0 +1,373 @@
+# std/iter
+
+Lazy, single-pass iterator pipelines. `std/iter` gives a `List<T>` an
+`iter()` method that turns it into an iterator, a set of lazy adapters (`map`,
+`filter`, `take`, `skip`, `enumerate`) that you chain with method calls, and a
+set of consumers (`collect`, `count`, `fold`, `any`, `all`, `find`,
+`for_each`) that drive a pipeline to completion.
+
+```raven
+import std/iter { collect }
+
+fun main() {
+    let xs = [1, 2, 3, 4, 5]
+    let doubled = collect(xs.iter().map(fun(x: Int) -> Int = x * 2))
+    for x in doubled {
+        print(x)        // 2, 4, 6, 8, 10
+    }
+}
+```
+
+## Importing
+
+The adapters (`map`, `filter`, `take`, `skip`, `enumerate`) are methods on the
+iterator types, so they are available once you have an iterator. The consumers
+are free functions, so you bring in the ones you use by name:
+
+```raven
+import std/iter { collect, fold }
+```
+
+You can list any of `collect`, `count`, `fold`, `any`, `all`, `find`, and
+`for_each` inside the `{ ... }`. The bridge (`iter()` on `List<T>`) and the
+adapter methods come along with the module.
+
+## Lazy vs eager
+
+The adapters are **lazy**: building a chain like
+`xs.iter().map(f).filter(g)` does no work and touches no element. Each adapter
+is a small struct that remembers its source iterator (and, where applicable, a
+closure). Nothing runs until a **consumer** pulls elements through. A consumer
+walks the chain one element at a time, in a single pass.
+
+```raven
+import std/iter { count }
+
+fun main() {
+    let xs = [1, 2, 3, 4]
+    // No mapping happens here; this just describes a pipeline.
+    let pipeline = xs.iter().map(fun(x: Int) -> Int = x * 10)
+    // The consumer is what actually pulls elements through.
+    print(count(pipeline))      // 4
+}
+```
+
+Only a consumer that builds a list (`collect`) allocates. The other consumers
+return a scalar or an `Option<T>` without allocating an intermediate list.
+
+## The bridge: `List<T>` to an iterator
+
+### `iter(self) -> ListIter<T>`
+
+Defined on `List<T>`. Returns a `ListIter<T>` that walks the list by index.
+This is the usual entry point into a pipeline.
+
+```raven
+import std/iter { collect }
+
+fun main() {
+    let xs = [10, 20, 30]
+    for x in collect(xs.iter()) {
+        print(x)                    // 10, 20, 30
+    }
+}
+```
+
+### `from_list<T>(xs: List<T>) -> ListIter<T>`
+
+The free-function form of the same bridge, for when you prefer a call over a
+method. `from_list(xs)` and `xs.iter()` produce the same `ListIter<T>`.
+
+## Adapters
+
+Each adapter is a generic struct over its element type(s) and a bounded source
+`S: Iterator<T>`. The adapter methods are defined on every concrete iterator
+type, so chaining is uniform: `xs.iter().map(f).filter(g).take(n)`. Each
+adapter's `next` pulls from its source on demand.
+
+### `map`
+
+```raven
+fun map<U>(self, f: fun(T) -> U) -> MapIter<T, U, Self>
+```
+
+Apply a closure to each element, yielding the result. The element type can
+change (`T` to `U`).
+
+```raven
+import std/iter { collect }
+
+fun main() {
+    let xs = [1, 2, 3]
+    let squares = collect(xs.iter().map(fun(x: Int) -> Int = x * x))
+    for s in squares {
+        print(s)    // 1, 4, 9
+    }
+}
+```
+
+### `filter`
+
+```raven
+fun filter(self, pred: fun(T) -> Bool) -> Filter<T, Self>
+```
+
+Keep only the elements for which `pred` returns `true`. `next` pulls from the
+source until the predicate holds or the source is exhausted.
+
+```raven
+import std/iter { collect }
+
+fun main() {
+    let xs = [1, 2, 3, 4, 5, 6]
+    let evens = collect(xs.iter().filter(fun(x: Int) -> Bool = x % 2 == 0))
+    for e in evens {
+        print(e)        // 2, 4, 6
+    }
+}
+```
+
+### `take`
+
+```raven
+fun take(self, n: Int) -> Take<T, Self>
+```
+
+Yield at most the first `n` elements, then stop. Because the pipeline is lazy,
+later elements are never produced.
+
+```raven
+import std/iter { collect }
+
+fun main() {
+    let xs = [1, 2, 3, 4, 5]
+    for x in collect(xs.iter().take(3)) {
+        print(x)                            // 1, 2, 3
+    }
+}
+```
+
+### `skip`
+
+```raven
+fun skip(self, n: Int) -> Skip<T, Self>
+```
+
+Discard the first `n` elements, then pass the rest through.
+
+```raven
+import std/iter { collect }
+
+fun main() {
+    let xs = [1, 2, 3, 4, 5]
+    for x in collect(xs.iter().skip(2)) {
+        print(x)                            // 3, 4, 5
+    }
+}
+```
+
+### `enumerate`
+
+```raven
+fun enumerate(self) -> Enumerate<T, Self>
+```
+
+Pair each element with its running index, starting at `0`. Raven has no tuples
+yet, so `enumerate` yields an `Indexed<T>` record instead of a `(Int, T)`
+pair:
+
+```raven
+struct Indexed<T> {
+    index: Int,
+    value: T,
+}
+```
+
+Read `.index` and `.value` off each element:
+
+```raven
+import std/iter { for_each }
+
+fun main() {
+    let xs = ["a", "b", "c"]
+    for_each(
+        xs.iter().enumerate(),
+        fun(p: Indexed<String>) -> Unit = print("${p.index}: ${p.value}"),
+    )
+    // 0: a
+    // 1: b
+    // 2: c
+}
+```
+
+`enumerate` is a terminal adapter in the chaining methods: it produces an
+`Enumerate<T, S>`, which you hand directly to a consumer rather than chaining
+further adapters onto.
+
+## Consumers
+
+Consumers are free generic functions over any `S: Iterator<T>`. A consumer is
+what drives the pipeline, so every pipeline ends in exactly one consumer call.
+
+### `collect<T, S: Iterator<T>>(it: S) -> List<T>`
+
+Gather every remaining element into a `List<T>`, in order.
+
+```raven
+import std/iter { collect }
+
+fun main() {
+    let xs = [1, 2, 3]
+    let out = collect(xs.iter())
+    print(out.len())                // 3
+}
+```
+
+### `count<T, S: Iterator<T>>(it: S) -> Int`
+
+Count the remaining elements.
+
+```raven
+import std/iter { count }
+
+fun main() {
+    let xs = [1, 2, 3, 4]
+    let odds = count(xs.iter().filter(fun(x: Int) -> Bool = x % 2 == 1))
+    print(odds)     // 2
+}
+```
+
+### `fold<T, A, S: Iterator<T>>(it: S, init: A, f: fun(A, T) -> A) -> A`
+
+Left fold: start from `init` and combine the running accumulator with each
+element.
+
+```raven
+import std/iter { fold }
+
+fun main() {
+    let xs = [1, 2, 3, 4]
+    let sum = fold(xs.iter(), 0, fun(acc: Int, x: Int) -> Int = acc + x)
+    print(sum)      // 10
+}
+```
+
+### `any<T, S: Iterator<T>>(it: S, pred: fun(T) -> Bool) -> Bool`
+
+True when at least one element satisfies `pred`. Stops at the first match.
+
+### `all<T, S: Iterator<T>>(it: S, pred: fun(T) -> Bool) -> Bool`
+
+True when every element satisfies `pred`. Vacuously true for an empty
+iterator.
+
+```raven
+import std/iter { any, all }
+
+fun main() {
+    let xs = [2, 4, 6]
+    print(any(xs.iter(), fun(x: Int) -> Bool = x > 5))      // true
+    print(all(xs.iter(), fun(x: Int) -> Bool = x % 2 == 0)) // true
+}
+```
+
+### `find<T, S: Iterator<T>>(it: S, pred: fun(T) -> Bool) -> Option<T>`
+
+The first element satisfying `pred`, or `None` when none does.
+
+```raven
+import std/iter { find }
+
+fun main() {
+    let xs = [1, 3, 5, 8, 9]
+    let first_even = find(xs.iter(), fun(x: Int) -> Bool = x % 2 == 0)
+    print(match first_even {
+        Some(v) -> v,
+        None -> -1,
+    })      // 8
+}
+```
+
+### `for_each<T, S: Iterator<T>>(it: S, f: fun(T) -> Unit)`
+
+Apply `f` to each element for its side effect.
+
+```raven
+import std/iter { for_each }
+
+fun main() {
+    let xs = [1, 2, 3]
+    for_each(xs.iter(), fun(x: Int) -> Unit = print(x))
+    // 1
+    // 2
+    // 3
+}
+```
+
+## Worked example: combining adapters and a consumer
+
+A pipeline is built with the adapter methods and then handed to a consumer.
+Here `iter().filter(...).map(...).take(...)` describes the work lazily, and
+`collect` runs it in a single pass:
+
+```raven
+import std/iter { collect }
+
+fun main() {
+    let xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    // filter keeps the even numbers, map scales them, take stops at three.
+    let even = fun(x: Int) -> Bool = x % 2 == 0
+    let scale = fun(x: Int) -> Int = x * 10
+    let pipeline = xs.iter().filter(even).map(scale).take(3)
+
+    for value in collect(pipeline) {
+        print(value)        // 20, 40, 60
+    }
+}
+```
+
+Because `take(3)` is lazy, the chain only ever pulls enough elements to
+produce three results; it never maps `80` or `100`.
+
+You can swap the final consumer to ask a different question of the same
+pipeline. With `fold` instead of `collect`:
+
+```raven
+import std/iter { fold }
+
+fun main() {
+    let xs = [1, 2, 3, 4, 5, 6]
+    let total = fold(
+        xs.iter().filter(fun(x: Int) -> Bool = x % 2 == 0),
+        0,
+        fun(acc: Int, x: Int) -> Int = acc + x,
+    )
+    print(total)        // 12
+}
+```
+
+## for-loops
+
+A `for x in <iterable>` loop drives any value whose type implements
+`Iterator`, calling `next` until it returns `None`. Lists and ranges work
+directly; an iterator pipeline works the same way, so you can loop over one
+instead of calling a consumer:
+
+```raven
+import std/iter
+
+fun main() {
+    let xs = [1, 2, 3]
+    for x in xs.iter().map(fun(x: Int) -> Int = x + 100) {
+        print(x)        // 101, 102, 103
+    }
+}
+```
+
+## See also
+
+- [std/string](string.md) for text methods you can `map` over.
+- [std/io](io.md) for printing pipeline results.
+- The [language reference](../language-reference.md) for closures, generics,
+  and `for` loops.

--- a/docs/v2/guide/stdlib/json.md
+++ b/docs/v2/guide/stdlib/json.md
@@ -1,0 +1,250 @@
+# std/json
+
+Parse and serialize JSON. `std/json` is a recursive descent parser
+(`parse`) and a compact serializer (`stringify`) written in pure Raven, with
+a `JsonValue` enum for the parsed value tree.
+
+```raven
+import std/json { parse, stringify }
+
+fun main() {
+    match parse("{\"name\": \"Ada\", \"id\": 7}") {
+        Ok(v) -> print(stringify(v)),     // {"name":"Ada","id":7}
+        Err(e) -> print("bad json"),
+    }
+}
+```
+
+JSON string literals embedded in Raven source need escaped quotes, so the
+text `{"name": "Ada"}` is written `"{\"name\": \"Ada\"}"`.
+
+## Importing
+
+```raven
+import std/json { parse, stringify }
+```
+
+Bring in just what you use. The accessor methods on `JsonValue` (`is_null`,
+`as_bool`, `get`, ...) come along with the `JsonValue` type, so a selective
+import of `parse` and `stringify` is enough for most code. Import the type
+explicitly when you name it:
+
+```raven
+import std/json { parse, stringify, JsonValue }
+```
+
+## The value type
+
+A parsed JSON document is a `JsonValue`, a tagged union over the six JSON
+shapes:
+
+```raven
+enum JsonValue {
+    Null,
+    Bool(Bool),
+    Number(Float),
+    Str(String),
+    Array(List<JsonValue>),
+    Object(Map<String, JsonValue>),
+}
+```
+
+Construct variants with the qualified form (`JsonValue.Null`,
+`JsonValue.Bool(true)`, `JsonValue.Number(1.0)`, `JsonValue.Str(s)`,
+`JsonValue.Array(list)`, `JsonValue.Object(map)`). Match with the bare
+variant names (`Null`, `Bool(b)`, `Number(n)`, ...).
+
+`Object` holds a `std/collections` `Map<String, JsonValue>`. The serializer
+emits members in the Map's key order (the hash-bucket layout), not insertion
+order.
+
+### Numbers are Float
+
+Every JSON number, integer or not, parses to `Number(Float)`. Raven `Float`
+is an IEEE 754 double, so integers beyond the 53-bit mantissa (roughly
+9.0e15) lose precision. There is no separate integer JSON type, so a
+whole-number value like `7` comes back as `Number(7.0)` and serializes again
+as `7`.
+
+## Parsing
+
+### `parse(text: String) -> Result<JsonValue, Error>`
+
+Parse `text` as a single JSON value. The parser handles nested objects and
+arrays (including empty `{}` and `[]`), strings, numbers, `true`, `false`,
+`null`, and inter-token whitespace (space, tab, newline, carriage return).
+Any non-whitespace content after the top-level value is rejected.
+
+`parse` returns a `Result`, so handle both arms with `match`:
+
+```raven
+import std/json { parse }
+
+fun main() {
+    match parse("[1, 2, 3]") {
+        Ok(v) -> print("parsed ok"),
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+A failure is an `std/error` `Error` tagged with `kind` `"json"`. The message
+names roughly what failed and, for an unexpected or trailing byte, the byte
+offset.
+
+String escapes decode as in standard JSON: the two-character escapes
+`\" \\ \/ \b \f \n \r \t`, and a `\uXXXX` escape for a code point (UTF-8
+encoded into the result). A high surrogate followed by a low surrogate
+decodes to the astral code point; a lone surrogate decodes to U+FFFD.
+
+## Navigating a parsed value
+
+A `JsonValue` is a tree. Two methods step into containers and four extract a
+scalar. The container steps return `Option<JsonValue>`, and the extractors
+return an `Option` of the underlying type, so a wrong-kind or missing lookup
+is a normal `None` rather than an error.
+
+### `get(self, key: String) -> Option<JsonValue>`
+
+The member of an object by key, or `None` when the value is not an object or
+the key is absent.
+
+### `at(self, i: Int) -> Option<JsonValue>`
+
+The element of an array by index, or `None` when out of range or not an
+array.
+
+### `is_null(self) -> Bool`
+
+True only for the `Null` variant.
+
+### `as_bool(self) -> Option<Bool>`
+
+`Some(b)` for a `Bool`, else `None`.
+
+### `as_number(self) -> Option<Float>`
+
+`Some(n)` for a `Number`, else `None`. Remember every JSON number is a
+`Float`.
+
+### `as_string(self) -> Option<String>`
+
+`Some(s)` for a `Str`, else `None`.
+
+A typical read chains a container step and then an extractor, handling each
+`Option` with `match`:
+
+```raven
+import std/json { parse }
+
+fun main() {
+    match parse("{\"port\": 8080}") {
+        Ok(v) -> {
+            match v.get("port") {
+                Some(field) -> {
+                    match field.as_number() {
+                        Some(n) -> print(n),     // 8080
+                        None -> print("port is not a number"),
+                    }
+                }
+                None -> print("no port field"),
+            }
+        }
+        Err(e) -> print("bad json"),
+    }
+}
+```
+
+Reaching into nested data composes the same way: `v.get("user")` returns an
+`Option<JsonValue>` you match on, then call `.get("name")` or `.at(0)` on the
+inner value.
+
+## Serializing
+
+### `stringify(value: JsonValue) -> String`
+
+Compact serialization with no spaces between tokens. Object members are
+emitted in the Map's key order. String escaping is the reverse of parsing:
+`"` and `\` are escaped, control bytes below `0x20` use the `\b \f \n \r \t`
+shorthands where they exist and `\u00XX` otherwise, and every other byte
+passes through unchanged.
+
+A whole-number `Float` renders the way the runtime prints it, so `1.0`
+serializes as `1` and `0.15` serializes as `0.15`.
+
+```raven
+import std/json { parse, stringify }
+
+fun main() {
+    match parse("{ \"a\" : 1 , \"b\" : [ true , null ] }") {
+        Ok(v) -> print(stringify(v)),     // {"a":1,"b":[true,null]}
+        Err(e) -> print("bad json"),
+    }
+}
+```
+
+## Derived conversions
+
+`std/json` also defines two traits for converting between a Raven value and
+its JSON form:
+
+```raven
+trait ToJson {
+    fun to_json(self) -> JsonValue
+}
+
+trait FromJson {
+    fun from_json(j: JsonValue) -> Result<Self, Error>
+}
+```
+
+`to_json` is an ordinary `self` method; `from_json` is an associated
+function called as `Point.from_json(j)`. Built-in impls cover `Int`, `Float`,
+`Bool`, `String`, `List<T>`, and `Option<T>` so field recursion bottoms out.
+An `Int` round-trips through `Float` (JSON has one number type) and loses
+precision beyond 2^53; a number decodes back to `Int` by truncation toward
+zero.
+
+Annotate a user struct or enum with `@derive(ToJson, FromJson)` to get these
+traits automatically: a struct serializes to an object keyed by field name,
+an enum to a tagged object. See the [derive spec](../../specs/derive.md) for
+the full encoding and the helper functions the derive emits.
+
+## Worked example: read a config field
+
+```raven
+import std/json { parse }
+
+// Pull the "name" string out of a JSON object, with a fallback for any
+// shape that does not match.
+fun config_name(text: String) -> String {
+    return match parse(text) {
+        Ok(v) -> {
+            match v.get("name") {
+                Some(field) -> {
+                    match field.as_string() {
+                        Some(name) -> name,
+                        None -> "unnamed",
+                    }
+                }
+                None -> "unnamed",
+            }
+        }
+        Err(e) -> "invalid",
+    }
+}
+
+fun main() {
+    print(config_name("{\"name\": \"raven\", \"version\": 2}"))   // raven
+    print(config_name("{\"version\": 2}"))                        // unnamed
+    print(config_name("not json"))                                // invalid
+}
+```
+
+## See also
+
+- [std/io](io.md) for reading the text you hand to `parse`.
+- The [derive spec](../../specs/derive.md) for `@derive(ToJson, FromJson)`
+  on your own types.
+- The [language reference](../language-reference.md) for `match`, `Result`,
+  and `Option`.

--- a/docs/v2/guide/stdlib/math.md
+++ b/docs/v2/guide/stdlib/math.md
@@ -1,0 +1,178 @@
+# std/math
+
+Numeric constants and functions. Everything in `std/math` is a free
+function, so you bring names into scope with a selective import:
+
+```raven
+import std/math { sqrt, pow_int }
+
+fun main() {
+    print(sqrt(2.0))        // 1.4142135623730951
+    print(pow_int(2, 10))   // 1024
+}
+```
+
+## Importing
+
+```raven
+import std/math { sqrt, pow, abs_int, pi }
+```
+
+List exactly the names you use inside the `{ ... }`. The transcendental and
+rounding functions (`sqrt`, `sin`, `floor`, ...) bind to the platform C math
+library, so their accuracy is the host libm's. The integer helpers,
+`pow_int`, and the constants are pure Raven.
+
+## Int and Float are separate
+
+Raven has no implicit `Int` to `Float` conversion, and there is no numeric
+overloading. Integer math and float math therefore come as two distinct sets
+of functions, named apart (`min_int` vs `min`, `abs_int` vs `abs`). Pass an
+`Int` to the `_int` helpers and a `Float` to the float helpers. The language
+has no numeric cast yet, so the rounding functions (`floor`, `round`, and
+friends) return a whole-valued `Float`, not an `Int`.
+
+## Integer functions
+
+All take and return `Int`.
+
+### `abs_int(x: Int) -> Int`
+
+Absolute value.
+
+### `min_int(a: Int, b: Int) -> Int` and `max_int(a: Int, b: Int) -> Int`
+
+The smaller and the larger of two integers.
+
+### `clamp_int(x: Int, lo: Int, hi: Int) -> Int`
+
+Clamp `x` into the closed range `[lo, hi]`: return `lo` if `x < lo`, `hi` if
+`x > hi`, otherwise `x`.
+
+### `pow_int(base: Int, exp: Int) -> Int`
+
+`base` raised to `exp`, computed by squaring. A negative `exp` has no integer
+result and returns `0`. The result is exact when it fits in a 64-bit signed
+integer; overflow is not detected.
+
+```raven
+import std/math { abs_int, min_int, max_int, clamp_int, pow_int }
+
+fun main() {
+    print(abs_int(0 - 7))           // 7
+    print(min_int(3, 9))            // 3
+    print(max_int(3, 9))            // 9
+    print(clamp_int(15, 0, 10))     // 10
+    print(pow_int(2, 8))            // 256
+}
+```
+
+## Float functions
+
+All take and return `Float`.
+
+### `abs(x: Float) -> Float`
+
+Absolute value (the C `fabs`).
+
+### `min(a: Float, b: Float) -> Float` and `max(a: Float, b: Float) -> Float`
+
+The smaller and the larger of two floats.
+
+### `clamp(x: Float, lo: Float, hi: Float) -> Float`
+
+Clamp `x` into the closed range `[lo, hi]`.
+
+### `sqrt(x: Float) -> Float`
+
+Square root.
+
+### `pow(base: Float, exp: Float) -> Float`
+
+`base` raised to `exp`.
+
+### `exp(x: Float) -> Float`
+
+`e` raised to `x`.
+
+### `ln(x: Float) -> Float`
+
+Natural logarithm (the C `log`).
+
+### `floor(x: Float) -> Float`, `ceil(x: Float) -> Float`, `round(x: Float) -> Float`, `trunc(x: Float) -> Float`
+
+Round toward minus infinity, toward plus infinity, to the nearest whole
+value, and toward zero. Each returns a whole-valued `Float`.
+
+### `sin(x: Float) -> Float` and `cos(x: Float) -> Float`
+
+Sine and cosine, with the angle in radians.
+
+```raven
+import std/math { sqrt, pow, exp, ln, abs, min, max, clamp, floor, ceil, round, trunc, sin, cos }
+
+fun main() {
+    print(sqrt(2.0))            // 1.4142135623730951
+    print(pow(2.0, 10.0))       // 1024.0
+    print(abs(0.0 - 3.5))       // 3.5
+    print(min(2.5, 1.5))        // 1.5
+    print(clamp(9.0, 0.0, 1.0)) // 1.0
+    print(floor(2.7))           // 2.0
+    print(ceil(2.1))            // 3.0
+    print(round(2.5))           // 3.0
+    print(trunc(0.0 - 2.7))     // -2.0
+}
+```
+
+## Constants
+
+The language has no `Float` const items yet, so the constants are
+zero-argument functions returning `Float`. Call them with `()`.
+
+### `pi() -> Float`
+
+3.141592653589793
+
+### `e() -> Float`
+
+2.718281828459045
+
+### `tau() -> Float`
+
+6.283185307179586 (a full turn, `2 * pi`).
+
+```raven
+import std/math { pi, e, tau, sin }
+
+fun main() {
+    print(pi())             // 3.141592653589793
+    print(tau())            // 6.283185307179586
+    print(sin(pi()))        // ~0 (libm rounding)
+}
+```
+
+## Worked example: distance between two points
+
+`sqrt` plus `pow` gives the Euclidean distance between two points.
+
+```raven
+import std/math { sqrt, pow }
+
+fun distance(x1: Float, y1: Float, x2: Float, y2: Float) -> Float {
+    let dx = x2 - x1
+    let dy = y2 - y1
+    return sqrt(pow(dx, 2.0) + pow(dy, 2.0))
+}
+
+fun main() {
+    print(distance(0.0, 0.0, 3.0, 4.0))     // 5.0
+}
+```
+
+## See also
+
+- [std/cmp](cmp.md) for `min`/`max`/`clamp` over the generic `Ord` trait
+  rather than numbers directly.
+- [std/random](random.md) for random number generation.
+- The [language reference](../language-reference.md) for the `Int` and
+  `Float` types and numeric literals.

--- a/docs/v2/guide/stdlib/net.md
+++ b/docs/v2/guide/stdlib/net.md
@@ -1,0 +1,253 @@
+# std/net
+
+TCP networking: connect a client stream, bind a listener and accept
+connections, read and write bytes, resolve DNS names, and probe whether an
+address is reachable. The handle types (`TcpStream`, `TcpListener`) and the
+free functions all return values through the `Result<T, Error>` model.
+
+```raven
+import std/net { connect }
+
+fun main() {
+    match connect("example.com:80") {
+        Ok(stream) -> {
+            stream.close()
+            print("connected")
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Importing
+
+```raven
+import std/net { connect, listen, dns_lookup, reachable }
+```
+
+Select the free functions you use. The methods on `TcpStream` and
+`TcpListener` arrive with the types, so they need no separate selector.
+
+A socket cannot cross the FFI boundary, so the runtime keeps the real socket
+in a process-wide registry and hands Raven an opaque integer id. `TcpStream`
+and `TcpListener` are thin structs wrapping that id; every method looks the
+socket up by id and acts on it.
+
+```raven
+struct TcpStream { id: Int }
+struct TcpListener { id: Int }
+```
+
+You rarely touch `id` directly. Build the handles with `connect`, `listen`,
+and `accept`, and use the methods below.
+
+## The error model
+
+Every fallible operation returns `Result<T, Error>` where `Error` is the
+[std/error](error.md) type tagged with kind `"net"`. The message is a short
+context prefix (the operation name) joined to the OS error text. Match on the
+`Result`, or use the [std/error](error.md) combinators to thread it.
+
+```raven
+import std/net { connect }
+
+fun main() {
+    match connect("127.0.0.1:9999") {
+        Ok(stream) -> stream.close(),
+        Err(e) -> print(e.message),     // e.g. connect: ...
+    }
+}
+```
+
+The one exception is `reachable`, which never fails and returns a plain
+`Bool` rather than a `Result`.
+
+## Connecting a client
+
+### `connect(addr: String) -> Result<TcpStream, Error>`
+
+Open a TCP stream to `addr` in `"host:port"` form. On success you get an open
+`TcpStream`; on failure an `Err` carrying the OS message.
+
+```raven
+import std/net { connect }
+
+fun main() {
+    match connect("example.com:80") {
+        Ok(stream) -> {
+            print("connected")
+            stream.close()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Reading and writing a stream
+
+The stream methods come in with the `TcpStream` type.
+
+### `read(self, max: Int) -> Result<String, Error>`
+
+Read up to `max` bytes and return them as a `String`. The payload is a byte
+buffer carried in a `String` (lossy UTF-8 at the FFI boundary), not
+guaranteed text. A clean end of stream returns `Ok("")`, so an empty result
+means EOF rather than an error.
+
+### `write(self, data: String) -> Result<Int, Error>`
+
+Write all bytes of `data` and return the count written.
+
+### `set_read_timeout_ms(self, ms: Int)`
+
+Set the read timeout in milliseconds. A value of `0` means no timeout
+(blocking reads); a positive value makes a stalled read fail rather than hang.
+This method does not return a `Result`.
+
+### `close(self)`
+
+Close the stream, releasing the runtime-side socket. It does not return a
+`Result`.
+
+```raven
+import std/net { connect }
+
+fun main() {
+    match connect("example.com:80") {
+        Ok(stream) -> {
+            stream.set_read_timeout_ms(2000)
+            match stream.write("GET / HTTP/1.0\r\n\r\n") {
+                Ok(n) -> print("sent ${n} bytes"),
+                Err(e) -> print(e.message),
+            }
+            match stream.read(1024) {
+                Ok(reply) -> print(reply),
+                Err(e) -> print(e.message),
+            }
+            stream.close()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Binding a listener
+
+### `listen(addr: String) -> Result<TcpListener, Error>`
+
+Bind a TCP listener to `addr` in `"host:port"` form.
+
+### `accept(self) -> Result<TcpStream, Error>`
+
+A method on `TcpListener`. Block until a connection arrives and return the
+accepted `TcpStream`. The block is intentional: Raven v2 has no concurrency,
+so accept waits rather than polling.
+
+A server loops: bind once with `listen`, then call `accept` repeatedly,
+serving each accepted stream before accepting the next.
+
+```raven
+import std/net { listen }
+
+fun serve() {
+    match listen("127.0.0.1:7878") {
+        Ok(server) -> {
+            while true {
+                match server.accept() {
+                    Ok(client) -> {
+                        match client.read(1024) {
+                            Ok(req) -> {
+                                client.write("hello\n")
+                            }
+                            Err(e) -> print(e.message),
+                        }
+                        client.close()
+                    }
+                    Err(e) -> print(e.message),
+                }
+            }
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+Because v2 has no threads, a single program is a client or a server, not both
+at once.
+
+## Resolving and probing
+
+### `dns_lookup(host: String) -> Result<List<String>, Error>`
+
+Resolve `host` to its IP addresses as a `List<String>`. An empty result is an
+empty list, not a one-element list of `""`.
+
+```raven
+import std/net { dns_lookup }
+
+fun main() {
+    match dns_lookup("example.com") {
+        Ok(addrs) -> {
+            let i = 0
+            while i < addrs.len() {
+                print(addrs[i])
+                i = i + 1
+            }
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+### `reachable(addr: String) -> Bool`
+
+Probe whether `addr` in `"host:port"` form accepts a TCP connection within a
+short timeout. This is a non-failing check: it returns a plain `Bool` and
+never sets an error.
+
+```raven
+import std/net { reachable }
+
+fun main() {
+    if reachable("127.0.0.1:7878") {
+        print("up")
+    } else {
+        print("down")
+    }
+}
+```
+
+## Worked example: a one-shot client
+
+Connect, send a request, read the reply, and close, handling the `Result` at
+each step.
+
+```raven
+import std/net { connect }
+
+fun fetch(addr: String, request: String) -> Result<String, Error> {
+    let stream = connect(addr)?
+    stream.set_read_timeout_ms(3000)
+    stream.write(request)?
+    let reply = stream.read(4096)?
+    stream.close()
+    return Ok(reply)
+}
+
+fun main() {
+    match fetch("example.com:80", "GET / HTTP/1.0\r\n\r\n") {
+        Ok(body) -> print(body),
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## See also
+
+- [std/http](http.md) builds request and response handling on top of TCP.
+- [std/error](error.md) for the `Error` type, `error_kind`, and the `?`
+  operator used above.
+- [std/string](string.md) for slicing and scanning the byte buffers that
+  `read` returns.
+</content>
+</invoke>

--- a/docs/v2/guide/stdlib/path.md
+++ b/docs/v2/guide/stdlib/path.md
@@ -1,0 +1,209 @@
+# std/path
+
+Pure path string manipulation on the POSIX `/` separator. Every function
+here is plain string work. Nothing in this module touches the disk: it
+never checks whether a file exists, never reads a directory, never
+resolves a real path. For anything that talks to the filesystem, reach for
+[std/fs](fs.md) instead.
+
+```raven
+import std/path { join, basename, dirname, extension, stem, is_absolute }
+
+fun main() {
+    let p = join("src", "main.rv")      // src/main.rv
+    print(dirname(p))                   // src
+    print(basename(p))                  // main.rv
+    print(extension(p))                 // rv
+}
+```
+
+## Importing
+
+The functions have no natural single receiver, so they are free functions
+brought in by a selective import:
+
+```raven
+import std/path { join, basename, dirname, extension, stem, is_absolute }
+```
+
+Pull in only the names you use. The module is built on `std/string`'s
+`String` methods, and the import merges that dependency transitively, so
+you do not need a separate `import std/string`.
+
+## The path model
+
+A path is a `String` whose components are separated by `/`. That is the
+only separator this module understands. Windows backslash (`\`) paths,
+drive letters, and UNC paths are out of scope: a `\` is treated as an
+ordinary path byte, not a separator.
+
+Indices are byte offsets, consistent with `std/string`. Paths are assumed
+to be valid UTF-8 with the separator and the dot appearing only as their
+own single-byte ASCII forms.
+
+## Surface
+
+| Function | Result | Summary |
+|---|---|---|
+| `join(a: String, b: String) -> String` | `String` | join two parts with a single `/` |
+| `basename(p: String) -> String` | `String` | final component after the last `/` |
+| `dirname(p: String) -> String` | `String` | everything up to the last `/` |
+| `extension(p: String) -> String` | `String` | text after the last `.` in the basename |
+| `stem(p: String) -> String` | `String` | basename without its extension |
+| `is_absolute(p: String) -> Bool` | `Bool` | whether `p` starts with `/` |
+
+## Building a path
+
+### `join(a: String, b: String) -> String`
+
+Join two path parts with a single `/`. The result never doubles the
+separator: it stays one `/` whether `a` ends with a slash, `b` begins with
+one, or both. If either operand is empty, the other is returned unchanged.
+
+```raven
+import std/path { join }
+
+fun main() {
+    print(join("src", "main.rv"))       // src/main.rv
+    print(join("src/", "main.rv"))      // src/main.rv
+    print(join("src", "/main.rv"))      // src/main.rv
+    print(join("src/", "/main.rv"))     // src/main.rv
+    print(join("", "main.rv"))          // main.rv
+    print(join("src", ""))              // src
+}
+```
+
+## Decomposing a path
+
+### `basename(p: String) -> String`
+
+The final component, everything after the last `/`. When `p` contains no
+`/`, the whole string is the basename.
+
+```raven
+import std/path { basename }
+
+fun main() {
+    print(basename("src/lib/main.rv"))  // main.rv
+    print(basename("main.rv"))          // main.rv (no slash)
+    print(basename("/etc/hosts"))       // hosts
+}
+```
+
+### `dirname(p: String) -> String`
+
+Everything up to the last `/`. Two edge cases are worth remembering:
+
+- When there is no `/`, `dirname` returns `"."` (the current directory).
+- When the only `/` is at index 0, it returns `"/"` (the root).
+
+```raven
+import std/path { dirname }
+
+fun main() {
+    print(dirname("src/lib/main.rv"))   // src/lib
+    print(dirname("main.rv"))           // . (no slash)
+    print(dirname("/hosts"))            // / (slash only at index 0)
+}
+```
+
+### `extension(p: String) -> String`
+
+The substring after the last `.` in the basename, or `""` when there is no
+dot. The dot is inspected on the basename only, so a `.` in a parent
+directory name does not count. A leading dot marks a dotfile, not an
+extension: the extension of `.gitignore` is `""`.
+
+```raven
+import std/path { extension }
+
+fun main() {
+    print(extension("archive.tar.gz"))  // gz (last dot wins)
+    print(extension("README"))          // "" (no dot)
+    print(extension(".gitignore"))      // "" (leading dot, a dotfile)
+    print(extension("a.b/main"))        // "" (dot is in the directory part)
+}
+```
+
+### `stem(p: String) -> String`
+
+The basename with its extension removed: the part `extension` leaves
+behind. For a name without an extension, the whole basename is the stem,
+and a dotfile keeps its leading dot.
+
+```raven
+import std/path { stem }
+
+fun main() {
+    print(stem("src/main.rv"))          // main
+    print(stem("archive.tar.gz"))       // archive.tar (only the last dot)
+    print(stem("README"))               // README (no extension)
+    print(stem(".gitignore"))           // .gitignore (dotfile, no extension)
+}
+```
+
+### `is_absolute(p: String) -> Bool`
+
+True when `p` starts with `/`. The empty string is relative.
+
+```raven
+import std/path { is_absolute }
+
+fun main() {
+    print(is_absolute("/usr/bin"))      // true
+    print(is_absolute("usr/bin"))       // false
+    print(is_absolute(""))              // false
+}
+```
+
+## Worked example: rename a path's extension
+
+This walks a path apart, swaps its extension, and joins it back together
+using only documented functions.
+
+```raven
+import std/path { join, dirname, stem, is_absolute }
+
+fun with_extension(p: String, ext: String) -> String {
+    let dir = dirname(p)
+    let name = stem(p).concat(".").concat(ext)
+    if dir == "." {
+        return name
+    }
+    return join(dir, name)
+}
+
+fun main() {
+    print(with_extension("src/report.txt", "md"))   // src/report.md
+    print(with_extension("notes.txt", "md"))         // notes.md
+    print(is_absolute("/tmp/a"))                      // true
+}
+```
+
+## Relationship to std/fs
+
+`std/path` and [std/fs](fs.md) split cleanly along one line: `std/path` is
+strings, `std/fs` is the disk.
+
+- `std/path` answers questions about the shape of a path string
+  (`dirname`, `basename`, `extension`) and builds new ones (`join`). It
+  never opens, reads, or stats anything, so its results hold even for
+  paths that do not exist.
+- [std/fs](fs.md) is where existence checks, reading, writing, and
+  directory listing live. When you need to know whether a path is really
+  on disk, use `std/fs`.
+
+A common pattern is to compute a target path with `std/path`, then hand
+that string to `std/fs` to actually read or write it.
+
+## Not yet covered
+
+A `normalize` function (resolving `.` and `..` segments and collapsing
+repeated separators) is deferred and not part of this module today. The
+functions above do no such resolution: they operate on the literal bytes
+of the path you pass in.
+
+## See also
+
+- [std/fs](fs.md) for filesystem access (existence, reading, writing).
+- [std/string](string.md) for the `String` methods this module builds on.

--- a/docs/v2/guide/stdlib/process.md
+++ b/docs/v2/guide/stdlib/process.md
@@ -1,0 +1,179 @@
+# std/process
+
+Run external programs and read back their output. A run spawns the program,
+waits for it to finish, and hands you the captured exit code, stdout, and
+stderr as an `Output` value. There is no streaming: a child runs to
+completion in a single call.
+
+```raven
+import std/process { run }
+
+fun main() {
+    let args = ["--version"]
+    match run("git", args) {
+        Ok(out) -> print(out.stdout),
+        Err(e) -> print("could not run git: ${e.message}"),
+    }
+}
+```
+
+## Importing
+
+```raven
+import std/process { run, run_with_input }
+```
+
+Bring in just the functions you call. The `success` method on `Output` comes
+in with the type and needs no separate selector.
+
+## The `Output` type
+
+```raven
+struct Output { code: Int, stdout: String, stderr: String }
+```
+
+A finished child's captured result.
+
+| Field | Meaning |
+|-------|---------|
+| `code` | The exit code. `0` is a clean exit; any other value is the program's own status. A child killed by a signal with no exit code reports `-1`. |
+| `stdout` | Everything the child wrote to standard output, captured in full. |
+| `stderr` | Everything the child wrote to standard error, captured in full. |
+
+### `success(self) -> Bool`
+
+True when `code` is `0`.
+
+```raven
+import std/process { run }
+
+fun main() {
+    let no_args: List<String> = []
+    match run("true", no_args) {
+        Ok(out) -> print(out.success()),     // true
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Running a program
+
+### `run(program: String, args: List<String>) -> Result<Output, Error>`
+
+Spawn `program` with `args`, feed it no stdin, and wait for it to finish. On
+success returns `Ok(Output)` with the captured code, stdout, and stderr.
+
+`args` is the argument list with no leading program name (that is `program`).
+When a program takes no arguments, pass an explicitly typed empty list so the
+element type is known:
+
+```raven
+let no_args: List<String> = []
+```
+
+A bare `[]` has no element type the checker can infer here, so the annotation
+is required.
+
+```raven
+import std/process { run }
+
+fun main() {
+    let args = ["-l", "/tmp"]
+    match run("ls", args) {
+        Ok(out) -> print(out.stdout),
+        Err(e) -> print("spawn failed: ${e.message}"),
+    }
+}
+```
+
+### `run_with_input(program: String, args: List<String>, input: String) -> Result<Output, Error>`
+
+Like `run`, but writes `input` to the child's stdin and then closes it. Use
+this for programs that read from standard input.
+
+```raven
+import std/process { run_with_input }
+
+fun main() {
+    let no_args: List<String> = []
+    match run_with_input("cat", no_args, "hello\n") {
+        Ok(out) -> print(out.stdout),        // hello
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## A non-zero exit is not an error
+
+A program that spawns and runs but exits with a non-zero code is a normal,
+successful run: its code and output are captured and `run` returns
+`Ok(Output)`. You decide what a non-zero exit means by inspecting `code` (or
+calling `success()`).
+
+The `Err` path is taken only on a spawn failure, for example when the program
+is not found or cannot be executed. The error is
+`Err(Error { kind: "process", message })`, where `message` is the OS error
+text. The `Error` type comes from [std/error](error.md).
+
+```raven
+import std/process { run }
+
+fun main() {
+    let args = ["status", "--short"]
+    match run("git", args) {
+        Ok(out) -> {
+            if out.success() {
+                print(out.stdout)
+            } else {
+                // The program ran but reported a non-zero status.
+                print("git exited with ${out.code}")
+                print(out.stderr)
+            }
+        },
+        Err(e) -> print("could not start git: ${e.message}"),
+    }
+}
+```
+
+## Worked example: read the current branch
+
+Run `git` to print the current branch name, falling back to a label when the
+command is missing or reports a failure.
+
+```raven
+import std/process { run }
+import std/string
+
+fun current_branch() -> String {
+    let args = ["rev-parse", "--abbrev-ref", "HEAD"]
+    return match run("git", args) {
+        Ok(out) -> {
+            if out.success() {
+                out.stdout.trim()
+            } else {
+                "unknown"
+            }
+        },
+        Err(_) -> "no git",
+    }
+}
+
+fun main() {
+    print(current_branch())
+}
+```
+
+## Notes
+
+- A run captures stdout and stderr in full before returning. There is no
+  incremental or streaming output.
+- An argument that itself contains a NUL byte (`\0`) is not supported.
+- A child that reads no stdin under `run` sees end of input immediately.
+  Under `run_with_input`, a broken pipe (the child exits without reading) is
+  ignored and you still get its captured output.
+
+## See also
+
+- [std/error](error.md) for the `Error` type and the `Result` model used by
+  `run` and `run_with_input`.
+- [std/string](string.md) for trimming and inspecting captured output.

--- a/docs/v2/guide/stdlib/random.md
+++ b/docs/v2/guide/stdlib/random.md
@@ -1,0 +1,202 @@
+# std/random
+
+A small, reproducible pseudo-random generator. `Rng` is a value type holding
+the generator state; its methods draw the next value and mutate that state in
+place.
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(42)
+    print(rng.gen_range(1, 7))      // a dice roll in [1, 7)
+}
+```
+
+## Importing
+
+```raven
+import std/random
+```
+
+`std/random` adds a `struct Rng` and its `impl Rng` block, so a bare import
+brings the constructors (`Rng.new`, `Rng.from_entropy`) and every method below
+into scope. Import the whole module (not a selective `{ ... }` list).
+
+This generator is **not** cryptographically secure. Do not use it for keys,
+tokens, or anything where predictability is a risk.
+
+## Reproducibility
+
+The generator is splitmix64: the same seed always yields the same sequence of
+draws. That determinism is the point of seeded construction, and it makes
+`std/random` a good fit for reproducible tests and simulations.
+
+`Rng.from_entropy()` instead seeds from a runtime source (a high-resolution
+timestamp mixed with the process id), so its stream is not reproducible across
+runs. Reach for it when you want a fresh, unpredictable sequence.
+
+```raven
+import std/random
+
+fun main() {
+    let a = Rng.new(7)
+    let b = Rng.new(7)
+    print(a.next_int() == b.next_int())     // true: same seed, same draw
+}
+```
+
+## Constructing
+
+### `Rng.new(seed: Int) -> Rng`
+
+A generator seeded with `seed`. Deterministic: two generators built from the
+same seed produce identical sequences.
+
+### `Rng.from_entropy() -> Rng`
+
+A generator seeded from a runtime time/pid source. Non-reproducible across
+runs.
+
+## Drawing numbers
+
+### `next_int(self) -> Int`
+
+The next raw 64-bit draw. Values span the full `Int` range and may be negative.
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(1)
+    print(rng.next_int())       // some i64 value
+    print(rng.next_int())       // the next one in the sequence
+}
+```
+
+### `gen_range(self, lo: Int, hi: Int) -> Int`
+
+A value in the half-open interval `[lo, hi)`: `lo` is possible, `hi` is not.
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(99)
+    print(rng.gen_range(0, 6))      // one of 0, 1, 2, 3, 4, 5
+}
+```
+
+The result is a non-negative draw reduced modulo `(hi - lo)`. The modulo
+introduces a small bias when the range does not evenly divide the draw space,
+but for typical small ranges the bias is negligible. If `lo >= hi` the function
+returns `lo`.
+
+### `next_float(self) -> Float`
+
+A `Float` in `[0.0, 1.0)`. It takes the top 53 bits of a draw and scales by
+2^-53 (the full f64 mantissa width), so every representable multiple of 2^-53
+in the interval is reachable.
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(3)
+    print(rng.next_float())     // e.g. 0.234...
+}
+```
+
+### `next_bool(self) -> Bool`
+
+`true` or `false` from the low bit of a draw, a fair coin flip.
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(5)
+    print(rng.next_bool())      // true or false
+}
+```
+
+## Working with lists
+
+### `choice<T>(self, xs: List<T>) -> Option<T>`
+
+A random element of `xs`, or `None` when the list is empty. Because the result
+is an `Option<T>`, unwrap it with a `match` (or your preferred `Option` helper)
+before use.
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(12)
+    let colors = ["red", "green", "blue"]
+
+    match rng.choice(colors) {
+        Some(c) -> print(c),
+        None -> print("empty"),
+    }
+}
+```
+
+### `shuffle<T>(self, xs: List<T>)`
+
+Shuffles `xs` in place using Fisher-Yates. It returns nothing; the list passed
+in is reordered.
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(2024)
+    let deck = [1, 2, 3, 4, 5]
+    rng.shuffle(deck)
+    for card in deck {
+        print(card)     // some permutation of 1, 2, 3, 4, 5
+    }
+}
+```
+
+## Worked example: a reproducible sampler
+
+A seeded generator makes a test deterministic: pick the same seed and the
+output never drifts between runs.
+
+```raven
+import std/random
+
+fun main() {
+    let rng = Rng.new(7)
+    let words = ["alpha", "beta", "gamma", "delta"]
+
+    // Draw three random words.
+    let i = 0
+    while i < 3 {
+        match rng.choice(words) {
+            Some(w) -> print(w),
+            None -> print("(none)"),
+        }
+        i = i + 1
+    }
+
+    // Shuffle the deck in place and report a coin flip.
+    rng.shuffle(words)
+    for w in words {
+        print(w)
+    }
+    print(rng.next_bool())
+}
+```
+
+Run it twice with the same seed and you get byte-for-byte identical output.
+Change the `7` to `Rng.from_entropy()` and each run differs.
+
+## See also
+
+- [std/math](math.md) for the numeric functions you will often pair with
+  random draws.
+- The [language reference](../language-reference.md) for `Option`, `match`, and
+  generics.

--- a/docs/v2/guide/stdlib/regex.md
+++ b/docs/v2/guide/stdlib/regex.md
@@ -1,0 +1,256 @@
+# std/regex
+
+Regular expressions: compile a pattern once into a reusable handle, then test
+for a match, find the first match or every match, pull out capture groups,
+replace matches, and split on a pattern.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    match compile("[0-9]+") {
+        Ok(re) -> {
+            print(re.is_match("order 42"))      // true
+            re.free()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Importing
+
+```raven
+import std/regex { compile }
+```
+
+`compile` is the entry point. The methods on `Regex` arrive with the type, so
+they need no separate selector.
+
+## Compiling a pattern
+
+A pattern is compiled once into a `Regex` handle, then reused for every match
+operation. Compiling is the only fallible step: an invalid pattern is reported
+here rather than at each match.
+
+### `compile(pattern: String) -> Result<Regex, Error>`
+
+Compile `pattern` into a reusable `Regex`. On success the result is
+`Ok(Regex)`. An invalid pattern is `Err(Error)` from [std/error](error.md),
+tagged with kind `"regex"`, its message the underlying syntax error.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    let result = compile("(")       // unbalanced group
+    match result {
+        Ok(re) -> re.free(),
+        Err(e) -> print(e.message),     // a regex syntax error
+    }
+}
+```
+
+## Freeing a handle
+
+A compiled `Regex` holds a runtime handle that lives outside the garbage
+collector: the runtime keeps the compiled pattern in a process-wide registry
+and hands Raven an opaque id. There is no destructor, so call `free()` when you
+are done with a pattern. Not freeing leaks the registry entry for the life of
+the process.
+
+For a short program with a fixed set of patterns the leak is bounded and
+harmless, but a long-running program that compiles patterns dynamically should
+free each one once it is no longer needed.
+
+### `free(self)`
+
+Release the compiled pattern and drop its registry entry. Do not call any other
+method on the handle afterward.
+
+## Matching
+
+### `is_match(self, text: String) -> Bool`
+
+True when the pattern matches anywhere in `text`.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    match compile("^[a-z]+$") {
+        Ok(re) -> {
+            print(re.is_match("raven"))     // true
+            print(re.is_match("R2D2"))      // false
+            re.free()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+### `find(self, text: String) -> Option<String>`
+
+The first match in `text`, or `None` when there is no match. A matched empty
+string is `Some("")`, distinct from `None`.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    match compile("[0-9]+") {
+        Ok(re) -> {
+            match re.find("room 237, floor 4") {
+                Some(s) -> print(s),        // 237
+                None -> print("no digits"),
+            }
+            re.free()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+### `find_all(self, text: String) -> List<String>`
+
+Every non-overlapping match in `text`, in order. No matches yields an empty
+list.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    match compile("[0-9]+") {
+        Ok(re) -> {
+            for n in re.find_all("a1 b22 c333") {
+                print(n)        // 1, then 22, then 333
+            }
+            re.free()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Capture groups
+
+### `captures(self, text: String) -> List<String>`
+
+The capture groups of the first match: group 0 (the whole match) first, then
+groups 1, 2, and so on. An unmatched optional group is an empty string. No
+match yields an empty list.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    match compile("([0-9]+)-([0-9]+)") {
+        Ok(re) -> {
+            let groups = re.captures("range 10-20 here")
+            print(groups[0])        // 10-20  (whole match)
+            print(groups[1])        // 10
+            print(groups[2])        // 20
+            re.free()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Replacing
+
+### `replace_all(self, text: String, repl: String) -> String`
+
+Replace every non-overlapping match in `text` with `repl`. Group references in
+`repl` are honored: `$1` and `${1}` for numbered groups, `$name` for named
+groups.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    match compile("([a-z]+)@([a-z]+)") {
+        Ok(re) -> {
+            let masked = re.replace_all("ada@host bob@host", "$1@***")
+            print(masked)       // ada@*** bob@***
+            re.free()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Splitting
+
+### `split(self, text: String) -> List<String>`
+
+Split `text` on the pattern, returning the pieces in order.
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    match compile("[, ]+") {     // commas and spaces, run together
+        Ok(re) -> {
+            for part in re.split("a, b,  c   d") {
+                print(part)     // a, b, c, d
+            }
+            re.free()
+        }
+        Err(e) -> print(e.message),
+    }
+}
+```
+
+## Supported syntax
+
+The engine is RE2-style, with linear-time matching and **no** backreferences
+and **no** lookaround (no `\1` inside the pattern, no `(?=...)` or `(?<=...)`).
+The usual constructs are supported: character classes, anchors, quantifiers,
+alternation, groups, named groups, and Unicode classes.
+
+## A note on newlines in results
+
+`find_all`, `captures`, and `split` return their pieces as a `List<String>`.
+Internally the pieces are joined on `\n` to cross the runtime boundary, so a
+matched substring or split piece that itself contains a literal newline reads
+back as two list elements. A pattern that does not match newline content is
+unaffected.
+
+## Worked example: parsing key=value lines
+
+```raven
+import std/regex { compile }
+
+fun main() {
+    let lines = ["host=localhost", "port=8080", "debug=true"]
+
+    // Match the value that follows `=` on each line.
+    match compile("=([a-z0-9]+)") {
+        Ok(re) -> {
+            for line in lines {
+                match re.find(line) {
+                    Some(hit) -> print("${line} -> ${hit}"),    // ... -> =localhost, ...
+                    None -> print("skip: ${line}"),
+                }
+            }
+            re.free()
+        }
+        Err(e) -> print("bad pattern: ${e.message}"),
+    }
+}
+```
+
+Output (`find` returns the whole match, so the `=` is included):
+
+```
+host=localhost -> =localhost
+port=8080 -> =8080
+debug=true -> =true
+```
+
+## See also
+
+- [std/string](string.md) for literal substring search and replace when you do
+  not need a full pattern.
+- [std/error](error.md) for the `Error` type that `compile` returns on failure.

--- a/docs/v2/guide/stdlib/string.md
+++ b/docs/v2/guide/stdlib/string.md
@@ -1,0 +1,219 @@
+# std/string
+
+Methods for working with text. `std/string` adds an `impl String` block, so
+a bare `import std/string` brings every method below into scope as a method
+on any `String` value.
+
+```raven
+import std/string
+
+fun main() {
+    let name = "  Ada Lovelace  "
+    print(name.trim().to_upper())     // ADA LOVELACE
+}
+```
+
+## Importing
+
+```raven
+import std/string
+```
+
+Import the whole module (not a selective `{ ... }` list): the methods are
+merged from an `impl String` block, and the bare import is what merges it.
+
+Two methods are built into the compiler and need **no** import:
+
+| Built in | Meaning |
+|----------|---------|
+| `String.len()` | byte length (alias of `length`) |
+| `String.is_empty()` | `len() == 0` |
+
+Everything else (`concat`, `to_upper`, `substring`, `replace`, ...) comes
+from `import std/string`.
+
+## A note on bytes
+
+Indices, lengths, and slices count **UTF-8 bytes**, not Unicode code points.
+For plain ASCII text a byte is a character, so this rarely matters; for text
+with multi-byte characters, an index addresses one byte of the encoding.
+Case mapping (`to_upper` / `to_lower`) is ASCII only and leaves other bytes
+unchanged.
+
+## Inspecting
+
+### `length(self) -> Int`
+
+The number of UTF-8 bytes in the string. `len` is a built-in alias.
+
+```raven
+import std/string
+
+fun main() {
+    print("raven".length())     // 5
+    print("raven".len())        // 5 (built in, no import needed)
+}
+```
+
+### `is_empty(self) -> Bool`
+
+True when the string has no bytes. Also available built in.
+
+### `is_blank(self) -> Bool`
+
+True when the string is empty or contains only ASCII whitespace (space, tab,
+newline, carriage return, vertical tab, form feed).
+
+```raven
+import std/string
+
+fun main() {
+    print("   \t\n".is_blank())     // true
+    print(" x ".is_blank())         // false
+}
+```
+
+## Slicing
+
+### `char_at(self, i: Int) -> String`
+
+The single byte at index `i`, returned as a one-byte string. An out-of-range
+index yields the empty string. (For multi-byte characters this returns one
+byte of the encoding, not the whole character.)
+
+### `substring(self, start: Int, end: Int) -> String`
+
+The half-open byte range `[start, end)`, clamped to `0..length`. A `start`
+at or past `end` yields the empty string.
+
+```raven
+import std/string
+
+fun main() {
+    print("raven".substring(1, 4))      // ave
+    print("raven".char_at(0))           // r
+}
+```
+
+## Case and whitespace
+
+### `to_upper(self) -> String` and `to_lower(self) -> String`
+
+ASCII case mapping. Bytes `a`-`z` and `A`-`Z` are mapped; every other byte
+is left as is.
+
+### `trim(self) -> String`
+
+Remove leading and trailing ASCII whitespace. Interior whitespace is kept.
+
+```raven
+import std/string
+
+fun main() {
+    print("Hello".to_upper())           // HELLO
+    print("  hi  ".trim())              // hi
+}
+```
+
+### `repeat(self, n: Int) -> String`
+
+The string concatenated `n` times. A non-positive `n` yields the empty
+string.
+
+```raven
+import std/string
+
+fun main() {
+    print("ab".repeat(3))       // ababab
+}
+```
+
+## Searching
+
+### `index_of(self, needle: String) -> Int`
+
+The byte index of the first occurrence of `needle`, or `-1` when it is
+absent. An empty needle matches at `0`.
+
+### `contains(self, needle: String) -> Bool`
+
+True when `needle` occurs anywhere in the string.
+
+### `starts_with(self, prefix: String) -> Bool` and `ends_with(self, suffix: String) -> Bool`
+
+Prefix and suffix tests, compared by bytes.
+
+### `matches_at(self, needle: String, at: Int) -> Bool`
+
+True when the bytes of `needle` occur starting at byte index `at`. The
+building block the other search methods use; handy for hand-written
+scanning.
+
+```raven
+import std/string
+
+fun main() {
+    let path = "report.csv"
+    print(path.ends_with(".csv"))       // true
+    print(path.index_of("."))           // 6
+    print(path.contains("port"))        // true
+}
+```
+
+## Transforming
+
+### `concat(self, other: String) -> String`
+
+Join two strings. String interpolation (`"${a}${b}"`) is usually clearer for
+building up text, but `concat` is the explicit method form.
+
+### `replace(self, from: String, to: String) -> String`
+
+Replace every non-overlapping occurrence of `from` with `to`, scanning left
+to right. An empty `from` returns the input unchanged.
+
+```raven
+import std/string
+
+fun main() {
+    print("a-b-c".replace("-", "+"))        // a+b+c
+    print("one".concat(" ").concat("two"))  // one two
+}
+```
+
+## Comparison and matching
+
+`String` values compare lexicographically by bytes with `<`, `<=`, `>`, and
+`>=`, and they support `==`. A string literal can also be a `match` pattern,
+compared by content:
+
+```raven
+fun classify(word: String) -> Int {
+    return match word {
+        "yes" -> 1,
+        "no" -> 0,
+        _ -> -1,
+    }
+}
+```
+
+## Worked example: a tiny slug builder
+
+```raven
+import std/string
+
+fun slug(title: String) -> String {
+    return title.trim().to_lower().replace(" ", "-")
+}
+
+fun main() {
+    print(slug("  Hello World  "))      // hello-world
+}
+```
+
+## See also
+
+- [std/fmt](fmt.md) for padding, joining, and number formatting.
+- [std/regex](regex.md) for pattern matching beyond literal substrings.
+- The [language reference](../language-reference.md) for string literals,
+  interpolation, and block strings.

--- a/docs/v2/guide/stdlib/sync.md
+++ b/docs/v2/guide/stdlib/sync.md
@@ -1,0 +1,199 @@
+# std/sync
+
+Goroutine-style concurrency primitives: channels for passing values between
+green threads. `std/sync` pairs with the `spawn` keyword, which starts a
+goroutine running a `fun() -> Unit` closure. Goroutines are cooperative green
+threads: exactly one runs at a time, and a goroutine keeps running until it
+hits a yield point (a blocking channel operation or an explicit `yield_now()`),
+at which the scheduler resumes another ready goroutine.
+
+```raven
+import std/sync { channel, channel_buffered, yield_now }
+
+fun main() {
+    let ch = channel()
+    spawn(fun() -> Unit {
+        ch.send(42)
+    })
+    print(ch.recv())        // 42
+}
+```
+
+Channels in this slice carry `Int` values.
+
+## Importing
+
+```raven
+import std/sync { channel, channel_buffered, yield_now }
+```
+
+`channel`, `channel_buffered`, and `yield_now` are free functions, so import
+the ones you use by name. `send` and `recv` are methods on `Channel` and need
+no separate import once you hold a channel value.
+
+The `spawn` keyword is part of the language itself and needs no import. It
+takes a closure of type `fun() -> Unit` and starts it as a goroutine.
+
+## Creating channels
+
+### `channel() -> Channel`
+
+Create an unbuffered (rendezvous) channel. A `send` blocks until a receiver is
+ready to take the value, and a `recv` blocks until a sender hands one over. The
+two sides meet: nothing is stored in between.
+
+```raven
+import std/sync { channel, channel_buffered, yield_now }
+
+fun main() {
+    let ch = channel()
+    spawn(fun() -> Unit {
+        ch.send(7)          // blocks until main receives
+    })
+    print(ch.recv())        // 7
+}
+```
+
+### `channel_buffered(cap: Int) -> Channel`
+
+Create a buffered channel of capacity `cap`. A `send` returns immediately while
+there is room in the buffer, and only blocks once the buffer is full. A `recv`
+takes the oldest buffered value, and blocks only when the buffer is empty.
+
+```raven
+import std/sync { channel, channel_buffered, yield_now }
+
+fun main() {
+    let ch = channel_buffered(2)
+    ch.send(1)              // room: returns at once
+    ch.send(2)              // room: returns at once
+    print(ch.recv())        // 1
+    print(ch.recv())        // 2
+}
+```
+
+## Channel methods
+
+### `send(self, value: Int)`
+
+Send `value`, blocking until the channel can accept it. On an unbuffered
+channel it blocks until a receiver is ready; on a buffered channel it blocks
+only when the buffer is full. When a `send` blocks, the goroutine yields to the
+scheduler so other goroutines can run.
+
+### `recv(self) -> Int`
+
+Receive a value, blocking until one is available. On an empty channel the
+goroutine yields to the scheduler and resumes when a sender delivers a value.
+
+```raven
+import std/sync { channel, channel_buffered, yield_now }
+
+fun main() {
+    let ch = channel()
+    spawn(fun() -> Unit {
+        ch.send(10)
+        ch.send(20)
+    })
+    print(ch.recv())        // 10
+    print(ch.recv())        // 20
+}
+```
+
+## Yielding
+
+### `yield_now()`
+
+Yield control to the scheduler so other ready goroutines can run, then resume
+later. This is the explicit cooperative yield point. You rarely need it when
+your goroutines communicate over channels, since `send` and `recv` already
+yield when they block, but it is useful for handing off in a tight loop that
+otherwise never reaches a blocking operation.
+
+```raven
+import std/sync { channel, channel_buffered, yield_now }
+
+fun main() {
+    spawn(fun() -> Unit {
+        print(1)
+        yield_now()
+        print(3)
+    })
+    print(2)
+}
+```
+
+## Pairing channels with `spawn`
+
+`spawn` starts a goroutine from a `fun() -> Unit` closure. The closure can
+capture channels from the surrounding scope and use them to communicate with
+`main` (which is itself goroutine 0) or with other goroutines.
+
+```raven
+import std/sync { channel, channel_buffered, yield_now }
+
+fun main() {
+    let ch = channel()
+
+    // Producer goroutine: send three values, then a sentinel.
+    spawn(fun() -> Unit {
+        ch.send(100)
+        ch.send(200)
+        ch.send(300)
+        ch.send(-1)
+    })
+
+    // Main consumes until the sentinel.
+    loop {
+        let v = ch.recv()
+        if v == -1 {
+            break
+        }
+        print(v)            // 100, 200, 300
+    }
+}
+```
+
+When `main` returns the program exits, and any goroutines still alive (ready or
+blocked) are abandoned without finishing. If every goroutine ends up blocked
+with none ready, the scheduler reports a deadlock and exits.
+
+## Worked example: a worker over a buffered channel
+
+A buffered channel decouples the producer from the consumer so the producer can
+get ahead while the consumer catches up.
+
+```raven
+import std/sync { channel_buffered, yield_now }
+
+fun main() {
+    let jobs = channel_buffered(4)
+
+    // Worker: read each job and print its square.
+    spawn(fun() -> Unit {
+        loop {
+            let n = jobs.recv()
+            if n == 0 {
+                break
+            }
+            print(n * n)        // 1, 4, 9, 16
+        }
+    })
+
+    // Feed work, then a 0 to signal done.
+    let k = 1
+    while k <= 4 {
+        jobs.send(k)
+        k = k + 1
+    }
+    jobs.send(0)
+
+    // Give the worker a turn to drain the channel before main exits.
+    yield_now()
+}
+```
+
+## See also
+
+- The [language reference](../language-reference.md#concurrency) for `spawn`,
+  goroutines, the cooperative scheduler, and deadlock behavior.

--- a/docs/v2/guide/stdlib/test.md
+++ b/docs/v2/guide/stdlib/test.md
@@ -1,0 +1,182 @@
+# std/test
+
+Assertions for writing test programs in Raven. A test is an ordinary Raven
+program whose `main` calls these assertions: if every assertion holds, the
+program runs to completion and exits zero; if one fails, it panics with a
+message and aborts with a nonzero exit code.
+
+```raven
+import std/test { assert, assert_eq_int }
+import std/io { println }
+
+fun main() {
+    assert(1 + 1 == 2)
+    assert_eq_int(6 * 7, 42)
+    println("all passed")
+}
+```
+
+## Importing
+
+The assertions are free functions, so import the ones you use with a
+selective list:
+
+```raven
+import std/test { assert, assert_msg, assert_true, assert_false, assert_eq_int, assert_eq_str }
+```
+
+## The test model
+
+Raven has no attributes or reflection, so there is no test discovery or
+registration framework. A test is just a normal program. Build and run it:
+exit zero means every assertion held, and a nonzero exit means one failed.
+The panic message naming the failure goes to stderr.
+
+A test runner is whatever invokes the compiled program and checks its exit
+code (a shell loop, a CI step, or `rvpm run`). Because a failing assertion
+aborts the whole process, the first failure stops the program; assertions
+after it do not run.
+
+## Assertions
+
+Each assertion checks a condition and, when it does not hold, panics with a
+fixed message and exits nonzero.
+
+### `assert(cond: Bool)`
+
+Fails when `cond` is false. Panic message: `assertion failed`.
+
+```raven
+import std/test { assert }
+
+fun main() {
+    assert(2 > 1)
+    assert("raven".len() == 5)
+}
+```
+
+### `assert_msg(cond: Bool, msg: String)`
+
+Fails when `cond` is false, panicking with the caller-supplied `msg`. Use
+this when you want the failure to explain itself.
+
+```raven
+import std/test { assert_msg }
+
+fun main() {
+    let n = 7
+    assert_msg(n % 2 == 1, "n should be odd")
+}
+```
+
+### `assert_true(cond: Bool)`
+
+Fails when `cond` is false. Panic message: `assertion failed: expected true`.
+
+### `assert_false(cond: Bool)`
+
+Fails when `cond` is true. Panic message: `assertion failed: expected false`.
+
+```raven
+import std/test { assert_true, assert_false }
+import std/string
+
+fun main() {
+    assert_true("report.csv".ends_with(".csv"))
+    assert_false("report.csv".ends_with(".txt"))
+}
+```
+
+### `assert_eq_int(a: Int, b: Int)`
+
+Fails when `a != b`. The panic message interpolates both operands
+(`assertion failed: ${a} != ${b}`), so a failure shows the mismatched
+values.
+
+```raven
+import std/test { assert_eq_int }
+
+fun double(x: Int) -> Int {
+    return x * 2
+}
+
+fun main() {
+    assert_eq_int(double(21), 42)
+}
+```
+
+### `assert_eq_str(a: String, b: String)`
+
+Fails when `a != b`, compared by content. The panic message interpolates
+both operands (`assertion failed: ${a} != ${b}`).
+
+```raven
+import std/test { assert_eq_str }
+import std/string
+
+fun main() {
+    assert_eq_str("Hello".to_upper(), "HELLO")
+}
+```
+
+## Worked example: a test program
+
+A test file is a regular `.rv` program with a `main` that asserts. The
+program below exercises a couple of helpers and exits zero only if every
+check passes:
+
+```raven
+import std/test { assert, assert_eq_int, assert_eq_str }
+import std/string
+import std/io { println }
+
+fun add(a: Int, b: Int) -> Int {
+    return a + b
+}
+
+fun shout(s: String) -> String {
+    return s.trim().to_upper()
+}
+
+fun main() {
+    assert_eq_int(add(2, 3), 5)
+    assert_eq_int(add(-1, 1), 0)
+    assert(add(10, 10) > 15)
+
+    assert_eq_str(shout("  hi  "), "HI")
+    assert_eq_str(shout("raven"), "RAVEN")
+
+    println("all tests passed")
+}
+```
+
+Run it directly:
+
+```
+raven run tests/math_test.rv
+```
+
+If `shout("raven")` ever returned the wrong value, the program would print
+the interpolated mismatch to stderr and exit nonzero instead of printing
+`all tests passed`.
+
+## Running tests in a project
+
+A test is a normal Raven program, so you run it the same way you run any
+other:
+
+- `raven run path/to/test.rv` compiles and runs a single test file.
+- `raven build path/to/test.rv` compiles it to a binary you can invoke
+  later (handy for CI, where the exit code is the pass/fail signal).
+- Inside an `rvpm` project, point `main.rv` (or a dedicated entry) at your
+  assertions and use `rvpm run`. See the
+  [rvpm guide](../rvpm.md) for project layout and how `rvpm run` builds and
+  executes the package entry.
+
+To run several test files, drive them from a shell loop or CI step and check
+each exit code; the first nonzero exit marks a failure.
+
+## See also
+
+- [rvpm guide](../rvpm.md) for project structure and running a package.
+- [std/string](string.md) for the string methods used in the examples above.

--- a/docs/v2/guide/stdlib/time.md
+++ b/docs/v2/guide/stdlib/time.md
@@ -1,0 +1,199 @@
+# std/time
+
+Date and time over the raven-runtime C ABI, backed by `chrono`. Every value
+is UTC, and there is no local-timezone handling. Timestamps are Unix time:
+whole seconds, except `now_millis`, which is milliseconds. The functions are
+brought into scope with a selective import.
+
+```raven
+import std/time { now, format_timestamp }
+
+fun main() {
+    print(format_timestamp(now(), "%Y-%m-%d"))      // today's UTC date
+}
+```
+
+## Importing
+
+Pull in the functions you use with a selective `{ ... }` list:
+
+```raven
+import std/time { now, now_millis, from_timestamp, weekday, format_timestamp, parse_timestamp, sleep_millis }
+```
+
+## Timestamp unit
+
+A timestamp is an `Int` holding Unix time in UTC. Everywhere except
+`now_millis` the unit is **whole seconds** since 1970-01-01 00:00:00 UTC.
+`from_timestamp`, `weekday`, `format_timestamp`, and the value returned by
+`parse_timestamp` all use seconds. `now_millis` returns **milliseconds**, and
+`sleep_millis` takes a duration in **milliseconds**; divide a millisecond
+value by 1000 before passing it to the seconds-based functions.
+
+## Datetime structs
+
+`from_timestamp` returns a `DateTime`, which nests a `Date` and a `Time`:
+
+```raven
+struct Date { year: Int, month: Int, day: Int }
+struct Time { hour: Int, minute: Int, second: Int }
+struct DateTime { date: Date, time: Time }
+```
+
+`month` is 1 through 12, `day` is 1 through 31, `hour` is 0 through 23, and
+`minute` and `second` are 0 through 59.
+
+Each struct has a `ToString` impl producing ISO-like text. A `Date` renders
+as `1970-01-01` (year zero-padded to four digits, month and day to two), a
+`Time` as `00:00:00`, and a `DateTime` as the two joined by a space,
+`1970-01-01 00:00:00`.
+
+```raven
+import std/time { from_timestamp }
+
+fun main() {
+    let dt = from_timestamp(0)
+    print(dt.to_string())           // 1970-01-01 00:00:00
+    print(dt.date.year)             // 1970
+    print(dt.time.hour)             // 0
+}
+```
+
+## Current time
+
+### `now() -> Int`
+
+The current Unix timestamp in whole seconds (UTC).
+
+### `now_millis() -> Int`
+
+The current Unix time in milliseconds (UTC).
+
+```raven
+import std/time { now, now_millis }
+
+fun main() {
+    let secs = now()
+    let millis = now_millis()
+    print(millis / 1000 - secs)     // 0 (same instant, different units)
+}
+```
+
+## Decomposition
+
+### `from_timestamp(ts: Int) -> DateTime`
+
+Decompose a Unix timestamp (seconds, UTC) into a `DateTime`. A timestamp
+outside chrono's representable range falls back to the epoch.
+
+### `weekday(ts: Int) -> Int`
+
+The weekday of `ts` (UTC) as `0` for Sunday through `6` for Saturday.
+
+```raven
+import std/time { from_timestamp, weekday }
+
+fun main() {
+    let dt = from_timestamp(1700000000)
+    print(dt.to_string())           // 2023-11-14 22:13:20
+    print(weekday(1700000000))      // 2 (Tuesday)
+}
+```
+
+## Formatting and parsing
+
+`pattern` is a chrono strftime pattern. Common tokens:
+
+| Token | Meaning |
+|-------|---------|
+| `%Y`  | year, four digits |
+| `%m`  | month, `01` through `12` |
+| `%d`  | day of month, `01` through `31` |
+| `%H`  | hour, `00` through `23` |
+| `%M`  | minute, `00` through `59` |
+| `%S`  | second, `00` through `59` |
+
+### `format_timestamp(ts: Int, pattern: String) -> String`
+
+Render the UTC datetime of `ts` with the given chrono strftime pattern, for
+example `"%Y-%m-%d %H:%M:%S"`.
+
+```raven
+import std/time { format_timestamp }
+
+fun main() {
+    print(format_timestamp(1700000000, "%Y-%m-%d %H:%M:%S"))    // 2023-11-14 22:13:20
+    print(format_timestamp(1700000000, "%Y/%m/%d"))             // 2023/11/14
+}
+```
+
+### `parse_timestamp(text: String, pattern: String) -> Result<Int, Error>`
+
+Parse `text` as a UTC datetime by the given pattern and return the Unix
+timestamp in seconds. Parsing is fallible: on failure it returns an `Err`
+holding a `std/error` `Error` tagged with kind `"time"`. Handle the `Result`
+with a `match` or the `?` operator.
+
+```raven
+import std/time { parse_timestamp }
+
+fun main() {
+    let parsed = parse_timestamp("2023-11-14 22:13:20", "%Y-%m-%d %H:%M:%S")
+    match parsed {
+        Ok(ts) -> print(ts),                    // 1700000000
+        Err(e) -> print(e.to_string()),
+    }
+
+    let bad = parse_timestamp("not a date", "%Y-%m-%d")
+    match bad {
+        Ok(ts) -> print(ts),
+        Err(e) -> print(e.kind()),              // time
+    }
+}
+```
+
+## Sleep
+
+### `sleep_millis(ms: Int)`
+
+Sleep the current thread for `ms` milliseconds. A negative value is treated
+as zero.
+
+```raven
+import std/time { sleep_millis }
+
+fun main() {
+    sleep_millis(100)       // pause for 100 ms
+}
+```
+
+## Worked example: a formatted timestamp round trip
+
+Format the current time, then parse the formatted text back to a timestamp:
+
+```raven
+import std/time { now, format_timestamp, parse_timestamp, from_timestamp, weekday }
+
+fun main() {
+    let ts = now()
+    let pattern = "%Y-%m-%d %H:%M:%S"
+    let text = format_timestamp(ts, pattern)
+    print(text)                             // for example 2026-06-05 09:41:00
+
+    let dt = from_timestamp(ts)
+    print(dt.date.year)                     // 2026
+    print(weekday(ts))                      // 0 (Sunday) through 6 (Saturday)
+
+    match parse_timestamp(text, pattern) {
+        Ok(round_tripped) -> print(round_tripped == ts),   // true
+        Err(e) -> print(e.to_string()),
+    }
+}
+```
+
+## See also
+
+- [std/error](error.md) for the `Error` type that `parse_timestamp` returns,
+  plus helpers like `is_ok`, `unwrap_or`, and `with_context`.
+- [std/string](string.md) for building and inspecting the text you format and
+  parse.

--- a/docs/v2/guide/tutorials/task-tracker.md
+++ b/docs/v2/guide/tutorials/task-tracker.md
@@ -1,0 +1,227 @@
+# Tutorial: modeling data with structs and enums
+
+This tutorial builds a small in-memory task tracker. It is a tour of Raven's
+type system: structs to group data, enums (sum types) to model a value that is
+one of several shapes, methods with `impl`, exhaustive `match`, and `Option`
+for a lookup that might find nothing. Every step compiles and runs.
+
+If you are new to the language, skim the
+[language reference](../language-reference.md) for syntax as you go.
+
+## Step 1: a struct for a task
+
+A struct groups related fields under one type. A task has an id and a title:
+
+```raven
+struct Task {
+    id: Int,
+    title: String,
+}
+
+fun main() {
+    let t = Task { id: 1, title: "write docs" }
+    print("#${t.id} ${t.title}")        // #1 write docs
+}
+```
+
+You build a struct value with `Type { field: value, ... }` and read a field
+with `value.field`. Types are checked: leaving out a field or giving one the
+wrong type is a compile error, not a surprise at runtime.
+
+## Step 2: a status that is one of several
+
+A task has a status, and a status is exactly one of a fixed set: to do, doing,
+or done. That is a sum type, written as an `enum`. Add it and a field for it:
+
+```raven
+enum Status {
+    Todo,
+    Doing,
+    Done,
+}
+
+struct Task {
+    id: Int,
+    title: String,
+    status: Status,
+}
+
+fun main() {
+    let t = Task { id: 1, title: "write docs", status: Status.Doing }
+    print(t.title)
+}
+```
+
+You construct a variant with the qualified form `Status.Doing`. To turn a
+status into text, use `match`, which checks that you handle every variant:
+
+```raven
+fun label(s: Status) -> String {
+    return match s {
+        Todo -> "todo",
+        Doing -> "doing",
+        Done -> "done",
+    }
+}
+```
+
+In a `match` pattern the variants are written bare (`Todo`, not
+`Status.Todo`). If you add a fourth variant later and forget to handle it
+here, the compiler rejects the program until you do. That is exhaustiveness
+checking, and it is one of the main reasons to reach for an enum.
+
+## Step 3: a variant that carries data
+
+Some statuses need more than a name. A blocked task should say what it is
+waiting on. A variant can carry a payload, so give `Blocked` a `String`:
+
+```raven
+enum Status {
+    Todo,
+    Doing,
+    Done,
+    Blocked(String),
+}
+```
+
+Now a `match` arm for `Blocked` binds the payload to a name you can use:
+
+```raven
+fun label(s: Status) -> String {
+    return match s {
+        Todo -> "todo",
+        Doing -> "doing",
+        Done -> "done",
+        Blocked(reason) -> "blocked: ${reason}",
+    }
+}
+```
+
+Construct it with the payload: `Status.Blocked("waiting on review")`. The
+payload travels with the value, and the only way to read it is to `match`,
+which forces you to consider the blocked case wherever a status is inspected.
+
+## Step 4: behavior with `impl`
+
+Functions that belong to a type live in an `impl` block and take `self`. Move
+the formatting onto `Task` as a method:
+
+```raven
+impl Task {
+    fun line(self) -> String {
+        let tag = match self.status {
+            Todo -> "todo",
+            Doing -> "doing",
+            Done -> "done",
+            Blocked(reason) -> "blocked: ${reason}",
+        }
+        return "#${self.id} [${tag}] ${self.title}"
+    }
+}
+```
+
+You call it as `t.line()`. Methods keep the data and the operations on it
+together, and `self` gives access to every field.
+
+## Step 5: look something up with `Option`
+
+Searching a list might find nothing, and Raven has no `null` to return in that
+case. The answer is `Option<T>`: `Some(value)` when there is a result, `None`
+when there is not. A lookup by id:
+
+```raven
+fun find(tasks: List<Task>, id: Int) -> Option<Task> {
+    for t in tasks {
+        if t.id == id {
+            return Some(t)
+        }
+    }
+    return None
+}
+```
+
+The caller `match`es on the result and cannot forget the missing case:
+
+```raven
+match find(tasks, 2) {
+    Some(t) -> print("found: ${t.title}"),
+    None -> print("not found"),
+}
+```
+
+## The whole program
+
+Putting it together:
+
+```raven
+enum Status {
+    Todo,
+    Doing,
+    Done,
+    Blocked(String),
+}
+
+struct Task {
+    id: Int,
+    title: String,
+    status: Status,
+}
+
+impl Task {
+    fun line(self) -> String {
+        let tag = match self.status {
+            Todo -> "todo",
+            Doing -> "doing",
+            Done -> "done",
+            Blocked(reason) -> "blocked: ${reason}",
+        }
+        return "#${self.id} [${tag}] ${self.title}"
+    }
+}
+
+fun find(tasks: List<Task>, id: Int) -> Option<Task> {
+    for t in tasks {
+        if t.id == id {
+            return Some(t)
+        }
+    }
+    return None
+}
+
+fun main() {
+    let tasks: List<Task> = [
+        Task { id: 1, title: "write docs", status: Status.Doing },
+        Task { id: 2, title: "ship release", status: Status.Blocked("waiting on review") },
+        Task { id: 3, title: "fix bug", status: Status.Done },
+    ]
+
+    for t in tasks {
+        print(t.line())
+    }
+
+    match find(tasks, 2) {
+        Some(t) -> print("found: ${t.title}"),
+        None -> print("not found"),
+    }
+}
+```
+
+Output:
+
+```
+#1 [doing] write docs
+#2 [blocked: waiting on review] ship release
+#3 [done] fix bug
+found: ship release
+```
+
+## Where to go next
+
+- Count how many tasks are in each status with a `Map<String, Int>` from
+  [std/collections](../stdlib/collections.md), keyed by `label(t.status)`.
+- Filter to just the blocked tasks and print their reasons.
+- Persist the list as JSON with [std/json](../stdlib/json.md), or derive
+  serialization with `@derive(ToJson)` (see the language reference).
+
+See the [word-frequency tutorial](word-frequency.md) for a program that reads
+input and uses regular expressions.

--- a/docs/v2/guide/tutorials/word-frequency.md
+++ b/docs/v2/guide/tutorials/word-frequency.md
@@ -1,0 +1,259 @@
+# Tutorial: a word-frequency counter
+
+This tutorial builds a small program that counts how often each word appears
+in a piece of text and prints the words from most to least common. Along the
+way you will use regular expressions, a hash map, structs, and a custom sort.
+Every step compiles and runs, so you can follow along and check your output.
+
+If you have not yet, read [Getting started](../getting-started.md) to install
+the compiler and learn `raven build`.
+
+## Step 1: print some text
+
+Start with the smallest thing that runs. Create `wordfreq.rv`:
+
+```raven
+fun main() {
+    let text = "the cat sat on the mat the cat ran"
+    print(text)
+}
+```
+
+```bash
+raven build wordfreq.rv -o wordfreq
+./wordfreq
+```
+
+You should see the line printed back. Now make it do something useful.
+
+## Step 2: pull out the words
+
+Text is made of words separated by spaces and punctuation. A regular
+expression is the cleanest way to extract just the word-like runs. The
+pattern `[a-z]+` matches one or more lowercase letters, and `find_all`
+returns every match as a `List<String>`.
+
+```raven
+import std/regex { compile }
+import std/string
+
+fun main() {
+    let text = "the cat sat on the mat the cat ran"
+
+    match compile("[a-z]+") {
+        Ok(re) -> {
+            for word in re.find_all(text.to_lower()) {
+                print(word)
+            }
+            re.free()
+        }
+        Err(e) -> print("bad pattern"),
+    }
+}
+```
+
+A few things to notice:
+
+- `compile` returns a `Result<Regex, Error>`, so you `match` on it. A valid
+  pattern gives `Ok(re)`; a malformed one gives `Err(e)`.
+- `text.to_lower()` (from [std/string](../stdlib/string.md)) folds the text to
+  lowercase first, so `The` and `the` count as the same word.
+- A compiled regex holds a runtime handle outside the garbage collector, so
+  you call `re.free()` when you are done with it. See
+  [std/regex](../stdlib/regex.md).
+
+Running this prints each word on its own line.
+
+## Step 3: count with a map
+
+To count, keep a `Map<String, Int>` from each word to how many times you have
+seen it. For each word, look it up: if it is already there, store one more;
+if not, start it at one. [std/collections](../stdlib/collections.md) provides
+the map.
+
+```raven
+import std/regex { compile }
+import std/collections
+import std/string
+
+fun tally(text: String) -> Map<String, Int> {
+    let counts: Map<String, Int> = Map.new()
+    match compile("[a-z]+") {
+        Ok(re) -> {
+            for word in re.find_all(text.to_lower()) {
+                match counts.get(word) {
+                    Some(n) -> counts.set(word, n + 1),
+                    None -> counts.set(word, 1),
+                }
+            }
+            re.free()
+        }
+        Err(e) -> print("bad pattern"),
+    }
+    return counts
+}
+
+fun main() {
+    let counts = tally("the cat sat on the mat the cat ran")
+    for key in counts.keys() {
+        match counts.get(key) {
+            Some(n) -> print("${key}: ${n}"),
+            None -> {},
+        }
+    }
+}
+```
+
+The annotation `let counts: Map<String, Int> = Map.new()` tells the compiler
+the key and value types, since an empty map has nothing to infer them from.
+`counts.get(word)` returns an `Option<Int>`: `Some(n)` when the word is
+present, `None` when it is not. That is how the language models "might be
+absent" without a `null`.
+
+This prints each word and its count, but in no particular order.
+
+## Step 4: rank by frequency
+
+To print the words from most to least common, gather the entries into a list
+and sort it. A `Map` does not order its keys, so build a list of pairs first.
+Model a pair as a small struct, then sort with a comparator from
+[std/cmp](../stdlib/cmp.md):
+
+```raven
+import std/regex { compile }
+import std/collections
+import std/string
+import std/cmp { sorted_by }
+
+struct WordCount {
+    word: String,
+    count: Int,
+}
+
+fun tally(text: String) -> Map<String, Int> {
+    let counts: Map<String, Int> = Map.new()
+    match compile("[a-z]+") {
+        Ok(re) -> {
+            for word in re.find_all(text.to_lower()) {
+                match counts.get(word) {
+                    Some(n) -> counts.set(word, n + 1),
+                    None -> counts.set(word, 1),
+                }
+            }
+            re.free()
+        }
+        Err(e) -> print("bad pattern"),
+    }
+    return counts
+}
+
+fun ranked(counts: Map<String, Int>) -> List<WordCount> {
+    let pairs: List<WordCount> = []
+    for key in counts.keys() {
+        match counts.get(key) {
+            Some(n) -> pairs.push(WordCount { word: key, count: n }),
+            None -> {},
+        }
+    }
+    // A comparator returns a negative number when `a` should come first. Using
+    // `b.count - a.count` orders by count, highest first.
+    return sorted_by(pairs, fun(a: WordCount, b: WordCount) -> Int = b.count - a.count)
+}
+
+fun main() {
+    let counts = tally("the cat sat on the mat the cat ran")
+    for wc in ranked(counts) {
+        print("${wc.word}: ${wc.count}")
+    }
+}
+```
+
+Output:
+
+```
+the: 3
+cat: 2
+mat: 1
+sat: 1
+on: 1
+ran: 1
+```
+
+`sorted_by` takes the list and a comparator closure. The comparator returns an
+`Int`: negative when the first argument should sort before the second, zero
+when they tie, positive otherwise. `b.count - a.count` produces a negative
+number when `b` has fewer occurrences than `a`, which puts the larger count
+first.
+
+## Step 5: read from a file
+
+The hardcoded string was handy for testing. To count a real file, read it
+with [std/fs](../stdlib/fs.md) and feed its contents to `tally`. `read`
+returns `Result<String, Error>`, so a missing file is handled the same way a
+bad regex was: with a `match`. Here is the complete program, reading from
+`input.txt`:
+
+```raven
+import std/fs { read }
+import std/regex { compile }
+import std/collections
+import std/string
+import std/cmp { sorted_by }
+
+struct WordCount {
+    word: String,
+    count: Int,
+}
+
+fun tally(text: String) -> Map<String, Int> {
+    let counts: Map<String, Int> = Map.new()
+    match compile("[a-z]+") {
+        Ok(re) -> {
+            for word in re.find_all(text.to_lower()) {
+                match counts.get(word) {
+                    Some(n) -> counts.set(word, n + 1),
+                    None -> counts.set(word, 1),
+                }
+            }
+            re.free()
+        }
+        Err(e) -> print("bad pattern"),
+    }
+    return counts
+}
+
+fun ranked(counts: Map<String, Int>) -> List<WordCount> {
+    let pairs: List<WordCount> = []
+    for key in counts.keys() {
+        match counts.get(key) {
+            Some(n) -> pairs.push(WordCount { word: key, count: n }),
+            None -> {},
+        }
+    }
+    return sorted_by(pairs, fun(a: WordCount, b: WordCount) -> Int = b.count - a.count)
+}
+
+fun main() {
+    match read("input.txt") {
+        Ok(text) -> {
+            for wc in ranked(tally(text)) {
+                print("${wc.word}: ${wc.count}")
+            }
+        }
+        Err(e) -> print("could not read input.txt"),
+    }
+}
+```
+
+## Where to go next
+
+- Limit the output to the top ten words by stopping the loop after ten
+  iterations.
+- Skip common stop words ("the", "on", "a") by checking each word against a
+  `Set<String>` from [std/collections](../stdlib/collections.md) before
+  counting it.
+- Read the filename from the command line with
+  [std/env](../stdlib/env.md)'s `args()` instead of hardcoding `input.txt`.
+
+See the [Modeling data tutorial](task-tracker.md) next for a deeper look at
+structs, enums, and pattern matching.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,41 @@ nav:
   - Home: index.md
   - Getting Started: v2/guide/getting-started.md
   - Language Reference: v2/guide/language-reference.md
-  - Standard Library: v2/guide/standard-library.md
+  - Tutorials:
+    - Word-frequency counter: v2/guide/tutorials/word-frequency.md
+    - Modeling data with structs and enums: v2/guide/tutorials/task-tracker.md
+  - Standard Library:
+    - Overview: v2/guide/standard-library.md
+    - Core traits: v2/guide/stdlib/core.md
+    - Text and formatting:
+      - std/string: v2/guide/stdlib/string.md
+      - std/fmt: v2/guide/stdlib/fmt.md
+      - std/regex: v2/guide/stdlib/regex.md
+      - std/encoding: v2/guide/stdlib/encoding.md
+    - Data structures and iteration:
+      - std/collections: v2/guide/stdlib/collections.md
+      - std/iter: v2/guide/stdlib/iter.md
+      - std/cmp: v2/guide/stdlib/cmp.md
+      - std/hash: v2/guide/stdlib/hash.md
+    - Numbers:
+      - std/math: v2/guide/stdlib/math.md
+      - std/random: v2/guide/stdlib/random.md
+    - Input, output, and the system:
+      - std/io: v2/guide/stdlib/io.md
+      - std/fs: v2/guide/stdlib/fs.md
+      - std/path: v2/guide/stdlib/path.md
+      - std/env: v2/guide/stdlib/env.md
+      - std/process: v2/guide/stdlib/process.md
+      - std/time: v2/guide/stdlib/time.md
+    - Networking:
+      - std/net: v2/guide/stdlib/net.md
+      - std/http: v2/guide/stdlib/http.md
+      - std/json: v2/guide/stdlib/json.md
+    - Concurrency, errors, FFI, testing:
+      - std/sync: v2/guide/stdlib/sync.md
+      - std/error: v2/guide/stdlib/error.md
+      - std/ffi: v2/guide/stdlib/ffi.md
+      - std/test: v2/guide/stdlib/test.md
   - rvpm: v2/guide/rvpm.md
   - Migrate from v1: v2/migration.md
   - v1 docs:


### PR DESCRIPTION
## Summary

Makes the v2 docs developer-friendly, with detailed standard library coverage and tutorials.

**Standard library, one page per module.** The stdlib was a single thin page (one short section per module). It is now a reference page for each of the 24 bundled modules: `core`, `string`, `fmt`, `regex`, `encoding`, `collections`, `iter`, `cmp`, `hash`, `math`, `random`, `io`, `fs`, `path`, `env`, `process`, `time`, `net`, `http`, `json`, `sync`, `error`, `ffi`, `test`. Each page explains the module's purpose, the correct import form, every function and method with its exact signature, and short worked examples, ending in a complete worked program and cross-links to related modules. The landing page becomes a concise overview of how imports work, the `Result`/`Option` convention, and a categorized index.

**Two end-to-end tutorials.**
- *Word-frequency counter*: reads a file, tokenizes with a regex, counts with a `Map`, ranks with a custom comparator. Built up step by step.
- *Modeling data with structs and enums*: a task tracker covering structs, enums with payloads, `impl` methods, exhaustive `match`, and `Option`.

**Accuracy.** Every Raven code block that is a full program (about 200 of them across the new pages plus the tutorials) was compiled and run with the current toolchain. Several agent-drafted examples were corrected against real behavior: `String` has no `split` method, method chains stay on one line, an empty `Map`/`Set` needs a type annotation, and printing a list iterates its elements. The language-reference examples were also compile-checked.

**Navigation.** The new pages are wired into `mkdocs.yml` under a Tutorials section and a categorized Standard Library section. `mkdocs build` is clean (the one pre-existing `README.md`/`index.md` warning is unrelated).

## Notes

Docs-only change. The `docs.yml` workflow rebuilds the site on merge. No source or test changes.
