### PR TITLE
feat(codegen): emit a GC safepoint poll at loop headers

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -177,6 +177,16 @@ impl<'cx, 'func> FunctionLowering<'cx, 'func> {
                     enter_defer_frame(self.cx, &mut builder);
                 }
             }
+            // A loop header polls a GC safepoint at its top, so a thread in a
+            // long non-allocating loop still reaches a safepoint and can be
+            // parked for a stop-the-world collection (allocating loops poll at
+            // the allocator). A single atomic load when no collection is pending.
+            if mir_block.is_loop_header {
+                if let Some(sp) = self.cx.runtime_id(intrinsics::RUNTIME_GC_SAFEPOINT) {
+                    let sp_ref = self.cx.module().declare_func_in_func(sp, builder.func);
+                    builder.ins().call(sp_ref, &[]);
+                }
+            }
             lower_block(
                 self.cx,
                 &mut builder,

--- a/src/mir/builder.rs
+++ b/src/mir/builder.rs
@@ -90,9 +90,16 @@ impl FunctionBuilder {
             id,
             statements: Vec::new(),
             terminator: pending_terminator(),
+            is_loop_header: false,
         });
         self.block_set.push(false);
         id
+    }
+
+    /// Mark `block` as a loop header, so the back end emits a safepoint poll at
+    /// its top (see [`MirBlock::is_loop_header`]).
+    pub fn mark_loop_header(&mut self, block: MirBlockId) {
+        self.blocks[block.0 as usize].is_loop_header = true;
     }
 
     /// Emit a statement at the tail of `block`.

--- a/src/mir/ir.rs
+++ b/src/mir/ir.rs
@@ -399,6 +399,11 @@ pub struct MirBlock {
     pub id: MirBlockId,
     pub statements: Vec<MirStatement>,
     pub terminator: MirTerminator,
+    /// True if this block is a loop header (the target of a loop's back-edge).
+    /// The back end emits a GC safepoint poll at its top, so a goroutine in a
+    /// long non-allocating loop still reaches a safepoint and can be parked for a
+    /// stop-the-world collection. Allocating loops already poll at the allocator.
+    pub is_loop_header: bool,
 }
 
 /// A function in MIR.

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -904,6 +904,7 @@ fn lower_expr_block(cx: &mut LowerCx<'_>, block: &HirBlock) -> MirOperand {
 
 fn lower_loop(cx: &mut LowerCx<'_>, body: &HirBlock, ty: MirType) -> MirOperand {
     let header = cx.builder.new_block();
+    cx.builder.mark_loop_header(header);
     let cont = cx.builder.new_block();
     let result = cx.builder.fresh_temp("loop", ty);
 
@@ -932,6 +933,7 @@ fn lower_loop(cx: &mut LowerCx<'_>, body: &HirBlock, ty: MirType) -> MirOperand 
 
 fn lower_while(cx: &mut LowerCx<'_>, cond: &HirExpr, body: &HirBlock, _ty: MirType) -> MirOperand {
     let header = cx.builder.new_block();
+    cx.builder.mark_loop_header(header);
     let body_bb = cx.builder.new_block();
     let cont = cx.builder.new_block();
 


### PR DESCRIPTION
Closes the **last gap** in the M:N collector (#212/#237): a thread in a long non-allocating loop never reached a safepoint, so a stop-the-world collection another goroutine triggered would wait for it forever (an allocating loop polls at the allocator and was already fine).

## What
Every loop header now carries a `raven_gc_safepoint` poll at its top, so each iteration is a point where the thread can be parked with a complete shadow stack. MIR marks the header block (`is_loop_header`, set by `lower_loop`/`lower_while`); the back end emits the poll when lowering such a block. The poll is a **single atomic load when no collection is pending**, so it is behavior- and output-preserving single-threaded.

## Verification
lib (519, **MIR snapshots unchanged**), golden, codegen_smoke, concurrency_parallel (48000), and **a goroutine spinning 30M iterations in a non-allocating loop while another allocates hard at a 2 KiB GC threshold now completes** (it would hang before this).

Watching the benchmark for the per-iteration poll cost; if it regresses, the poll becomes an inline flag-load + branch instead of a call. Refs #237, part of #212.


Closes #237 (completed together with #361 and #363).