### PR TITLE
fix(resolve): clear error when a method uses `self` without declaring it

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -110,6 +110,10 @@ pub enum ResolveError {
         candidates: Vec<Span>,
     },
     SelfOutsideImpl,
+    /// `self` used in a method that does not take `self` as its first
+    /// parameter. Distinct from `SelfOutsideImpl`: the use is inside an `impl`,
+    /// but the enclosing method has no `self` to refer to.
+    SelfNotMethodParam,
     /// A resolve-stage diagnostic that does not fit the structured variants,
     /// carrying its own message (for example a `@derive(...)` rejection).
     Other(String),
@@ -135,6 +139,12 @@ impl fmt::Display for ResolveError {
             }
             ResolveError::SelfOutsideImpl => {
                 write!(f, "`self` or `Self` used outside an `impl` block")
+            }
+            ResolveError::SelfNotMethodParam => {
+                write!(
+                    f,
+                    "`self` is used here, but this method has no `self` parameter"
+                )
             }
             ResolveError::Other(msg) => write!(f, "{}", msg),
         }

--- a/src/resolve/tests.rs
+++ b/src/resolve/tests.rs
@@ -149,6 +149,22 @@ fn self_inside_impl_is_ok() {
 }
 
 #[test]
+fn self_without_self_param_is_an_error() {
+    // A method that uses `self` but does not declare it as a parameter is
+    // rejected at resolve time, rather than surfacing as a confusing codegen
+    // error (a field access on a Unit `self`).
+    let file = parse_src(
+        "struct T { items: List<Int> }\nimpl T {\n    fun add(n: Int) { self.items.push(n) }\n}\n",
+        "test.rv",
+    );
+    let err = resolve_file(&file, &mut NoLoader).unwrap_err();
+    assert!(matches!(
+        err,
+        RavenError::Resolve(ResolveError::SelfNotMethodParam, _, _)
+    ));
+}
+
+#[test]
 fn self_upper_inside_impl_resolves_to_self_type() {
     let file = parse_src(
         "struct Pair { x: Int, y: Int }\nimpl Pair {\n    fun make() -> Self { Pair { x: 1, y: 2 } }\n}\n",

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -313,6 +313,21 @@ fn walk_expr(
                     expr.span.clone(),
                 ));
             }
+            // `self` is bound (as `SelfValue`) only when the enclosing method
+            // declares it as a parameter. Without that, the back end has no
+            // `self` value to produce, so reject the use here with a clear
+            // message rather than letting it surface as a confusing codegen
+            // error (a field access on a Unit `self`).
+            if !matches!(
+                scope.lookup("self").map(|e| &e.binding),
+                Some(Binding::SelfValue)
+            ) {
+                return Err(RavenError::resolve(
+                    ResolveError::SelfNotMethodParam,
+                    expr.span.clone(),
+                )
+                .with_hint("add `self` as the method's first parameter: `fun name(self, ...)`"));
+            }
             map.bind_use(&expr.span, Binding::SelfValue);
         }
         ExprKind::SelfUpper => {


### PR DESCRIPTION
**Closes #372.**

A method referencing `self.field` but omitting `self` from its parameters failed with the opaque `unsupported MIR construct: field base used a Unit value` instead of a clear diagnostic (reported while dogfooding).

**Root cause:** resolve only checked `self` was inside an `impl` (`SelfOutsideImpl`), not that the method *declared* `self`. `self` is bound as `SelfValue` only when it's a parameter, so an undeclared `self` still resolved, was typed as the impl type, and reached MIR with no `self` local, becoming Unit, then `self.field` is a field access on Unit -> back-end error.

**Fix:** the `self` use site now requires `self` to be bound; otherwise it's a resolve error (`SelfNotMethodParam`) with a help to add `self` as the first parameter. Now:
```
error: `self` is used here, but this method has no `self` parameter
  ...
  help: add `self` as the method's first parameter: `fun name(self, ...)`
```
`Self` (the type) is unaffected; `self` in nested blocks/closures still resolves through the scope stack. Regression test added; lib (520) and clippy pass.