### PR TITLE
build: release 2.15.0, HTTP server and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.15.0] - 2026-06-08
+
+### Added
+
+- HTTP server in `std/http` (#378), written entirely in Raven on top of `std/net` (TCP), so it needs no new runtime code. Build a routing table on a `Server` and call `listen`. The surface is typed and ergonomic: a `Method` enum; a `Request` with the method, path, lowercased headers, captured `:name` path params, a decoded query map, and the body, plus `header`/`param`/`query_value` accessors; a `Response` with constructors (`ok`, `text`, `html`, `json`, `created`, `no_content`, `not_found`, `bad_request`, `server_error`, `redirect`) and chaining builders (`header`, `content_type`, `status_code`); and a `Server` with `get`/`post`/`put`/`delete`/`patch`/`route` registration. Handlers are `fun(Request) -> Response` values. Routes match in registration order, `:name` segments capture, and a non-match falls through to a 404. Connections are served one at a time; per-connection concurrency waits on a scheduler fix (#377).
+
+### Fixed
+
+- A method that uses `self` but does not declare it as a parameter now reports a clear resolve error pointing at the use, with a help to add `self`, instead of the opaque back-end error `field base used a Unit value` (#372).
+- Generic bounds are now enforced on types written in declarations. A `Map<K, V>` whose key type lacks `Eq`/`Hash` (or any generic instantiation that violates its declaration's bounds) is rejected at type-check with a `does not implement` error, instead of surfacing as an unresolved `K$hash` callee at codegen. Covers struct fields, enum payloads, function parameters and returns, impl methods, and explicit `let`/`const` annotations (#374).
+
 ## [2.14.0] - 2026-06-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.14.0"
+version = "2.15.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.14.0"
+version = "2.15.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.14.0"
+version = "2.15.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/standard-library.md
+++ b/docs/v2/guide/standard-library.md
@@ -126,7 +126,7 @@ helpers.
 | Module | What it is for |
 |--------|----------------|
 | [std/net](stdlib/net.md) | TCP sockets |
-| [std/http](stdlib/http.md) | an HTTP client |
+| [std/http](stdlib/http.md) | an HTTP client and server |
 | [std/json](stdlib/json.md) | JSON parse and stringify |
 
 ### Concurrency, errors, FFI, testing

--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -1,11 +1,12 @@
 # std/http
 
-A small HTTP/1.1 client built on [std/net](net.md). It sends `GET`, `POST`,
-`PUT`, `DELETE`, `PATCH`, and `HEAD` requests and hands back a captured
-response. Every call
-returns `Result<HttpResponse, Error>`, so transport failures (DNS, connect,
-timeout) come back as an [std/error](error.md) `Error` you handle with
-`match`.
+A small HTTP/1.1 **client** and **server**, both built on [std/net](net.md).
+The client sends `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, and `HEAD` requests
+and hands back a captured response. Every call returns
+`Result<HttpResponse, Error>`, so transport failures (DNS, connect, timeout)
+come back as an [std/error](error.md) `Error` you handle with `match`. The
+server (`Server`, `Request`, `Response`, `Method`) lets you route requests to
+handler functions; jump to [Server](#server) below.
 
 ```rust
 import std/http { get }
@@ -200,6 +201,153 @@ fun main() {
     fetch("https://example.com")
 }
 ```
+
+## Server
+
+The server side of `std/http` runs an HTTP/1.1 endpoint. You build a routing
+table on a `Server`, then `listen`. A handler is a function from a `Request` to
+a `Response`.
+
+```rust
+import std/http { Server, Request, Response }
+
+fun hello(req: Request) -> Response {
+    return Response.text("Hello, ${req.param("name")}!")
+}
+
+fun main() {
+    let app = Server.new()
+    app.get("/", fun(req: Request) -> Response = Response.html("<h1>Raven</h1>"))
+    app.get("/hello/:name", hello)
+    app.post("/echo", fun(req: Request) -> Response = Response.json(req.body))
+    app.listen("127.0.0.1:8080")
+}
+```
+
+`listen` binds the address and blocks, serving connections one at a time.
+
+### Routing
+
+Register a handler per method with `get`, `post`, `put`, `delete`, or `patch`
+(or the general `route(method, pattern, handler)`). Routes are tried in the
+order you register them; the first match wins, and a request that matches none
+gets a `404`.
+
+A path segment written `:name` is a **capture**: it matches any single segment
+and binds it under that name, read in the handler with `req.param("name")`.
+
+```rust
+app.get("/users/:id", show_user)        // /users/42  -> param("id") == "42"
+app.get("/users/:id/posts/:slug", show) // two captures
+```
+
+### Handlers
+
+A handler is a value of type `fun(Request) -> Response`. Use a named function
+for anything with more than one statement, or a single-expression closure for a
+one-liner:
+
+```rust
+fun show_user(req: Request) -> Response {
+    let id = req.param("id")
+    return Response.json("{\"id\": \"${id}\"}")
+}
+
+app.get("/users/:id", show_user)
+app.get("/ping", fun(req: Request) -> Response = Response.text("pong"))
+```
+
+### `struct Request`
+
+```rust
+struct Request {
+    method: Method,
+    path: String,
+    version: String,
+    headers: Map<String, String>,   // keys lowercased
+    params: Map<String, String>,    // captured :name segments
+    query: Map<String, String>,     // decoded query string
+    body: String,
+}
+```
+
+The accessors return `""` when a key is absent, so you can use them without
+unwrapping an `Option`:
+
+| Method | Returns |
+|--------|---------|
+| `req.header(name)` | a request header (case-insensitive), `""` if absent |
+| `req.param(name)` | a captured path segment, `""` if absent |
+| `req.query_value(name)` | a query-string value, `""` if absent |
+
+```rust
+fun search(req: Request) -> Response {
+    let q = req.query_value("q")       // /search?q=birds -> "birds"
+    let auth = req.header("authorization")
+    return Response.json("{\"q\": \"${q}\"}")
+}
+```
+
+### `struct Response`
+
+Build a response with a constructor, then refine it with chaining builders.
+
+```rust
+struct Response {
+    status: Int,
+    headers: Map<String, String>,
+    body: String,
+}
+```
+
+| Constructor | Status | Content-Type |
+|-------------|--------|--------------|
+| `Response.ok(body)` / `Response.text(body)` | 200 | `text/plain` |
+| `Response.html(body)` | 200 | `text/html` |
+| `Response.json(body)` | 200 | `application/json` |
+| `Response.created(body)` | 201 | `text/plain` |
+| `Response.no_content()` | 204 | none |
+| `Response.not_found()` | 404 | `text/plain` |
+| `Response.bad_request(msg)` | 400 | `text/plain` |
+| `Response.server_error(msg)` | 500 | `text/plain` |
+| `Response.redirect(location)` | 302 | sets `Location` |
+| `Response.with_body(status, body)` | any | none |
+
+The builders return the response, so they chain:
+
+```rust
+fun create(req: Request) -> Response {
+    return Response.created(req.body)
+        .header("X-Created-By", "raven")
+}
+```
+
+| Builder | Effect |
+|---------|--------|
+| `resp.header(name, value)` | set a response header |
+| `resp.content_type(value)` | set `Content-Type` |
+| `resp.status_code(code)` | replace the status code |
+
+`listen` adds `Content-Length` and `Connection: close` for you when it writes
+the response.
+
+### `enum Method`
+
+```rust
+enum Method { Get, Post, Put, Delete, Patch, Head, Options, Unknown }
+```
+
+`req.method` is one of these. `Unknown` stands for any verb the server does not
+model and never matches a registered route. The enum derives `Eq` and
+`ToString`, so you can compare it or print it.
+
+### Connections are served one at a time
+
+`listen` accepts and serves connections sequentially: it reads a request,
+runs the handler, writes the response, and only then accepts the next
+connection. Handling each connection on its own goroutine is the natural next
+step, but is held by a scheduler issue, so a slow handler currently delays the
+clients behind it.
 
 ## See also
 

--- a/docs/v2/guide/tutorials/http-server.md
+++ b/docs/v2/guide/tutorials/http-server.md
@@ -1,0 +1,287 @@
+# Tutorial: a guestbook HTTP server
+
+This tutorial builds a small HTTP server with [std/http](../stdlib/http.md): a
+guestbook that lists messages, accepts new ones over `POST`, and serves one
+message by id. Along the way you meet routing, path captures, request bodies,
+JSON and HTML responses, and a little in-memory state. Every step compiles and
+runs.
+
+The server is pure Raven on top of [std/net](../stdlib/net.md), so there is
+nothing to install. You run the program, then talk to it from another terminal
+with `curl` (or a browser).
+
+## Step 1: hello, server
+
+A server is a `Server` with a routing table. You register a handler for a path,
+then `listen`. A handler is a function from a `Request` to a `Response`.
+
+```rust
+import std/http { Server, Request, Response }
+
+fun home(req: Request) -> Response {
+    return Response.text("Hello from Raven!")
+}
+
+fun main() {
+    let app = Server.new()
+    app.get("/", home)
+    print("listening on http://127.0.0.1:8080")
+    app.listen("127.0.0.1:8080")
+}
+```
+
+Run it, then from another terminal:
+
+```text
+$ curl http://127.0.0.1:8080/
+Hello from Raven!
+```
+
+`app.listen` binds the address and blocks, serving requests until you stop the
+process (Ctrl-C). `Response.text` builds a `200 OK` with a `text/plain` body;
+the server adds the `Content-Length` and `Connection` headers for you.
+
+## Step 2: capturing part of the path
+
+A path segment written `:name` matches any single segment and captures it. Read
+it in the handler with `req.param("name")`:
+
+```rust
+fun greet(req: Request) -> Response {
+    return Response.text("Hi, ${req.param("name")}!")
+}
+
+fun main() {
+    let app = Server.new()
+    app.get("/greet/:name", greet)
+    app.listen("127.0.0.1:8080")
+}
+```
+
+```text
+$ curl http://127.0.0.1:8080/greet/ada
+Hi, ada!
+```
+
+A request that matches no route gets a `404` automatically, so `/greet` with no
+name (a different shape) does not reach `greet`.
+
+## Step 3: choosing a response
+
+`Response` has a constructor per common case, so you say what you mean:
+
+```rust
+Response.text("plain")          // 200, text/plain
+Response.html("<h1>hi</h1>")    // 200, text/html
+Response.json("{\"ok\":true}")  // 200, application/json
+Response.created("made it")     // 201
+Response.not_found()            // 404
+Response.bad_request("why")     // 400
+```
+
+Builders refine a response and chain, because each returns the response:
+
+```rust
+fun teapot(req: Request) -> Response {
+    return Response.text("short and stout")
+        .status_code(418)
+        .header("X-Brewing", "true")
+}
+```
+
+## Step 4: reading the request body
+
+For `POST` and `PUT`, the request carries a body in `req.body`. This handler
+echoes whatever it receives back as JSON:
+
+```rust
+fun echo(req: Request) -> Response {
+    if req.body.length() == 0 {
+        return Response.bad_request("send a body")
+    }
+    return Response.json(req.body)
+}
+
+fun main() {
+    let app = Server.new()
+    app.post("/echo", echo)
+    app.listen("127.0.0.1:8080")
+}
+```
+
+```text
+$ curl -X POST -d '{"hi":"there"}' http://127.0.0.1:8080/echo
+{"hi":"there"}
+```
+
+## Step 5: keeping state
+
+A guestbook needs to remember messages between requests. A module-level `let`
+is shared by every handler, and a handler can push to it. Seed it with one
+message:
+
+```rust
+let messages: List<String> = ["Welcome to the guestbook!"]
+
+fun add_message(req: Request) -> Response {
+    if req.body.length() == 0 {
+        return Response.bad_request("message body is empty")
+    }
+    messages.push(req.body)
+    return Response.created(req.body)
+}
+```
+
+Each `POST` appends to the same `messages` list, so the data accumulates across
+requests for as long as the server runs.
+
+## Step 6: listing and fetching
+
+To list the messages as a JSON array, build the array text by joining the
+entries. (A real service would reach for [std/json](../stdlib/json.md) to
+escape values; here we keep it to string building.)
+
+```rust
+fun messages_json() -> String {
+    let out = "["
+    let i = 0
+    while i < messages.len() {
+        if i > 0 {
+            out = out.concat(",")
+        }
+        out = out.concat("\"").concat(messages[i]).concat("\"")
+        i += 1
+    }
+    return out.concat("]")
+}
+
+fun list_messages(req: Request) -> Response {
+    return Response.json(messages_json())
+}
+```
+
+To fetch one message by its index, the captured `:id` arrives as a `String`, so
+parse it. `parse_int` returns an `Option<Int>`, which a `match` turns into
+either a lookup or a `400`:
+
+```rust
+fun message_at(i: Int) -> Response {
+    if i >= 0 && i < messages.len() {
+        return Response.json("\"".concat(messages[i]).concat("\""))
+    }
+    return Response.not_found()
+}
+
+fun get_message(req: Request) -> Response {
+    return match req.param("id").parse_int() {
+        Some(i) -> message_at(i),
+        None -> Response.bad_request("id must be a number"),
+    }
+}
+```
+
+`get_message` returns the value of the `match`: each arm produces a `Response`,
+so there is no early `return` inside the arms.
+
+## The whole program
+
+```rust
+import std/http { Server, Request, Response }
+import std/string
+
+let messages: List<String> = ["Welcome to the guestbook!"]
+
+fun messages_json() -> String {
+    let out = "["
+    let i = 0
+    while i < messages.len() {
+        if i > 0 {
+            out = out.concat(",")
+        }
+        out = out.concat("\"").concat(messages[i]).concat("\"")
+        i += 1
+    }
+    return out.concat("]")
+}
+
+fun home(req: Request) -> Response {
+    let body = "<h1>Guestbook</h1><ul>"
+    let i = 0
+    while i < messages.len() {
+        body = body.concat("<li>").concat(messages[i]).concat("</li>")
+        i += 1
+    }
+    return Response.html(body.concat("</ul>"))
+}
+
+fun list_messages(req: Request) -> Response {
+    return Response.json(messages_json())
+}
+
+fun add_message(req: Request) -> Response {
+    if req.body.length() == 0 {
+        return Response.bad_request("message body is empty")
+    }
+    messages.push(req.body)
+    return Response.created(req.body).header("Location", "/messages")
+}
+
+fun message_at(i: Int) -> Response {
+    if i >= 0 && i < messages.len() {
+        return Response.json("\"".concat(messages[i]).concat("\""))
+    }
+    return Response.not_found()
+}
+
+fun get_message(req: Request) -> Response {
+    return match req.param("id").parse_int() {
+        Some(i) -> message_at(i),
+        None -> Response.bad_request("id must be a number"),
+    }
+}
+
+fun main() {
+    let app = Server.new()
+    app.get("/", home)
+    app.get("/messages", list_messages)
+    app.post("/messages", add_message)
+    app.get("/messages/:id", get_message)
+    print("Guestbook on http://127.0.0.1:8080")
+    app.listen("127.0.0.1:8080")
+}
+```
+
+## Trying it
+
+Run the program, then in another terminal:
+
+```text
+$ curl http://127.0.0.1:8080/messages
+["Welcome to the guestbook!"]
+
+$ curl -X POST -d "Raven was here" http://127.0.0.1:8080/messages
+Raven was here
+
+$ curl http://127.0.0.1:8080/messages
+["Welcome to the guestbook!","Raven was here"]
+
+$ curl http://127.0.0.1:8080/messages/1
+"Raven was here"
+
+$ curl -i http://127.0.0.1:8080/messages/9
+HTTP/1.1 404 Not Found
+...
+```
+
+Open `http://127.0.0.1:8080/` in a browser to see the messages as a list.
+
+## Where to go next
+
+- The [std/http](../stdlib/http.md) reference lists every `Request` accessor,
+  `Response` constructor, and `Server` method, including `query_value` for
+  reading `?key=value` query strings.
+- The server handles one connection at a time. A request that takes a while to
+  answer holds up the clients behind it; per-connection concurrency is a planned
+  improvement.
+- [std/json](../stdlib/json.md) builds and parses JSON properly (with escaping),
+  which you want once message text can contain quotes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - Tutorials:
     - Word-frequency counter: v2/guide/tutorials/word-frequency.md
     - Modeling data with structs and enums: v2/guide/tutorials/task-tracker.md
+    - A guestbook HTTP server: v2/guide/tutorials/http-server.md
     - Calling C from Raven: v2/guide/tutorials/c-interop.md
   - Standard Library:
     - Overview: v2/guide/standard-library.md


### PR DESCRIPTION
Release prep for **2.15.0**.

## Since 2.14.0
- **HTTP server** in `std/http` (#378), a typed `Server`/`Request`/`Response`/`Method` API over TCP.
- Fix: clear error when a method uses `self` without declaring it (#372).
- Fix: enforce generic bounds on types written in declarations (#374).

## This PR
- Version -> 2.15.0; CHANGELOG 2.15.0 section.
- **Docs:** `std/http` guide gains a Server section; new tutorial **"A guestbook HTTP server"** (verified end-to-end with curl) added under Tutorials in the mkdocs nav; stdlib overview lists `std/http` as client and server.

After merge, tag `v2.15.0` to cut the release.