### PR TITLE
ci(release): build Linux on ubuntu-22.04 for glibc compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,10 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            os: ubuntu-latest
+            # Build on the oldest supported Ubuntu so the binary links
+            # against an older glibc and runs on 22.04 and 24.04 alike
+            # (glibc is backward compatible, not forward compatible).
+            os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - name: windows-x86_64
             os: windows-latest
@@ -248,7 +251,9 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            os: ubuntu-latest
+            # Smoke-test on the build baseline (22.04) to confirm the
+            # binary runs against its target glibc.
+            os: ubuntu-22.04
           - name: windows-x86_64
             os: windows-latest
           - name: macos-arm64


### PR DESCRIPTION
Pins the Linux release build (and its smoke test) to `ubuntu-22.04` instead of `ubuntu-latest` (24.04). glibc is backward compatible but not forward compatible, so building on the older image makes the binary run on both 22.04 and 24.04. Takes effect on the next release; no re-release of 2.4.3 needed.