### PR TITLE
fix(hir): ==/!= on structs and enums compare by value, not identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.10.2] - 2026-06-06
+
+### Fixed
+
+- `==` and `!=` on a struct or enum that implements `Eq` (including via `@derive(Eq)`) now compare by value instead of by object identity. Previously the operators compared the operands' heap pointers, so two equal values (for example `Status.Doing == Status.Doing`, or two structs with equal fields) compared unequal even though the derived `equals` method itself was correct. HIR lowering now rewrites the operator to a call to the type's `equals` method (the same way `print` routes a value through `to_string`); a primitive keeps the native compare, a `String` keeps its byte-equality path, and a type with no `Eq` impl is unchanged.
+
 ## [2.10.1] - 2026-06-06
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.10.1"
+version = "2.10.2"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/derive.md
+++ b/docs/v2/specs/derive.md
@@ -77,6 +77,15 @@ The `other` parameter is annotated with the concrete self type (for example
 `Point`, or `Pair<A, B>`) rather than `Self`, because the type checker does
 not yet accept `Self` as a non-receiver parameter type.
 
+The `==` and `!=` operators on a struct or enum that implements `Eq` (whether
+derived or hand-written) dispatch to its `equals` method, so equality is by
+value, not by object identity; `!=` negates the result. HIR lowering rewrites
+the operator to the method call, the same way `print` routes a non-`String`
+through `to_string`. A primitive keeps the native machine compare, and a
+`String` keeps its byte-equality path; a type with no `Eq` impl keeps the
+identity compare (a struct or enum without `@derive(Eq)` should derive it to
+compare by value).
+
 ### Hash
 
 ```rust

--- a/examples/v2/derive_eq.rv
+++ b/examples/v2/derive_eq.rv
@@ -1,0 +1,39 @@
+// @derive(Eq) makes `==` and `!=` compare by value (through the generated
+// `equals` method), not by object identity. The struct comparison recurses
+// into the enum field's derived equality. Prints:
+//   in progress
+//   not done
+//   same task
+//   different task
+@derive(Eq, ToString)
+enum Status {
+    Todo,
+    Doing,
+    Done,
+}
+
+@derive(Eq)
+struct Task {
+    id: Int,
+    status: Status,
+}
+
+fun main() {
+    let s = Status.Doing
+    if s == Status.Doing {
+        print("in progress")
+    }
+    if s != Status.Done {
+        print("not done")
+    }
+
+    let a = Task { id: 1, status: Status.Doing }
+    let b = Task { id: 1, status: Status.Doing }
+    let c = Task { id: 2, status: Status.Doing }
+    if a == b {
+        print("same task")
+    }
+    if a != c {
+        print("different task")
+    }
+}

--- a/examples/v2/derive_eq.rv.out
+++ b/examples/v2/derive_eq.rv.out
@@ -1,0 +1,4 @@
+in progress
+not done
+same task
+different task

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -178,10 +178,37 @@ pub(crate) fn lower_expr(
         ExprKind::Binary { op, lhs, rhs } => {
             let l = lower_expr(lhs, &Ty::Error, cx)?;
             let r = lower_expr(rhs, &Ty::Error, cx)?;
-            HirExprKind::Binary {
-                op: lower_binop(*op),
-                lhs: Box::new(l),
-                rhs: Box::new(r),
+            // `==`/`!=` on a struct or enum that implements `Eq` (a derived or
+            // hand-written `equals` method) dispatch to that method, so
+            // equality is by value rather than object identity. The
+            // conversion is a `MethodCall`, which MIR resolves to the type's
+            // `equals` symbol (the same way `print` routes through
+            // `to_string`). `!=` negates the result. A primitive keeps the
+            // native compare below, and `String` keeps its own contents path
+            // in MIR; a type without an `Eq` impl is unchanged.
+            if matches!(op, BinaryOp::Eq | BinaryOp::Ne)
+                && type_has_equals(cx.env, l.ty.strip_self())
+            {
+                let call = HirExprKind::MethodCall {
+                    receiver: Box::new(l),
+                    name: "equals".into(),
+                    args: vec![r],
+                };
+                if matches!(op, BinaryOp::Ne) {
+                    let eq = make_expr(call, Ty::Bool, span.clone());
+                    HirExprKind::Unary {
+                        op: HirUnaryOp::Not,
+                        operand: Box::new(eq),
+                    }
+                } else {
+                    call
+                }
+            } else {
+                HirExprKind::Binary {
+                    op: lower_binop(*op),
+                    lhs: Box::new(l),
+                    rhs: Box::new(r),
+                }
             }
         }
         ExprKind::Range {
@@ -747,6 +774,25 @@ fn lower_unop(op: UnaryOp) -> HirUnaryOp {
         UnaryOp::Not => HirUnaryOp::Not,
         UnaryOp::Ref => HirUnaryOp::Ref,
     }
+}
+
+/// Whether `ty` is a struct or enum that implements `Eq` (any impl on the type
+/// provides an `equals` method), so `==`/`!=` on it should dispatch to that
+/// method rather than compare the heap pointers. Matched by the type's head
+/// name, which covers the concrete and generic (`impl<T: Eq> Eq for Pair<T>`)
+/// cases the derive pass and hand-written impls produce.
+fn type_has_equals(env: &crate::tycheck::TypeEnv, ty: &Ty) -> bool {
+    let head = match ty {
+        Ty::Struct { name, .. } | Ty::Enum { name, .. } => name.as_str(),
+        _ => return false,
+    };
+    env.impls.iter().any(|imp| {
+        imp.methods.contains_key("equals")
+            && matches!(
+                &imp.self_ty,
+                Ty::Struct { name, .. } | Ty::Enum { name, .. } if name == head
+            )
+    })
 }
 
 fn lower_binop(op: BinaryOp) -> HirBinaryOp {

--- a/tests/golden.rs
+++ b/tests/golden.rs
@@ -80,6 +80,13 @@ fn v2_examples_match_golden_baselines() {
 
         ran += 1;
 
+        // Normalize line endings before storing or comparing: a program that
+        // prints through C `printf` emits CRLF on Windows (the CRT text mode),
+        // and git normalizes the committed `.rv.out` baseline to LF, so the
+        // raw bytes would spuriously differ across platforms.
+        let normalize = |s: &str| s.replace("\r\n", "\n");
+        let stdout = normalize(&stdout);
+
         if update {
             std::fs::write(&example.baseline, &stdout)
                 .unwrap_or_else(|e| panic!("write baseline {}: {}", example.baseline.display(), e));
@@ -87,7 +94,7 @@ fn v2_examples_match_golden_baselines() {
         }
 
         let expected = match std::fs::read_to_string(&example.baseline) {
-            Ok(s) => s,
+            Ok(s) => normalize(&s),
             Err(e) => {
                 failures.push(format!(
                     "{}: missing baseline {} ({}); run RAVEN_UPDATE_GOLDEN=1 to create it",


### PR DESCRIPTION
Fixes #340.

## Bug
`==`/`!=` on a struct or enum compared the operands' heap pointers, so two equal values compared unequal, even with `@derive(Eq)`. The derived `equals` was correct; only the operator dispatch was wrong. `Status.Doing == Status.Doing` returned `false`.

## Fix
HIR lowering rewrites `==`/`!=` on a type with an `Eq` impl to a call to its `equals` method (`!=` negates), mirroring how `print` routes a value through `to_string`. Primitives keep the native compare; `String` keeps its byte-equality path; a type without `Eq` is unchanged (no new error, so `Option`/`List` etc. that lack `Eq` still compile, see note).

## Testing
- New golden `derive_eq` covering `==`/`!=` on a derived-Eq enum and a struct that recurses into an enum field. The existing `use_derive` example only called `.equals()` directly, which is why this slipped through.
- Verified `!=`, primitives, strings, and no-Eq aggregates are unaffected; full `cargo test` (518 lib + golden), `cargo fmt --check`, `cargo clippy` clean.
- Also normalized CRLF in the golden harness so a `printf`-using example (CRLF on Windows) matches its git-normalized LF baseline (this was failing the golden locally on Windows, unrelated to the fix).

## Follow-up (not in this PR)
Stdlib aggregates (`Option`, `Result`, `List`, `Map`, `Set`) have no `Eq` impl, so `==` on them is still identity-compare. Giving them `Eq` (so `Some(1) == Some(1)` works) is a natural next step.

## Version
Patch bump to `2.10.2`.