### PR TITLE
docs: use rust code fences for syntax highlighting

### DIFF
--- a/docs/PRODUCTION_ROADMAP.md
+++ b/docs/PRODUCTION_ROADMAP.md
@@ -55,7 +55,7 @@ Help: Add ';' at the end of the statement
 ### 1.2 Operator Precedence & Associativity ⭐⭐⭐⭐⭐ (CRITICAL)
 
 **Current Problem**: Left-to-right parsing, no precedence
-```raven
+```rust
 let x = 2 + 3 * 4;  // Currently: (2 + 3) * 4 = 20
                      // Should be: 2 + (3 * 4) = 14
 ```
@@ -94,7 +94,7 @@ let x = 2 + 3 * 4;  // Currently: (2 + 3) * 4 = 20
 **Current Problem**: All variables are global
 
 **Need**: Block-level scoping
-```raven
+```rust
 let x: int = 10;
 if (true) {
     let x: int = 20;  // Different x, shadows outer
@@ -123,7 +123,7 @@ print(x);  // 10
 **Current Problem**: Functions can be declared but NOT called!
 
 **Need**: Function call expressions
-```raven
+```rust
 fun add(a: int, b: int) -> int {
     return a + b;
 }
@@ -154,7 +154,7 @@ print(result);
 **Status**: Core array support is implemented in the reference interpreter (1D and multi-dimensional types, literals, indexing, assignment, `len()`, and common array methods).
 
 **Need** (historical sketch; syntax below is illustrative):
-```raven
+```rust
 let numbers: int[] = [1, 2, 3, 4, 5];
 print(numbers[0]);  // 1
 
@@ -181,7 +181,7 @@ let length: int = len(numbers);  // 5
 ### 1.6 string Operations ⭐⭐⭐☆☆ (MEDIUM PRIORITY)
 
 **Need**: string manipulation
-```raven
+```rust
 let name: string = "Raven";
 let len: int = len(name);  // 5
 
@@ -206,7 +206,7 @@ let upper: string = uppercase(name);  // "RAVEN"
 **Need**: Infrastructure for built-in functions
 
 **Core Built-ins Needed**:
-```raven
+```rust
 // Type conversion
 int(value)
 float(value)
@@ -254,7 +254,7 @@ split(s: string, delim: string) -> [string]
 ### 2.2 Module System ⭐⭐⭐⭐☆ (HIGH PRIORITY)
 
 **Need**: Import/export mechanism
-```raven
+```rust
 // math.rv
 fun add(a: int, b: int) -> int {
     return a + b;
@@ -284,7 +284,7 @@ let result: int = math.add(5, 10);
 ### 2.3 Standard Library Modules
 
 #### 2.3.1 `io` Module
-```raven
+```rust
 import io;
 
 let content: string = io.read_file("data.txt");
@@ -302,7 +302,7 @@ let line: string = io.read_line();
 ---
 
 #### 2.3.2 `math` Module
-```raven
+```rust
 import math;
 
 let pi: float = math.pi;
@@ -322,7 +322,7 @@ let rounded: int = math.round(3.7);
 ---
 
 #### 2.3.3 `string` Module
-```raven
+```rust
 import str from "str";
 
 let upper: string = string.uppercase("hello");
@@ -339,7 +339,7 @@ let joined: string = string.join(parts, "-");
 ---
 
 #### 2.3.4 `collections` Module (Advanced)
-```raven
+```rust
 import collections;
 
 let map: Map<string, int> = collections.new_map();
@@ -355,7 +355,7 @@ set.add(5);
 ## 📋 PHASE 3: Advanced Features
 
 ### 3.1 Structs & Methods ⭐⭐⭐⭐☆
-```raven
+```rust
 struct Person {
     name: string;
     age: int;
@@ -372,7 +372,7 @@ p.greet();
 ---
 
 ### 3.2 Enums ⭐⭐⭐☆☆
-```raven
+```rust
 enum Color {
     Red,
     Green,
@@ -385,7 +385,7 @@ let c: Color = Color.Red;
 ---
 
 ### 3.3 Pattern Matching ⭐⭐⭐☆☆
-```raven
+```rust
 match value {
     0 => print("zero"),
     1 => print("one"),
@@ -396,7 +396,7 @@ match value {
 ---
 
 ### 3.4 Error Handling ⭐⭐⭐⭐☆
-```raven
+```rust
 enum Result<T, E> {
     Ok(T),
     Err(E)

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ docs/
 Use triple backticks with language specification:
 
 ````markdown
-```raven
+```rust
 fun main() -> void {
     print("Hello, Raven!");
 }

--- a/docs/STDLIB_SPEC.md
+++ b/docs/STDLIB_SPEC.md
@@ -36,7 +36,7 @@ raven/
 ## Core Built-ins (No Import Required)
 
 ### Type Conversion
-```raven
+```rust
 // Integer conversions
 fun int(value: any) -> int;
 fun float(value: any) -> float;
@@ -51,7 +51,7 @@ let b: bool = bool(1);          // Int to bool (0=false, else=true)
 ```
 
 ### I/O Functions
-```raven
+```rust
 // Print without newline
 fun print(value: any) -> void;
 
@@ -68,7 +68,7 @@ let name: string = input("Enter name: ");
 ```
 
 ### Collection Functions
-```raven
+```rust
 // Get length of string or array
 fun len(collection: any) -> int;
 
@@ -78,7 +78,7 @@ let count: int = len([1, 2, 3]);  // 3
 ```
 
 ### Utility Functions
-```raven
+```rust
 // Type checking
 fun type_of(value: any) -> string;
 
@@ -92,7 +92,7 @@ let t: string = type_of(42);  // "int"
 
 ### File Operations
 
-```raven
+```rust
 import io;
 
 // Read entire file to string
