### PR TITLE
ci(release): trim the linux-x86_64 runner comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            # Build on the oldest supported Ubuntu so the binary links
-            # against an older glibc and runs on 22.04 and 24.04 alike
-            # (glibc is backward compatible, not forward compatible).
             os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - name: windows-x86_64


### PR DESCRIPTION
Removes the verbose explanatory comment on the linux-x86_64 build runner; the `ubuntu-22.04` pin stays. Follow-up to #324.