### PR TITLE
feat(stdlib): Eq for Option, Result, List, Set, and Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.11.0] - 2026-06-06
+
+### Added
+
+- `Eq` for the built-in generic and collection types, so `==`/`!=` compare them by value: `Option<T>`, `Result<T, E>`, and `List<T>` (in std/core, always available), and `Set<T>` and `Map<K, V>` (in std/collections; Set and Map compare order-independently). An element type must itself implement `Eq`, which the bound requires. A follow-up to the 2.10.2 operator fix (#340): previously these compared by object identity, so `Some(1) == Some(1)` and `[1, 2] == [1, 2]` were `false`; they are now `true` (#342).
+
 ## [2.10.2] - 2026-06-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.10.2"
+version = "2.11.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.10.2"
+version = "2.11.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.10.2"
+version = "2.11.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/derive.md
+++ b/docs/v2/specs/derive.md
@@ -77,14 +77,18 @@ The `other` parameter is annotated with the concrete self type (for example
 `Point`, or `Pair<A, B>`) rather than `Self`, because the type checker does
 not yet accept `Self` as a non-receiver parameter type.
 
-The `==` and `!=` operators on a struct or enum that implements `Eq` (whether
-derived or hand-written) dispatch to its `equals` method, so equality is by
-value, not by object identity; `!=` negates the result. HIR lowering rewrites
-the operator to the method call, the same way `print` routes a non-`String`
-through `to_string`. A primitive keeps the native machine compare, and a
-`String` keeps its byte-equality path; a type with no `Eq` impl keeps the
-identity compare (a struct or enum without `@derive(Eq)` should derive it to
-compare by value).
+The `==` and `!=` operators on any type that implements `Eq` (whether derived
+or hand-written) dispatch to its `equals` method, so equality is by value, not
+by object identity; `!=` negates the result. HIR lowering rewrites the operator
+to the method call, the same way `print` routes a non-`String` through
+`to_string`. A primitive keeps the native machine compare, and a `String` keeps
+its byte-equality path; a type with no `Eq` impl keeps the identity compare (a
+struct or enum without `@derive(Eq)` should derive it to compare by value).
+
+The built-in generic types `Option<T>`, `Result<T, E>`, and `List<T>` implement
+`Eq` in `std/core`, and `Set<T>` and `Map<K, V>` in `std/collections` (these
+two compare order-independently), so `==`/`!=` work on them by value when the
+element type implements `Eq`.
 
 ### Hash
 

--- a/examples/v2/collection_eq.rv
+++ b/examples/v2/collection_eq.rv
@@ -1,0 +1,43 @@
+// `==`/`!=` compare the built-in generic types and the collection types by
+// value, not by object identity: Option, Result, and List (always available),
+// plus Set and Map from std/collections. Set and Map compare order
+// independently. An element type must itself implement Eq, which Int, String,
+// and a @derive(Eq) type satisfy. Prints:
+//   options equal
+//   results differ
+//   lists differ
+//   sets equal
+//   maps equal
+import std/collections
+
+fun main() {
+    let a: Int? = Some(1)
+    let b: Int? = Some(1)
+    if a == b {
+        print("options equal")
+    }
+
+    let r1: Result<Int, String> = Ok(1)
+    let r2: Result<Int, String> = Err("no")
+    if r1 != r2 {
+        print("results differ")
+    }
+
+    let xs = [1, 2, 3]
+    let ys = [1, 2, 4]
+    if xs != ys {
+        print("lists differ")
+    }
+
+    let s1: Set<Int> = {1, 2, 3}
+    let s2: Set<Int> = {3, 2, 1}
+    if s1 == s2 {
+        print("sets equal")
+    }
+
+    let m1: Map<String, Int> = ["a": 1, "b": 2]
+    let m2: Map<String, Int> = ["b": 2, "a": 1]
+    if m1 == m2 {
+        print("maps equal")
+    }
+}

--- a/examples/v2/collection_eq.rv.out
+++ b/examples/v2/collection_eq.rv.out
@@ -1,0 +1,5 @@
+options equal
+results differ
+lists differ
+sets equal
+maps equal

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -776,22 +776,32 @@ fn lower_unop(op: UnaryOp) -> HirUnaryOp {
     }
 }
 