@@ -124,7 +124,7 @@ if (io.file_exists("config.txt")) {
 
 ### Console Operations
 
-```raven
+```rust
 import io;
 
 // Read single line from console
@@ -147,7 +147,7 @@ let name: string = io.read_line();
 
 ### Constants
 
-```raven
+```rust
 import math;
 
 let pi: float = math.PI;       // 3.14159265359
@@ -157,7 +157,7 @@ let tau: float = math.TAU;      // 6.28318530718
 
 ### Basic Math
 
-```raven
+```rust
 import math;
 
 // Absolute value
@@ -190,7 +190,7 @@ let rounded: int = math.round(3.7);        // 4
 
 ### Trigonometry
 
-```raven
+```rust
 import math;
 
 fun math.sin(radians: float) -> float;
@@ -212,7 +212,7 @@ let angle: float = math.to_radians(90.0);   // 1.57...
 
 ### Random Numbers (Future)
 
-```raven
+```rust
 import math;
 
 fun math.random() -> float;  // Random float [0.0, 1.0)
@@ -225,7 +225,7 @@ fun math.random_int(min: int, max: int) -> int;
 
 ### Transformation
 
-```raven
+```rust
 import str from "str";
 
 // Case conversion
@@ -249,7 +249,7 @@ let rev: string = str.reverse("abc");        // "cba"
 
 ### Searching & Testing
 
-```raven
+```rust
 import str from "str";
 
 // Check if string contains substring
@@ -270,7 +270,7 @@ let idx: int = str.index_of("hello", "ll");                  // 2
 
 ### Splitting & Joining
 
-```raven
+```rust
 import str from "str";
 
 // Split string by delimiter
@@ -290,7 +290,7 @@ let replaced: string = str.replace("hello", "l", "r");  // "herro"
 
 ### Character Operations
 
-```raven
+```rust
 import str from "str";
 
 // Get character at index
@@ -312,7 +312,7 @@ let letter: string = str.from_char_code(65);  // "A"
 
 ## `array` Module (Extended Array Functions)
 
-```raven
+```rust
 import array;
 
 // Add element to end
@@ -350,7 +350,7 @@ array.reverse(nums);           // [3, 2, 1]
 
 ## `time` Module (Future)
 
-```raven
+```rust
 import time;
 
 // Get current timestamp
@@ -372,7 +372,7 @@ let formatted: string = time.format(now, "YYYY-MM-DD");
 
 ## `json` Module (Future)
 
-```raven
+```rust
 import json;
 
 // Parse JSON string
@@ -390,7 +390,7 @@ let json_str: string = json.stringify(data);
 
 ## `http` Module (Future)
 
-```raven
+```rust
 import http;
 
 // Make HTTP GET request
@@ -461,7 +461,7 @@ raven/
 
 ## Example Usage
 
-```raven
+```rust
 // Math operations
 import math;
 

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -6,7 +6,7 @@ These examples demonstrate the fundamental features of Raven programming languag
 
 The classic first program:
 
-```raven
+```rust
 fun main() -> void {
     print("Hello, World!");
 }
@@ -16,7 +16,7 @@ main();
 
 ## Variables and Types
 
-```raven
+```rust
 fun main() -> void {
     let name: string = "Alice";
     let age: int = 25;
@@ -32,7 +32,7 @@ main();
 
 ## Arrays
 
-```raven
+```rust
 fun main() -> void {
     let numbers: int[] = [1, 2, 3, 4, 5];
     
@@ -60,7 +60,7 @@ main();
 
 ### If Statements
 
-```raven
+```rust
 fun main() -> void {
     let age: int = 18;
     
@@ -78,7 +78,7 @@ main();
 
 ### While Loops
 
-```raven
+```rust
 fun main() -> void {
     let i: int = 0;
     
@@ -93,7 +93,7 @@ main();
 
 ### For Loops
 
-```raven
+```rust
 fun main() -> void {
     let numbers: int[] = [10, 20, 30, 40, 50];
     
@@ -109,7 +109,7 @@ main();
 
 ### Simple Functions
 
-```raven
+```rust
 fun greet(name: string) -> void {
     print(format("Hello, {}!", name));
 }
@@ -129,7 +129,7 @@ main();
 
 ### Recursive Functions
 
-```raven
+```rust
 fun factorial(n: int) -> int {
     if (n <= 1) {
         return 1;
@@ -147,7 +147,7 @@ main();
 
 ## Structs
 
-```raven
+```rust
 struct Person {
     name: string,
     age: int,
@@ -175,7 +175,7 @@ main();
 
 ### Struct Methods (OOP)
 
-```raven
+```rust
 struct Person {
     name: string,
     age: int
@@ -203,7 +203,7 @@ main();
 
 ## Enums
 
-```raven
+```rust
 enum HttpStatus {
     OK,
     NotFound,
@@ -227,7 +227,7 @@ main();
 
 ## File Operations
 
-```raven
+```rust
 fun main() -> void {
     let filename: string = "test.txt";
     let content: string = "Hello from Raven!";
@@ -253,7 +253,7 @@ main();
 
 ## User Input
 
-```raven
+```rust
 fun main() -> void {
     let name: string = input("Enter your name: ");
     let ageStr: string = input("Enter your age: ");
@@ -267,7 +267,7 @@ main();
 
 ## Error Handling
 
-```raven
+```rust
 fun divide(a: float, b: float) -> float {
     if (b == 0.0) {
         print("Error: Division by zero");
@@ -289,7 +289,7 @@ main();
 
 ## Complete Example: Calculator
 
-```raven
+```rust
 fun add(a: float, b: float) -> float {
     return a + b;
 }

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -6,7 +6,7 @@ Let's get you up and running with Raven in just a few minutes!
 
 Create a file called `hello.rv`:
 
-```raven
+```rust
 fun main() -> void {
     print("Hello, Raven!");
 }
@@ -43,7 +43,7 @@ raven> exit
 
 ### Variables
 
-```raven
+```rust
 let name: string = "Alice";
 let age: int = 25;
 let height: float = 5.9;
@@ -52,7 +52,7 @@ let isActive: bool = true;
 
 ### Arrays
 
-```raven
+```rust
 let numbers: int[] = [1, 2, 3, 4, 5];
 numbers.push(6);
 print(numbers);  // [1, 2, 3, 4, 5, 6]
@@ -60,7 +60,7 @@ print(numbers);  // [1, 2, 3, 4, 5, 6]
 
 ### Control Flow
 
-```raven
+```rust
 let age: int = 18;
 
 if (age < 18) {
@@ -79,7 +79,7 @@ while (i < 5) {
 
 ### Functions
 
-```raven
+```rust
 fun greet(name: string) -> void {
     print(format("Hello, {}!", name));
 }
@@ -98,7 +98,7 @@ print(result);  // 8
 
 ### Structs
 
-```raven
+```rust
 struct Person {
     name: string,
     age: int,
@@ -116,7 +116,7 @@ print(person.name);  // Alice
 
 ### Enums
 
-```raven
+```rust
 enum HttpStatus {
     OK,
     NotFound,
@@ -129,7 +129,7 @@ print(status);  // HttpStatus::OK
 
 ## File Operations
 
-```raven
+```rust
 // Write to file
 let content: string = "Hello from Raven!";
 write_file("output.txt", content);

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Raven is a statically typed, compiled language. You write high level code with t
 
 The short version: the readability of Python, the type system and sum types of Rust, the simplicity of Go, and real C interop, in one compiled language.
 
-```raven
+```rust
 fun main() {
     let names = ["Ada", "Alan", "Grace"]
     for name in names {
@@ -31,7 +31,7 @@ raven build hello.rv -o hello
 
 ## A fuller taste
 
-```raven
+```rust
 import std/io { println }
 
 trait Shape {

--- a/docs/language-reference/data-types.md
+++ b/docs/language-reference/data-types.md
@@ -7,7 +7,7 @@ Raven is a statically-typed language with a rich type system that provides safet
 ### Integer (`int`)
 64-bit signed integers.
 
-```raven
+```rust
 let age: int = 25;
 let count: int = -10;
 let maxValue: int = 9223372036854775807;
@@ -16,7 +16,7 @@ let maxValue: int = 9223372036854775807;
 ### Float (`float`)
 64-bit floating-point numbers.
 
-```raven
+```rust
 let pi: float = 3.14159;
 let temperature: float = 98.6;
 let precision: float = 0.001;
@@ -25,7 +25,7 @@ let precision: float = 0.001;
 ### Boolean (`bool`)
 True or false values.
 
-```raven
+```rust
 let isActive: bool = true;
 let isComplete: bool = false;
 let isValid: bool = (age > 18);
@@ -34,7 +34,7 @@ let isValid: bool = (age > 18);
 ### string (`string`)
 UTF-8 encoded strings. Inside double-quoted literals, backslash escapes are supported (for example `\"`, `\\`, `\n`, `\r`, `\t`, `\0`), so JSON-like payloads such as `"{\"hello\":1}"` parse as a single string value.
 
-```raven
+```rust
 let name: string = "Alice";
 let message: string = "Hello, World!";
 let empty: string = "";
@@ -46,20 +46,20 @@ let json: string = "{\"hello\":1}";
 Arrays are collections of elements of the same type.
 
 ### Integer Arrays
-```raven
+```rust
 let numbers: int[] = [1, 2, 3, 4, 5];
 let emptyNumbers: int[] = [];
 let singleNumber: int[] = [42];
 ```
 
 ### string Arrays
-```raven
+```rust
 let names: string[] = ["Alice", "Bob", "Charlie"];
 let words: string[] = ["Hello", "World"];
 ```
 
 ### Boolean Arrays
-```raven
+```rust
 let flags: bool[] = [true, false, true];
 let results: bool[] = [];
 ```
@@ -68,7 +68,7 @@ let results: bool[] = [];
 
 Array types nest: each `[]` adds one dimension. Element types must match at every level.
 
-```raven
+```rust
 // 2D: matrix of int
 let grid: int[][] = [[1, 2, 3], [4, 5, 6]];
 let empty2d: int[][] = [];                    // zero rows
@@ -87,7 +87,7 @@ let cube: int[][][] = [[[1, 2]], [[3, 4]]];
 ### Structs
 Custom data structures with named fields.
 
-```raven
+```rust
 struct Person {
     name: string,
     age: int,
@@ -112,7 +112,7 @@ let point: Point = Point { x: 10.5, y: 20.0 };
 ### Struct Methods
 Structs can have methods defined with `impl` blocks. Each method receives `self` as the first parameter.
 
-```raven
+```rust
 struct Person {
     name: string,
     age: int
@@ -140,7 +140,7 @@ p.have_birthday();     // Mutates p in place
 ### Enums
 Custom types with a set of named variants.
 
-```raven
+```rust
 enum HttpStatus {
     OK,
     NotFound,
@@ -164,7 +164,7 @@ let color: Color = Color::Red;
 
 Raven can infer types in some cases, but explicit typing is recommended for clarity.
 
-```raven
+```rust
 // Explicit typing (recommended)
 let name: string = "Alice";
 let age: int = 25;
@@ -178,7 +178,7 @@ let age = 25;        // Inferred as int
 
 Raven performs static type checking at compile time.
 
-```raven
+```rust
 let name: string = "Alice";
 let age: int = 25;
 
@@ -193,7 +193,7 @@ let result: string = format("{} is {} years old", name, age);
 
 Raven provides built-in functions for type conversion.
 
-```raven
+```rust
 let number: int = 42;
 let text: string = format("{}", number);  // Convert int to string
 
@@ -206,7 +206,7 @@ let input: string = "123";
 
 The `void` type represents the absence of a value, used for functions that don't return anything.
 
-```raven
+```rust
 fun greet(name: string) -> void {
     print(format("Hello, {}!", name));
     // No return statement needed

--- a/docs/standard-library/overview.md
+++ b/docs/standard-library/overview.md
@@ -19,7 +19,7 @@ Raven comes with a comprehensive standard library that provides essential functi
 Raven provides several built-in functions that are always available:
 
 ### Output Functions
-```raven
+```rust
 // Print to console
 print("Hello, World!");
 
@@ -28,13 +28,13 @@ print(format("User: {}, Age: {}", name, age));
 ```
 
 ### Input Functions
-```raven
+```rust
 // Get user input
 let name: string = input("Enter your name: ");
 ```
 
 ### Type Functions
-```raven
+```rust
 // Get type information
 let value: int = 42;
 print(type(value));  // "int"
@@ -44,7 +44,7 @@ let status: HttpStatus = enum_from_string("HttpStatus", "OK");
 ```
 
 ### File Functions
-```raven
+```rust
 // File operations
 write_file("data.txt", "Hello, World!");
 let content: string = read_file("data.txt");
@@ -52,7 +52,7 @@ let exists: bool = file_exists("data.txt");
 ```
 
 ### Array Functions
-```raven
+```rust
 // Array utilities
 let numbers: int[] = [1, 2, 3, 4, 5];
 print(len(numbers));  // 5
@@ -65,7 +65,7 @@ let slice: int[] = numbers.slice(1, 3);
 
 Multi-dimensional arrays use repeated `[]` in the type and chained `[index]` in expressions (see [Data types](../language-reference/data-types.md#multi-dimensional-arrays)):
 
-```raven
+```rust
 let grid: int[][] = [[1, 2], [3, 4]];
 grid[0][1] = 9;
 ```
@@ -74,7 +74,7 @@ grid[0][1] = 9;
 
 Import modules using the `import` statement:
 
-```raven
+```rust
 import "math";
 import "collections";
 import str from "str";
@@ -89,7 +89,7 @@ let parsed: string[] = json.parse("{\"name\":\"Raven\"}");
 
 ## JSON Module Quick Example
 
-```raven
+```rust
 import "json";
 
 let raw: string = "{\"name\":\"Raven\",\"stars\":27}";
@@ -110,7 +110,7 @@ let pretty: string = json.pretty(raw, 2);
 
 Each module follows a consistent structure:
 
-```raven
+```rust
 // Module: math.rv
 export fun math_add(a: float, b: float) -> float {
     return a + b;
@@ -140,7 +140,7 @@ export struct Vector {
 
 Standard library functions use consistent error handling:
 
-```raven
+```rust
 // File operations may fail
 if (file_exists("config.txt")) {
     let config: string = read_file("config.txt");

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -19,7 +19,7 @@ Spaces, tabs, and newlines separate tokens. Whitespace is required only where tw
 
 Comments are **tokens** in the parser: they can appear between many top-level and block statements and inside struct, enum, and `impl` bodies, so tools like **`rvpm fmt`** can preserve them when reformatting.
 
-```raven
+```rust
 // line comment
 let x: int = 1;
 
@@ -106,7 +106,7 @@ User-defined types are referred to by identifier: struct and enum names. Array d
 
 Every `let` declaration must include an explicit type:
 
-```raven
+```rust
 let name: type = expression;
 ```
 
@@ -187,26 +187,26 @@ Inside `{ }` (function bodies, `if`, `while`, `for`), allowed statements include
 
 ### Variable declaration
 
-```raven
+```rust
 let name: type = expression;
 let name: type;   // only for types with defaults (see above)
 ```
 
 ### Expression statement
 
-```raven
+```rust
 expression;
 ```
 
 ### Assignment
 
-```raven
+```rust
 assignable_expression = expression;
 ```
 
 ### `return`
 
-```raven
+```rust
 return expression;
 ```
 
@@ -214,7 +214,7 @@ Every function path should match the declared return type; `void` functions typi
 
 ### `print`
 
-```raven
+```rust
 print ( argument ( , argument )* ) ;
 ```
 
@@ -222,7 +222,7 @@ print ( argument ( , argument )* ) ;
 
 ### Conditional
 
-```raven
+```rust
 if ( expression ) {
   statements
 } elseif ( expression ) {
@@ -239,7 +239,7 @@ else {
 
 **While:**
 
-```raven
+```rust
 while ( expression ) {
   statements
 }
@@ -247,7 +247,7 @@ while ( expression ) {
 
 **For** (C-style; initialization must be a `let` declaration):
 
-```raven
+```rust
 for ( let name: type = expression; expression; name = expression ) {
   statements
 }
@@ -259,7 +259,7 @@ The increment clause must be an assignment to an identifier (for example `i = i 
 
 ## Functions
 
-```raven
+```rust
 fun name ( parameter : type ( , parameter : type )* ) -> return_type {
   statements
 }
@@ -275,7 +275,7 @@ Parameters use the same type syntax as variables. The body is a single block.
 
 ### Struct
 
-```raven
+```rust
 struct Name {
   field : type ( , field : type )*
 }
@@ -285,7 +285,7 @@ Fields are separated by commas. Trailing commas are not required.
 
 ### `impl` (methods)
 
-```raven
+```rust
 impl StructName {
   fun method(self) -> return_type { statements }
   fun method(self : StructName, param: type) -> return_type { statements }
@@ -299,7 +299,7 @@ Methods are called with `value.method(arguments)`; fields use `value.field`.
 
 ### Enum
 
-```raven
+```rust
 enum Name {
   Variant ( , Variant )*
 }
@@ -315,19 +315,19 @@ Variants are identifiers, separated by commas. Variants are referenced as `Name:
 
 **Whole module path (string):**
 
-```raven
+```rust
 import "path.rv";
 ```
 
 **Import with namespace alias:**
 
-```raven
+```rust
 import alias from "path.rv";
 ```
 
 **Selective import:**
 
-```raven
+```rust
 import { name ( , name )* } from "path.rv";
 ```
 
@@ -335,7 +335,7 @@ Each import ends with `;`. The path is a string literal.
 
 ### Export
 
-```raven
+```rust
 export let name: type = expression;
 export fun name(…) -> type { … }
 ```

--- a/docs/v2/2026-05-22-v2-roadmap.md
+++ b/docs/v2/2026-05-22-v2-roadmap.md
@@ -96,7 +96,7 @@ The pillars name five languages. Surveying their reception, here's what Raven v2
 The heritage review surfaces concrete features the original design needs. Adding them to scope:
 
 1. **`defer` statement** (from Go, replaces C++ RAII). Schedules a callback to run at scope exit, in LIFO order. Used for file close, lock release, etc.
-   ```raven
+   ```rust
    fun read_config() -> Result<Config, IoError> {
        let f = open("config.toml")?
        defer f.close()
@@ -182,7 +182,7 @@ A snapshot of the syntax. Every detail here is open to revision during phase-lev
 
 ### Variables, types, primitives
 
-```raven
+```rust
 let x = 5                  // Int inferred; mutable
 let pi: Float = 3.14       // explicit type when needed
 let counter = 0            // mutable by default
@@ -200,7 +200,7 @@ Primitives: `Int` (i64), `Float` (f64), `Bool`, `String`, `Char`, plus `()` (uni
 
 ### Strings with interpolation
 
-```raven
+```rust
 let greeting = "Hello, ${name}!"           // ${expr} interpolation
 let multiline = """
     block string,
@@ -210,7 +210,7 @@ let multiline = """
 
 ### Collections
 
-```raven
+```rust
 let nums: List<Int> = [1, 2, 3]
 let scores: Map<String, Int> = ["a": 1, "b": 2]
 let unique: Set<String> = {"x", "y"}
@@ -220,7 +220,7 @@ Generic `List<T>`, `Map<K, V>`, `Set<T>` in stdlib. No raw arrays at the languag
 
 ### Functions, closures
 
-```raven
+```rust
 fun add(a: Int, b: Int) -> Int = a + b     // single-expression body
 
 fun greet(name: String) -> String {
@@ -233,7 +233,7 @@ let triple = { x -> x * 3 }                 // shorthand lambda
 
 ### Control flow
 
-```raven
+```rust
 for x in 0..10 { print(x) }                 // range
 for item in list { print(item) }            // iterator
 for (i, item) in list.enumerate() { ... }   // destructured
@@ -249,7 +249,7 @@ No semicolons. Newlines and braces handle separation. C-style for-loops are gone
 
 ### Deterministic cleanup with `defer`
 
-```raven
+```rust
 fun process(path: String) -> Result<Int, IoError> {
     let f = File.open(path)?
     defer f.close()             // runs at scope exit, LIFO order
@@ -263,7 +263,7 @@ fun process(path: String) -> Result<Int, IoError> {
 
 ### Structs, traits, impls
 
-```raven
+```rust
 struct Point {
     x: Float
     y: Float
@@ -295,7 +295,7 @@ Traits are the only polymorphism mechanism. `dyn Trait` is the trait-object synt
 
 ### Sum types + pattern matching
 
-```raven
+```rust
 enum Shape {
     Circle(radius: Float)
     Rectangle(width: Float, height: Float)
@@ -317,7 +317,7 @@ fun area(s: Shape) -> Float =
 
 ### Optionals and Results
 
-```raven
+```rust
 let maybe: Int? = some_lookup(key)         // sugar for Option<Int>
 match maybe {
     Some(n) -> print(n)
@@ -333,7 +333,7 @@ No more sentinel `0` returns or empty-string failures. Failure is in the type si
 
 ### Modules and imports
 
-```raven
+```rust
 import std/io                              // stdlib module
 import std/collections/{Map, Set}          // selective
 import github.com/martian56/raven-http     // third-party from GitHub
@@ -344,7 +344,7 @@ import http "github.com/martian56/raven-http" as h   // aliased
 
 ### C FFI
 
-```raven
+```rust
 extern "C" {
     fun strlen(s: CStr) -> Int
     fun open(path: CStr, flags: Int) -> Int
@@ -361,7 +361,7 @@ let n = strlen(c"hello")   // c"..." is a null-terminated C string literal
 
 Rationale: keeps the language clean and matches the "simplicity of Go" pillar — module-level identifiers are part of the module's API, full stop. Users who want to signal "internal" can use a naming convention (e.g. leading underscore `_helper_fn`) but it's documentation, not enforcement.
 
-```raven
+```rust
 fun greet(name: String) -> String { ... }       // automatically importable
 struct User { name: String, age: Int }          // automatically importable
 ```

--- a/docs/v2/guide/getting-started.md
+++ b/docs/v2/guide/getting-started.md
@@ -36,7 +36,7 @@ The binaries land in `target/release/`. Add that directory to your
 
 Every program starts at `fun main()`. Create `hello.rv`:
 
-```raven
+```rust
 fun main() {
     print("Hello, Raven!")
 }

--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -9,7 +9,7 @@ There is no top level statement execution: a program runs from `fun main()`.
 `let` introduces a binding. Bindings are mutable: you can reassign them
 and mutate their fields and elements.
 
-```raven
+```rust
 fun main() {
     let n = 10
     n = n + 5
@@ -21,7 +21,7 @@ A type annotation is optional. When omitted the type is inferred from the
 initializer; annotate when the type cannot be inferred (for example an
 empty list).
 
-```raven
+```rust
 let count: Int = 0
 let names: List<String> = []
 ```
@@ -33,7 +33,7 @@ an initializer may be any expression (including a function call), not only a
 constant. A heap-valued global (a `String`, `List`, struct, and so on) is
 kept alive for the whole program.
 
-```raven
+```rust
 fun seed() -> Int = 10
 
 let counter: Int = 0        // mutable, shared across functions
@@ -49,7 +49,7 @@ fun record(name: String) {
 `const` introduces an immutable binding: reassigning it (or compound
 assigning, like `+=`) is a compile error.
 
-```raven
+```rust
 fun main() {
     const LIMIT = 5
     LIMIT = 6            // error: cannot assign to `LIMIT`, it is a `const`
@@ -61,7 +61,7 @@ type and a value, and its initializer must be a constant expression (a
 literal, or an arithmetic, comparison, bitwise, or boolean combination of
 literals), which is folded and inlined at each use site.
 
-```raven
+```rust
 const MAX: Int = 100
 const SECS_PER_HOUR: Int = 60 * 60
 ```
@@ -70,7 +70,7 @@ Inside a function body a `const` is an immutable local. It has stack
 storage, so its initializer may be any expression (including a function
 call), not only a constant one.
 
-```raven
+```rust
 fun main() {
     const DOUBLED = compute()    // runtime value, still immutable
 }
@@ -89,7 +89,7 @@ Type names are PascalCase.
 | `Char`   | a single Unicode scalar value |
 | `Unit`   | the empty value, written `()` |
 
-```raven
+```rust
 let i: Int = 42
 let f: Float = 3.14
 let b: Bool = true
@@ -106,7 +106,7 @@ A regular string uses double quotes and processes escapes (`\n`, `\t`,
 `\\`, `\"`, `\x41`, `\u{1F600}`). String interpolation embeds an
 expression with `${...}`:
 
-```raven
+```rust
 fun main() {
     let name = "Raven"
     let a = 3
@@ -119,7 +119,7 @@ fun main() {
 A block string uses triple quotes and is raw: no escapes are processed
 and newlines are preserved exactly.
 
-```raven
+```rust
 let text = """
 line one
 line two
@@ -145,7 +145,7 @@ Bitwise: `&`, `|`, `^`, `~`, `<<`, `>>`.
 Ranges produce a range value used by `for`. `a..b` is half open (excludes
 `b`); `a..=b` is inclusive.
 
-```raven
+```rust
 for x in 0..5 {        // 0, 1, 2, 3, 4
     print(x)
 }
@@ -162,7 +162,7 @@ Compound assignment operators apply an operation in place: `+=`, `-=`,
 A function declares typed parameters and an optional return type. A
 function with no return type returns `Unit`.
 
-```raven
+```rust
 fun add(a: Int, b: Int) -> Int {
     return a + b
 }
@@ -171,7 +171,7 @@ fun add(a: Int, b: Int) -> Int {
 A function may use an expression body with `=`, where the trailing
 expression is the return value:
 
-```raven
+```rust
 fun square(x: Int) -> Int = x * x
 ```
 
@@ -183,7 +183,7 @@ A lambda is written with `fun(params) -> Ret = body` or a block body.
 Closures capture surrounding locals by value. A function type is written
 `fun(ArgTypes) -> Ret`.
 
-```raven
+```rust
 fun apply(f: fun(Int) -> Int, x: Int) -> Int {
     return f(x)
 }
@@ -197,7 +197,7 @@ fun main() {
 
 A closure can be returned, carrying its captured values:
 
-```raven
+```rust
 fun make_adder(n: Int) -> fun(Int) -> Int {
     return fun(x: Int) -> Int = x + n
 }
@@ -208,13 +208,13 @@ fun make_adder(n: Int) -> fun(Int) -> Int {
 `if` / `else if` / `else` chooses a branch. It works as a statement and
 as an expression that yields a value:
 
-```raven
+```rust
 let label = if n > 0 { "positive" } else { "non-positive" }
 ```
 
 `while` loops while a condition holds:
 
-```raven
+```rust
 let i = 0
 while i < 10 {
     i = i + 1
@@ -223,7 +223,7 @@ while i < 10 {
 
 `loop` is an unconditional loop. It evaluates to the operand of `break`:
 
-```raven
+```rust
 let first = loop {
     break 42
 }
@@ -231,7 +231,7 @@ let first = loop {
 
 `for ... in` iterates a range or a list:
 
-```raven
+```rust
 let xs = [3, 5, 7]
 let total = 0
 for v in xs {
@@ -251,7 +251,7 @@ the function's return, not when the inner block exits. Deferred
 expressions run in reverse order of registration (last in, first out),
 and only those actually reached at runtime run.
 
-```raven
+```rust
 fun demo() -> Int {
     defer print(1)
     defer print(2)
@@ -263,7 +263,7 @@ fun demo() -> Int {
 Because a defer is function-scoped, the order across nested blocks is the
 same LIFO order, measured by when each `defer` statement ran:
 
-```raven
+```rust
 fun f() -> Int {
     print(1)
     if true {
@@ -286,7 +286,7 @@ side effects and cannot change the return value. Defers do not run on a
 A struct groups named, typed fields. Construct it with a struct literal,
 read fields with `.`, and assign to fields and elements.
 
-```raven
+```rust
 struct Point { x: Int, y: Int }
 
 fun main() {
@@ -300,7 +300,7 @@ Methods are declared in an `impl` block. A method takes `self` as its
 first parameter. A function in an `impl` block without `self` is an
 associated function, the idiomatic constructor, called as `Type.func()`.
 
-```raven
+```rust
 struct Counter { n: Int }
 
 impl Counter {
@@ -322,7 +322,7 @@ fun main() {
 
 Methods can also be declared on built in types:
 
-```raven
+```rust
 impl Int {
     fun doubled(self) -> Int = self * 2
 }
@@ -335,7 +335,7 @@ tuple variant with positional payloads, or a struct variant with named
 fields. Construct a variant with `EnumName.Variant` (or
 `EnumName.Variant(args)` for a payload). Match with the bare variant name.
 
-```raven
+```rust
 enum Color {
     Red,
     Green,
@@ -372,7 +372,7 @@ selected arm. Match is exhaustive: every case must be covered. Patterns
 include literals, ranges, the wildcard `_`, enum variants binding their
 payload, and struct fields. An arm may carry a guard with `if`.
 
-```raven
+```rust
 fun classify(n: Int) -> String {
     return match n {
         0 -> "zero",
@@ -393,7 +393,7 @@ literal is comma-separated `key: value` pairs in brackets, `["a": 1,
 "b": 2]`. Both come from `std/collections`, so the literals need
 `import std/collections` in scope (see the [standard library](standard-library.md#stdcollections)).
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -423,7 +423,7 @@ the same bound the collection types carry.
 A trait declares methods that a type can implement. Implement it with
 `impl Trait for Type`. A trait method may have a default body.
 
-```raven
+```rust
 trait Speak {
     fun sound(self) -> Int
 }
@@ -444,7 +444,7 @@ Functions, structs, enums, and impl blocks can take type parameters in
 angle brackets. A bound `T: Trait` constrains a parameter to types that
 implement the trait. Use `+` to require several bounds.
 
-```raven
+```rust
 fun show<T: ToString>(label: String, x: T) -> String {
     return "${label}=${x}"
 }
@@ -462,7 +462,7 @@ Generic code is monomorphized: a distinct machine specialization is
 emitted for each concrete type the program uses. A method can introduce
 its own type parameters separate from the type's:
 
-```raven
+```rust
 impl<T> Box<T> {
     fun mapped<U>(self, f: fun(T) -> U) -> U = f(self.value)
 }
@@ -475,7 +475,7 @@ impl<T> Box<T> {
 bare constructors `Some`, `None`, `Ok`, and `Err`. The type `T?` is sugar
 for `Option<T>`.
 
-```raven
+```rust
 fun divide(a: Int, b: Int) -> Result<Int, Error> {
     if b == 0 {
         return Err(error("divide by zero"))
@@ -501,7 +501,7 @@ which keeps error handling flat. `error` and the `Result` helpers live in
 trait, dispatched at runtime through a vtable. Passing a concrete value
 where `dyn Trait` is expected boxes it as a fat pointer.
 
-```raven
+```rust
 trait Speak {
     fun sound(self) -> Int
 }
@@ -521,7 +521,7 @@ program multiplexes many of them onto one OS thread, and exactly one runs
 at a time. A goroutine runs until it reaches a yield point, then the
 scheduler resumes another ready goroutine.
 
-```raven
+```rust
 spawn(fun() -> Unit {
     // goroutine body
 })
@@ -535,7 +535,7 @@ yielding to the scheduler until the counterpart operation runs.
 `yield_now()` yields explicitly. Channels carry `Int` values in this
 release.
 
-```raven
+```rust
 import std/sync { channel }
 
 fun main() {
@@ -573,7 +573,7 @@ parallelism, `select`, and non-blocking IO are future work.
 path. A selective import binds named items; a bare import merges the
 module (used for modules that add methods or constructors).
 
-```raven
+```rust
 import std/io { println }
 import std/collections
 import "./helpers"
@@ -602,7 +602,7 @@ in scope without an import.
 `extern "C" { ... }` declares foreign function signatures. Call them like
 ordinary functions. Arguments and returns use C types.
 
-```raven
+```rust
 extern "C" {
     fun abs(x: CInt) -> CInt
     fun strlen(s: CStr) -> CSize
@@ -634,7 +634,7 @@ narrowed to f32 at the call and a `CFloat` return is widened back to a
 `Float`. The integer and float C return types satisfy `ToString`, so a
 `CInt` or `CDouble` result prints and interpolates directly.
 
-```raven
+```rust
 extern "C" {
     fun sqrtf(x: CFloat) -> CFloat
 }
@@ -653,7 +653,7 @@ not itself a valid `const char *`. `from_cstr` reads a `CStr` back into a
 it, so it leaks one buffer per call; hoist the conversion out of a hot
 loop.
 
-```raven
+```rust
 import std/ffi { to_cstr, from_cstr }
 
 extern "C" {
@@ -674,7 +674,7 @@ through it: `alloc<T>(count)` reserves a buffer, `free<T>(p)` releases it,
 `offset<T>(p, i)` advances by `i` elements (scaled by `sizeof(T)`),
 `null_ptr<T>()` is the null pointer, and `is_null<T>(p)` tests it.
 
-```raven
+```rust
 import std/ffi { alloc, free, load, store, offset, is_null, null_ptr }
 
 fun main() {
@@ -704,7 +704,7 @@ be C-FFI types so the C ABI is well defined. A capturing closure (a local
 of function type) is rejected, since C cannot supply its capture
 environment.
 
-```raven
+```rust
 import std/ffi { alloc, free, load, store, offset }
 
 extern "C" {
@@ -739,7 +739,7 @@ struct whose fields are all integer-class C scalars (`CInt`, `CLong`,
 8 bytes (one machine register). A larger struct, or one with a float
 field, is rejected; pass a `CPtr<...>` to it instead.
 
-```raven
+```rust
 @repr(C)
 struct Point {
     x: CInt
@@ -777,7 +777,7 @@ synthesizes trait impls from the type definition, so you do not hand write
 `Hash`, `ToString`, `Debug`, `ToJson`, and `FromJson`. A field or payload
 type must itself implement the trait being derived.
 
-```raven
+```rust
 import std/collections { Map, Set }
 
 @derive(Eq, Hash, ToString, Debug)
@@ -804,7 +804,7 @@ fun main() {
 function that decodes one back, returning a `Result`. Combine `to_json`
 with `stringify`, and `parse` with `from_json`, for a round trip.
 
-```raven
+```rust
 import std/json { JsonValue, stringify, parse }
 
 @derive(ToJson, FromJson, Eq)
@@ -841,7 +841,7 @@ A matcher binds metavariables: `$x:expr` captures a balanced expression
 and `$x:ident` captures one identifier. The template splices `$x` back in.
 Wrap each splice in parentheses where precedence matters.
 
-```raven
+```rust
 macro twice { ($x:expr) => { ($x) + ($x) } }
 
 fun main() {
@@ -855,7 +855,7 @@ matches a sub-pattern several times, with an optional separator between
 the closing `)` and the marker. In the template it expands once per
 capture.
 
-```raven
+```rust
 macro sum_all { ($($x:expr),*) => { (0 $(+ ($x))*) } }
 
 fun main() {
@@ -878,7 +878,7 @@ compiles. `type_name<T>()` returns the rendered name of a type,
 a generic function each resolves to the concrete type bound to `T` at that
 instantiation.
 
-```raven
+```rust
 struct Point { x: Int, y: Int }
 
 fun introspect<T>() {
@@ -903,7 +903,7 @@ and `variant_field_types<T>()` gives each variant's payload type names as an
 inner list (empty for a unit variant), so the inner length is the variant's
 payload arity.
 
-```raven
+```rust
 enum Shape { Circle(radius: Float) Rectangle(w: Float, h: Float) Dot }
 
 variant_names<Shape>()        // ["Circle", "Rectangle", "Dot"]
@@ -917,7 +917,7 @@ its struct fields, `get_field(a, name)` reads one field back as an
 `Option<Any>`, and `cast<T>(a)` recovers a concrete value as an
 `Option<T>` (`None` for the wrong `T`).
 
-```raven
+```rust
 struct User { id: Int, name: String }
 
 fun describe(a: Any) {

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -59,7 +59,7 @@ Unknown fields are rejected so typos surface early.
 A dependency is a `github.com/<user>/<repo>` path pinned to an explicit
 git ref. In source, import it by its path:
 
-```raven
+```rust
 import "github.com/martian56/raven-http" as http
 import "github.com/martian56/raven-http" { get }
 ```

--- a/docs/v2/guide/standard-library.md
+++ b/docs/v2/guide/standard-library.md
@@ -12,7 +12,7 @@ use depends on what the module provides.
 
 **Selective import** brings named free functions into scope:
 
-```raven
+```rust
 import std/math { sqrt, pow_int }
 
 fun main() {
@@ -23,7 +23,7 @@ fun main() {
 **Bare import** brings in a module that adds methods or constructors to a
 type (it merges an `impl` block or registers a type):
 
-```raven
+```rust
 import std/string                  // adds methods to String
 import std/collections             // registers Map.new() / Set.new()
 
@@ -49,7 +49,7 @@ Two rules are worth memorizing up front:
 `Hash`, `Iterator<T>`) and implements them for the primitive types. It is
 auto-imported, so you never write `import std/core`:
 
-```raven
+```rust
 fun describe<T: ToString>(x: T) -> String = x.to_string()
 ```
 
@@ -62,7 +62,7 @@ absent returns `Option<T>`. There are no exceptions and no `null`. Handle a
 `Result` with `match`, or propagate it with the `?` operator inside a
 function that itself returns `Result`:
 
-```raven
+```rust
 import std/fs { read }
 
 fun load(path: String) -> Result<String, Error> {

--- a/docs/v2/guide/stdlib/cmp.md
+++ b/docs/v2/guide/stdlib/cmp.md
@@ -4,7 +4,7 @@ Free generic functions for ordering and sorting. They build on the prelude
 `Ord` trait, so any type that implements `compare` works with them, including
 your own structs.
 
-```raven
+```rust
 import std/cmp { min, max, sort }
 
 fun main() {
@@ -21,7 +21,7 @@ fun main() {
 These functions have no natural single receiver, so they come in through a
 selective import: list the names you want inside `{ ... }`.
 
-```raven
+```rust
 import std/cmp { sort, sorted_by, min, max, clamp, max_of, min_of }
 ```
 
@@ -32,7 +32,7 @@ import std/cmp { sort, sorted_by, min, max, clamp, max_of, min_of }
 Most functions here are bound by `T: Ord`. The prelude `Ord` trait is one
 method:
 
-```raven
+```rust
 fun compare(self, other: Self) -> Int
 ```
 
@@ -55,7 +55,7 @@ The lesser of `a` and `b`. On a tie (`a` and `b` compare equal) it returns
 
 The greater of `a` and `b`. On a tie it returns `a`.
 
-```raven
+```rust
 import std/cmp { min, max }
 
 fun main() {
@@ -69,7 +69,7 @@ fun main() {
 Constrain `x` to the range `[lo, hi]`: returns `lo` when `x < lo`, `hi` when
 `x > hi`, and `x` otherwise.
 
-```raven
+```rust
 import std/cmp { clamp }
 
 fun main() {
@@ -87,7 +87,7 @@ A new list with the elements of `xs` in ascending order. The input is not
 mutated. `sort` delegates to `sorted_by` using `a.compare(b)` as the
 comparator.
 
-```raven
+```rust
 import std/cmp { sort }
 
 fun main() {
@@ -111,7 +111,7 @@ The comparator follows the same convention as `compare`: given two elements
 when their order does not matter, and a positive `Int` when `a` should come
 after `b`. To sort descending, flip the comparison.
 
-```raven
+```rust
 import std/cmp { sorted_by }
 
 fun main() {
@@ -142,7 +142,7 @@ The smallest element of `xs`, or `None` when the list is empty.
 Because both return an `Option<T>`, you match on the result to handle the
 empty list:
 
-```raven
+```rust
 import std/cmp { max_of, min_of }
 
 fun main() {
@@ -162,7 +162,7 @@ fun main() {
 
 ## Worked example: sort and pick the top
 
-```raven
+```rust
 import std/cmp { sort, max_of }
 
 fun main() {

--- a/docs/v2/guide/stdlib/collections.md
+++ b/docs/v2/guide/stdlib/collections.md
@@ -5,7 +5,7 @@ Hash-backed `Set<T>` and `Map<K, V>` over keys that implement the prelude
 remove are O(1) average. `List<T>` is built into the language (literals,
 indexing, `len`, `push`, `pop`, `get`) and needs no import.
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -21,7 +21,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/collections
 ```
 
@@ -36,7 +36,7 @@ Element and key/value types are inferred from the first use: `s.add(1)`
 fixes `s` as `Set<Int>`. Where no later use pins them, write the type
 arguments on the call:
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -66,7 +66,7 @@ keyed on them do not satisfy the bound.
 Set and map values have literal syntax. Both lower to the constructors
 above, so they need the same `import std/collections` in scope.
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -128,7 +128,7 @@ holds duplicates.
 Remove `x` if present, returning whether it was. Order within a bucket is not
 preserved.
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -170,7 +170,7 @@ True when `k` has an entry in the map.
 
 `Some(v)` when `k` is present, otherwise `None`. Handle it with `match`:
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -208,7 +208,7 @@ Every value in the map, aligned with `keys()`: the value at index `i` in
 Remove the entry for `k` if present, returning whether it was. Order within a
 bucket is not preserved.
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -235,7 +235,7 @@ across runs.
 
 ## Worked example: word frequencies
 
-```raven
+```rust
 import std/collections
 import std/string
 

--- a/docs/v2/guide/stdlib/core.md
+++ b/docs/v2/guide/stdlib/core.md
@@ -5,7 +5,7 @@ prelude: the compiler merges it into every program before name resolution, so
 its traits and impls are always in scope. You never write `import std/core`,
 and there is nothing to import selectively.
 
-```raven
+```rust
 fun main() {
     print(42.to_string())           // 42
     print(3.compare(7) < 0)         // true (3 sorts before 7)
@@ -31,7 +31,7 @@ type that implements it, including your own.
 
 ## ToString
 
-```raven
+```rust
 trait ToString {
     fun to_string(self) -> String
 }
@@ -45,7 +45,7 @@ Built in for `Int`, `Float`, `Bool`, `Char`, and `String`. The scalar impls
 render through interpolation (`"${self}"`); `ToString for String` returns the
 string unchanged.
 
-```raven
+```rust
 fun main() {
     print(42.to_string())           // 42
     print(true.to_string())         // true
@@ -58,7 +58,7 @@ fun main() {
 
 ## Eq
 
-```raven
+```rust
 trait Eq {
     fun equals(self, other: Self) -> Bool
 }
@@ -67,7 +67,7 @@ trait Eq {
 Structural equality. Built in for `Int`, `Float`, `Bool`, `Char`, and
 `String`. The scalar impls compare with `==`; `String` compares byte by byte.
 
-```raven
+```rust
 fun main() {
     print(2.equals(2))              // true
     print("ab".equals("ab"))        // true
@@ -77,7 +77,7 @@ fun main() {
 
 ## Ord
 
-```raven
+```rust
 trait Ord {
     fun compare(self, other: Self) -> Int
 }
@@ -88,7 +88,7 @@ Total ordering. `compare` returns a negative `Int` when `self` sorts before
 after. Built in for `Int`, `Float`, `Char`, `Bool` (`false` sorts before
 `true`), and `String` (lexicographic over bytes).
 
-```raven
+```rust
 fun main() {
     print(3.compare(7))             // -1
     print(7.compare(3))             //  1
@@ -100,7 +100,7 @@ fun main() {
 Use the sign of the result rather than the exact magnitude: only `< 0`,
 `== 0`, and `> 0` are guaranteed.
 
-```raven
+```rust
 fun max<T: Ord>(a: T, b: T) -> T {
     if a.compare(b) >= 0 {
         return a
@@ -116,7 +116,7 @@ fun main() {
 
 ## Hash
 
-```raven
+```rust
 trait Hash {
     fun hash(self) -> Int
 }
@@ -129,7 +129,7 @@ hashes.
 
 `Hash for Char` and `Hash for Float` are not provided yet.
 
-```raven
+```rust
 fun main() {
     print(7.hash())                 // 7
     print(true.hash())              // 1
@@ -138,7 +138,7 @@ fun main() {
 
 ## Iterator&lt;T&gt;
 
-```raven
+```rust
 trait Iterator<T> {
     fun next(self) -> Option<T>
 }
@@ -157,7 +157,7 @@ it. Inside the function you can then call the trait's methods on that
 parameter. Dispatch is resolved statically at each call site, so there is no
 runtime overhead.
 
-```raven
+```rust
 fun describe<T: ToString>(x: T) -> String {
     return "value: ${x.to_string()}"
 }
@@ -172,7 +172,7 @@ fun main() {
 A type participates in a bound by implementing the trait. Implement it for your
 own struct or enum and that type becomes usable everywhere the bound appears:
 
-```raven
+```rust
 struct Point {
     x: Int,
     y: Int,
@@ -196,7 +196,7 @@ fun main() {
 Most of the time you do not hand-write these impls. `@derive(...)` on a struct
 or enum generates them from the fields:
 
-```raven
+```rust
 @derive(Eq, Hash, ToString, Debug)
 struct User {
     id: Int,
@@ -211,7 +211,7 @@ being derived. See the `@derive` section of the
 
 ## Worked example: generic comparison and sorting key
 
-```raven
+```rust
 struct Score {
     name: String,
     points: Int,

--- a/docs/v2/guide/stdlib/encoding.md
+++ b/docs/v2/guide/stdlib/encoding.md
@@ -4,7 +4,7 @@ Hex and standard base64 over the bytes of a `String`. These are free
 functions that turn a `String`'s raw bytes into encoded text and decode the
 inverse.
 
-```raven
+```rust
 import std/encoding { hex_encode, base64_encode, base64_decode }
 
 fun main() {
@@ -19,7 +19,7 @@ fun main() {
 Every entry is a free function, so bind the ones you need with a selective
 import:
 
-```raven
+```rust
 import std/encoding { hex_encode, hex_decode, base64_encode, base64_decode }
 ```
 
@@ -43,7 +43,7 @@ defined value rather than failing (see [Invalid input](#invalid-input)).
 Encode each input byte as two lowercase hex digits. The result is twice as
 long as the input.
 
-```raven
+```rust
 import std/encoding { hex_encode }
 
 fun main() {
@@ -57,7 +57,7 @@ fun main() {
 The inverse of `hex_encode`. Reads the input two digits at a time, accepting
 lowercase, uppercase, or mixed hex (`0-9`, `a-f`, `A-F`).
 
-```raven
+```rust
 import std/encoding { hex_decode }
 
 fun main() {
@@ -68,7 +68,7 @@ fun main() {
 
 Round-tripping is exact for any input:
 
-```raven
+```rust
 import std/encoding { hex_encode, hex_decode }
 
 fun main() {
@@ -85,7 +85,7 @@ Encode the input bytes with the standard base64 alphabet (`A-Z`, `a-z`,
 `0-9`, `+`, `/`) and `=` padding. Every three input bytes become four output
 characters; one or two trailing bytes are padded with `=`.
 
-```raven
+```rust
 import std/encoding { base64_encode }
 
 fun main() {
@@ -101,7 +101,7 @@ fun main() {
 The inverse of `base64_encode`. Honors trailing `=` padding to recover how
 many bytes the final group yields.
 
-```raven
+```rust
 import std/encoding { base64_decode }
 
 fun main() {
@@ -113,7 +113,7 @@ fun main() {
 
 Encode then decode round-trips for any input:
 
-```raven
+```rust
 import std/encoding { base64_encode, base64_decode }
 
 fun main() {
@@ -143,7 +143,7 @@ Both can be added later without changing the existing functions.
 
 ## Worked example: a hex dump round trip
 
-```raven
+```rust
 import std/encoding { hex_encode, hex_decode }
 
 fun main() {

--- a/docs/v2/guide/stdlib/env.md
+++ b/docs/v2/guide/stdlib/env.md
@@ -4,7 +4,7 @@ Access to the process environment: environment variables, command-line
 arguments, process exit, and platform info. The primitives bind the
 raven-runtime C ABI; the convenience functions are pure Raven on top of them.
 
-```raven
+```rust
 import std/env { get_env_or, os_name }
 
 fun main() {
@@ -16,7 +16,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/env { get_env, has_env, get_env_or, args, arg_count, arg_at, exit, os_name, arch }
 ```
 
@@ -31,7 +31,7 @@ A variable set to the empty string and a variable that is not set both
 yield `""`, so `get_env` alone cannot tell them apart: use `has_env` to
 distinguish unset from empty.
 
-```raven
+```rust
 import std/env { get_env }
 
 fun main() {
@@ -49,7 +49,7 @@ True when `name` is set in the environment, regardless of its value
 The value of `name`, or `default` when `name` is unset. This is the usual
 way to read configuration with a fallback.
 
-```raven
+```rust
 import std/env { get_env_or }
 
 fun main() {
@@ -75,7 +75,7 @@ is out of range.
 All process arguments as a list, with index 0 being the program path.
 This is pure Raven: it loops `arg_at` over `0..arg_count()`.
 
-```raven
+```rust
 import std/env { args }
 
 fun main() {
@@ -95,7 +95,7 @@ fun main() {
 Terminate the process with status `code`. It does not return; any code
 after a call to `exit` is unreachable.
 
-```raven
+```rust
 import std/env { arg_count, exit }
 
 fun main() {
@@ -117,7 +117,7 @@ The target operating system: `"windows"`, `"linux"`, or `"macos"`.
 
 The target CPU architecture, for example `"x86_64"` or `"aarch64"`.
 
-```raven
+```rust
 import std/env { os_name, arch }
 
 fun main() {
@@ -128,7 +128,7 @@ fun main() {
 
 ## Worked example: a small greeting tool
 
-```raven
+```rust
 import std/env { args, get_env_or, os_name, exit }
 
 fun main() {

--- a/docs/v2/guide/stdlib/error.md
+++ b/docs/v2/guide/stdlib/error.md
@@ -7,7 +7,7 @@ message and an optional kind, context chaining as an error propagates, and a
 small set of free functions for the cases where matching a `Result` by hand
 gets verbose.
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun divide(a: Int, b: Int) -> Result<Int, Error> {
@@ -27,7 +27,7 @@ fun main() {
 
 Import the free functions you use by name:
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 ```
 
@@ -56,7 +56,7 @@ whose return type matches (a `Result` for `?` on a `Result`, an `Option` for
 
 A function that uses `?` to chain failing steps:
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun positive(n: Int) -> Result<Int, Error> {
@@ -78,7 +78,7 @@ Each `?` keeps the happy path flat: if `positive` returns an `Err`,
 
 A caller handles the result with `match`:
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun positive(n: Int) -> Result<Int, Error> {
@@ -112,7 +112,7 @@ bug has made the program unable to continue.
 Build an `Error` with the given message and an empty kind. This is the usual
 constructor for an ad hoc failure.
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun check_age(age: Int) -> Result<Int, Error> {
@@ -128,7 +128,7 @@ fun check_age(age: Int) -> Result<Int, Error> {
 Build an `Error` tagged with a kind, for example `"io"` or `"parse"`. The kind
 is a free-form `String`; callers can branch on it with `e.kind()`.
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun open_config(path: String) -> Result<String, Error> {
@@ -149,7 +149,7 @@ The message text.
 
 The kind tag, or `""` when the error was built with `error`.
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun main() {
@@ -165,7 +165,7 @@ A new `Error` whose message is `ctx + ": " + message`, preserving the kind. Use
 it to add a higher-level explanation to a lower-level failure as it propagates.
 It returns a new `Error` and does not mutate the receiver.
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun load_settings(path: String) -> Result<String, Error> {
@@ -185,7 +185,7 @@ The display form: the bare `message` when the kind is empty, otherwise
 `kind + ": " + message`. This comes from the `ToString` impl, so `print(e)`
 uses it too.
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun main() {
@@ -212,7 +212,7 @@ True when `r` is `Err`.
 
 The `Ok` value, or `default` when `r` is an `Err`.
 
-```raven
+```rust
 import std/error { error, unwrap_or, is_err }
 
 fun divide(a: Int, b: Int) -> Result<Int, Error> {
@@ -238,7 +238,7 @@ you care whether a value is present but not why it failed.
 
 Keep the error: map `Err(e)` to `Some(e)` and `Ok(v)` to `None`.
 
-```raven
+```rust
 import std/error { error, ok }
 
 fun divide(a: Int, b: Int) -> Result<Int, Error> {
@@ -262,7 +262,7 @@ This ties the pieces together: failing steps return `Result<T, Error>`, `?`
 propagates failures, `with_context` annotates them as they rise, and the caller
 recovers with `unwrap_or`.
 
-```raven
+```rust
 import std/error { error, error_kind, is_ok, is_err, unwrap_or, ok, err }
 
 fun check_port(port: Int) -> Result<Int, Error> {

--- a/docs/v2/guide/stdlib/ffi.md
+++ b/docs/v2/guide/stdlib/ffi.md
@@ -5,7 +5,7 @@ Bridges for the C foreign-function interface. `std/ffi` converts a Raven
 `CPtr<T>` for allocating, reading, and writing C memory. Use it alongside an
 `extern "C"` block to call C functions with runtime values.
 
-```raven
+```rust
 import std/ffi { to_cstr, from_cstr }
 
 extern "C" {
@@ -27,7 +27,7 @@ at runtime, which has no compile-time form.
 
 Bring in just the helpers you use:
 
-```raven
+```rust
 import std/ffi { to_cstr, from_cstr }
 import std/ffi { alloc, free, load, store, offset, is_null, null_ptr }
 ```
@@ -67,7 +67,7 @@ Read the null-terminated bytes at `p`, stopping at the first NUL, and build an
 ordinary GC-managed Raven `String` (the terminator is dropped). The resulting
 `String` is traced and reclaimed like any other.
 
-```raven
+```rust
 import std/ffi { to_cstr, from_cstr }
 
 fun main() {
@@ -122,7 +122,7 @@ The null `CPtr<T>`.
 
 ### Example: a buffer of `CInt`
 
-```raven
+```rust
 import std/ffi { alloc, free, load, store, offset, is_null, null_ptr }
 
 fun main() {
@@ -154,7 +154,7 @@ fun main() {
 Declare the C function in an `extern "C"` block, then pass a `to_cstr`
 conversion of a runtime `String` where the signature expects a `CStr`:
 
-```raven
+```rust
 import std/ffi { to_cstr, from_cstr }
 
 extern "C" {

--- a/docs/v2/guide/stdlib/fmt.md
+++ b/docs/v2/guide/stdlib/fmt.md
@@ -4,7 +4,7 @@ String formatting helpers and a `Debug` trait. These are the building blocks
 that compose with string interpolation: pad and align fields, repeat and join
 strings, render integers in a base, and produce quoted debug output.
 
-```raven
+```rust
 import std/fmt { pad_left, to_hex }
 import std/io { println }
 
@@ -25,7 +25,7 @@ it, not a printf replacement.
 
 The formatting helpers are free functions, bound with a selective import:
 
-```raven
+```rust
 import std/fmt { repeat, pad_left, pad_right, center, join, to_radix, to_binary, to_octal, to_hex, pad_int }
 ```
 
@@ -34,7 +34,7 @@ into scope like `std/string`'s methods). Once the module is imported, the
 `debug` method dispatches on the receiver's type and needs no explicit
 selector:
 
-```raven
+```rust
 import std/fmt
 
 fun main() {
@@ -58,7 +58,7 @@ to its length minus one. See [std/string](string.md) for the same byte model.
 
 `s` concatenated `n` times. A non-positive `n` yields the empty string.
 
-```raven
+```rust
 import std/fmt { repeat }
 
 fun main() {
@@ -76,7 +76,7 @@ that does not exceed the current length returns `s` unchanged.
 
 Right-pad `s` with `fill` until its byte length is at least `width`.
 
-```raven
+```rust
 import std/fmt { pad_left, pad_right }
 
 fun main() {
@@ -90,7 +90,7 @@ fun main() {
 Center `s` in a field of byte width `width`, padding with `fill`. An odd
 amount of padding puts the extra byte on the right.
 
-```raven
+```rust
 import std/fmt { center }
 
 fun main() {
@@ -103,7 +103,7 @@ fun main() {
 
 Join `parts` with `sep` between adjacent elements.
 
-```raven
+```rust
 import std/fmt { join }
 
 fun main() {
@@ -121,7 +121,7 @@ renders as `"0"`. Digits are `0-9` then lowercase `a-f`. The conversion works
 in the negative domain (accumulating the negative magnitude), so the most
 negative i64 has no overflowing negation.
 
-```raven
+```rust
 import std/fmt { to_radix }
 
 fun main() {
@@ -135,7 +135,7 @@ fun main() {
 
 Thin wrappers over `to_radix` for base 2, 8, and 16.
 
-```raven
+```rust
 import std/fmt { to_binary, to_octal, to_hex }
 
 fun main() {
@@ -152,7 +152,7 @@ stays leftmost and the zero fill goes between the sign and the digits, so
 `pad_int(-7, 4)` is `"-007"`. A `width` that does not exceed the rendered
 length returns the value unchanged.
 
-```raven
+```rust
 import std/fmt { pad_int }
 
 fun main() {
@@ -164,7 +164,7 @@ fun main() {
 
 ## The `Debug` trait
 
-```raven
+```rust
 trait Debug {
     fun debug(self) -> String
 }
@@ -185,7 +185,7 @@ Char and String quoting does not escape inner quotes: a String containing a
 `"` reproduces it literally inside the surrounding quotes. So `"hi".debug()` is
 the 4-character string `"hi"`.
 
-```raven
+```rust
 import std/fmt
 
 fun main() {
@@ -198,7 +198,7 @@ fun main() {
 
 ## Worked example: a fixed-width table row
 
-```raven
+```rust
 import std/fmt { pad_right, pad_int, join, to_hex }
 import std/io { println }
 

--- a/docs/v2/guide/stdlib/fs.md
+++ b/docs/v2/guide/stdlib/fs.md
@@ -5,7 +5,7 @@ list and size entries, query existence, and manipulate path strings. The
 fallible operations return `Result<T, Error>`; the queries return a plain
 `Bool`; the path helpers are pure string work with no runtime call.
 
-```raven
+```rust
 import std/fs { write, read }
 
 fun main() {
@@ -18,7 +18,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/fs { read, write, append, remove_file, create_dir, remove_dir, list_dir, size, exists, is_file, is_dir, join, dirname, basename, split }
 ```
 
@@ -26,7 +26,7 @@ import std/fs { read, write, append, remove_file, create_dir, remove_dir, list_d
 names you want. A bare `import std/fs` does not bring the functions into
 scope. Import only what a given file uses:
 
-```raven
+```rust
 import std/fs { read, exists }
 ```
 
@@ -43,7 +43,7 @@ empty string or a `-1`, it comes back as an `Err`. The two ways to consume a
 
 Handle each arm explicitly with `match`:
 
-```raven
+```rust
 import std/fs { read }
 
 fun main() {
@@ -57,7 +57,7 @@ fun main() {
 Or propagate the error to the caller with `?`, which unwraps `Ok` and
 returns early on `Err`:
 
-```raven
+```rust
 import std/fs { read, write }
 
 fun copy(src: String, dst: String) -> Result<Bool, Error> {
@@ -72,7 +72,7 @@ fun copy(src: String, dst: String) -> Result<Bool, Error> {
 
 Read the whole file at `path` and return it as a single `String`.
 
-```raven
+```rust
 import std/fs { read }
 
 fun main() {
@@ -90,7 +90,7 @@ success. The `Bool` payload is always `true`; it exists only so the success
 arm carries a value (the surface uses `Result<Bool, Error>` rather than a
 unit payload).
 
-```raven
+```rust
 import std/fs { write }
 
 fun main() {
@@ -106,7 +106,7 @@ fun main() {
 Write `contents` to the end of `path`, creating the file when it is absent.
 Returns `Ok(true)` on success.
 
-```raven
+```rust
 import std/fs { append }
 
 fun log_line(line: String) -> Result<Bool, Error> {
@@ -125,7 +125,7 @@ Remove the file at `path`. Returns `Ok(true)` on success.
 Create the directory at `path`, including any missing parent directories, so
 creating a nested path in one call succeeds. Returns `Ok(true)` on success.
 
-```raven
+```rust
 import std/fs { create_dir }
 
 fun main() {
@@ -146,7 +146,7 @@ Remove the directory at `path` and all of its contents recursively. Returns
 Return the entry names (not full paths) of the directory at `path`. An empty
 directory yields an empty list, not a one-element list containing `""`.
 
-```raven
+```rust
 import std/fs { list_dir }
 
 fun main() {
@@ -165,7 +165,7 @@ fun main() {
 
 Return the file size at `path` in bytes.
 
-```raven
+```rust
 import std/fs { size }
 
 fun main() {
@@ -179,7 +179,7 @@ fun main() {
 The `?` operator is the shorter form, but it only works inside a function that
 itself returns `Result`, not in `main`:
 
-```raven
+```rust
 import std/fs { size }
 
 fun total(a: String, b: String) -> Result<Int, Error> {
@@ -189,7 +189,7 @@ fun total(a: String, b: String) -> Result<Int, Error> {
 
 ## Boolean checks
 
-```raven
+```rust
 fun exists(path: String) -> Bool
 fun is_file(path: String) -> Bool
 fun is_dir(path: String) -> Bool
@@ -200,7 +200,7 @@ These return a plain `Bool`, never a `Result`. A missing path is a normal
 a regular file (a directory, say), and `is_dir` is `false` for anything that
 is not a directory.
 
-```raven
+```rust
 import std/fs { exists, is_dir, read }
 
 fun main() {
@@ -216,7 +216,7 @@ fun main() {
 
 ## Path helpers
 
-```raven
+```rust
 fun join(a: String, b: String) -> String
 fun basename(p: String) -> String
 fun dirname(p: String) -> String
@@ -235,7 +235,7 @@ Join two path segments with a single `/`, collapsing a trailing slash on `a`
 or a leading slash on `b` so the result never doubles the separator. An empty
 segment returns the other unchanged.
 
-```raven
+```rust
 import std/fs { join }
 
 fun main() {
@@ -249,7 +249,7 @@ fun main() {
 The final component of `p` (everything after the last `/`). A path with no
 slash returns unchanged.
 
-```raven
+```rust
 import std/fs { basename }
 
 fun main() {
@@ -263,7 +263,7 @@ fun main() {
 Everything before the last `/`. A path with no slash returns `"."`; a path
 whose only slash is at the front returns `"/"`.
 
-```raven
+```rust
 import std/fs { dirname }
 
 fun main() {
@@ -277,7 +277,7 @@ fun main() {
 Split `p` on `/` into its components, dropping empty pieces produced by
 leading, trailing, or repeated separators.
 
-```raven
+```rust
 import std/fs { split }
 
 fun main() {
@@ -293,7 +293,7 @@ fun main() {
 Write a file, confirm it exists, then read it back. Each fallible step uses
 `?` to bail out on the first error, and the caller decides what to do with it.
 
-```raven
+```rust
 import std/fs { write, read, exists }
 import std/error { error_kind }
 

--- a/docs/v2/guide/stdlib/hash.md
+++ b/docs/v2/guide/stdlib/hash.md
@@ -4,7 +4,7 @@ Non-cryptographic hashing building blocks: free functions that hash the bytes
 of a `String` or mix an `Int`. They are fast, well-known mixing functions meant
 for hash tables, checksums, and folding several values into one composite hash.
 
-```raven
+```rust
 import std/hash { fnv1a }
 
 fun main() {
@@ -28,7 +28,7 @@ combining the hashes of a struct's fields.
 Every entry is a free function, so bring in the ones you need with a selective
 import:
 
-```raven
+```rust
 import std/hash { fnv1a, djb2, hash_int, combine, checksum }
 ```
 
@@ -66,7 +66,7 @@ FNV-1a over the bytes of `s`, the 64-bit variant. A good general-purpose string
 hash with strong avalanche behavior for short keys. Prefer this when you want
 one string hash and are unsure which to pick.
 
-```raven
+```rust
 import std/hash { fnv1a }
 
 fun main() {
@@ -80,7 +80,7 @@ fun main() {
 The classic djb2 hash: start at `5381`, then `hash = hash * 33 + byte` for each
 byte. Simple and fast; included as a well-known alternative to `fnv1a`.
 
-```raven
+```rust
 import std/hash { djb2 }
 
 fun main() {
@@ -94,7 +94,7 @@ A plain additive checksum: the sum of the byte values in `s`. Cheaper and
 weaker than the hashes above, so use it only for quick change detection (did
 this string change?), not for distributing keys across buckets.
 
-```raven
+```rust
 import std/hash { checksum }
 
 fun main() {
@@ -110,7 +110,7 @@ A splitmix64-style bit-mix. Sequential integers (`0, 1, 2, ...`) hash to
 scattered, well-spread values, which is what you want before using them as
 table indices.
 
-```raven
+```rust
 import std/hash { hash_int }
 
 fun main() {
@@ -125,7 +125,7 @@ Fold `value` into `seed` and return the mixed result (the boost `hash_combine`
 recipe, using the 32-bit golden ratio constant). Chain it to hash a sequence of
 values into a single hash:
 
-```raven
+```rust
 import std/hash { hash_int, combine }
 
 fun main() {
@@ -147,7 +147,7 @@ uses to key its hash-based containers. These functions are the building blocks
 a user's own `Hash` impl can call: hash each field, then fold the results with
 `combine`.
 
-```raven
+```rust
 import std/hash { hash_int, combine }
 
 struct Point { x: Int, y: Int }
@@ -165,7 +165,7 @@ impl Hash for Point {
 Hash a small struct by mixing a string field and an integer field into one
 value, suitable for use as a key.
 
-```raven
+```rust
 import std/hash { fnv1a, hash_int, combine }
 
 struct User { name: String, id: Int }

--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -6,7 +6,7 @@ returns `Result<HttpResponse, Error>`, so transport failures (DNS, connect,
 timeout) come back as an [std/error](error.md) `Error` you handle with
 `match`.
 
-```raven
+```rust
 import std/http { get }
 
 fun main() {
@@ -19,7 +19,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/http { get, post, put, delete, request }
 ```
 
@@ -30,7 +30,7 @@ module and needs no separate selector.
 
 ### `struct HttpResponse`
 
-```raven
+```rust
 struct HttpResponse {
     status_code: Int,
     status_text: String,
@@ -57,7 +57,7 @@ server's value. Only transport failures (DNS, connect, timeout, malformed
 response) take the `Err` path. Inspect `status_code` yourself to tell a 200
 from a 404:
 
-```raven
+```rust
 import std/http { get }
 
 fun main() {
@@ -80,7 +80,7 @@ fun main() {
 
 Send a `GET` to `url`. No request body.
 
-```raven
+```rust
 import std/http { get }
 
 fun main() {
@@ -98,7 +98,7 @@ fun main() {
 
 Send `body` to `url` with a `POST`.
 
-```raven
+```rust
 import std/http { post }
 
 fun main() {
@@ -125,7 +125,7 @@ none), and `headers` is a String of `Key: Value` lines separated by `\n`
 (pass `""` for none). Use `request` when you need a custom method or
 request headers.
 
-```raven
+```rust
 import std/http { request }
 
 fun main() {
@@ -145,7 +145,7 @@ and `""` for headers.
 
 This GETs a URL, reports the status, and prints the body only on a 200.
 
-```raven
+```rust
 import std/http { get }
 
 fun fetch(url: String) {

--- a/docs/v2/guide/stdlib/io.md
+++ b/docs/v2/guide/stdlib/io.md
@@ -4,7 +4,7 @@ Console input and output: write lines to standard output and read lines from
 standard input. The functions here are free functions, so you import the ones
 you need by name.
 
-```raven
+```rust
 import std/io { println, input }
 
 fun main() {
@@ -15,7 +15,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/io { print, println, input, read_line }
 ```
 
@@ -29,7 +29,7 @@ You do not need `std/io` to print. The `print` builtin is always in scope and
 accepts any value whose type implements `ToString`, so it works on numbers,
 booleans, and your own types without conversion:
 
-```raven
+```rust
 fun main() {
     print(42)               // 42
     print(true)             // true
@@ -49,7 +49,7 @@ Write `s` to standard output with no trailing newline. The argument must be a
 `String`; build one with interpolation or [std/string](string.md) methods if
 you have other values to include.
 
-```raven
+```rust
 import std/io { print }
 
 fun main() {
@@ -62,7 +62,7 @@ fun main() {
 
 Write `s` to standard output followed by a newline.
 
-```raven
+```rust
 import std/io { println }
 
 fun main() {
@@ -79,7 +79,7 @@ Write `prompt` to standard output with no trailing newline, then read one line
 from standard input and return it without its trailing newline. At end of
 input the returned string is empty.
 
-```raven
+```rust
 import std/io { input }
 
 fun main() {
@@ -96,7 +96,7 @@ Read one line from standard input and return it without its trailing newline,
 printing no prompt. At end of input the returned string is empty, which is how
 you detect that the stream is exhausted.
 
-```raven
+```rust
 import std/io { read_line }
 import std/string
 
@@ -111,7 +111,7 @@ fun main() {
 Read lines until the input ends, skipping blank ones. The empty string from
 `read_line` at end of input ends the loop.
 
-```raven
+```rust
 import std/io { read_line, println }
 import std/string
 

--- a/docs/v2/guide/stdlib/iter.md
+++ b/docs/v2/guide/stdlib/iter.md
@@ -6,7 +6,7 @@ Lazy, single-pass iterator pipelines. `std/iter` gives a `List<T>` an
 set of consumers (`collect`, `count`, `fold`, `any`, `all`, `find`,
 `for_each`) that drive a pipeline to completion.
 
-```raven
+```rust
 import std/iter { collect }
 
 fun main() {
@@ -24,7 +24,7 @@ The adapters (`map`, `filter`, `take`, `skip`, `enumerate`) are methods on the
 iterator types, so they are available once you have an iterator. The consumers
 are free functions, so you bring in the ones you use by name:
 
-```raven
+```rust
 import std/iter { collect, fold }
 ```
 
@@ -40,7 +40,7 @@ is a small struct that remembers its source iterator (and, where applicable, a
 closure). Nothing runs until a **consumer** pulls elements through. A consumer
 walks the chain one element at a time, in a single pass.
 
-```raven
+```rust
 import std/iter { count }
 
 fun main() {
@@ -62,7 +62,7 @@ return a scalar or an `Option<T>` without allocating an intermediate list.
 Defined on `List<T>`. Returns a `ListIter<T>` that walks the list by index.
 This is the usual entry point into a pipeline.
 
-```raven
+```rust
 import std/iter { collect }
 
 fun main() {
@@ -87,14 +87,14 @@ adapter's `next` pulls from its source on demand.
 
 ### `map`
 
-```raven
+```rust
 fun map<U>(self, f: fun(T) -> U) -> MapIter<T, U, Self>
 ```
 
 Apply a closure to each element, yielding the result. The element type can
 change (`T` to `U`).
 
-```raven
+```rust
 import std/iter { collect }
 
 fun main() {
@@ -108,14 +108,14 @@ fun main() {
 
 ### `filter`
 
-```raven
+```rust
 fun filter(self, pred: fun(T) -> Bool) -> Filter<T, Self>
 ```
 
 Keep only the elements for which `pred` returns `true`. `next` pulls from the
 source until the predicate holds or the source is exhausted.
 
-```raven
+```rust
 import std/iter { collect }
 
 fun main() {
@@ -129,14 +129,14 @@ fun main() {
 
 ### `take`
 
-```raven
+```rust
 fun take(self, n: Int) -> Take<T, Self>
 ```
 
 Yield at most the first `n` elements, then stop. Because the pipeline is lazy,
 later elements are never produced.
 
-```raven
+```rust
 import std/iter { collect }
 
 fun main() {
@@ -149,13 +149,13 @@ fun main() {
 
 ### `skip`
 
-```raven
+```rust
 fun skip(self, n: Int) -> Skip<T, Self>
 ```
 
 Discard the first `n` elements, then pass the rest through.
 
-```raven
+```rust
 import std/iter { collect }
 
 fun main() {
@@ -168,7 +168,7 @@ fun main() {
 
 ### `enumerate`
 
-```raven
+```rust
 fun enumerate(self) -> Enumerate<T, Self>
 ```
 
@@ -176,7 +176,7 @@ Pair each element with its running index, starting at `0`. Raven has no tuples
 yet, so `enumerate` yields an `Indexed<T>` record instead of a `(Int, T)`
 pair:
 
-```raven
+```rust
 struct Indexed<T> {
     index: Int,
     value: T,
@@ -185,7 +185,7 @@ struct Indexed<T> {
 
 Read `.index` and `.value` off each element:
 
-```raven
+```rust
 import std/iter { for_each }
 
 fun main() {
@@ -213,7 +213,7 @@ what drives the pipeline, so every pipeline ends in exactly one consumer call.
 
 Gather every remaining element into a `List<T>`, in order.
 
-```raven
+```rust
 import std/iter { collect }
 
 fun main() {
@@ -227,7 +227,7 @@ fun main() {
 
 Count the remaining elements.
 
-```raven
+```rust
 import std/iter { count }
 
 fun main() {
@@ -242,7 +242,7 @@ fun main() {
 Left fold: start from `init` and combine the running accumulator with each
 element.
 
-```raven
+```rust
 import std/iter { fold }
 
 fun main() {
@@ -261,7 +261,7 @@ True when at least one element satisfies `pred`. Stops at the first match.
 True when every element satisfies `pred`. Vacuously true for an empty
 iterator.
 
-```raven
+```rust
 import std/iter { any, all }
 
 fun main() {
@@ -275,7 +275,7 @@ fun main() {
 
 The first element satisfying `pred`, or `None` when none does.
 
-```raven
+```rust
 import std/iter { find }
 
 fun main() {
@@ -292,7 +292,7 @@ fun main() {
 
 Apply `f` to each element for its side effect.
 
-```raven
+```rust
 import std/iter { for_each }
 
 fun main() {
@@ -310,7 +310,7 @@ A pipeline is built with the adapter methods and then handed to a consumer.
 Here `iter().filter(...).map(...).take(...)` describes the work lazily, and
 `collect` runs it in a single pass:
 
-```raven
+```rust
 import std/iter { collect }
 
 fun main() {
@@ -333,7 +333,7 @@ produce three results; it never maps `80` or `100`.
 You can swap the final consumer to ask a different question of the same
 pipeline. With `fold` instead of `collect`:
 
-```raven
+```rust
 import std/iter { fold }
 
 fun main() {
@@ -354,7 +354,7 @@ A `for x in <iterable>` loop drives any value whose type implements
 directly; an iterator pipeline works the same way, so you can loop over one
 instead of calling a consumer:
 
-```raven
+```rust
 import std/iter
 
 fun main() {

--- a/docs/v2/guide/stdlib/json.md
+++ b/docs/v2/guide/stdlib/json.md
@@ -4,7 +4,7 @@ Parse and serialize JSON. `std/json` is a recursive descent parser
 (`parse`) and a compact serializer (`stringify`) written in pure Raven, with
 a `JsonValue` enum for the parsed value tree.
 
-```raven
+```rust
 import std/json { parse, stringify }
 
 fun main() {
@@ -20,7 +20,7 @@ text `{"name": "Ada"}` is written `"{\"name\": \"Ada\"}"`.
 
 ## Importing
 
-```raven
+```rust
 import std/json { parse, stringify }
 ```
 
@@ -29,7 +29,7 @@ Bring in just what you use. The accessor methods on `JsonValue` (`is_null`,
 import of `parse` and `stringify` is enough for most code. Import the type
 explicitly when you name it:
 
-```raven
+```rust
 import std/json { parse, stringify, JsonValue }
 ```
 
@@ -38,7 +38,7 @@ import std/json { parse, stringify, JsonValue }
 A parsed JSON document is a `JsonValue`, a tagged union over the six JSON
 shapes:
 
-```raven
+```rust
 enum JsonValue {
     Null,
     Bool(Bool),
@@ -77,7 +77,7 @@ Any non-whitespace content after the top-level value is rejected.
 
 `parse` returns a `Result`, so handle both arms with `match`:
 
-```raven
+```rust
 import std/json { parse }
 
 fun main() {
@@ -134,7 +134,7 @@ True only for the `Null` variant.
 A typical read chains a container step and then an extractor, handling each
 `Option` with `match`:
 
-```raven
+```rust
 import std/json { parse }
 
 fun main() {
@@ -172,7 +172,7 @@ passes through unchanged.
 A whole-number `Float` renders the way the runtime prints it, so `1.0`
 serializes as `1` and `0.15` serializes as `0.15`.
 
-```raven
+```rust
 import std/json { parse, stringify }
 
 fun main() {
@@ -188,7 +188,7 @@ fun main() {
 `std/json` also defines two traits for converting between a Raven value and
 its JSON form:
 
-```raven
+```rust
 trait ToJson {
     fun to_json(self) -> JsonValue
 }
@@ -212,7 +212,7 @@ the full encoding and the helper functions the derive emits.
 
 ## Worked example: read a config field
 
-```raven
+```rust
 import std/json { parse }
 
 // Pull the "name" string out of a JSON object, with a fallback for any

--- a/docs/v2/guide/stdlib/math.md
+++ b/docs/v2/guide/stdlib/math.md
@@ -3,7 +3,7 @@
 Numeric constants and functions. Everything in `std/math` is a free
 function, so you bring names into scope with a selective import:
 
-```raven
+```rust
 import std/math { sqrt, pow_int }
 
 fun main() {
@@ -14,7 +14,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/math { sqrt, pow, abs_int, pi }
 ```
 
@@ -55,7 +55,7 @@ Clamp `x` into the closed range `[lo, hi]`: return `lo` if `x < lo`, `hi` if
 result and returns `0`. The result is exact when it fits in a 64-bit signed
 integer; overflow is not detected.
 
-```raven
+```rust
 import std/math { abs_int, min_int, max_int, clamp_int, pow_int }
 
 fun main() {
@@ -108,7 +108,7 @@ value, and toward zero. Each returns a whole-valued `Float`.
 
 Sine and cosine, with the angle in radians.
 
-```raven
+```rust
 import std/math { sqrt, pow, exp, ln, abs, min, max, clamp, floor, ceil, round, trunc, sin, cos }
 
 fun main() {
@@ -141,7 +141,7 @@ zero-argument functions returning `Float`. Call them with `()`.
 
 6.283185307179586 (a full turn, `2 * pi`).
 
-```raven
+```rust
 import std/math { pi, e, tau, sin }
 
 fun main() {
@@ -155,7 +155,7 @@ fun main() {
 
 `sqrt` plus `pow` gives the Euclidean distance between two points.
 
-```raven
+```rust
 import std/math { sqrt, pow }
 
 fun distance(x1: Float, y1: Float, x2: Float, y2: Float) -> Float {

--- a/docs/v2/guide/stdlib/net.md
+++ b/docs/v2/guide/stdlib/net.md
@@ -5,7 +5,7 @@ connections, read and write bytes, resolve DNS names, and probe whether an
 address is reachable. The handle types (`TcpStream`, `TcpListener`) and the
 free functions all return values through the `Result<T, Error>` model.
 
-```raven
+```rust
 import std/net { connect }
 
 fun main() {
@@ -21,7 +21,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/net { connect, listen, dns_lookup, reachable }
 ```
 
@@ -33,7 +33,7 @@ in a process-wide registry and hands Raven an opaque integer id. `TcpStream`
 and `TcpListener` are thin structs wrapping that id; every method looks the
 socket up by id and acts on it.
 
-```raven
+```rust
 struct TcpStream { id: Int }
 struct TcpListener { id: Int }
 ```
@@ -48,7 +48,7 @@ Every fallible operation returns `Result<T, Error>` where `Error` is the
 context prefix (the operation name) joined to the OS error text. Match on the
 `Result`, or use the [std/error](error.md) combinators to thread it.
 
-```raven
+```rust
 import std/net { connect }
 
 fun main() {
@@ -69,7 +69,7 @@ The one exception is `reachable`, which never fails and returns a plain
 Open a TCP stream to `addr` in `"host:port"` form. On success you get an open
 `TcpStream`; on failure an `Err` carrying the OS message.
 
-```raven
+```rust
 import std/net { connect }
 
 fun main() {
@@ -109,7 +109,7 @@ This method does not return a `Result`.
 Close the stream, releasing the runtime-side socket. It does not return a
 `Result`.
 
-```raven
+```rust
 import std/net { connect }
 
 fun main() {
@@ -146,7 +146,7 @@ so accept waits rather than polling.
 A server loops: bind once with `listen`, then call `accept` repeatedly,
 serving each accepted stream before accepting the next.
 
-```raven
+```rust
 import std/net { listen }
 
 fun serve() {
@@ -182,7 +182,7 @@ at once.
 Resolve `host` to its IP addresses as a `List<String>`. An empty result is an
 empty list, not a one-element list of `""`.
 
-```raven
+```rust
 import std/net { dns_lookup }
 
 fun main() {
@@ -205,7 +205,7 @@ Probe whether `addr` in `"host:port"` form accepts a TCP connection within a
 short timeout. This is a non-failing check: it returns a plain `Bool` and
 never sets an error.
 
-```raven
+```rust
 import std/net { reachable }
 
 fun main() {
@@ -222,7 +222,7 @@ fun main() {
 Connect, send a request, read the reply, and close, handling the `Result` at
 each step.
 
-```raven
+```rust
 import std/net { connect }
 
 fun fetch(addr: String, request: String) -> Result<String, Error> {

--- a/docs/v2/guide/stdlib/path.md
+++ b/docs/v2/guide/stdlib/path.md
@@ -6,7 +6,7 @@ never checks whether a file exists, never reads a directory, never
 resolves a real path. For anything that talks to the filesystem, reach for
 [std/fs](fs.md) instead.
 
-```raven
+```rust
 import std/path { join, basename, dirname, extension, stem, is_absolute }
 
 fun main() {
@@ -22,7 +22,7 @@ fun main() {
 The functions have no natural single receiver, so they are free functions
 brought in by a selective import:
 
-```raven
+```rust
 import std/path { join, basename, dirname, extension, stem, is_absolute }
 ```
 
@@ -60,7 +60,7 @@ Join two path parts with a single `/`. The result never doubles the
 separator: it stays one `/` whether `a` ends with a slash, `b` begins with
 one, or both. If either operand is empty, the other is returned unchanged.
 
-```raven
+```rust
 import std/path { join }
 
 fun main() {
@@ -80,7 +80,7 @@ fun main() {
 The final component, everything after the last `/`. When `p` contains no
 `/`, the whole string is the basename.
 
-```raven
+```rust
 import std/path { basename }
 
 fun main() {
@@ -97,7 +97,7 @@ Everything up to the last `/`. Two edge cases are worth remembering:
 - When there is no `/`, `dirname` returns `"."` (the current directory).
 - When the only `/` is at index 0, it returns `"/"` (the root).
 
-```raven
+```rust
 import std/path { dirname }
 
 fun main() {
@@ -114,7 +114,7 @@ dot. The dot is inspected on the basename only, so a `.` in a parent
 directory name does not count. A leading dot marks a dotfile, not an
 extension: the extension of `.gitignore` is `""`.
 
-```raven
+```rust
 import std/path { extension }
 
 fun main() {
@@ -131,7 +131,7 @@ The basename with its extension removed: the part `extension` leaves
 behind. For a name without an extension, the whole basename is the stem,
 and a dotfile keeps its leading dot.
 
-```raven
+```rust
 import std/path { stem }
 
 fun main() {
@@ -146,7 +146,7 @@ fun main() {
 
 True when `p` starts with `/`. The empty string is relative.
 
-```raven
+```rust
 import std/path { is_absolute }
 
 fun main() {
@@ -161,7 +161,7 @@ fun main() {
 This walks a path apart, swaps its extension, and joins it back together
 using only documented functions.
 
-```raven
+```rust
 import std/path { join, dirname, stem, is_absolute }
 
 fun with_extension(p: String, ext: String) -> String {

--- a/docs/v2/guide/stdlib/process.md
+++ b/docs/v2/guide/stdlib/process.md
@@ -5,7 +5,7 @@ waits for it to finish, and hands you the captured exit code, stdout, and
 stderr as an `Output` value. There is no streaming: a child runs to
 completion in a single call.
 
-```raven
+```rust
 import std/process { run }
 
 fun main() {
@@ -19,7 +19,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/process { run, run_with_input }
 ```
 
@@ -28,7 +28,7 @@ in with the type and needs no separate selector.
 
 ## The `Output` type
 
-```raven
+```rust
 struct Output { code: Int, stdout: String, stderr: String }
 ```
 
@@ -44,7 +44,7 @@ A finished child's captured result.
 
 True when `code` is `0`.
 
-```raven
+```rust
 import std/process { run }
 
 fun main() {
@@ -67,14 +67,14 @@ success returns `Ok(Output)` with the captured code, stdout, and stderr.
 When a program takes no arguments, pass an explicitly typed empty list so the
 element type is known:
 
-```raven
+```rust
 let no_args: List<String> = []
 ```
 
 A bare `[]` has no element type the checker can infer here, so the annotation
 is required.
 
-```raven
+```rust
 import std/process { run }
 
 fun main() {
@@ -91,7 +91,7 @@ fun main() {
 Like `run`, but writes `input` to the child's stdin and then closes it. Use
 this for programs that read from standard input.
 
-```raven
+```rust
 import std/process { run_with_input }
 
 fun main() {
@@ -115,7 +115,7 @@ is not found or cannot be executed. The error is
 `Err(Error { kind: "process", message })`, where `message` is the OS error
 text. The `Error` type comes from [std/error](error.md).
 
-```raven
+```rust
 import std/process { run }
 
 fun main() {
@@ -140,7 +140,7 @@ fun main() {
 Run `git` to print the current branch name, falling back to a label when the
 command is missing or reports a failure.
 
-```raven
+```rust
 import std/process { run }
 import std/string
 

--- a/docs/v2/guide/stdlib/random.md
+++ b/docs/v2/guide/stdlib/random.md
@@ -4,7 +4,7 @@ A small, reproducible pseudo-random generator. `Rng` is a value type holding
 the generator state; its methods draw the next value and mutate that state in
 place.
 
-```raven
+```rust
 import std/random
 
 fun main() {
@@ -15,7 +15,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/random
 ```
 
@@ -36,7 +36,7 @@ draws. That determinism is the point of seeded construction, and it makes
 timestamp mixed with the process id), so its stream is not reproducible across
 runs. Reach for it when you want a fresh, unpredictable sequence.
 
-```raven
+```rust
 import std/random
 
 fun main() {
@@ -64,7 +64,7 @@ runs.
 
 The next raw 64-bit draw. Values span the full `Int` range and may be negative.
 
-```raven
+```rust
 import std/random
 
 fun main() {
@@ -78,7 +78,7 @@ fun main() {
 
 A value in the half-open interval `[lo, hi)`: `lo` is possible, `hi` is not.
 
-```raven
+```rust
 import std/random
 
 fun main() {
@@ -98,7 +98,7 @@ A `Float` in `[0.0, 1.0)`. It takes the top 53 bits of a draw and scales by
 2^-53 (the full f64 mantissa width), so every representable multiple of 2^-53
 in the interval is reachable.
 
-```raven
+```rust
 import std/random
 
 fun main() {
@@ -111,7 +111,7 @@ fun main() {
 
 `true` or `false` from the low bit of a draw, a fair coin flip.
 
-```raven
+```rust
 import std/random
 
 fun main() {
@@ -128,7 +128,7 @@ A random element of `xs`, or `None` when the list is empty. Because the result
 is an `Option<T>`, unwrap it with a `match` (or your preferred `Option` helper)
 before use.
 
-```raven
+```rust
 import std/random
 
 fun main() {
@@ -147,7 +147,7 @@ fun main() {
 Shuffles `xs` in place using Fisher-Yates. It returns nothing; the list passed
 in is reordered.
 
-```raven
+```rust
 import std/random
 
 fun main() {
@@ -165,7 +165,7 @@ fun main() {
 A seeded generator makes a test deterministic: pick the same seed and the
 output never drifts between runs.
 
-```raven
+```rust
 import std/random
 
 fun main() {

--- a/docs/v2/guide/stdlib/regex.md
+++ b/docs/v2/guide/stdlib/regex.md
@@ -4,7 +4,7 @@ Regular expressions: compile a pattern once into a reusable handle, then test
 for a match, find the first match or every match, pull out capture groups,
 replace matches, and split on a pattern.
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {
@@ -20,7 +20,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/regex { compile }
 ```
 
@@ -39,7 +39,7 @@ Compile `pattern` into a reusable `Regex`. On success the result is
 `Ok(Regex)`. An invalid pattern is `Err(Error)` from [std/error](error.md),
 tagged with kind `"regex"`, its message the underlying syntax error.
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {
@@ -74,7 +74,7 @@ method on the handle afterward.
 
 True when the pattern matches anywhere in `text`.
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {
@@ -94,7 +94,7 @@ fun main() {
 The first match in `text`, or `None` when there is no match. A matched empty
 string is `Some("")`, distinct from `None`.
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {
@@ -116,7 +116,7 @@ fun main() {
 Every non-overlapping match in `text`, in order. No matches yields an empty
 list.
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {
@@ -140,7 +140,7 @@ The capture groups of the first match: group 0 (the whole match) first, then
 groups 1, 2, and so on. An unmatched optional group is an empty string. No
 match yields an empty list.
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {
@@ -165,7 +165,7 @@ Replace every non-overlapping match in `text` with `repl`. Group references in
 `repl` are honored: `$1` and `${1}` for numbered groups, `$name` for named
 groups.
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {
@@ -186,7 +186,7 @@ fun main() {
 
 Split `text` on the pattern, returning the pieces in order.
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {
@@ -219,7 +219,7 @@ unaffected.
 
 ## Worked example: parsing key=value lines
 
-```raven
+```rust
 import std/regex { compile }
 
 fun main() {

--- a/docs/v2/guide/stdlib/string.md
+++ b/docs/v2/guide/stdlib/string.md
@@ -4,7 +4,7 @@ Methods for working with text. `std/string` adds an `impl String` block, so
 a bare `import std/string` brings every method below into scope as a method
 on any `String` value.
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -15,7 +15,7 @@ fun main() {
 
 ## Importing
 
-```raven
+```rust
 import std/string
 ```
 
@@ -46,7 +46,7 @@ unchanged.
 
 The number of UTF-8 bytes in the string. `len` is a built-in alias.
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -64,7 +64,7 @@ True when the string has no bytes. Also available built in.
 True when the string is empty or contains only ASCII whitespace (space, tab,
 newline, carriage return, vertical tab, form feed).
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -86,7 +86,7 @@ byte of the encoding, not the whole character.)
 The half-open byte range `[start, end)`, clamped to `0..length`. A `start`
 at or past `end` yields the empty string.
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -106,7 +106,7 @@ is left as is.
 
 Remove leading and trailing ASCII whitespace. Interior whitespace is kept.
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -120,7 +120,7 @@ fun main() {
 The string concatenated `n` times. A non-positive `n` yields the empty
 string.
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -149,7 +149,7 @@ True when the bytes of `needle` occur starting at byte index `at`. The
 building block the other search methods use; handy for hand-written
 scanning.
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -172,7 +172,7 @@ building up text, but `concat` is the explicit method form.
 Replace every non-overlapping occurrence of `from` with `to`, scanning left
 to right. An empty `from` returns the input unchanged.
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -187,7 +187,7 @@ fun main() {
 `>=`, and they support `==`. A string literal can also be a `match` pattern,
 compared by content:
 
-```raven
+```rust
 fun classify(word: String) -> Int {
     return match word {
         "yes" -> 1,
@@ -199,7 +199,7 @@ fun classify(word: String) -> Int {
 
 ## Worked example: a tiny slug builder
 
-```raven
+```rust
 import std/string
 
 fun slug(title: String) -> String {

--- a/docs/v2/guide/stdlib/sync.md
+++ b/docs/v2/guide/stdlib/sync.md
@@ -7,7 +7,7 @@ threads: exactly one runs at a time, and a goroutine keeps running until it
 hits a yield point (a blocking channel operation or an explicit `yield_now()`),
 at which the scheduler resumes another ready goroutine.
 
-```raven
+```rust
 import std/sync { channel, channel_buffered, yield_now }
 
 fun main() {
@@ -23,7 +23,7 @@ Channels in this slice carry `Int` values.
 
 ## Importing
 
-```raven
+```rust
 import std/sync { channel, channel_buffered, yield_now }
 ```
 
@@ -42,7 +42,7 @@ Create an unbuffered (rendezvous) channel. A `send` blocks until a receiver is
 ready to take the value, and a `recv` blocks until a sender hands one over. The
 two sides meet: nothing is stored in between.
 
-```raven
+```rust
 import std/sync { channel, channel_buffered, yield_now }
 
 fun main() {
@@ -60,7 +60,7 @@ Create a buffered channel of capacity `cap`. A `send` returns immediately while
 there is room in the buffer, and only blocks once the buffer is full. A `recv`
 takes the oldest buffered value, and blocks only when the buffer is empty.
 
-```raven
+```rust
 import std/sync { channel, channel_buffered, yield_now }
 
 fun main() {
@@ -86,7 +86,7 @@ scheduler so other goroutines can run.
 Receive a value, blocking until one is available. On an empty channel the
 goroutine yields to the scheduler and resumes when a sender delivers a value.
 
-```raven
+```rust
 import std/sync { channel, channel_buffered, yield_now }
 
 fun main() {
@@ -110,7 +110,7 @@ your goroutines communicate over channels, since `send` and `recv` already
 yield when they block, but it is useful for handing off in a tight loop that
 otherwise never reaches a blocking operation.
 
-```raven
+```rust
 import std/sync { channel, channel_buffered, yield_now }
 
 fun main() {
@@ -129,7 +129,7 @@ fun main() {
 capture channels from the surrounding scope and use them to communicate with
 `main` (which is itself goroutine 0) or with other goroutines.
 
-```raven
+```rust
 import std/sync { channel, channel_buffered, yield_now }
 
 fun main() {
@@ -163,7 +163,7 @@ with none ready, the scheduler reports a deadlock and exits.
 A buffered channel decouples the producer from the consumer so the producer can
 get ahead while the consumer catches up.
 
-```raven
+```rust
 import std/sync { channel_buffered, yield_now }
 
 fun main() {

--- a/docs/v2/guide/stdlib/test.md
+++ b/docs/v2/guide/stdlib/test.md
@@ -5,7 +5,7 @@ program whose `main` calls these assertions: if every assertion holds, the
 program runs to completion and exits zero; if one fails, it panics with a
 message and aborts with a nonzero exit code.
 
-```raven
+```rust
 import std/test { assert, assert_eq_int }
 import std/io { println }
 
@@ -21,7 +21,7 @@ fun main() {
 The assertions are free functions, so import the ones you use with a
 selective list:
 
-```raven
+```rust
 import std/test { assert, assert_msg, assert_true, assert_false, assert_eq_int, assert_eq_str }
 ```
 
@@ -46,7 +46,7 @@ fixed message and exits nonzero.
 
 Fails when `cond` is false. Panic message: `assertion failed`.
 
-```raven
+```rust
 import std/test { assert }
 
 fun main() {
@@ -60,7 +60,7 @@ fun main() {
 Fails when `cond` is false, panicking with the caller-supplied `msg`. Use
 this when you want the failure to explain itself.
 
-```raven
+```rust
 import std/test { assert_msg }
 
 fun main() {
@@ -77,7 +77,7 @@ Fails when `cond` is false. Panic message: `assertion failed: expected true`.
 
 Fails when `cond` is true. Panic message: `assertion failed: expected false`.
 
-```raven
+```rust
 import std/test { assert_true, assert_false }
 import std/string
 
@@ -93,7 +93,7 @@ Fails when `a != b`. The panic message interpolates both operands
 (`assertion failed: ${a} != ${b}`), so a failure shows the mismatched
 values.
 
-```raven
+```rust
 import std/test { assert_eq_int }
 
 fun double(x: Int) -> Int {
@@ -110,7 +110,7 @@ fun main() {
 Fails when `a != b`, compared by content. The panic message interpolates
 both operands (`assertion failed: ${a} != ${b}`).
 
-```raven
+```rust
 import std/test { assert_eq_str }
 import std/string
 
@@ -125,7 +125,7 @@ A test file is a regular `.rv` program with a `main` that asserts. The
 program below exercises a couple of helpers and exits zero only if every
 check passes:
 
-```raven
+```rust
 import std/test { assert, assert_eq_int, assert_eq_str }
 import std/string
 import std/io { println }

--- a/docs/v2/guide/stdlib/time.md
+++ b/docs/v2/guide/stdlib/time.md
@@ -5,7 +5,7 @@ is UTC, and there is no local-timezone handling. Timestamps are Unix time:
 whole seconds, except `now_millis`, which is milliseconds. The functions are
 brought into scope with a selective import.
 
-```raven
+```rust
 import std/time { now, format_timestamp }
 
 fun main() {
@@ -17,7 +17,7 @@ fun main() {
 
 Pull in the functions you use with a selective `{ ... }` list:
 
-```raven
+```rust
 import std/time { now, now_millis, from_timestamp, weekday, format_timestamp, parse_timestamp, sleep_millis }
 ```
 
@@ -34,7 +34,7 @@ value by 1000 before passing it to the seconds-based functions.
 
 `from_timestamp` returns a `DateTime`, which nests a `Date` and a `Time`:
 
-```raven
+```rust
 struct Date { year: Int, month: Int, day: Int }
 struct Time { hour: Int, minute: Int, second: Int }
 struct DateTime { date: Date, time: Time }
@@ -48,7 +48,7 @@ as `1970-01-01` (year zero-padded to four digits, month and day to two), a
 `Time` as `00:00:00`, and a `DateTime` as the two joined by a space,
 `1970-01-01 00:00:00`.
 
-```raven
+```rust
 import std/time { from_timestamp }
 
 fun main() {
@@ -69,7 +69,7 @@ The current Unix timestamp in whole seconds (UTC).
 
 The current Unix time in milliseconds (UTC).
 
-```raven
+```rust
 import std/time { now, now_millis }
 
 fun main() {
@@ -90,7 +90,7 @@ outside chrono's representable range falls back to the epoch.
 
 The weekday of `ts` (UTC) as `0` for Sunday through `6` for Saturday.
 
-```raven
+```rust
 import std/time { from_timestamp, weekday }
 
 fun main() {
@@ -118,7 +118,7 @@ fun main() {
 Render the UTC datetime of `ts` with the given chrono strftime pattern, for
 example `"%Y-%m-%d %H:%M:%S"`.
 
-```raven
+```rust
 import std/time { format_timestamp }
 
 fun main() {
@@ -134,7 +134,7 @@ timestamp in seconds. Parsing is fallible: on failure it returns an `Err`
 holding a `std/error` `Error` tagged with kind `"time"`. Handle the `Result`
 with a `match` or the `?` operator.
 
-```raven
+```rust
 import std/time { parse_timestamp }
 
 fun main() {
@@ -159,7 +159,7 @@ fun main() {
 Sleep the current thread for `ms` milliseconds. A negative value is treated
 as zero.
 
-```raven
+```rust
 import std/time { sleep_millis }
 
 fun main() {
@@ -171,7 +171,7 @@ fun main() {
 
 Format the current time, then parse the formatted text back to a timestamp:
 
-```raven
+```rust
 import std/time { now, format_timestamp, parse_timestamp, from_timestamp, weekday }
 
 fun main() {

--- a/docs/v2/guide/tutorials/task-tracker.md
+++ b/docs/v2/guide/tutorials/task-tracker.md
@@ -12,7 +12,7 @@ If you are new to the language, skim the
 
 A struct groups related fields under one type. A task has an id and a title:
 
-```raven
+```rust
 struct Task {
     id: Int,
     title: String,
@@ -33,7 +33,7 @@ wrong type is a compile error, not a surprise at runtime.
 A task has a status, and a status is exactly one of a fixed set: to do, doing,
 or done. That is a sum type, written as an `enum`. Add it and a field for it:
 
-```raven
+```rust
 enum Status {
     Todo,
     Doing,
@@ -55,7 +55,7 @@ fun main() {
 You construct a variant with the qualified form `Status.Doing`. To turn a
 status into text, use `match`, which checks that you handle every variant:
 
-```raven
+```rust
 fun label(s: Status) -> String {
     return match s {
         Todo -> "todo",
@@ -75,7 +75,7 @@ checking, and it is one of the main reasons to reach for an enum.
 Some statuses need more than a name. A blocked task should say what it is
 waiting on. A variant can carry a payload, so give `Blocked` a `String`:
 
-```raven
+```rust
 enum Status {
     Todo,
     Doing,
@@ -86,7 +86,7 @@ enum Status {
 
 Now a `match` arm for `Blocked` binds the payload to a name you can use:
 
-```raven
+```rust
 fun label(s: Status) -> String {
     return match s {
         Todo -> "todo",
@@ -106,7 +106,7 @@ which forces you to consider the blocked case wherever a status is inspected.
 Functions that belong to a type live in an `impl` block and take `self`. Move
 the formatting onto `Task` as a method:
 
-```raven
+```rust
 impl Task {
     fun line(self) -> String {
         let tag = match self.status {
@@ -129,7 +129,7 @@ Searching a list might find nothing, and Raven has no `null` to return in that
 case. The answer is `Option<T>`: `Some(value)` when there is a result, `None`
 when there is not. A lookup by id:
 
-```raven
+```rust
 fun find(tasks: List<Task>, id: Int) -> Option<Task> {
     for t in tasks {
         if t.id == id {
@@ -142,7 +142,7 @@ fun find(tasks: List<Task>, id: Int) -> Option<Task> {
 
 The caller `match`es on the result and cannot forget the missing case:
 
-```raven
+```rust
 match find(tasks, 2) {
     Some(t) -> print("found: ${t.title}"),
     None -> print("not found"),
@@ -153,7 +153,7 @@ match find(tasks, 2) {
 
 Putting it together:
 
-```raven
+```rust
 enum Status {
     Todo,
     Doing,

--- a/docs/v2/guide/tutorials/word-frequency.md
+++ b/docs/v2/guide/tutorials/word-frequency.md
@@ -12,7 +12,7 @@ the compiler and learn `raven build`.
 
 Start with the smallest thing that runs. Create `wordfreq.rv`:
 
-```raven
+```rust
 fun main() {
     let text = "the cat sat on the mat the cat ran"
     print(text)
@@ -33,7 +33,7 @@ expression is the cleanest way to extract just the word-like runs. The
 pattern `[a-z]+` matches one or more lowercase letters, and `find_all`
 returns every match as a `List<String>`.
 
-```raven
+```rust
 import std/regex { compile }
 import std/string
 
@@ -71,7 +71,7 @@ seen it. For each word, look it up: if it is already there, store one more;
 if not, start it at one. [std/collections](../stdlib/collections.md) provides
 the map.
 
-```raven
+```rust
 import std/regex { compile }
 import std/collections
 import std/string
@@ -119,7 +119,7 @@ and sort it. A `Map` does not order its keys, so build a list of pairs first.
 Model a pair as a small struct, then sort with a comparator from
 [std/cmp](../stdlib/cmp.md):
 
-```raven
+```rust
 import std/regex { compile }
 import std/collections
 import std/string
@@ -193,7 +193,7 @@ returns `Result<String, Error>`, so a missing file is handled the same way a
 bad regex was: with a `match`. Here is the complete program, reading from
 `input.txt`:
 
-```raven
+```rust
 import std/fs { read }
 import std/regex { compile }
 import std/collections

--- a/docs/v2/migration.md
+++ b/docs/v2/migration.md
@@ -38,7 +38,7 @@ became `Unit`.
 
 v1:
 
-```raven
+```rust
 let name: string = "Raven";
 let count: int = 0;
 let ratio: float = 0.5;
@@ -47,7 +47,7 @@ let ready: bool = true;
 
 v2:
 
-```raven
+```rust
 let name: String = "Raven"
 let count: Int = 0
 let ratio: Float = 0.5
@@ -67,14 +67,14 @@ statement execution, and starts the program at `fun main()`.
 
 v1:
 
-```raven
+```rust
 let message: string = "Hello, Raven!";
 print(message);
 ```
 
 v2:
 
-```raven
+```rust
 fun main() {
     let message = "Hello, Raven!"
     print(message)
@@ -85,7 +85,7 @@ A v1 file that defined `main` and then called it loses the trailing call:
 
 v1:
 
-```raven
+```rust
 fun main() -> void {
     print("hi");
 }
@@ -94,7 +94,7 @@ main();
 
 v2:
 
-```raven
+```rust
 fun main() {
     print("hi")
 }
@@ -108,14 +108,14 @@ example an empty list).
 
 v1:
 
-```raven
+```rust
 let count: int = 0;
 let names: string[] = [];
 ```
 
 v2:
 
-```raven
+```rust
 let count = 0
 let names: List<String> = []
 ```
@@ -124,7 +124,7 @@ v2 bindings are mutable: you can reassign a `let` and mutate its fields and
 elements, the same as v1 `let`. For a module level compile time constant,
 v2 adds `const`, which requires both a type and a value:
 
-```raven
+```rust
 const MAX: Int = 100
 ```
 
@@ -136,7 +136,7 @@ body with `=` for one liners.
 
 v1:
 
-```raven
+```rust
 fun add(a: int, b: int) -> int {
     return a + b;
 }
@@ -148,7 +148,7 @@ fun greet(name: string) -> void {
 
 v2:
 
-```raven
+```rust
 fun add(a: Int, b: Int) -> Int {
     return a + b
 }
@@ -163,7 +163,7 @@ fun square(n: Int) -> Int = n * n
 The last block expression is also the return value, so `return` is
 optional at the tail of a function:
 
-```raven
+```rust
 fun classify(age: Int) -> String {
     if age < 18 {
         "Too young"
@@ -175,7 +175,7 @@ fun classify(age: Int) -> String {
 
 v2 adds first class closures and function types, which v1 did not have:
 
-```raven
+```rust
 fun apply(f: fun(Int) -> Int, x: Int) -> Int = f(x)
 
 fun main() {
@@ -192,7 +192,7 @@ The C-style `for` is gone. v2 has `for x in <range or list>`. Ranges are
 
 v1:
 
-```raven
+```rust
 let i: int = 0;
 while (i < 5) {
     print(i);
@@ -206,7 +206,7 @@ for (let j: int = 0; j < 5; j = j + 1) {
 
 v2:
 
-```raven
+```rust
 let i = 0
 while i < 5 {
     print(i)
@@ -223,7 +223,7 @@ keyword becomes two words, `else if`:
 
 v1:
 
-```raven
+```rust
 if (age < 18) {
     print("Too young");
 } elseif (age < 30) {
@@ -235,7 +235,7 @@ if (age < 18) {
 
 v2:
 
-```raven
+```rust
 if age < 18 {
     print("Too young")
 } else if age < 30 {
@@ -248,7 +248,7 @@ if age < 18 {
 v2 adds two more loop forms. `loop` is an unconditional loop whose value is
 the operand of `break`, and `break`/`continue` work in every loop:
 
-```raven
+```rust
 let first = loop {
     break 42
 }
@@ -257,7 +257,7 @@ let first = loop {
 Unlike v1, `if` is also an expression in v2, so it can produce a value
 directly:
 
-```raven
+```rust
 let label = if n > 0 { "positive" } else { "non-positive" }
 ```
 
@@ -269,14 +269,14 @@ replaces them with the generic `List<T>`, and adds `Map<K, V>` and
 
 v1:
 
-```raven
+```rust
 let numbers: int[] = [1, 2, 3];
 let words: string[] = ["a", "b"];
 ```
 
 v2:
 
-```raven
+```rust
 let numbers: List<Int> = [1, 2, 3]
 let words: List<String> = ["a", "b"]
 ```
@@ -284,7 +284,7 @@ let words: List<String> = ["a", "b"]
 `Map` and `Set` come from a module import and are created with their
 associated functions:
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -318,7 +318,7 @@ fallibility part of the type. `Result<T, E>` is `Ok(T)` or `Err(E)`,
 
 v1, sentinel style:
 
-```raven
+```rust
 // returns 0 to mean "cannot divide"
 fun divide(a: int, b: int) -> int {
     if (b == 0) {
@@ -330,7 +330,7 @@ fun divide(a: int, b: int) -> int {
 
 v2, typed errors:
 
-```raven
+```rust
 import std/error { error }
 
 fun divide(a: Int, b: Int) -> Result<Int, Error> {
@@ -351,7 +351,7 @@ fun main() {
 `?` keeps multi step error handling flat: each call returns early on
 `Err`, so the body reads like the happy path.
 
-```raven
+```rust
 fun pipeline(a: Int, b: Int) -> Result<Int, Error> {
     let x = divide(a, b)?
     let y = divide(x, 2)?
@@ -362,7 +362,7 @@ fun pipeline(a: Int, b: Int) -> Result<Int, Error> {
 Where v1 might return an empty string for "not found", v2 returns
 `Option<T>` and the caller matches it. `T?` is sugar for `Option<T>`.
 
-```raven
+```rust
 fun unwrap_or(x: Option<Int>, fallback: Int) -> Int {
     return match x {
         None -> fallback,
@@ -379,7 +379,7 @@ moves string operations onto methods.
 
 v1:
 
-```raven
+```rust
 let name: string = "Raven";
 print(format("Hello, {}!", name));
 print(format("sum is {}", 3 + 4));
@@ -387,7 +387,7 @@ print(format("sum is {}", 3 + 4));
 
 v2:
 
-```raven
+```rust
 fun main() {
     let name = "Raven"
     print("Hello, ${name}!")
@@ -400,7 +400,7 @@ String methods such as `to_upper`, `to_lower`, `trim`, `repeat`,
 `std/string`. A file must `import std/string` to call them, which merges
 the `impl String` block so the methods resolve by receiver type.
 
-```raven
+```rust
 import std/string
 
 fun main() {
@@ -418,7 +418,7 @@ fun main() {
 A v2 block string uses triple quotes and is raw (no escapes, newlines
 preserved):
 
-```raven
+```rust
 let text = """
 line one
 line two
@@ -433,7 +433,7 @@ imports come in a few shapes.
 
 v1:
 
-```raven
+```rust
 import math;
 import str from "str";
 import { trim, capitalize } from "str";
@@ -441,7 +441,7 @@ import { trim, capitalize } from "str";
 
 v2:
 
-```raven
+```rust
 import std/math { abs_int, min_int, max_int }
 import std/string
 import std/io { println }
@@ -476,7 +476,7 @@ v1 enums were plain tags, referenced as `Color::Red`, and converted from
 strings with `enum_from_string`. v2 uses `EnumName.Variant`, lets a
 variant carry data, and matches with the bare variant name.
 
-```raven
+```rust
 enum Shape {
     Circle(Float),
     Square(Float),
@@ -497,7 +497,7 @@ fun main() {
 `match` is exhaustive (every case must be covered) and supports literals,
 ranges, the wildcard `_`, struct fields, and guards with `if`:
 
-```raven
+```rust
 fun classify(n: Int) -> String {
     return match n {
         0 -> "zero",
@@ -513,7 +513,7 @@ A trait declares methods a type can implement; `impl Trait for Type`
 provides the implementation, and `impl Type { ... }` adds inherent methods
 and associated functions (the idiomatic constructor, called `Type.new()`).
 
-```raven
+```rust
 struct Point { x: Int, y: Int }
 
 impl ToString for Point {
@@ -536,7 +536,7 @@ Functions, structs, enums, and impl blocks can take type parameters in
 angle brackets. A bound `T: Trait` constrains the parameter; use `+` for
 several bounds. Generic code is monomorphized per concrete type.
 
-```raven
+```rust
 fun describe<T: ToString>(x: T) -> String = x.to_string()
 
 struct Box<T> {
@@ -552,7 +552,7 @@ impl<T> Box<T> {
 dispatched at runtime. Use a generic bound when the concrete type is known
 at the call site, `dyn Trait` when it is not.
 
-```raven
+```rust
 trait Speak {
     fun sound(self) -> Int
 }
@@ -566,7 +566,7 @@ fun describe(s: dyn Speak) -> Int = s.sound()
 returns, in reverse order of registration. It is the v2 way to do cleanup
 that v1 had to place by hand at each return.
 
-```raven
+```rust
 fun demo() -> Int {
     defer print(1)
     defer print(2)
@@ -581,7 +581,7 @@ fun demo() -> Int {
 (`collect`, `fold`, `count`) over any `Iterator`. `list.iter()` bridges a
 `List` into the pipeline.
 
-```raven
+```rust
 import std/iter { collect, fold, count }
 
 fun main() {
@@ -597,7 +597,7 @@ fun main() {
 ordinary functions, using C types (`CInt`, `CLong`, `CSize`, `CStr`,
 `CDouble`). A `c"..."` literal produces a `CStr`.
 
-```raven
+```rust
 extern "C" {
     fun abs(x: CInt) -> CInt
     fun strlen(s: CStr) -> CSize
@@ -684,7 +684,7 @@ translations.
 
 v1:
 
-```raven
+```rust
 let i: int = 0;
 while (i < 5) {
     print(i);
@@ -698,7 +698,7 @@ for (let j: int = 0; j < 5; j = j + 1) {
 
 v2 (`examples/v2/loops.rv`):
 
-```raven
+```rust
 fun main() {
     let i = 0
     while i < 5 {
@@ -720,7 +720,7 @@ an `else if` chain.
 
 v1 (the calculation core):
 
-```raven
+```rust
 let result: float = 0.0;
 if (operation == "+") {
     result = num1 + num2;
@@ -742,7 +742,7 @@ print(format("Result: {} {} {} = {}", num1, operation, num2, result));
 
 v2 (`examples/v2/calculator.rv`):
 
-```raven
+```rust
 fun apply(op: String, a: Float, b: Float) -> Float {
     if op == "+" {
         a + b
@@ -772,7 +772,7 @@ converted strings to variants with `enum_from_string`.
 
 v1:
 
-```raven
+```rust
 enum HttpStatus {
     OK,
     NotFound,
@@ -793,7 +793,7 @@ main();
 v2 (`examples/v2/enum_demo.rv`) reaches a variant with `.` and turns a
 variant into text with an exhaustive `match`:
 
-```raven
+```rust
 enum HttpStatus {
     Ok,
     NotFound,
@@ -825,7 +825,7 @@ namespace (`math.abs`, `str.trim`). v2 imports named items from a
 
 v1:
 
-```raven
+```rust
 import math;
 import str from "str";
 
@@ -840,7 +840,7 @@ main();
 
 v2 (`examples/v2/standard_library_demo.rv`):
 
-```raven
+```rust
 import std/math { abs_int, min_int, max_int, pow_int }
 import std/string
 

--- a/docs/v2/specs/associated-functions.md
+++ b/docs/v2/specs/associated-functions.md
@@ -11,7 +11,7 @@ An associated function is a `fun` inside an `impl` block whose first
 parameter is not `self`. The same `impl` block may mix associated
 functions and instance methods:
 
-```raven
+```rust
 struct Counter { n: Int }
 
 impl Counter {
@@ -26,7 +26,7 @@ impl Counter {
 A generic implementing type's associated function may return the generic
 type:
 
-```raven
+```rust
 impl<T: Eq + Hash> Set<T> {
     fun new() -> Set<T> {
         let buckets: List<List<T>> = []
@@ -46,7 +46,7 @@ The leading `Type` is a type name: a user struct or enum, or a built-in
 type (`Int`, `String`, `Array`, ...). Type arguments may be written on the
 type for a generic associated function (`Set<Int>.new()`).
 
-```raven
+```rust
 let a = Counter.new()
 let b = Counter.with(41)
 let s = Set<Int>.new()
@@ -75,7 +75,7 @@ With explicit type arguments (`Set<Int>.new()`) the parameters are fixed
 directly. Without them (`Set.new()`), the element type is left as an
 inference variable and solved from later use within the same body:
 
-```raven
+```rust
 let s = Set.new()   // T is an inference variable
 s.add(7)            // unifies T = Int
 ```

--- a/docs/v2/specs/derive.md
+++ b/docs/v2/specs/derive.md
@@ -11,7 +11,7 @@ metaprogramming work (macros, reflection) builds on, tracked under issue
 The attribute sits on its own line immediately before a `struct` or `enum`
 declaration:
 
-```raven
+```rust
 @derive(Eq, Hash, ToString, Debug)
 struct Point { x: Int, y: Int }
 
@@ -62,7 +62,7 @@ when any type derives one of them.
 
 ### Eq
 
-```raven
+```rust
 fun equals(self, other: Point) -> Bool
 ```
 
@@ -79,7 +79,7 @@ not yet accept `Self` as a non-receiver parameter type.
 
 ### Hash
 
-```raven
+```rust
 fun hash(self) -> Int
 ```
 
@@ -94,7 +94,7 @@ element, since the hash-backed collections require `Eq + Hash` keys.
 
 ### ToString
 
-```raven
+```rust
 fun to_string(self) -> String
 ```
 
@@ -106,7 +106,7 @@ fun to_string(self) -> String
 
 ### Debug
 
-```raven
+```rust
 fun debug(self) -> String
 ```
 
@@ -123,7 +123,7 @@ debug     -> User { name: "ann", age: 30 }
 
 ### ToJson
 
-```raven
+```rust
 fun to_json(self) -> JsonValue
 ```
 
@@ -140,7 +140,7 @@ source order. Combine `to_json` with `stringify` to get a `String`.
 
 ### FromJson
 
-```raven
+```rust
 fun from_json(j: JsonValue) -> Result<Self, Error>
 ```
 
@@ -181,14 +181,14 @@ structs and enums; it never generates impls for the built-in types.
 For a generic type the synthesized impl is generic with the derived trait as
 a bound on every type parameter. Deriving `Eq` on
 
-```raven
+```rust
 @derive(Eq)
 struct Pair<A, B> { first: A, second: B }
 ```
 
 generates
 
-```raven
+```rust
 impl<A: Eq, B: Eq> Eq for Pair<A, B> {
     fun equals(self, other: Pair<A, B>) -> Bool {
         return self.first.equals(other.first) && self.second.equals(other.second)

--- a/docs/v2/specs/ffi.md
+++ b/docs/v2/specs/ffi.md
@@ -31,7 +31,7 @@ Source -> Lexer -> Parser -> Resolver -> Tycheck -> HIR -> MIR -> Codegen -> Lin
 
 ## Syntax
 
-```raven
+```rust
 extern "C" {
     fun strlen(s: CStr) -> CSize
     fun abs(x: CInt) -> CInt
@@ -48,7 +48,7 @@ extern "C" {
 
 A call uses the foreign name directly:
 
-```raven
+```rust
 fun main() {
     let n = strlen(c"hello")
     print(n)

--- a/docs/v2/specs/gc.md
+++ b/docs/v2/specs/gc.md
@@ -142,7 +142,7 @@ runs.
 
 A function with two GC locals (`a`, `b`) and one GC temporary (`mid`):
 
-```raven
+```rust
 fn join(a: String, b: String) -> String {
     let mid: String = ", ";
     return concat(concat(a, mid), b);

--- a/docs/v2/specs/macros.md
+++ b/docs/v2/specs/macros.md
@@ -81,7 +81,7 @@ parsing, a call's template is spliced wherever the call appears, so a
 template that parses as one or more items or statements is valid in those
 positions:
 
-```raven
+```rust
 macro def_point { () => { struct Point { x: Int, y: Int } } }
 macro emit { ($x:expr) => { print($x) } }
 

--- a/docs/v2/specs/reflection.md
+++ b/docs/v2/specs/reflection.md
@@ -4,7 +4,7 @@ Compile-time type reflection exposes a small amount of type information to
 user code, resolved while the program is compiled. This is the first slice
 of the reflection work tracked under issue #216. It ships these builtins:
 
-```raven
+```rust
 type_name<T>() -> String
 field_names<T>() -> List<String>
 field_types<T>() -> List<String>
@@ -24,7 +24,7 @@ an `Any` type and is a separate follow-up (see below).
 `type_name<T>()` evaluates to the rendered name of the concrete type `T`,
 as a `String`.
 
-```raven
+```rust
 type_name<Int>()                  // "Int"
 type_name<String>()               // "String"
 type_name<Point>()                // "Point"
@@ -43,7 +43,7 @@ the built-in generics by their spelling (`List<Int>`, `Option<Int>`,
 Inside a generic function, `type_name<T>()` resolves to the concrete type
 bound to `T` at each instantiation:
 
-```raven
+```rust
 fun describe<T>() -> String {
     return type_name<T>()
 }
@@ -61,7 +61,7 @@ instantiations of the same generic body produce two different names.
 `field_names<T>()` evaluates to the field names of the struct type `T`, in
 declaration order, as a `List<String>`.
 
-```raven
+```rust
 struct Point { x: Int, y: Int }
 
 field_names<Point>()    // ["x", "y"]
@@ -81,7 +81,7 @@ declaration order, as a `List<String>` of rendered type names. It is the
 positional counterpart to `field_names`: index `i` of one lines up with
 index `i` of the other, so the two together describe each field.
 
-```raven
+```rust
 struct User { id: Int, name: String, active: Bool }
 
 field_names<User>()    // ["id", "name", "active"]
@@ -92,7 +92,7 @@ field_types<User>()    // ["Int", "String", "Bool"]
 For a generic struct, each field type is rendered at its concrete
 instantiation, so a generic field reads as the type it is bound to:
 
-```raven
+```rust
 struct Box<T> { value: T }
 
 field_types<Box<Int>>()       // ["Int"]
@@ -109,7 +109,7 @@ string lists) remains a possible future surface; this slice pairs
 declaration order, as a `List<String>`. It is the enum counterpart to
 `field_names`.
 
-```raven
+```rust
 enum Shape { Circle(radius: Float) Rectangle(width: Float, height: Float) Dot }
 
 variant_names<Shape>()    // ["Circle", "Rectangle", "Dot"]
@@ -126,7 +126,7 @@ scalar, a built-in generic) is a compile error. The built-in `Option` and
 holding that variant's payload field type names. A unit variant has an empty
 inner list, so the inner list's length is the variant's payload arity.
 
-```raven
+```rust
 enum Shape { Circle(radius: Float) Rectangle(width: Float, height: Float) Dot }
 
 variant_names<Shape>()        // ["Circle", "Rectangle", "Dot"]
@@ -136,7 +136,7 @@ variant_field_types<Shape>()  // [["Float"], ["Float", "Float"], []]
 For a generic enum each payload type is rendered at its concrete
 instantiation, the same per-monomorphization mechanic as `field_types`:
 
-```raven
+```rust
 enum Tree<T> { Leaf(value: T) Branch(left: T, right: T) Empty }
 
 variant_field_types<Tree<Int>>()    // [["Int"], ["Int", "Int"], []]

--- a/docs/v2/specs/std-cmp.md
+++ b/docs/v2/specs/std-cmp.md
@@ -10,7 +10,7 @@ is built into the language and needs no import.
 These functions have no natural single receiver, so they are free
 functions bound by a selective import:
 
-```raven
+```rust
 import std/cmp { sort, max, min, max_of }
 
 fun main() {

--- a/docs/v2/specs/std-collections.md
+++ b/docs/v2/specs/std-collections.md
@@ -12,7 +12,7 @@ called as `Type.new()`. A plain `import std/collections` is enough, since
 the call resolves the function on the named type rather than an imported
 name:
 
-```raven
+```rust
 import std/collections
 
 fun main() {
@@ -41,7 +41,7 @@ Set and map values have literal syntax (issue #156). Both lower to the
 constructors above, so they need the same `import std/collections` in
 scope.
 
-```raven
+```rust
 import std/collections
 
 fun main() {

--- a/docs/v2/specs/std-encoding.md
+++ b/docs/v2/specs/std-encoding.md
@@ -14,7 +14,7 @@ likewise returns the decoded bytes as a `String`.
 
 All entries are free functions, bound with a selective import:
 
-```raven
+```rust
 import std/encoding { hex_encode, hex_decode, base64_encode, base64_decode }
 
 fun main() {

--- a/docs/v2/specs/std-env.md
+++ b/docs/v2/specs/std-env.md
@@ -7,7 +7,7 @@ them.
 
 ## Import
 
-```raven
+```rust
 import std/env { get_env, has_env, get_env_or, args, arg_count, arg_at, exit, os_name, arch }
 ```
 
@@ -15,7 +15,7 @@ import std/env { get_env, has_env, get_env_or, args, arg_count, arg_at, exit, os
 
 ### Environment variables
 
-```raven
+```rust
 fun get_env(name: String) -> String
 fun has_env(name: String) -> Bool
 fun get_env_or(name: String, default: String) -> String
@@ -37,7 +37,7 @@ A value that is not valid UTF-8 is reported as `""`.
 
 ### Command-line arguments
 
-```raven
+```rust
 fun arg_count() -> Int
 fun arg_at(i: Int) -> String
 fun args() -> List<String>
@@ -51,7 +51,7 @@ Index 0 is the program path; the user-supplied arguments start at index 1.
 
 ### Process exit
 
-```raven
+```rust
 fun exit(code: Int)
 ```
 
@@ -62,7 +62,7 @@ runtime call (`std::process::exit`) never comes back.
 
 ### Platform info
 
-```raven
+```rust
 fun os_name() -> String
 fun arch() -> String
 ```

--- a/docs/v2/specs/std-error.md
+++ b/docs/v2/specs/std-error.md
@@ -8,7 +8,7 @@ small set of free functions over `Result`.
 
 ## Import
 
-```raven
+```rust
 import std/error { error, unwrap_or, is_ok }
 import std/io { println }
 

--- a/docs/v2/specs/std-ffi.md
+++ b/docs/v2/specs/std-ffi.md
@@ -9,14 +9,14 @@ needs a conversion, which is what `to_cstr` and `from_cstr` provide.
 
 ## Import
 
-```raven
+```rust
 import std/ffi { to_cstr, from_cstr }
 import std/ffi { alloc, free, load, store, offset, is_null, null_ptr }
 ```
 
 ## Surface
 
-```raven
+```rust
 fun to_cstr(s: String) -> CStr
 fun from_cstr(p: CStr) -> String
 ```
@@ -36,7 +36,7 @@ Both wrappers are pure Raven over two raven-runtime symbols bound through
 `CPtr<T>` is a usable raw pointer. The following generic functions read and
 write C memory through it and obtain or release a buffer:
 
-```raven
+```rust
 fun alloc<T>(count: Int) -> CPtr<T>
 fun free<T>(p: CPtr<T>)
 fun load<T>(p: CPtr<T>) -> T
@@ -156,7 +156,7 @@ function that takes a callback call back into Raven. A non-capturing
 top-level Raven function can be passed where a `CFnPtr` is expected by
 naming it bare:
 
-```raven
+```rust
 extern "C" {
     fun qsort(base: CPtr<CInt>, count: CSize, size: CSize, cmp: CFnPtr)
 }
@@ -217,7 +217,7 @@ compile-time-known strings; use `to_cstr` for a `String` value. See
 
 `examples/v2/use_ffi.rv` converts runtime Strings and calls libc:
 
-```raven
+```rust
 import std/ffi { to_cstr, from_cstr }
 import std/io { println }
 
@@ -290,7 +290,7 @@ A small C struct can cross the FFI by value, both as an argument and as a
 return. The Raven side declares a struct with C memory layout by marking it
 `@repr(C)`:
 
-```raven
+```rust
 @repr(C)
 struct Point {
     x: CInt

--- a/docs/v2/specs/std-fmt.md
+++ b/docs/v2/specs/std-fmt.md
@@ -28,7 +28,7 @@ All formatting helpers are free functions, bound with a selective import. The
 `Debug` trait's `debug` method dispatches by the receiver's type and needs no
 explicit selector.
 
-```raven
+```rust
 import std/fmt { repeat, pad_left, pad_right, center, join, to_radix, to_binary, to_octal, to_hex, pad_int }
 import std/io { println }
 

--- a/docs/v2/specs/std-fs.md
+++ b/docs/v2/specs/std-fs.md
@@ -7,7 +7,7 @@ add the Result/Error model in pure Raven on top.
 
 ## Import
 
-```raven
+```rust
 import std/fs { read, write, append, remove_file, create_dir, remove_dir, list_dir, size, exists, is_file, is_dir, join, dirname, basename, split }
 ```
 
@@ -26,7 +26,7 @@ wrapper turns a non-empty last error into an `Err`.
 
 ## Fallible surface
 
-```raven
+```rust
 fun read(path: String) -> Result<String, Error>
 fun write(path: String, contents: String) -> Result<Bool, Error>
 fun append(path: String, contents: String) -> Result<Bool, Error>
@@ -59,7 +59,7 @@ yields an empty list, not a one-element list containing `""`.
 
 ## Non-fallible queries
 
-```raven
+```rust
 fun exists(path: String) -> Bool
 fun is_file(path: String) -> Bool
 fun is_dir(path: String) -> Bool
@@ -71,7 +71,7 @@ These return a plain `Bool` and never an error: a missing path is a normal
 
 ## Path manipulation
 
-```raven
+```rust
 fun join(a: String, b: String) -> String
 fun dirname(path: String) -> String
 fun basename(path: String) -> String

--- a/docs/v2/specs/std-hash.md
+++ b/docs/v2/specs/std-hash.md
@@ -13,7 +13,7 @@ a package, per the stdlib charter.
 
 All entries are free functions, bound with a selective import:
 
-```raven
+```rust
 import std/hash { fnv1a, djb2, hash_int, combine }
 
 fun main() {
@@ -53,7 +53,7 @@ for `Int`, `Bool`, and `String`. These functions are building blocks a user's
 own `Hash` impl can call. A struct can hash its fields and fold them with
 `combine`:
 
-```raven
+```rust
 import std/hash { fnv1a, hash_int, combine }
 
 struct Point { x: Int, y: Int }

--- a/docs/v2/specs/std-http.md
+++ b/docs/v2/specs/std-http.md
@@ -7,7 +7,7 @@ pure Raven.
 
 ## Import
 
-```raven
+```rust
 import std/http { get, post, put, delete, request }
 ```
 
@@ -16,7 +16,7 @@ selector.
 
 ## Surface
 
-```raven
+```rust
 struct HttpResponse {
     status_code: Int,
     status_text: String,

--- a/docs/v2/specs/std-json.md
+++ b/docs/v2/specs/std-json.md
@@ -6,7 +6,7 @@ serializer. The value tree is the `JsonValue` enum.
 
 ## Value type
 
-```raven
+```rust
 enum JsonValue {
     Null,
     Bool(Bool),
@@ -34,7 +34,7 @@ IEEE 754 double, so integers beyond the 53-bit mantissa (roughly
 
 ## Import
 
-```raven
+```rust
 import std/json { parse, stringify }
 
 fun main() {
@@ -126,7 +126,7 @@ is already a free function for the same reason.
 form, plus hand-written impls for the built-in types so field recursion
 bottoms out.
 
-```raven
+```rust
 trait ToJson {
     fun to_json(self) -> JsonValue
 }

--- a/docs/v2/specs/std-math.md
+++ b/docs/v2/specs/std-math.md
@@ -57,7 +57,7 @@ no overloading.
 The transcendental and rounding functions bind directly to the C runtime
 math library through `extern "C"`:
 
-```raven
+```rust
 extern "C" {
     fun sqrt(x: Float) -> Float
     fun pow(base: Float, exp: Float) -> Float

--- a/docs/v2/specs/std-net.md
+++ b/docs/v2/specs/std-net.md
@@ -7,7 +7,7 @@ wrappers add the Result/Error model and the handle types in pure Raven.
 
 ## Import
 
-```raven
+```rust
 import std/net { connect, listen, dns_lookup, reachable }
 ```
 
@@ -41,7 +41,7 @@ wrapper turns a non-empty last error (or, for the id-returning ops, an id of
 
 ## Surface
 
-```raven
+```rust
 struct TcpStream { id: Int }
 struct TcpListener { id: Int }
 

--- a/docs/v2/specs/std-path.md
+++ b/docs/v2/specs/std-path.md
@@ -19,7 +19,7 @@ path byte.
 The functions have no natural single receiver, so they are free functions
 bound by a selective import:
 
-```raven
+```rust
 import std/path { join, basename, dirname, extension, stem, is_absolute }
 
 fun main() {

--- a/docs/v2/specs/std-process.md
+++ b/docs/v2/specs/std-process.md
@@ -8,7 +8,7 @@ Raven.
 
 ## Import
 
-```raven
+```rust
 import std/process { run, run_with_input }
 ```
 
@@ -17,7 +17,7 @@ separate selector.
 
 ## Surface
 
-```raven
+```rust
 struct Output { code: Int, stdout: String, stderr: String }
 
 fun run(program: String, args: List<String>) -> Result<Output, Error>

--- a/docs/v2/specs/std-random.md
+++ b/docs/v2/specs/std-random.md
@@ -35,7 +35,7 @@ across runs. Use it when you want a fresh, unpredictable sequence.
 
 ## Import
 
-```raven
+```rust
 import std/random
 
 fun main() {

--- a/docs/v2/specs/std-regex.md
+++ b/docs/v2/specs/std-regex.md
@@ -9,7 +9,7 @@ pure Raven.
 
 ## Import
 
-```raven
+```rust
 import std/regex { compile }
 ```
 

--- a/docs/v2/specs/std-string.md
+++ b/docs/v2/specs/std-string.md
@@ -16,7 +16,7 @@ dogfoods the language itself.
 selectively. A bare module import merges its `impl String` block into the
 program; the methods are then resolved by the receiver type:
 
-```raven
+```rust
 import std/string
 
 fun main() {

--- a/docs/v2/specs/std-test.md
+++ b/docs/v2/specs/std-test.md
@@ -10,7 +10,7 @@ Raven has no attributes or reflection yet, so there is no test discovery
 or registration framework. A test is an ordinary Raven program whose
 `main` calls these assertions:
 
-```raven
+```rust
 import std/test { assert, assert_eq_int }
 import std/io { println }
 
@@ -30,7 +30,7 @@ checks its exit code (for example a shell loop or CI step).
 
 The assertions are free functions, so a selective import binds them:
 
-```raven
+```rust
 import std/test { assert, assert_msg, assert_true, assert_false, assert_eq_int, assert_eq_str }
 ```
 

--- a/docs/v2/specs/std-time.md
+++ b/docs/v2/specs/std-time.md
@@ -8,13 +8,13 @@ helpers are pure Raven on top of them.
 
 ## Import
 
-```raven
+```rust
 import std/time { now, now_millis, from_timestamp, weekday, format_timestamp, parse_timestamp, sleep_millis }
 ```
 
 ## Structs
 
-```raven
+```rust
 struct Date { year: Int, month: Int, day: Int }
 struct Time { hour: Int, minute: Int, second: Int }
 struct DateTime { date: Date, time: Time }
@@ -31,7 +31,7 @@ each have a `ToString` impl producing ISO-like text: a `Date` renders as
 
 ### Current time
 
-```raven
+```rust
 fun now() -> Int
 fun now_millis() -> Int
 ```
@@ -43,7 +43,7 @@ example `now() > 1700000000`).
 
 ### Decomposition
 
-```raven
+```rust
 fun from_timestamp(ts: Int) -> DateTime
 fun weekday(ts: Int) -> Int
 ```
@@ -59,7 +59,7 @@ Saturday (chrono's `num_days_from_sunday`).
 
 ### Formatting and parsing
 
-```raven
+```rust
 fun format_timestamp(ts: Int, pattern: String) -> String
 fun parse_timestamp(text: String, pattern: String) -> Result<Int, Error>
 ```
@@ -79,7 +79,7 @@ literal directly rather than calling `error_kind`.
 
 ### Sleep
 
-```raven
+```rust
 fun sleep_millis(ms: Int)
 ```
 

--- a/docs/v2/specs/stdlib.md
+++ b/docs/v2/specs/stdlib.md
@@ -107,7 +107,7 @@ for a `println(...)` call that bound to the bundled function.
 
 The working import form for a bundled module is the selective import:
 
-```raven
+```rust
 import std/io { println }
 ```
 


### PR DESCRIPTION
## Summary

`​```raven` code blocks rendered with no syntax highlighting on the docs site, because Pygments (used by mkdocs-material) has no `raven` lexer. Raven's surface syntax is close to Rust, so this switches every fenced Raven code block to `​```rust`, which Pygments highlights natively. Keywords, types, strings, and comments now color correctly across the guide, tutorials, standard library, and specs.

No toolchain, plugin, or `mkdocs.yml` change is needed (`rust` is a built-in Pygments lexer). 551 fences across 68 files.

Verified locally: `mkdocs build` is clean and the generated HTML carries `language-rust` and Pygments highlight spans.

Docs-only; the docs workflow redeploys the site on merge.
