### PR TITLE
feat(ffi): free_cstr for to_cstr buffers + a C-interop guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Raven are documented in this file.
 
 ### Added
 
+- FFI: `std/ffi` gains `free_cstr(p: CStr)`, which releases a buffer returned by `to_cstr`. The `to_cstr` buffer is now `malloc`-allocated so it can be freed (a null pointer is a no-op); previously it could only leak for the program's lifetime. A new "Calling C from Raven" tutorial walks through the whole FFI: extern declarations, the C type set, runtime-String conversion, `@repr(C)` structs by value, callbacks (including capturing closures), variadics, and raw pointers (#213).
 - `Eq` for the built-in generic and collection types, so `==`/`!=` compare them by value: `Option<T>`, `Result<T, E>`, and `List<T>` (in std/core, always available), and `Set<T>` and `Map<K, V>` (in std/collections; Set and Map compare order-independently). An element type must itself implement `Eq`, which the bound requires. A follow-up to the 2.10.2 operator fix (#340): previously these compared by object identity, so `Some(1) == Some(1)` and `[1, 2] == [1, 2]` were `false`; they are now `true` (#342).
 
 ## [2.10.2] - 2026-06-06

--- a/docs/v2/guide/stdlib/ffi.md
+++ b/docs/v2/guide/stdlib/ffi.md
@@ -41,9 +41,10 @@ Both `to_cstr` and `alloc` hand back memory that the garbage collector does
 
 - `alloc<T>(...)` memory is yours to `free`. You **must** call `free` on it, or
   it leaks for the rest of the program run.
-- `to_cstr(...)` copies into a fresh buffer that is valid for the rest of the
-  run. There is no `free` helper for it in this release: each call leaks one
-  buffer, so hoist the conversion out of hot loops.
+- `to_cstr(...)` copies into a fresh buffer. Release it with `free_cstr` when
+  the C side is done with it, or leave it for the rest of the run. A call that
+  is not freed leaks one buffer, so free each one or hoist the conversion out
+  of hot loops.
 
 The raw pointer access is unchecked, exactly like C. There are no bounds
 checks and no use-after-free protection. An out-of-range `offset`, or a
@@ -60,6 +61,13 @@ at the first byte. The result is a standalone copy (not the String's own
 length-prefixed buffer), so it is a valid `const char *` that a C function may
 read or retain after the call returns. Embedded NUL bytes are kept up to the
 first one, at which a C reader stops.
+
+### `free_cstr(p: CStr)`
+
+Release a buffer returned by `to_cstr`. A null pointer is a no-op, and the
+pointer must not be used after the call. Pass only a `to_cstr` result, not a
+`c"..."` literal (which is static) or a `CStr` from `from_cstr`'s source or
+another C function, which have a different owner.
 
 ### `from_cstr(p: CStr) -> String`
 

--- a/docs/v2/guide/tutorials/c-interop.md
+++ b/docs/v2/guide/tutorials/c-interop.md
@@ -1,0 +1,173 @@
+# Calling C from Raven
+
+Raven talks to C through an `extern "C"` block: you declare the C function's
+signature, then call it like an ordinary Raven function. The compiler emits a
+direct C-ABI call and the linker resolves the symbol (the C runtime is always
+on the link line; other libraries arrive with project link flags). This guide
+walks through the FFI from the simplest call to structs by value, callbacks,
+and variadics.
+
+The runnable examples live under `examples/v2/` (`ffi_*.rv`); each is checked by
+the golden suite, so the output shown here is exact.
+
+## A first call
+
+Declare the C function, then call it:
+
+```rust
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+    fun abs(x: CInt) -> CInt
+}
+
+fun main() {
+    print(strlen(c"hello")) // 5
+    print(abs(-7)) // 7
+}
+```
+
+`c"..."` is a C string literal: a static, null-terminated `const char *` with
+no allocation. A native `Int` is accepted where an integer C type (`CInt`,
+`CLong`, `CSize`) is expected, so `abs(-7)` checks without a cast.
+
+## The C type set
+
+| Raven | C | Notes |
+|-------|---|-------|
+| `CInt` | `int` | 32-bit |
+| `CLong`, `CSize` | `long`, `size_t` | 64-bit |
+| `CFloat`, `CDouble` | `float`, `double` | a native `Float` is accepted; `CFloat` narrows f64 to f32 |
+| `CStr` | `const char *` | from a `c"..."` literal or `to_cstr` |
+| `CPtr<T>` | `T *` | an opaque, typed pointer |
+| `CFnPtr` | a function pointer | for callbacks |
+
+## Passing a runtime String
+
+A `c"..."` literal is fixed at compile time. To pass a `String` value, convert
+it with `std/ffi`'s `to_cstr`, which copies into a fresh null-terminated
+buffer. The buffer lives outside the garbage collector; release it with
+`free_cstr` (or leave it for short-lived programs):
+
+```rust
+import std/ffi { to_cstr, free_cstr }
+
+extern "C" {
+    fun puts(s: CStr) -> CInt
+}
+
+fun main() {
+    let msg = "hello, " .concat("world")
+    let c = to_cstr(msg)
+    let _ = puts(c)
+    free_cstr(c)
+}
+```
+
+## Structs by value
+
+A struct marked `@repr(C)` crosses the C ABI by value, both as an argument and
+as a return value. Its fields must be C scalars (or nested `@repr(C)` structs):
+
+```rust
+@repr(C)
+struct Point {
+    x: CDouble,
+    y: CDouble,
+}
+
+extern "C" {
+    fun hypot(x: CDouble, y: CDouble) -> CDouble
+    fun length(p: Point) -> CDouble // a C function taking Point by value
+}
+```
+
+The back end follows each platform's ABI: small structs travel in registers
+(integer or SSE), and larger ones in memory or by reference, with a hidden
+return pointer where the ABI calls for one. There is no size limit, and a field
+may itself be a nested `@repr(C)` struct, whose bytes are inlined. A struct
+literal accepts native `Int`/`Float` for its C-scalar fields:
+`Point { x: 1.0, y: 2.0 }`. See `examples/v2/ffi_struct_*.rv`.
+
+## Callbacks
+
+A Raven function or closure can be passed where a C `CFnPtr` is expected, so a
+C API can call back into Raven. A **top-level function** passes directly:
+
+```rust
+extern "C" {
+    fun qsort(base: CPtr<CInt>, n: CSize, size: CSize, cmp: CFnPtr)
+}
+
+fun compare(a: CPtr<CInt>, b: CPtr<CInt>) -> CInt { ... }
+
+// qsort(buf, 5, 4, compare)
+```
+
+A **capturing closure** also works, through a generated trampoline. Because the
+closure carries an environment, you pass it to the C function's callback slot
+*and* to its `userdata` slot (a `CPtr<Unit>`); C threads the closure back to the
+trampoline, which invokes it. This is the userdata-last convention (for example
+glibc `qsort_r`):
+
+```rust
+extern "C" {
+    fun apply_cb(cb: CFnPtr, data: CPtr<Unit>, x: CLong) -> CLong
+}
+
+fun run(base: CLong) {
+    let add = fun(x: CLong) -> CLong = x + base // captures `base`
+    print(apply_cb(add, add, 5)) // add -> trampoline; add -> userdata
+}
+```
+
+The callback's parameters and return must be C types. A callback that allocates
+is safe: the collector traces the suspended Raven stack across the C call. A C
+API whose userdata is not the last callback argument (or that has none) needs a
+small C shim. See `examples/v2/ffi_callback_closure.rv`.
+
+## Variadic functions
+
+An `extern` signature ending in `...` is variadic; a call may pass extra
+arguments after the fixed ones:
+
+```rust
+extern "C" {
+    fun printf(fmt: CStr, ...) -> CInt
+}
+
+fun main() {
+    let _ = printf(c"%d items, %s\n", 3, c"ok")
+}
+```
+
+Each variadic argument must be a C integer or pointer type (or a native `Int`).
+**Float variadic arguments are rejected at compile time**, the backend cannot
+honor the platform's variadic float rules, so a `%f` format needs a fixed-arity
+C shim.
+
+## Raw pointers
+
+`std/ffi` wraps manual allocation and unchecked pointer access for buffers a C
+API reads or writes. The memory is outside the GC and is yours to `free`:
+
+```rust
+import std/ffi { alloc, store, load, free }
+
+fun main() {
+    let buf: CPtr<CInt> = alloc<CInt>(3)
+    store(buf, 10)
+    store(offset(buf, 1), 20)
+    print(load(buf)) // 10
+    free(buf)
+}
+```
+
+This is unchecked, exactly like C: no bounds checks, no use-after-free
+protection. Guard a possibly-null pointer with `is_null`.
+
+## Platform support and linking
+
+Raven ships for Linux and Windows x86_64. The C runtime (the CRT, including the
+`printf` family) is always on the link line; symbols from other libraries
+arrive through project link flags. See `docs/v2/specs/ffi.md` and
+`docs/v2/specs/std-ffi.md` for the full ABI rules and out-of-scope notes.

--- a/docs/v2/specs/std-ffi.md
+++ b/docs/v2/specs/std-ffi.md
@@ -99,14 +99,16 @@ return null, and keep the element type `T` consistent with the C side.
 
 ## Lifetime and ownership
 
-`to_cstr` allocates the null-terminated buffer outside the GC heap and
-does not reclaim it: the pointer is valid for the rest of the program run.
-This copy semantics is intentional. A C callee may read the pointer after
-the call returns or retain it, and the buffer must not move or be freed by
-a later garbage collection, so it cannot be the String's own GC-managed
-bytes. The cost is that each `to_cstr` call leaks one buffer; callers that
-convert in a hot loop should hoist the conversion. There is no `free`
-helper in this release.
+`to_cstr` allocates the null-terminated buffer outside the GC heap (with
+`malloc`) and does not reclaim it automatically: the pointer stays valid until
+the caller releases it with `free_cstr`, or for the rest of the program run if
+never freed. This copy semantics is intentional. A C callee may read the
+pointer after the call returns or retain it, and the buffer must not move or be
+freed by a later garbage collection, so it cannot be the String's own
+GC-managed bytes. Pass `free_cstr` only a `to_cstr` result, not a `c"..."`
+literal (which is static) or a `CStr` from another source; a freed pointer must
+not be used again. A caller that converts in a hot loop should free each buffer
+or hoist the conversion.
 
 `from_cstr` produces an ordinary GC-managed `String`, traced and reclaimed
 like any other. Embedded NUL bytes in the source `String` are preserved by
@@ -393,8 +395,6 @@ slot as a pointer so the collector traces it.
 
 ## Out of scope
 
-* A `free`/`drop` for buffers from `to_cstr` (copy-and-leak semantics).
-  Buffers from `alloc` do have `free`.
 * Callback APIs whose userdata is not the last callback argument (or that
   have no userdata argument). The trampoline is userdata-last; other shapes
   need a small C shim.

--- a/examples/v2/ffi_cstr_free.rv
+++ b/examples/v2/ffi_cstr_free.rv
@@ -1,0 +1,20 @@
+// std/ffi bridges a Raven String to a C string. `to_cstr` copies into a fresh
+// buffer (released with `free_cstr`); `from_cstr` reads a C string back into a
+// String. Prints:
+//   5
+//   roundtrip
+import std/ffi
+
+extern "C" {
+    fun strlen(s: CStr) -> CSize
+}
+
+fun main() {
+    let c = ffi.to_cstr("hello")
+    print(strlen(c)) // 5
+    ffi.free_cstr(c)
+
+    let r = ffi.to_cstr("roundtrip")
+    print(ffi.from_cstr(r)) // roundtrip
+    ffi.free_cstr(r)
+}

--- a/examples/v2/ffi_cstr_free.rv.out
+++ b/examples/v2/ffi_cstr_free.rv.out
@@ -1,0 +1,2 @@
+5
+roundtrip

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - Tutorials:
     - Word-frequency counter: v2/guide/tutorials/word-frequency.md
     - Modeling data with structs and enums: v2/guide/tutorials/task-tracker.md
+    - Calling C from Raven: v2/guide/tutorials/c-interop.md
   - Standard Library:
     - Overview: v2/guide/standard-library.md
     - Core traits: v2/guide/stdlib/core.md

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -538,10 +538,11 @@ pub extern "C" fn raven_float_to_int(value: f64) -> i64 {
 #[no_mangle]
 pub extern "C" fn raven_string_to_cstr(s: *const object::String) -> *const u8 {
     let len = object::raven_string_len(s) as usize;
-    // One extra byte for the terminating NUL. `raven_alloc` returns a
-    // non-null dangling pointer at size zero, which is fine for the empty
-    // string: byte index 0 is the NUL we write below.
-    let buf = raven_alloc(len + 1, 1);
+    // One extra byte for the terminating NUL. The buffer is `malloc`-ed (not
+    // GC- or `raven_alloc`-managed) so the caller can release it with
+    // `raven_cstr_free` (std/ffi's `free_cstr`), which is plain `free`.
+    // SAFETY: `malloc` is the C allocator; a null return is handled below.
+    let buf = unsafe { malloc(len + 1) } as *mut u8;
     if buf.is_null() {
         return std::ptr::null();
     }
@@ -555,6 +556,25 @@ pub extern "C" fn raven_string_to_cstr(s: *const object::String) -> *const u8 {
         *buf.add(len) = 0;
     }
     buf as *const u8
+}
+
+/// Free a buffer returned by `raven_string_to_cstr` (std/ffi's `to_cstr`).
+///
+/// A null pointer is a no-op. Only a `to_cstr` result may be passed: a
+/// `c"..."` literal is static and a `CStr` from another source has a
+/// different owner.
+///
+/// # Safety
+///
+/// `p` must be a live pointer returned by `raven_string_to_cstr` and not
+/// already freed.
+#[no_mangle]
+pub extern "C" fn raven_cstr_free(p: *const u8) {
+    if p.is_null() {
+        return;
+    }
+    // SAFETY: `to_cstr` allocates the buffer with `malloc`, so `free` matches.
+    unsafe { free(p as *mut std::ffi::c_void) }
 }
 
 /// Read the null-terminated bytes at `p` and build a Raven `String`.

--- a/stdlib/std/ffi.rv
+++ b/stdlib/std/ffi.rv
@@ -7,15 +7,25 @@
 extern "C" {
     fun raven_string_to_cstr(s: String) -> CStr
     fun raven_cstr_to_string(p: CStr) -> String
+    fun raven_cstr_free(p: CStr)
 }
 
 // Copy `s` into a fresh, null-terminated C string and return a `CStr`
-// pointing at it. The buffer is a standalone copy valid for the rest of
-// the program run, so it is safe to pass to a C function that reads (or
-// retains) the pointer. Embedded NUL bytes are kept up to the first one
-// a C reader stops at.
+// pointing at it. The buffer is a standalone heap copy, so it is safe to pass
+// to a C function that reads (or retains) the pointer. Embedded NUL bytes are
+// kept up to the first one a C reader stops at. Release the buffer with
+// `free_cstr` when done, or leave it for the program's lifetime if short
+// lived; it is not garbage collected.
 fun to_cstr(s: String) -> CStr {
     return raven_string_to_cstr(s)
+}
+
+// Free a `CStr` buffer returned by `to_cstr`. A null pointer is a no-op, and
+// the pointer must not be used afterwards. Pass only a `to_cstr` result: a
+// `c"..."` literal is static, and a `CStr` from `from_cstr`'s source or
+// another C function has a different owner.
+fun free_cstr(p: CStr) {
+    raven_cstr_free(p)
 }
 
 // Read the null-terminated bytes at `p` and build a Raven `String`. The


### PR DESCRIPTION
Fixes #344. Consolidation of the FFI epic (#213).

## free_cstr
`std/ffi` gains `free_cstr(p: CStr)` to release a `to_cstr` buffer. The buffer is now `malloc`-allocated (was the GC's `raven_alloc`) so plain `free` matches; `raven_cstr_free` is the backing runtime symbol. A null pointer is a no-op. Previously a `to_cstr` buffer could only leak for the program's lifetime.

## C-interop guide
A new "Calling C from Raven" tutorial (wired into the docs nav) walks through extern declarations, the C type set, runtime String conversion, `@repr(C)` structs by value, callbacks (top-level and capturing closures), variadics, and raw pointers. The std/ffi page and std-ffi spec are updated for `free_cstr`.

## Testing
- New golden `ffi_cstr_free` (`strlen(to_cstr(...))` + `free_cstr` + `from_cstr` roundtrip).
- Manually verified `free_cstr` releases the buffer and a null is a no-op.
- Full `cargo test` (golden + lib), fmt, clippy clean.

## Version
Part of the held `2.11.0` (releasing next with the stdlib Eq work).