### PR TITLE
chore: sync Cargo.lock to 2.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
  "chrono",
  "corosensei",


### PR DESCRIPTION
The committed lockfile still pinned the workspace packages at 2.11.0 while `Cargo.toml` is 2.12.0; cargo regenerates it on every build, so a fresh checkout shows a dirty `Cargo.lock`. Commits the regenerated lockfile. No functional change (the 2.12.0 release built correctly from `Cargo.toml`).