### PR TITLE
fix(tycheck): enforce generic bounds on types written in declarations

### DIFF
--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -776,7 +776,7 @@ fn resolve_type_path(
                 .map(|t| Ty::SelfTy(Box::new(t)))
                 .ok_or_else(|| {
                     RavenError::ty(
-                        TypeError::Custom("`Self` used outside an impl block".into()),
+                        TypeError::Custom("`Self` used outside an `impl` block".into()),
                         head.span.clone(),
                     )
                 });
@@ -857,7 +857,7 @@ fn resolve_type_path(
             .map(|t| Ty::SelfTy(Box::new(t)))
             .ok_or_else(|| {
                 RavenError::ty(
-                    TypeError::Custom("`Self` used outside an impl block".into()),
+                    TypeError::Custom("`Self` used outside an `impl` block".into()),
                     head.span.clone(),
                 )
             }),

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -724,7 +724,16 @@ impl<'a, 'b> Checker<'a, 'b> {
                 }
                 let declared = match ty {
                     Some(t) => match self.resolve_ast_ty(t) {
-                        Ok(d) => Some(d),
+                        Ok(d) => {
+                            // An explicit annotation such as `let m: Map<K, V>`
+                            // must satisfy the generic bounds it names, the same
+                            // check the declared-type pass applies to fields and
+                            // signatures.
+                            if let Err(e) = super::wf::check_type(self.env, &d, &stmt.span) {
+                                self.push_error(e);
+                            }
+                            Some(d)
+                        }
                         Err(e) => {
                             self.push_error(e);
                             Some(Ty::Error)

--- a/src/tycheck/mod.rs
+++ b/src/tycheck/mod.rs
@@ -29,6 +29,7 @@ pub mod pattern;
 pub mod stmt;
 pub mod ty;
 pub mod unify;
+pub mod wf;
 
 #[cfg(test)]
 mod tests;
@@ -203,6 +204,13 @@ pub fn check_file_all<'a>(
 ) -> Result<TypedFile<'a>, Vec<RavenError>> {
     let mut env = TypeEnv::new();
     collect::collect_declarations(resolved, &mut env).map_err(|e| vec![e])?;
+    // Reject declared types whose generic arguments do not satisfy the
+    // declaration's bounds (for example a `Map<K, V>` key without `Hash`), with
+    // a clear error here rather than an unresolved callee at codegen.
+    let wf_errors = wf::check_declared_types(&env);
+    if !wf_errors.is_empty() {
+        return Err(wf_errors);
+    }
     let mut types = TypeMap::new();
     expr::check_bodies(resolved, &env, &mut types)?;
     Ok(TypedFile {

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -64,6 +64,28 @@ fn const_local_is_usable() {
 }
 
 #[test]
+fn generic_arg_violating_a_bound_is_rejected() {
+    // A type written with a generic argument that does not satisfy the
+    // declaration's bound is rejected at type-check, not left to surface as an
+    // unresolved callee in the back end (the `Map<Uuid, V>` without `Hash`
+    // class of bug).
+    let err = check(
+        "trait Keyable {}\nstruct Holder<T: Keyable> { v: T }\nstruct Plain { x: Int }\nstruct Bad { h: Holder<Plain> }\n",
+    )
+    .unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => {
+            assert!(
+                matches!(*b, TypeError::BoundNotSatisfied { .. }),
+                "got: {:?}",
+                b
+            )
+        }
+        other => panic!("expected a bound error, got {:?}", other),
+    }
+}
+
+#[test]
 fn reassigning_a_const_local_is_rejected() {
     let err = check("fun f() {\n    const K: Int = 5\n    K = 7\n}\n").unwrap_err();
     match err {

--- a/src/tycheck/wf.rs
+++ b/src/tycheck/wf.rs
@@ -1,0 +1,154 @@
+//! Well-formedness of declared types.
+//!
+//! A generic type written with concrete arguments must satisfy the trait bounds
+//! its declaration requires. The inference path only verifies bounds on
+//! inference variables; a type written in a declaration (a struct field, a
+//! function parameter or return, an enum payload) resolves straight to a
+//! concrete `Ty` with no variable, so its arguments were never checked. That is
+//! why `Map<Uuid, V>` whose key has no `Hash` impl reached the back end as an
+//! unresolved `Uuid$hash` callee instead of a clear error.
+//!
+//! This pass runs after declaration collection (so every impl, including derived
+//! ones, is known) and reports a `BoundNotSatisfied` at the offending type. To
+//! stay free of false positives it only judges *simple* concrete arguments,
+//! primitives and monomorphic structs/enums, whose impl can be matched exactly;
+//! generic arguments (`List<Int>`, a type parameter, an inference variable) are
+//! left to the existing call-site machinery.
+
+use super::env::{tys_equal, GenericParamSig, TypeEnv, VariantPayloadSig};
+use super::ty::Ty;
+use crate::error::{RavenError, TypeError};
+use crate::span::Span;
+
+/// Check every declared type in `env`, returning all bound violations.
+pub fn check_declared_types(env: &TypeEnv) -> Vec<RavenError> {
+    let mut errs = Vec::new();
+    for s in env.structs.values() {
+        for f in &s.fields {
+            push_errs(env, &f.ty, &f.span, &mut errs);
+        }
+    }
+    for e in env.enums.values() {
+        for v in &e.variants {
+            match &v.payload {
+                VariantPayloadSig::Unit => {}
+                VariantPayloadSig::Tuple(tys) => {
+                    for t in tys {
+                        push_errs(env, t, &v.span, &mut errs);
+                    }
+                }
+                VariantPayloadSig::Struct(fields) => {
+                    for f in fields {
+                        push_errs(env, &f.ty, &f.span, &mut errs);
+                    }
+                }
+            }
+        }
+    }
+    for f in env.functions.values() {
+        for p in &f.params {
+            push_errs(env, p, &f.span, &mut errs);
+        }
+        push_errs(env, &f.ret, &f.span, &mut errs);
+    }
+    for imp in &env.impls {
+        for m in imp.methods.values() {
+            for p in &m.params {
+                push_errs(env, p, &m.span, &mut errs);
+            }
+            push_errs(env, &m.ret, &m.span, &mut errs);
+        }
+    }
+    errs
+}
+
+fn push_errs(env: &TypeEnv, ty: &Ty, span: &Span, errs: &mut Vec<RavenError>) {
+    if let Err(e) = check_type(env, ty, span) {
+        errs.push(e);
+    }
+}
+
+/// Recursively check that `ty`'s generic instantiations satisfy their bounds.
+/// Returns the first violation found. Used by the declared-type pass and by the
+/// body checker for explicit `let`/`const` type annotations.
+pub fn check_type(env: &TypeEnv, ty: &Ty, span: &Span) -> Result<(), RavenError> {
+    match ty {
+        Ty::Struct { id, args, .. } => {
+            let generics = env.structs.get(id).map(|s| &s.generics);
+            check_instantiation(env, generics, args, span)?;
+        }
+        Ty::Enum { id, args, .. } => {
+            let generics = env.enums.get(id).map(|e| &e.generics);
+            check_instantiation(env, generics, args, span)?;
+        }
+        Ty::List(t) | Ty::Option(t) | Ty::SelfTy(t) => check_type(env, t, span)?,
+        Ty::Result(a, b) => {
+            check_type(env, a, span)?;
+            check_type(env, b, span)?;
+        }
+        Ty::Function { params, ret } => {
+            for p in params {
+                check_type(env, p, span)?;
+            }
+            check_type(env, ret, span)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn check_instantiation(
+    env: &TypeEnv,
+    generics: Option<&Vec<GenericParamSig>>,
+    args: &[Ty],
+    span: &Span,
+) -> Result<(), RavenError> {
+    if let Some(generics) = generics {
+        for (arg, param) in args.iter().zip(generics.iter()) {
+            for bound in &param.bounds {
+                check_arg_bound(env, arg, bound, span)?;
+            }
+        }
+    }
+    for arg in args {
+        check_type(env, arg, span)?;
+    }
+    Ok(())
+}
+
+/// Require that `arg` satisfies `bound`, but only when `arg` is a *simple*
+/// concrete type whose impl can be matched exactly. Type parameters, inference
+/// variables, the error placeholder, and generic instantiations are passed over
+/// (the call-site machinery handles those, and matching a generic impl by
+/// structural equality would produce false positives).
+fn check_arg_bound(env: &TypeEnv, arg: &Ty, bound: &str, span: &Span) -> Result<(), RavenError> {
+    let simple = match arg {
+        Ty::Error | Ty::Var(_) | Ty::Param(_) => false,
+        Ty::Struct { args, .. } | Ty::Enum { args, .. } => args.is_empty(),
+        Ty::List(_) | Ty::Option(_) | Ty::Result(_, _) | Ty::Function { .. } => false,
+        Ty::SelfTy(_) => false,
+        _ => true, // primitives: Int, Float, Bool, Char, Str, ...
+    };
+    if !simple || type_satisfies(env, arg, bound) {
+        return Ok(());
+    }
+    let ty_name = format!("{}", arg);
+    Err(RavenError::ty(
+        TypeError::BoundNotSatisfied {
+            ty: ty_name.clone(),
+            trait_name: bound.to_string(),
+        },
+        span.clone(),
+    )
+    .with_hint(format!(
+        "`{ty_name}` must implement `{bound}` to be used here; add `@derive({bound})` to its definition, or write an `impl {bound} for {ty_name}`"
+    )))
+}
+
+/// Whether the environment holds an impl of `trait_name` whose self type equals
+/// `concrete` (the same match the checker uses for `implements_trait`).
+fn type_satisfies(env: &TypeEnv, concrete: &Ty, trait_name: &str) -> bool {
+    env.impls.iter().any(|imp| {
+        imp.trait_name.as_deref() == Some(trait_name) && tys_equal(&imp.self_ty, concrete)
+    })
+}


### PR DESCRIPTION
**Closes #374.**

A generic type written with concrete arguments that violate the declaration's bounds was not rejected. `Map<K, V>` requires `K: Eq + Hash`; a key type lacking them (`Map<Uuid, V>`, found while dogfooding) compiled past type-check and died in the back end with `unsupported MIR construct: unresolved callee: Uuid$hash`.

## Cause
The inference path only checks bounds on inference *variables* (`check_bound_eager` defers every concrete check and has no env access). A type written in a declaration resolves straight to a concrete `Ty`, so its arguments were bound-checked nowhere.

## Fix
A well-formedness pass (`tycheck::wf`) runs after declaration collection (every impl, including derived, known) and reports `BoundNotSatisfied` at the offending type. Covers **struct fields, enum payloads, function params/returns, impl methods, and explicit `let`/`const` annotations**:
```
error: `Key` does not implement `Eq`
  ...
  help: `Key` must implement `Eq` to be used here; add `@derive(Eq)` to its
        definition, or write an `impl Eq for Key`
```
To avoid false positives it judges only *simple* concrete arguments (primitives + monomorphic structs/enums whose impl matches exactly); type parameters, inference vars, and generic instantiations are left to the existing call-site machinery.

## Scope checked
- The flagged code paths from the audit: the `self`-without-`self`-param Unit-base error was fixed in #373; the `dyn Trait`-without-impl case is already caught at type-check; the remaining codegen `Unsupported` sites are internal invariants (intrinsic arity, vtable slots) not reachable from valid user syntax.
- A fully *inferred* binding with no annotation is the one remaining leak, tracked in **#375** (needs env-aware finalization).
- Error-message consistency: no em/en dashes anywhere in `src`; backticked `impl` in two messages to match the catalog.

## Verification
New regression test; lib (521), `codegen_smoke` (72), and golden all pass; valid `Map<Int,..>`/`Map<String,..>`/`@derive`d-key programs and the full example suite still compile. Refs #375.