### PR TITLE
feat(ffi): variadic C functions (slice E)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,13 @@ jobs:
           ffibig_out="$(./ffibig)"
           echo "ffi large-struct output: $ffibig_out"
           test "$ffibig_out" = "60"
+          # FFI: a variadic C call (printf), dispatched through call_indirect
+          # with a per-call signature. printf links via legacy_stdio on MSVC.
+          printf 'extern "C" {\n  fun printf(fmt: CStr, ...) -> CInt\n}\nfun main() {\n  let _ = printf(c"%%d-%%s\\n", 7, c"ok")\n}\n' > ffivar.rv
+          raven build ffivar.rv -o ffivar
+          ffivar_out="$(./ffivar)"
+          echo "ffi variadic output: $ffivar_out"
+          test "$ffivar_out" = "7-ok"
 
       - name: Smoke test (Windows zip)
         if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Raven are documented in this file.
 
 ### Added
 
+- FFI: variadic C functions can now be called. A signature ending in `...` (`fun printf(fmt: CStr, ...) -> CInt`) accepts extra arguments after the fixed parameters; each must be a C-FFI integer or pointer type (or a native `Int`). The back end builds a signature from the actual arguments at each call site and dispatches through `call_indirect`. Float variadic arguments are rejected at compile time, because the Cranelift backend cannot set the System V `al` register or apply the Windows x64 float-shadow rule; a `%f` format needs a fixed-arity C shim. On windows-msvc the `printf` family now links via `legacy_stdio_definitions.lib` (#330).
+
+### Added
+
 - FFI: `@repr(C)` structs of any size now cross the C ABI by value, removing the previous 16-byte limit. Up to 16 bytes a struct still crosses in registers; a larger one crosses in memory on the stack on System V AMD64 (the MEMORY class, via Cranelift's `StructArgument` with the size rounded up to 8 bytes) or by reference on Windows x64 and AArch64, and is returned through a hidden `sret` pointer on every target (#327).
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.9.0"
+version = "2.10.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/ffi.md
+++ b/docs/v2/specs/ffi.md
@@ -158,8 +158,27 @@ flags (an `[ffi]` section in `rv.toml` passing `-l<lib>` or `.lib`
 entries) arrive with `rvpm build`, tracked by issue #81. Until then a
 non-CRT symbol surfaces as an unresolved-symbol error at link time.
 
+## Variadic C functions
+
+A signature ending in `...` is variadic (`fun printf(fmt: CStr, ...) -> CInt`).
+A call may pass extra arguments after the fixed parameters; each must be a
+C-FFI integer or pointer type (`CInt`, `CLong`, `CSize`, `CStr`, `CPtr<T>`) or
+a native `Int`. The back end builds a signature from the actual arguments at
+each call site and dispatches through `call_indirect`.
+
+**Float variadic arguments are rejected at compile time.** The Cranelift
+backend cannot set the System V `al` register (the count of vector registers a
+variadic callee reads) or apply the Windows x64 rule that passes a floating
+vararg in both an integer and an SSE register, so a float vararg would
+miscompile. A format that needs `%f` must go through a fixed-arity C shim. The
+integer/pointer path is unaffected: `al` is only consulted for float formats.
+
+On `*-windows-msvc`, the `printf` family is provided by
+`legacy_stdio_definitions.lib` (the UCRT inlines it in headers), which the
+linker pulls in automatically.
+
 ## Out of scope
 
-* Variadic C functions (for example `printf` with format arguments).
 * Non-CRT libraries and their link flags (issue #81).
 * Dereferencing or arithmetic on `CPtr<T>`.
+* Float variadic arguments (see above).

--- a/docs/v2/specs/std-ffi.md
+++ b/docs/v2/specs/std-ffi.md
@@ -398,6 +398,6 @@ slot as a pointer so the collector traces it.
 * Callback APIs whose userdata is not the last callback argument (or that
   have no userdata argument). The trampoline is userdata-last; other shapes
   need a small C shim.
-* The rest of what `docs/v2/specs/ffi.md` lists out of scope (variadics,
-  non-CRT libraries).
+* The rest of what `docs/v2/specs/ffi.md` lists out of scope (float
+  variadic arguments, non-CRT libraries).
 ```

--- a/examples/v2/ffi_variadic.rv
+++ b/examples/v2/ffi_variadic.rv
@@ -1,0 +1,23 @@
+// FFI: calling a variadic C function. A variadic extern is declared with a
+// trailing `...`; extra C-FFI integer/pointer arguments may follow the fixed
+// ones. The back end dispatches the call through call_indirect with a
+// signature built from the actual arguments. Float varargs are rejected at
+// compile time (the back end cannot honor the variadic float ABI), so a
+// format like "%f" needs a C shim. Prints:
+//   1 2 3
+//   answer = 42
+//   no varargs
+extern "C" {
+    fun printf(fmt: CStr, ...) -> CInt
+}
+
+fun main() {
+    // Three integer varargs.
+    let _ = printf(c"%d %d %d\n", 1, 2, 3)
+
+    // A string and an integer vararg.
+    let _ = printf(c"%s = %d\n", c"answer", 42)
+
+    // A variadic function called with no extra arguments.
+    let _ = printf(c"no varargs\n")
+}

--- a/examples/v2/ffi_variadic.rv.out
+++ b/examples/v2/ffi_variadic.rv.out
@@ -1,0 +1,3 @@
+1 2 3
+answer = 42
+no varargs

--- a/src/ast/decl.rs
+++ b/src/ast/decl.rs
@@ -186,6 +186,9 @@ pub struct ExternFn {
     pub name: String,
     pub params: Vec<Param>,
     pub ret: Option<Type>,
+    /// True when the signature ends with `...`: extra C-FFI integer/pointer
+    /// arguments may be passed at a call (a variadic function like `printf`).
+    pub variadic: bool,
     pub span: Span,
 }
 

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -75,6 +75,10 @@ pub struct ModuleCx {
     /// symbol name. A call site uses it to marshal a by-value struct
     /// return back into a Raven heap struct.
     extern_rets: HashMap<String, MirType>,
+    /// Raw C symbol names of the variadic extern functions. A call to one
+    /// builds a per-call signature and dispatches through `call_indirect`,
+    /// since the fixed declared signature cannot carry the extra arguments.
+    variadic_externs: std::collections::HashSet<String>,
     /// Parameter types of each declared Raven function, keyed by its
     /// mangled name. A call site uses these to coerce each argument to the
     /// callee's parameter machine width (for example a native `Int` passed
@@ -144,6 +148,7 @@ impl ModuleCx {
             runtime: HashMap::new(),
             extern_params: HashMap::new(),
             extern_rets: HashMap::new(),
+            variadic_externs: std::collections::HashSet::new(),
             fn_params: HashMap::new(),
             strings: BTreeMap::new(),
             string_counter: 0,
@@ -729,6 +734,9 @@ impl ModuleCx {
             self.extern_params
                 .insert(ext.name.clone(), ext.params.clone());
             self.extern_rets.insert(ext.name.clone(), ext.ret.clone());
+            if ext.variadic {
+                self.variadic_externs.insert(ext.name.clone());
+            }
         }
         Ok(())
     }
@@ -787,6 +795,12 @@ impl ModuleCx {
     /// one. Used by a call site to coerce arguments to the C ABI width.
     pub fn extern_params(&self, name: &str) -> Option<&[MirType]> {
         self.extern_params.get(name).map(|v| v.as_slice())
+    }
+
+    /// True when `name` is a variadic extern C function, so a call dispatches
+    /// through `call_indirect` with a per-call signature.
+    pub fn extern_is_variadic(&self, name: &str) -> bool {
+        self.variadic_externs.contains(name)
     }
 
     /// Return type of a declared extern C function, if `name` names one.

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -2102,7 +2102,27 @@ fn lower_call(
             }
         }
     }
-    let inst = builder.ins().call(local_ref, &arg_vals);
+    // A variadic C function is called through `call_indirect` with a
+    // signature built from the actual arguments, since the fixed declared
+    // signature cannot describe the extra ones. The arguments are integer or
+    // pointer types (the type checker rejects float varargs), so no System V
+    // `al` count or Windows x64 float-shadow handling is needed.
+    let is_variadic_call = is_extern && cx.extern_is_variadic(&callee.mangled);
+    let inst = if is_variadic_call {
+        let mut sig = Signature::new(cx.default_call_conv());
+        for &v in &arg_vals {
+            let vt = builder.func.dfg.value_type(v);
+            sig.params.push(cranelift_codegen::ir::AbiParam::new(vt));
+        }
+        if let Some(rt) = extern_ret.as_ref().and_then(|t| cranelift_ty(t, ptr)) {
+            sig.returns.push(cranelift_codegen::ir::AbiParam::new(rt));
+        }
+        let sigref = builder.import_signature(sig);
+        let addr = builder.ins().func_addr(ptr, local_ref);
+        builder.ins().call_indirect(sigref, addr, &arg_vals)
+    } else {
+        builder.ins().call(local_ref, &arg_vals)
+    };
     // Capture results before popping roots, which emits further instructions.
     let results: Vec<Value> = builder.inst_results(inst).to_vec();
     pop_n_roots(cx, builder, roots, ptr);

--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -44,6 +44,10 @@ const MSVC_NATIVE_STATIC_LIBS: &[&str] = &[
     "ws2_32.lib",
     "dbghelp.lib",
     "/defaultlib:msvcrt",
+    // The UCRT inlines the `printf` family in its headers, so the bare
+    // symbols are not in `msvcrt.lib`. This compatibility lib provides them
+    // as real functions, so an FFI call to `printf`/`sprintf`/... resolves.
+    "/defaultlib:legacy_stdio_definitions",
 ];
 
 /// Where to find the runtime staticlib produced by Cargo.

--- a/src/hir/decl.rs
+++ b/src/hir/decl.rs
@@ -63,6 +63,8 @@ pub struct HirExternFn {
     pub name: String,
     pub params: Vec<HirTy>,
     pub ret: HirTy,
+    /// True for a variadic C function (`fun printf(fmt: CStr, ...)`).
+    pub variadic: bool,
     pub span: Span,
 }
 

--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -395,6 +395,7 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
                     name: item.name.clone(),
                     params,
                     ret,
+                    variadic: item.variadic,
                     span: item.span.clone(),
                 });
             }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -109,6 +109,8 @@ pub enum TokenKind {
     Eq,
     DotDot,
     DotDotEq,
+    /// `...`, the C variadic parameter marker in an `extern` signature.
+    DotDotDot,
     Question,
     Arrow,    // ->
     FatArrow, // =>
@@ -1002,6 +1004,10 @@ impl Lexer {
                     if self.peek() == Some('=') {
                         self.bump();
                         return make(self, TokenKind::DotDotEq);
+                    }
+                    if self.peek() == Some('.') {
+                        self.bump();
+                        return make(self, TokenKind::DotDotDot);
                     }
                     return make(self, TokenKind::DotDot);
                 }

--- a/src/mir/ir.rs
+++ b/src/mir/ir.rs
@@ -444,6 +444,9 @@ pub struct MirExternFn {
     pub params: Vec<MirType>,
     /// Return type, or `MirType::Unit` for a `void` return.
     pub ret: MirType,
+    /// True for a variadic C function (`fun printf(fmt: CStr, ...)`): a call
+    /// may pass extra C-FFI integer/pointer arguments after the fixed ones.
+    pub variadic: bool,
 }
 
 /// One C-layout field of a `@repr(C)` struct that crosses the FFI by

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -169,6 +169,7 @@ fn collect_externs(hir: &HirProgram) -> Vec<super::ir::MirExternFn> {
                     name: f.name.clone(),
                     params: f.params.iter().map(MirType::from_ty).collect(),
                     ret: MirType::from_ty(&f.ret),
+                    variadic: f.variadic,
                 });
             }
         }

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -497,7 +497,36 @@ impl Parser {
             self.expect(&TokenKind::Fun, "`fun`")?;
             let (name, _) = self.expect_ident("function name")?;
             self.expect(&TokenKind::LParen, "`(`")?;
-            let params = self.parse_param_list()?;
+            // Extern parameters, with an optional trailing `...` variadic
+            // marker. Parsed inline (rather than via `parse_param_list`) so the
+            // `...` is only accepted here, in an extern signature.
+            self.skip_newlines();
+            let mut params = Vec::new();
+            let mut variadic = false;
+            if !matches!(self.peek_kind(), TokenKind::RParen) {
+                loop {
+                    self.skip_newlines();
+                    if matches!(self.peek_kind(), TokenKind::DotDotDot) {
+                        self.advance();
+                        variadic = true;
+                        self.skip_newlines();
+                        break;
+                    }
+                    let (pname, name_span) = self.expect_ident("parameter name")?;
+                    self.expect(&TokenKind::Colon, "`:`")?;
+                    let ty = self.parse_type()?;
+                    let span = merge_spans(&name_span, &ty.span);
+                    params.push(Param {
+                        name: pname,
+                        ty,
+                        span,
+                    });
+                    self.skip_newlines();
+                    if !self.eat(&TokenKind::Comma) {
+                        break;
+                    }
+                }
+            }
             let rp = self.expect(&TokenKind::RParen, "`)`")?;
             let ret = if self.eat(&TokenKind::Arrow) {
                 Some(self.parse_type()?)
@@ -510,6 +539,7 @@ impl Parser {
                 name,
                 params,
                 ret,
+                variadic,
                 span: item_span,
             });
             self.skip_separators();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -461,6 +461,7 @@ pub(crate) fn describe_token(kind: &TokenKind) -> String {
         TokenKind::Eq => "`=`".to_string(),
         TokenKind::DotDot => "`..`".to_string(),
         TokenKind::DotDotEq => "`..=`".to_string(),
+        TokenKind::DotDotDot => "`...`".to_string(),
         TokenKind::Question => "`?`".to_string(),
         TokenKind::Arrow => "`->`".to_string(),
         TokenKind::FatArrow => "`=>`".to_string(),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -822,6 +822,22 @@ fn parses_extern_block() {
 }
 
 #[test]
+fn parses_variadic_extern() {
+    let f = parse_ok("extern \"C\" { fun printf(fmt: CStr, ...) -> CInt\n }\n");
+    let DeclKind::Extern(e) = &f.items[0].kind else {
+        panic!()
+    };
+    assert!(e.items[0].variadic);
+    assert_eq!(e.items[0].params.len(), 1);
+    // A signature without `...` is not variadic.
+    let g = parse_ok("extern \"C\" { fun abs(x: CInt) -> CInt\n }\n");
+    let DeclKind::Extern(e2) = &g.items[0].kind else {
+        panic!()
+    };
+    assert!(!e2.items[0].variadic);
+}
+
+#[test]
 fn parses_const_decl() {
     let f = parse_ok("const PI: Float = 3.14\n");
     let DeclKind::Const(c) = &f.items[0].kind else {

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -154,6 +154,7 @@ pub fn collect_declarations(
                             ret,
                             span: item.span.clone(),
                             has_self: false,
+                            variadic: item.variadic,
                         },
                     );
                 }
@@ -627,6 +628,7 @@ fn collect_fn_sig(
         ret,
         span: f.span.clone(),
         has_self,
+        variadic: false,
     })
 }
 

--- a/src/tycheck/env.rs
+++ b/src/tycheck/env.rs
@@ -110,6 +110,9 @@ pub struct FnSig {
     /// `self` receiver; the parser already includes `self` in the
     /// parameter list, so this flag is purely for diagnostics.
     pub has_self: bool,
+    /// True for a variadic `extern` C function (`fun printf(fmt: CStr, ...)`):
+    /// extra C-FFI integer/pointer arguments may follow the fixed parameters.
+    pub variadic: bool,
 }
 
 /// A trait declaration: a list of method signatures keyed by name.
@@ -274,6 +277,7 @@ mod tests {
                 ret: Ty::Int,
                 span: span(),
                 has_self: true,
+                variadic: false,
             },
         );
         env.impls.push(ImplSig {

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1363,7 +1363,25 @@ impl<'a, 'b> Checker<'a, 'b> {
                 ));
             }
         };
-        if params.len() != args.len() {
+        // A variadic `extern` C function accepts extra C-FFI arguments after
+        // its fixed parameters; look the flag up from the callee's signature.
+        let extern_variadic = match self.resolved.map.lookup(&callee.span) {
+            Some(Binding::Extern {
+                decl_id,
+                item_index,
+            }) => self
+                .env
+                .externs
+                .get(&(*decl_id, *item_index))
+                .is_some_and(|s| s.variadic),
+            _ => false,
+        };
+        let arity_ok = if extern_variadic {
+            args.len() >= params.len()
+        } else {
+            args.len() == params.len()
+        };
+        if !arity_ok {
             return Err(RavenError::ty(
                 TypeError::WrongArity {
                     func: describe_callee(callee),
@@ -1372,6 +1390,22 @@ impl<'a, 'b> Checker<'a, 'b> {
                 },
                 span.clone(),
             ));
+        }
+        // The arguments beyond the fixed parameters of a variadic C function
+        // must each be a C-FFI integer or pointer type. Floats are rejected:
+        // the back end cannot set the System V `al` register or apply the
+        // Windows x64 float-shadow rule, so a float vararg would miscompile.
+        for arg in args.iter().skip(params.len()) {
+            let a = self.check_expr(arg)?;
+            let ra = self.infer.resolve(&a);
+            if !is_variadic_ffi_arg(ra.strip_self()) {
+                return Err(ty_custom(
+                    &format!(
+                        "a variadic C argument must be a C-FFI integer or pointer type (CInt, CLong, CSize, CStr, CPtr<T>) or a native Int; got `{ra}`. Float varargs are not supported (wrap the call in a C shim)"
+                    ),
+                    &arg.span,
+                ));
+            }
         }
         // Whether this call targets a foreign C function; only then is a
         // struct argument marshaled by value and required to be `@repr(C)`.
@@ -3249,6 +3283,22 @@ fn is_int_ffi(ty: &Ty) -> bool {
 
 fn is_float_ffi(ty: &Ty) -> bool {
     matches!(ty, Ty::Ffi(FfiTy::CFloat) | Ty::Ffi(FfiTy::CDouble))
+}
+
+/// True for a type allowed as a variadic C argument: a C-FFI integer or
+/// pointer, or a native `Int`. Floats are excluded because the back end
+/// cannot honor the variadic float ABI (the System V `al` count and the
+/// Windows x64 float-shadow rule).
+fn is_variadic_ffi_arg(ty: &Ty) -> bool {
+    matches!(
+        ty,
+        Ty::Int
+            | Ty::Ffi(FfiTy::CInt)
+            | Ty::Ffi(FfiTy::CLong)
+            | Ty::Ffi(FfiTy::CSize)
+            | Ty::Ffi(FfiTy::CStr)
+            | Ty::Ffi(FfiTy::CPtr(_))
+    )
 }
 
 /// True for a C-FFI scalar or pointer type with a well-defined C ABI:

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -696,6 +696,37 @@ fn cfnptr_arg_rejects_non_ffi_closure_signature() {
 }
 
 #[test]
+fn variadic_extern_accepts_extra_ffi_args() {
+    // A variadic C function (`...`) accepts extra integer/pointer arguments
+    // after its fixed parameters.
+    check(
+        "extern \"C\" {\n    fun printf(fmt: CStr, ...) -> CInt\n}\nfun main() {\n    let _ = printf(c\"%d %s\", 1, c\"x\")\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn variadic_extern_rejects_float_arg() {
+    // A float variadic argument cannot be honored by the back end (System V
+    // `al`, Windows x64 float shadow), so it is rejected at compile time.
+    let err = check(
+        "extern \"C\" {\n    fun printf(fmt: CStr, ...) -> CInt\n}\nfun main() {\n    let _ = printf(c\"%f\", 3.14)\n}\n",
+    )
+    .unwrap_err();
+    assert!(matches!(err, RavenError::Type(_, _, _)));
+}
+
+#[test]
+fn non_variadic_extern_rejects_extra_args() {
+    // Without `...`, the arity is fixed.
+    let err = check(
+        "extern \"C\" {\n    fun abs(x: CInt) -> CInt\n}\nfun main() {\n    let _ = abs(1, 2)\n}\n",
+    )
+    .unwrap_err();
+    assert!(matches!(err, RavenError::Type(_, _, _)));
+}
+
+#[test]
 fn set_literal_type_checks() {
     check_with_prelude(
         "import std/collections\nfun main() {\n    let s: Set<Int> = {1, 2, 2}\n    let _ = s.len()\n}\n",


### PR DESCRIPTION
## Summary

The last FFI extension slice (#330, part of #213): calling variadic C functions. An extern signature ending in `...` is variadic:

```rust
extern "C" {
    fun printf(fmt: CStr, ...) -> CInt
}
```

A call may pass extra arguments after the fixed parameters. Each variadic argument must be a C-FFI integer or pointer type (`CInt`, `CLong`, `CSize`, `CStr`, `CPtr<T>`) or a native `Int`. The back end builds a signature from the actual arguments at the call site and dispatches through `call_indirect`, since the fixed declared signature can't carry the extra arguments.

### Float varargs are rejected at compile time
The Cranelift backend cannot set the System V `al` register (the count of vector registers a variadic callee reads) or apply the Windows x64 rule that duplicates a floating vararg into an SSE register, so a float vararg would miscompile. A `%f` format needs a fixed-arity C shim. The integer/pointer path is unaffected (`al` is only read for float formats), so `printf("%d %s", ...)` works.

### Threading
A `variadic` flag flows through the lexer (a new `...` token), parser, AST, type checker, HIR, MIR, and codegen. On windows-msvc the `printf` family is provided by `legacy_stdio_definitions.lib` (the UCRT inlines it in headers), added to the default link libraries.

## Testing
- Golden `ffi_variadic` (printf with integer/string varargs and with none).
- Type-checker tests: accept integer/pointer varargs, reject a float vararg with a clear message, keep non-variadic arity fixed. Parser test for `...`.
- **Windows verified locally** (printf, including zero varargs). **System V via this PR's CI golden suite.** A release smoke check on all platforms.
- Full `cargo test` (518 lib + golden), `cargo fmt --check`, `cargo clippy` clean.

## Version
Minor bump to `2.10.0`. Held unreleased.

Refs #213. Implements #330.
