### PR TITLE
release: 2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Raven are documented in this file.
 
 ## [Unreleased]
 
+## [2.4.4] - 2026-06-05
+
+### Fixed
+
+- The Linux release binary is now built on Ubuntu 22.04 instead of the latest runner image (24.04), so it links against an older glibc and runs on both Ubuntu 22.04 and 24.04. A binary built on 24.04 could fail to start on 22.04 with a `GLIBC_2.x not found` error, because glibc is backward compatible but not forward compatible. No source changes.
+
 ## [2.4.3] - 2026-06-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.4.2"
+version = "2.4.4"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.4.2"
+version = "2.4.4"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.4.3"
+version = "2.4.4"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
## Release 2.4.4

A packaging-only release: no source changes since 2.4.3.

### Fixed
- The Linux release binary is now built on **Ubuntu 22.04** (glibc 2.35) instead of `ubuntu-latest` (24.04), so it runs on both 22.04 and 24.04. A 24.04-built binary could fail on 22.04 with `GLIBC_2.x not found` (glibc is backward compatible, not forward compatible).

After merge, tag `v2.4.4` to trigger the release build.
