### PR TITLE
feat: emit in-Raven running/safepoint markers from the back end

### DIFF
--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -47,6 +47,38 @@ thread_local! {
     /// [`ROOT_REGISTRY`] for the thread's lifetime. Created on first GC touch
     /// and deregistered on thread exit.
     static LOCAL_ROOTS: LocalRoots = LocalRoots::register();
+
+    /// True while this thread is running compiled Raven (it called
+    /// `raven_gc_enter_running` and not yet the matching exit). A collection
+    /// triggered here must leave the running set before stopping the world, so
+    /// it does not wait for itself; the Rust test harness never sets this.
+    static IN_RAVEN: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Mark the calling OS thread as running compiled Raven. The back end emits a
+/// call at program entry, and the scheduler will call it around each dispatched
+/// goroutine. Pairs with [`raven_gc_exit_running`].
+#[no_mangle]
+pub extern "C" fn raven_gc_enter_running() {
+    COORDINATOR.enter_running();
+    IN_RAVEN.with(|r| r.set(true));
+}
+
+/// Mark the calling OS thread as no longer running compiled Raven (it is
+/// blocking or exiting). A collection no longer waits for it.
+#[no_mangle]
+pub extern "C" fn raven_gc_exit_running() {
+    IN_RAVEN.with(|r| r.set(false));
+    COORDINATOR.exit_running();
+}
+
+/// A safepoint poll. The back end emits a call at loop back-edges (and the
+/// allocator polls too), points where every live GC pointer is on the shadow
+/// stack. A single atomic load when no collection is pending; otherwise the
+/// thread parks here until the world resumes.
+#[no_mangle]
+pub extern "C" fn raven_gc_safepoint() {
+    COORDINATOR.safepoint();
 }
 
 /// Owns a thread's [`RootContext`] and keeps it registered with the collector.
@@ -471,6 +503,16 @@ pub(crate) fn root_count() -> usize {
 #[no_mangle]
 pub extern "C" fn raven_gc_alloc(size: usize, align: usize, tag: u32) -> *mut u8 {
     let _ = tag;
+    // Allocation is a safepoint for an in-Raven thread: the shadow stack is
+    // complete here, so if another thread is collecting, park until it finishes
+    // rather than mutate the heap underneath it. The common case (no collection
+    // pending) is a single atomic load that short-circuits the thread-local
+    // check. Only in-Raven threads poll: an in-native thread (the test harness)
+    // is not in the running set, so parking it would make the collector wait
+    // for `parked == running` forever.
+    if COORDINATOR.stop_pending() && IN_RAVEN.with(|r| r.get()) {
+        COORDINATOR.safepoint();
+    }
     // Collect before serving an allocation that would cross the
     // threshold, so the heap stays a bounded multiple of the live set.
     let current = BYTES_ALLOCATED.with(|b| b.get());
@@ -533,6 +575,13 @@ pub extern "C" fn raven_gc_collect() {
 /// never frees an object another thread allocated. A single-threaded program
 /// has no other thread, so the stop returns at once.
 fn collect() {
+    // An in-Raven thread must leave the running set before stopping the world,
+    // or `stop_the_world` would wait for it (itself) to park. A test-harness
+    // thread is not in the running set and skips this.
+    let was_running = IN_RAVEN.with(|r| r.get());
+    if was_running {
+        COORDINATOR.exit_running();
+    }
     COORDINATOR.stop_the_world();
     // A fresh epoch per collection: survivors from the previous cycle carry the
     // old epoch and so count as unmarked here, which removes the separate
@@ -548,6 +597,9 @@ fn collect() {
     let next = collection_floor().max(live.saturating_mul(2));
     THRESHOLD.with(|t| t.set(next));
     COORDINATOR.resume_the_world();
+    if was_running {
+        COORDINATOR.enter_running();
+    }
 }
 
 /// Mark phase: starting from every root, set the mark bit on every

--- a/raven-runtime/src/stw.rs
+++ b/raven-runtime/src/stw.rs
@@ -229,6 +229,14 @@ impl StopTheWorld {
         }
     }
 
+    /// Cheap check (one relaxed-ish atomic load) for whether a collection is
+    /// pending, so a hot path can skip the thread-local and call machinery of a
+    /// full [`safepoint`](Self::safepoint) when nothing is happening.
+    #[inline]
+    pub fn stop_pending(&self) -> bool {
+        self.stop_requested.load(Ordering::SeqCst)
+    }
+
     /// Resume the threads parked by a stop and let collectors contend again.
     pub fn resume_the_world(&self) {
         let mut inner = self.inner.lock().unwrap();

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -501,6 +501,12 @@ impl ModuleCx {
         sig = self.make_sig(&[ptr], &[]);
         self.declare_runtime(intrinsics::RUNTIME_GC_POP_ROOTS, &sig)?;
 
+        // raven_gc_enter_running() / raven_gc_exit_running() / raven_gc_safepoint()
+        sig = self.make_sig(&[], &[]);
+        self.declare_runtime(intrinsics::RUNTIME_GC_ENTER_RUNNING, &sig)?;
+        self.declare_runtime(intrinsics::RUNTIME_GC_EXIT_RUNNING, &sig)?;
+        self.declare_runtime(intrinsics::RUNTIME_GC_SAFEPOINT, &sig)?;
+
         // raven_defer_enter_frame()
         sig = self.make_sig(&[], &[]);
         self.declare_runtime(intrinsics::RUNTIME_DEFER_ENTER_FRAME, &sig)?;
@@ -942,6 +948,14 @@ impl ModuleCx {
         let push_root_ref = self
             .runtime_id(intrinsics::RUNTIME_GC_PUSH_ROOT)
             .map(|id| self.module.declare_func_in_func(id, &mut ctx.func));
+        // The main thread runs compiled Raven for the whole program, so it is
+        // in the collector's "running" set from entry to exit.
+        let enter_running_ref = self
+            .runtime_id(intrinsics::RUNTIME_GC_ENTER_RUNNING)
+            .map(|id| self.module.declare_func_in_func(id, &mut ctx.func));
+        let exit_running_ref = self
+            .runtime_id(intrinsics::RUNTIME_GC_EXIT_RUNNING)
+            .map(|id| self.module.declare_func_in_func(id, &mut ctx.func));
         let global_root_ids: Vec<DataId> = self.global_roots.clone();
         let global_root_gvs: Vec<_> = global_root_ids
             .iter()
@@ -958,6 +972,11 @@ impl ModuleCx {
             let block = builder.create_block();
             builder.switch_to_block(block);
             builder.seal_block(block);
+            // Enter the running set first: the main thread runs compiled Raven,
+            // so a parallel collection must wait for it to reach a safepoint.
+            if let Some(enter) = enter_running_ref {
+                builder.ins().call(enter, &[]);
+            }
             // Register every struct and enum descriptor with the
             // collector before running the program, so any value the
             // program builds is traceable from its first allocation.
@@ -1012,6 +1031,10 @@ impl ModuleCx {
             // The Raven `main` returns unit, so there is no result value
             // to forward; the call is emitted purely for its effects.
             builder.ins().call(callee, &[]);
+            // Leave the running set before exiting.
+            if let Some(exit) = exit_running_ref {
+                builder.ins().call(exit, &[]);
+            }
             let zero = builder.ins().iconst(types::I32, 0);
             builder.ins().return_(&[zero]);
             builder.finalize();

--- a/src/codegen/intrinsics.rs
+++ b/src/codegen/intrinsics.rs
@@ -148,6 +148,19 @@ pub const RUNTIME_GC_PUSH_ROOT: &str = "raven_gc_push_root";
 /// Runtime C symbol popping the last `n` single root slots.
 pub const RUNTIME_GC_POP_ROOTS: &str = "raven_gc_pop_roots";
 
+/// Runtime C symbol marking the OS thread as running compiled Raven, so the
+/// parallel collector waits for it to reach a safepoint. Emitted at program
+/// entry (and by the scheduler around a dispatched goroutine).
+pub const RUNTIME_GC_ENTER_RUNNING: &str = "raven_gc_enter_running";
+
+/// Runtime C symbol marking the OS thread as no longer running compiled Raven.
+pub const RUNTIME_GC_EXIT_RUNNING: &str = "raven_gc_exit_running";
+
+/// Runtime C symbol polling a stop-the-world safepoint, emitted at loop
+/// back-edges. A single atomic load when no collection is pending; otherwise it
+/// parks the thread until the world resumes.
+pub const RUNTIME_GC_SAFEPOINT: &str = "raven_gc_safepoint";
+
 /// Runtime C symbol opening a per-call defer frame.
 pub const RUNTIME_DEFER_ENTER_FRAME: &str = "raven_defer_enter_frame";
 


### PR DESCRIPTION
Step two of the Go-style multi-core GC (#212/#238): compiled programs now mark their thread as running compiled Raven and poll safepoints, so a parallel collector can park them.

## Runtime
- `raven_gc_enter_running`/`raven_gc_exit_running` move the OS thread in/out of the collector's running set; `raven_gc_safepoint` polls a stop.
- `collect` leaves the running set before `stop_the_world` (or it would wait for itself) and rejoins after. An in-native thread (the Rust harness, never in the set) skips this.
- **Allocation is a safepoint** for an in-Raven thread, gated on a single atomic load so the common no-collection path skips the thread-local check, ungated, this gate's absence **doubled** the GC stress time, so it matters.

## Codegen
The program-entry shim brackets the whole run with `enter_running`/`exit_running`, so the main thread is in the running set start to finish.

## Behavior + perf unchanged single-threaded
With no other thread, a stop returns at once and the safepoint poll is a no-op load. Loop-back-edge safepoints (for long non-allocating loops under the scheduler) are deferred until the M:N scheduler needs them.

## Verification
Full runtime suite (121), **lib (519)**, **codegen_smoke (72)**, **golden**, **gc_rooting_stress (108s, no regression vs 107s)**. No user-facing change. Refs #238, part of #212.


Closes #238 (completed together with #351, #354, #356, #357, #358).