### PR TITLE
build: release 2.14.0, concurrency toolkit complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.14.0] - 2026-06-07
+
+### Added
+
+- Synchronization primitives in `std/sync`, completing the concurrency toolkit over the parallel scheduler (#212). `Mutex` (`mutex()`, `lock`/`unlock`) guards shared mutable state across goroutines, built on a one-slot channel token. `WaitGroup` (`wait_group()`, `add`/`done`/`wait`) waits for a set of goroutines to finish. `sleep_millis(ms)` parks a goroutine for a duration. The wait-group and sleep leave the collector's running set while parked, so a concurrent collection is never blocked on them (#241).
+- `select_recv(channels)` in `std/sync` receives from whichever of several channels has a value first, returning a `SelectResult { index, value }` that names the channel (by position) and the value. The common recv-select for fan-in or waiting on data versus a cancellation signal; ties go to the lowest index (#239).
+- Blocking IO no longer stalls a collection. A goroutine parked in a blocking runtime call (`std/net` connect/accept/read/write, `std/http` request, `std/process` wait, `std/fs` read/write/append, or a stdin read) now runs the syscall outside the collector's running set, so a stop-the-world collection another goroutine triggers proceeds instead of freezing every goroutine for the length of the call. The M:N pool already kept other goroutines running on other workers during the call (#240).
+
 ## [2.13.0] - 2026-06-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.13.0"
+version = "2.14.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - Compiled to native machine code through Cranelift, into a single static binary.
 - Static typing with generics, traits, and sum types checked by an exhaustive `match`.
 - A tracing garbage collector and `Result`/`Option` instead of `null`.
-- Goroutines and channels that run in parallel across CPU cores (an M:N scheduler over a multi-threaded collector), and a C FFI for native libraries.
+- Goroutines and channels that run in parallel across CPU cores (an M:N scheduler over a multi-threaded collector), with mutexes, wait groups, and `select`, and a C FFI for native libraries.
 - A package manager (`rvpm`), one canonical formatter, and a VS Code extension.
 
 ## Quick Example


### PR DESCRIPTION
Release prep for **2.14.0**, the concurrency follow-ups that complete the #212 epic on top of the parallel scheduler shipped in 2.13.0:

- **Sync primitives** in std/sync: `Mutex`, `WaitGroup`, `sleep_millis` (#241).
- **`select_recv`** over multiple channels (#239).
- **Blocking IO** (net/fs/http/process/stdin) no longer stalls a collection (#240).

- Version -> 2.14.0 (minor; new features).
- CHANGELOG 2.14.0 section; README concurrency bullet mentions mutexes, wait groups, and select.

After merge, tag `v2.14.0` to cut the release. Refs #212.