### PR TITLE
feat(runtime): epoch-based GC marking (foundation for concurrent collection)

### DIFF
--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -25,6 +25,34 @@ use crate::object::{MapEntry, SetEntry, BOX_PAYLOAD_OFFSET};
 use crate::{raven_alloc, raven_dealloc};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Monotonic count of collections across all threads, the source of globally
+/// unique mark epochs. Global so two threads' collections never pick the same
+/// epoch (the basis for distinguishing a stale cross-thread mark once the
+/// collector is concurrent).
+static GC_EPOCH: AtomicU32 = AtomicU32::new(0);
+
+thread_local! {
+    /// The epoch of this thread's collection in progress. Marking writes it
+    /// into an object's `gc_bits`; an object is "marked" exactly when `gc_bits`
+    /// equals it. Each thread collects its own heap with its own epoch, so this
+    /// is thread-local: a global value would be overwritten by another thread's
+    /// concurrent collection between this thread's mark and sweep. Reusing the
+    /// `gc_bits` word as the epoch (rather than a wider field) keeps the pinned
+    /// 16-byte header layout. See `docs/v2/specs/concurrency-parallelism.md`.
+    static CURRENT_EPOCH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Allocate the next globally unique mark epoch, skipping 0 (a freshly zeroed
+/// header has `gc_bits == 0`, so epoch 0 must never mean "marked").
+fn next_epoch() -> u32 {
+    let mut e = GC_EPOCH.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+    if e == 0 {
+        e = GC_EPOCH.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+    }
+    e
+}
 
 /// A registered root: the address of a stack slot that holds a GC
 /// pointer (or null). The collector reads the slot's current value at
@@ -441,6 +469,10 @@ pub extern "C" fn raven_gc_collect() {
 
 /// Run one full mark-and-sweep cycle.
 fn collect() {
+    // A fresh epoch per collection: survivors from the previous cycle carry the
+    // old epoch and so count as unmarked here, which removes the separate
+    // clear-marks pass and is the basis for a future concurrent collector.
+    CURRENT_EPOCH.with(|e| e.set(next_epoch()));
     mark();
     sweep();
     // Reset the threshold to twice the surviving live bytes, never
@@ -490,19 +522,20 @@ fn mark() {
     }
 }
 
-/// Set the mark bit on `object` if it is non-null and not already
-/// marked. Returns true when this call marked it (so the caller should
-/// trace its children).
+/// Stamp `object` with the current collection epoch if it is non-null and not
+/// already stamped this cycle. Returns true when this call stamped it (so the
+/// caller should trace its children).
 fn mark_object(object: *mut ObjectHeader) -> bool {
     if object.is_null() {
         return false;
     }
+    let epoch = CURRENT_EPOCH.with(|e| e.get());
     // SAFETY: a registered object pointer is a live header.
     let header = unsafe { &mut *object };
-    if header.is_marked() {
+    if header.gc_bits == epoch {
         return false;
     }
-    header.set_mark();
+    header.gc_bits = epoch;
     true
 }
 
@@ -640,23 +673,23 @@ unsafe fn trace_object(object: *mut ObjectHeader, work: &mut Vec<*mut ObjectHead
     }
 }
 
-/// Sweep phase: free every unmarked object and clear the mark bit on
-/// survivors so the next cycle starts clean.
+/// Sweep phase: free every object not stamped with the current epoch. No
+/// clear pass is needed: the next collection takes a fresh epoch, so survivors
+/// are implicitly unmarked then.
 fn sweep() {
+    let epoch = CURRENT_EPOCH.with(|e| e.get());
     HEAP.with(|h| {
         let mut heap = h.borrow_mut();
         let mut write = 0usize;
         for read in 0..heap.len() {
             let object = heap[read];
             // SAFETY: every heap entry is a live registered header.
-            let marked = unsafe { (*object).is_marked() };
+            let marked = unsafe { (*object).gc_bits } == epoch;
             if marked {
-                // SAFETY: live header; clear the mark for next cycle.
-                unsafe { (*object).clear_mark() };
                 heap[write] = object;
                 write += 1;
             } else {
-                // SAFETY: unmarked and registered; free it.
+                // SAFETY: unmarked this cycle and registered; free it.
                 unsafe { free_one(object) };
             }
         }
@@ -816,11 +849,10 @@ mod collector_tests {
             raven_gc_push_root(&mut slot as *mut *mut u8);
             raven_gc_collect();
             assert_eq!(raven_gc_live_objects(), 1);
-            // The header is still valid and its mark bit was cleared.
+            // The header is still valid after the sweep.
             // SAFETY: the rooted object survived the sweep.
             unsafe {
                 assert_eq!((*(s)).header.tag, crate::object::TAG_STRING);
-                assert!(!(*(s)).header.is_marked());
             }
             raven_gc_pop_roots(1);
             raven_gc_collect();

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -36,8 +36,8 @@ pub use object::{
     raven_string_concat, raven_string_eq, raven_string_from_byte, raven_string_from_bytes,
     raven_string_len, raven_string_new, raven_string_substring, raven_struct_fields,
     raven_struct_new, Box as RavenBox, Closure as RavenClosure, List as RavenList, Map as RavenMap,
-    MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, GC_MARK_BIT,
-    OBJECT_ALIGN, TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING, TAG_STRUCT,
+    MapEntry, ObjectHeader, Set as RavenSet, SetEntry, String as RavenString, OBJECT_ALIGN,
+    TAG_BOX, TAG_CLOSURE, TAG_LIST, TAG_MAP, TAG_SET, TAG_STRING, TAG_STRUCT,
 };
 pub use reflect::{
     raven_any_field_names, raven_any_get_field, raven_any_new, raven_any_payload,

--- a/raven-runtime/src/object.rs
+++ b/raven-runtime/src/object.rs
@@ -73,10 +73,9 @@ pub const TAG_STRUCT: u32 = 0x07;
 
 /// Bit 0 of `ObjectHeader.gc_bits`: the mark bit the tracing collector
 /// sets during the mark phase and clears during sweep. The remaining
-/// `gc_bits` stay zero and are reserved for a future colour scheme. See
+/// `gc_bits` holds the mark epoch the collector stamps (see `gc.rs`). See
 /// `docs/v2/specs/gc.md`.
-pub const GC_MARK_BIT: u32 = 0x1;
-
+///
 /// Canonical 16-byte object header.
 ///
 /// Every heap allocation the GC traces starts with one of these,
@@ -88,8 +87,9 @@ pub const GC_MARK_BIT: u32 = 0x1;
 pub struct ObjectHeader {
     /// Discriminator picking one of the `TAG_*` constants.
     pub tag: u32,
-    /// Mark / colour bits reserved for the future tracing collector.
-    /// Always zero in the current scaffold.
+    /// The mark epoch: the collector stamps this with the current collection's
+    /// epoch when it marks the object reachable. Zero on a fresh object (which
+    /// never equals an epoch, so a fresh object is unmarked). See `gc.rs`.
     pub gc_bits: u32,
     /// Logical length in the unit appropriate for the tag (bytes for
     /// strings, elements for lists, entries for maps and sets).
@@ -100,7 +100,7 @@ pub struct ObjectHeader {
 }
 
 impl ObjectHeader {
-    /// Construct a header with the given tag and zeroed GC bits.
+    /// Construct a header with the given tag and a zero (unmarked) epoch.
     pub const fn new(tag: u32, len: u32, cap: u32) -> Self {
         Self {
             tag,
@@ -108,24 +108,6 @@ impl ObjectHeader {
             len,
             cap,
         }
-    }
-
-    /// Return true when the mark bit is set.
-    #[inline]
-    pub const fn is_marked(&self) -> bool {
-        self.gc_bits & GC_MARK_BIT != 0
-    }
-
-    /// Set the mark bit.
-    #[inline]
-    pub fn set_mark(&mut self) {
-        self.gc_bits |= GC_MARK_BIT;
-    }
-
-    /// Clear the mark bit.
-    #[inline]
-    pub fn clear_mark(&mut self) {
-        self.gc_bits &= !GC_MARK_BIT;
     }
 }
 


### PR DESCRIPTION
A piece of the Go-style multi-core GC build (#212/#238) that stands on its own and is behavior-preserving today.

## What
The object header is a **pinned 16-byte layout**, so the one-bit mark couldn't grow into a wider field. Instead `gc_bits` is reinterpreted as a **per-collection mark epoch**: each collection takes a fresh, globally unique epoch, and an object is marked exactly when `gc_bits == current_epoch`. A fresh header (0) never equals an epoch, so it reads unmarked.

## Why it's the right foundation
Each thread will collect **its own heap with its own epoch**, so a mark another thread's collection leaves on a shared object carries a *different* epoch and won't fool this thread's sweep, the stale-mark hazard a shared mark bit would have. So the current epoch is **thread-local**; the counter handing them out is **global** (unique). Bonus today: no clear-marks pass needed.

Removes the now-meaningless `is_marked`/`set_mark`/`clear_mark`/`GC_MARK_BIT` (a footgun once `gc_bits` is an epoch).

## A real bug caught + fixed in review
The first cut used a *global* epoch and a test that read the old mark bit. It failed deterministically in isolation (epoch 1 = odd = bit set) but passed in the full suite (other tests bumped the epoch even). Diagnosed to the global-epoch race and the obsolete bit assertion; fixed by making the epoch thread-local and dropping the bit methods.

## Verification
Behavior-preserving single-threaded: full runtime suite (119), **lib (519)**, **golden (all examples)**, **gc_rooting_stress (98s, end-to-end compiled GC stress)**, plus the previously-failing test now 10/10 in isolation. No user-facing change. Refs #238, part of #212.