-/// Whether `ty` is a struct or enum that implements `Eq` (any impl on the type
-/// provides an `equals` method), so `==`/`!=` on it should dispatch to that
-/// method rather than compare the heap pointers. Matched by the type's head
-/// name, which covers the concrete and generic (`impl<T: Eq> Eq for Pair<T>`)
+/// The head identity used to match a type against an `Eq` impl's self type,
+/// or `None` for a type whose `==` uses a native compare instead of `equals`
+/// (the primitives, and `String`, which has its own byte-equality path).
+/// `Set`/`Map` are ordinary structs, so they match through the `Struct` arm.
+fn eq_head(ty: &Ty) -> Option<String> {
+    match ty {
+        Ty::Struct { name, .. } | Ty::Enum { name, .. } => Some(name.clone()),
+        Ty::Option(_) => Some("Option".to_string()),
+        Ty::Result(_, _) => Some("Result".to_string()),
+        Ty::List(_) => Some("List".to_string()),
+        _ => None,
+    }
+}
+
+/// Whether `ty` is a type that implements `Eq` (an impl on it provides an
+/// `equals` method), so `==`/`!=` on it should dispatch to that method rather
+/// than compare the heap pointers. Matched by the type's head, which covers
+/// the concrete and generic (`impl<T: Eq> Eq for Pair<T>` / `Option<T>`)
 /// cases the derive pass and hand-written impls produce.
 fn type_has_equals(env: &crate::tycheck::TypeEnv, ty: &Ty) -> bool {
-    let head = match ty {
-        Ty::Struct { name, .. } | Ty::Enum { name, .. } => name.as_str(),
-        _ => return false,
+    let Some(head) = eq_head(ty) else {
+        return false;
     };
     env.impls.iter().any(|imp| {
         imp.methods.contains_key("equals")
-            && matches!(
-                &imp.self_ty,
-                Ty::Struct { name, .. } | Ty::Enum { name, .. } if name == head
-            )
+            && eq_head(&imp.self_ty).as_deref() == Some(head.as_str())
     })
 }
 

--- a/stdlib/std/collections.rv
+++ b/stdlib/std/collections.rv
@@ -412,3 +412,29 @@ impl<K: Eq + Hash, V> Map<K, V> {
         self.buckets = fresh
     }
 }
+
+// ----- Eq: `==`/`!=` compare by value -----
+
+impl<T: Eq + Hash> Eq for Set<T> {
+    fun equals(self, other: Set<T>) -> Bool {
+        return self.len() == other.len() && self.is_subset(other)
+    }
+}
+
+impl<K: Eq + Hash, V: Eq> Eq for Map<K, V> {
+    fun equals(self, other: Map<K, V>) -> Bool {
+        if self.len() != other.len() {
+            return false
+        }
+        let ks = self.keys()
+        let i = 0
+        while i < ks.len() {
+            let k = ks.get(i)
+            if !self.get(k).equals(other.get(k)) {
+                return false
+            }
+            i = i + 1
+        }
+        return true
+    }
+}

--- a/stdlib/std/core.rv
+++ b/stdlib/std/core.rv
@@ -79,6 +79,57 @@ impl Eq for String {
     }
 }
 
+// ----- Eq for the built-in generic types -----
+//
+// `==`/`!=` on these compare by value through `equals`: an element type must
+// itself implement `Eq`, which the bound requires.
+
+impl<T: Eq> Eq for Option<T> {
+    fun equals(self, other: Option<T>) -> Bool {
+        return match self {
+            Some(a) -> match other {
+                Some(b) -> a.equals(b),
+                None -> false,
+            },
+            None -> match other {
+                Some(_) -> false,
+                None -> true,
+            },
+        }
+    }
+}
+
+impl<T: Eq, E: Eq> Eq for Result<T, E> {
+    fun equals(self, other: Result<T, E>) -> Bool {
+        return match self {
+            Ok(a) -> match other {
+                Ok(b) -> a.equals(b),
+                Err(_) -> false,
+            },
+            Err(a) -> match other {
+                Ok(_) -> false,
+                Err(b) -> a.equals(b),
+            },
+        }
+    }
+}
+
+impl<T: Eq> Eq for List<T> {
+    fun equals(self, other: List<T>) -> Bool {
+        if self.len() != other.len() {
+            return false
+        }
+        let i = 0
+        while i < self.len() {
+            if !self.get(i).equals(other.get(i)) {
+                return false
+            }
+            i = i + 1
+        }
+        return true
+    }
+}
+
 // ----- Ord for the built-in scalar types -----
 
 impl Ord for Int {


### PR DESCRIPTION
Fixes #342. Follow-up to the 2.10.2 operator fix (#340).

`==`/`!=` now compare the built-in generic and collection types by value. Adds `impl Eq` for:
- `Option<T>`, `Result<T, E>`, `List<T>` in **std/core** (always available)
- `Set<T>`, `Map<K, V>` in **std/collections** (both compare **order-independently**)

An element type must itself implement `Eq` (the impl bound requires it). The HIR `==`/`!=` desugar now recognizes the built-in `Option`/`Result`/`List` types in addition to structs/enums; `Set`/`Map` are ordinary structs and were already covered.

## Testing
- New golden `collection_eq` (Option/Result/List/Set/Map, including order-independent Set/Map).
- Manually verified `Some(1) == Some(1)`, `[1,2,3] == [1,2,3]`, `{1,2,3} == {3,2,1}`, `["a":1,"b":2] == ["b":2,"a":1]` and their negations.
- Full `cargo test` (518 lib + golden), fmt, clippy clean.

## Version
Minor bump to `2.11.0` (held; releasing with the FFI consolidation work next).