### PR TITLE
build(release): drop macOS target, ship Linux and Windows x86_64 (2.10.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,6 @@ jobs:
           - name: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
-          - name: macos-arm64
-            os: macos-14
-            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v4
         with:
@@ -134,21 +131,6 @@ jobs:
           cargo deb --no-build --no-strip
           cargo generate-rpm
 
-      - name: Build macOS package
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          v="${{ steps.version.outputs.value }}"
-          bindir="target/${{ matrix.target }}/release"
-          root="pkgroot/usr/local/bin"
-          mkdir -p "$root"
-          cp "$bindir/raven" "$root/"
-          cp "$bindir/rvpm" "$root/"
-          cp "$bindir/libraven_runtime.a" "$root/"
-          pkgbuild --root pkgroot --identifier com.martian56.raven \
-            --version "$v" --install-location / \
-            "raven-$v-${{ matrix.target }}.pkg"
-
       - name: Build Windows MSI
         if: runner.os == 'Windows'
         shell: pwsh
@@ -180,23 +162,13 @@ jobs:
           $msi = Get-ChildItem target/wix/*.msi | Select-Object -First 1
           & signtool sign /f "$env:RUNNER_TEMP\cert.pfx" /p $env:WINDOWS_CERT_PASSWORD /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $msi.FullName
 
-      - name: Sign macOS package (optional)
-        if: ${{ runner.os == 'macOS' && env.APPLE_INSTALLER_IDENTITY != '' }}
-        shell: bash
-        env:
-          APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
-        run: |
-          v="${{ steps.version.outputs.value }}"
-          pkg="raven-$v-${{ matrix.target }}.pkg"
-          productsign --sign "$APPLE_INSTALLER_IDENTITY" "$pkg" "signed-$pkg"
-          mv "signed-$pkg" "$pkg"
 
       - name: Collect artifacts
         shell: bash
         run: |
           mkdir -p dist
           shopt -s nullglob
-          for f in *.tar.gz *.zip *.pkg target/debian/*.deb target/generate-rpm/*.rpm target/wix/*.msi; do
+          for f in *.tar.gz *.zip target/debian/*.deb target/generate-rpm/*.rpm target/wix/*.msi; do
             cp "$f" dist/
           done
           ls -l dist
@@ -225,9 +197,8 @@ jobs:
 
             - Linux: `.deb`, `.rpm`, or `.tar.gz`
             - Windows: `.msi` or `.zip`
-            - macOS (Apple Silicon): `.pkg` or `.tar.gz`
 
-            Each one installs the `raven` compiler and the `rvpm` package manager. Compiling a program also needs a C linker (the MSVC build tools on Windows, `cc` or `clang` on Linux and macOS).
+            Each one installs the `raven` compiler and the `rvpm` package manager. Compiling a program also needs a C linker (the MSVC build tools on Windows, `cc` or `clang` on Linux).
 
             The full changelog is in [CHANGELOG.md](https://github.com/martian56/raven/blob/main/CHANGELOG.md), and the docs are at [martian56.github.io/raven](https://martian56.github.io/raven/).
           generate_release_notes: true
@@ -253,8 +224,6 @@ jobs:
             os: ubuntu-22.04
           - name: windows-x86_64
             os: windows-latest
-          - name: macos-arm64
-            os: macos-14
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -277,17 +246,16 @@ jobs:
           echo "program output: $out"
           test "$out" = "hello"
           # FFI: a 16-byte @repr(C) struct returned by value, exercising the
-          # by-value struct ABI for this target (two registers on System V and
-          # AArch64). lldiv is in the C runtime on every platform.
+          # by-value struct ABI for this target (two registers on System V).
+          # lldiv is in the C runtime on every platform.
           printf '@repr(C)\nstruct D { quot: CLong, rem: CLong }\nextern "C" { fun lldiv(numer: CLong, denom: CLong) -> D }\nfun main() {\n  let r = lldiv(17, 5)\n  print(r.quot)\n  print(r.rem)\n}\n' > ffi.rv
           raven build ffi.rv -o ffi
           ffi_out="$(./ffi | tr '\n' ',')"
           echo "ffi struct-by-value output: $ffi_out"
           test "$ffi_out" = "3,2,"
           # FFI: a 16-byte float struct by value, exercising the float
-          # register classification (two SSE registers on System V, a
-          # 2-member homogeneous float aggregate in SIMD registers on
-          # AArch64). The fixtures ship in libraven_runtime.
+          # register classification (two SSE registers on System V). The
+          # fixtures ship in libraven_runtime.
           printf '@repr(C)\nstruct V2 { x: CDouble, y: CDouble }\nextern "C" {\n  fun raven_ffi_make_vec2d(x: CDouble, y: CDouble) -> V2\n  fun raven_ffi_vec2d_sum(v: V2) -> CDouble\n}\nfun main() {\n  let v = raven_ffi_make_vec2d(10.0, 20.0)\n  print(raven_ffi_vec2d_sum(v))\n}\n' > ffif.rv
           raven build ffif.rv -o ffif
           ffif_out="$(./ffif)"
@@ -301,7 +269,7 @@ jobs:
           echo "ffi callback output: $fficb_out"
           test "$fficb_out" = "105"
           # FFI: a 24-byte struct by value, over two registers (System V passes
-          # it in memory on the stack, Windows x64 and AArch64 by reference).
+          # it in memory on the stack, Windows x64 by reference).
           printf '@repr(C)\nstruct Big { a: CLong, b: CLong, c: CLong }\nextern "C" {\n  fun raven_ffi_make_big(a: CLong, b: CLong, c: CLong) -> Big\n  fun raven_ffi_big_sum(v: Big) -> CLong\n}\nfun main() {\n  let g = raven_ffi_make_big(10, 20, 30)\n  print(raven_ffi_big_sum(g))\n}\n' > ffibig.rv
           raven build ffibig.rv -o ffibig
           ffibig_out="$(./ffibig)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.10.1] - 2026-06-06
+
+### Changed
+
+- Dropped macOS as a release target. Raven now ships for Linux x86_64 and Windows x86_64. The macOS arm64 build was removed because the Apple arm64 ABI passes variadic arguments on the stack, which the Cranelift backend cannot express, so a variadic C call (added in 2.10.0) crashed on that platform. On the remaining x86_64 targets variadic arguments go in registers and work correctly. The AArch64 code paths stay in the compiler but are no longer built, shipped, or supported.
+
 ## [2.10.0] - 2026-06-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.10.0"
+version = "2.10.1"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ Download the installer or archive for your platform from the [releases page](htt
 
 - Linux: `.deb`, `.rpm`, or `.tar.gz`
 - Windows: `.msi` or `.zip`
-- macOS: `.pkg` or `.tar.gz` (Apple Silicon)
 
-This installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker on your machine (the MSVC build tools on Windows, `cc`/`clang` on Linux and macOS).
+This installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker on your machine (the MSVC build tools on Windows, `cc`/`clang` on Linux).
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ fun main() {
 
 ## Install
 
-Download the installer or archive for your platform from the [releases page](https://github.com/martian56/raven/releases): `.deb`/`.rpm`/`.tar.gz` for Linux, `.msi`/`.zip` for Windows, and `.pkg`/`.tar.gz` for macOS (Apple Silicon). Each one installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker (the MSVC build tools on Windows, `cc` or `clang` on Linux and macOS).
+Download the installer or archive for your platform from the [releases page](https://github.com/martian56/raven/releases): `.deb`/`.rpm`/`.tar.gz` for Linux and `.msi`/`.zip` for Windows. Each one installs the `raven` compiler and the `rvpm` package manager and adds them to your `PATH`. Compiling a program also needs a C linker (the MSVC build tools on Windows, `cc` or `clang` on Linux).
 
 If you would rather build from source, or want to track the latest commit:
 

--- a/docs/v2/guide/getting-started.md
+++ b/docs/v2/guide/getting-started.md
@@ -11,14 +11,13 @@ to a managed project with `rvpm`.
 
 Download the installer or archive for your platform from the
 [releases page](https://github.com/martian56/raven/releases): `.deb`,
-`.rpm`, or `.tar.gz` for Linux, `.msi` or `.zip` for Windows, and `.pkg`
-or `.tar.gz` for macOS (Apple Silicon). Each installs the
-`raven` compiler and the `rvpm` package manager and adds them to your
-`PATH`.
+`.rpm`, or `.tar.gz` for Linux, and `.msi` or `.zip` for Windows. Each
+installs the `raven` compiler and the `rvpm` package manager and adds them
+to your `PATH`.
 
 Compiling a program also needs a C linker on your machine: the MSVC build
-tools on Windows, or `cc`/`clang` on Linux and macOS. The compiler uses it
-to link the final binary.
+tools on Windows, or `cc`/`clang` on Linux. The compiler uses it to link
+the final binary.
 
 To build from source instead (for contributors, or to track the latest
 commit):

--- a/docs/v2/specs/release.md
+++ b/docs/v2/specs/release.md
@@ -8,14 +8,13 @@ Release.
 
 ## Artifacts per platform
 
-The build matrix covers three targets. Each target produces a portable archive
+The build matrix covers two targets. Each target produces a portable archive
 and the platform native installer.
 
 | Target | Archive | Installer |
 |--------|---------|-----------|
 | Linux x86_64 (`x86_64-unknown-linux-gnu`) | `.tar.gz` | `.deb`, `.rpm` |
 | Windows x86_64 (`x86_64-pc-windows-msvc`) | `.zip` | `.msi` |
-| macOS arm64 (`aarch64-apple-darwin`) | `.tar.gz` | `.pkg` |
 
 Every artifact bundles two binaries, `raven` (the compiler and build driver)
 and `rvpm` (the package manager), plus the `raven_runtime` static library.
@@ -49,7 +48,6 @@ finds it with no configuration:
 - `.deb` and `.rpm`: binaries and the runtime library install to `/usr/bin`.
 - `.msi`: all three files install to the application `bin` directory, which is
   added to the system PATH.
-- `.pkg`: all three files install to `/usr/local/bin`.
 
 The smoke jobs additionally set `RAVEN_RUNTIME_LIB` to the packaged path as a
 belt-and-suspenders check.
@@ -82,19 +80,12 @@ Windows Authenticode (MSI):
 - `WINDOWS_CERT_BASE64`: base64 encoded PFX certificate.
 - `WINDOWS_CERT_PASSWORD`: PFX password.
 
-macOS package signing:
-
-- `APPLE_INSTALLER_IDENTITY`: a Developer ID Installer identity available in the
-  runner keychain, used by `productsign`.
-
-Add these as repository or organization secrets to enable signing. Notarization
-and stapling for macOS can be layered on later with `notarytool` and `stapler`
-once an Apple account is wired up.
+Add these as repository or organization secrets to enable signing.
 
 ## Verification status
 
 The full multi-platform installer build runs only on a tag (or
-`workflow_dispatch`) using the Linux, Windows, and macOS runners, so it is
+`workflow_dispatch`) using the Linux and Windows runners, so it is
 confirmed by an actual tagged release run. The packaging configuration and the
 runtime-library location approach were validated locally: a staged Windows
 layout of `raven.exe`, `rvpm.exe`, and `raven_runtime.lib` in one directory


### PR DESCRIPTION
Removes macOS (aarch64-apple-darwin) from the release matrix and the user-facing platform docs.

## Why
v2.10.0's macOS arm64 build was the only target where a variadic C call (new in 2.10.0) crashed: **Apple's arm64 ABI passes variadic arguments on the stack**, which the Cranelift backend cannot express, so the register-passed args were read as garbage (the release smoke caught this, exit 139). On the remaining x86_64 targets variadic arguments go in registers and work correctly, so no per-target gating is needed and variadics is consistent across all supported platforms.

## Changes
- **release.yml**: drop the `macos-arm64` build and smoke matrix entries, the `pkgbuild`/`productsign` steps, the `.pkg` upload glob, and macOS lines in the release body and smoke comments.
- **Docs**: README, docs/index, docs/v2/guide/getting-started, docs/v2/specs/release now list Linux and Windows only.
- The AArch64 register-plan and Mach-O code paths stay in the compiler (correct and harmless) but are no longer built, shipped, or supported.

No source changes. After merge, the `v2.10.1` tag triggers a Linux + Windows release.