### PR TITLE
fix(tycheck): enforce generic bounds on inferred types

### DIFF
--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -334,6 +334,20 @@ impl<'a, 'b> Checker<'a, 'b> {
         self_ty: Option<Ty>,
         return_ty: Ty,
     ) -> Self {
+        // Hand the inference context the trait impls in scope so a pending
+        // bound is verified the moment its variable resolves to a concrete
+        // type (catches, for example, an inferred `Map` key with no `Hash`).
+        let mut infer = InferCtx::new();
+        infer.set_trait_impls(
+            env.impls
+                .iter()
+                .filter_map(|i| {
+                    i.trait_name
+                        .as_ref()
+                        .map(|t| (t.clone(), i.self_ty.clone()))
+                })
+                .collect(),
+        );
         Self {
             resolved,
             env,
@@ -343,7 +357,7 @@ impl<'a, 'b> Checker<'a, 'b> {
             locals: HashMap::new(),
             generic_scope: GenericScope::new(),
             param_bounds: HashMap::new(),
-            infer: InferCtx::new(),
+            infer,
             array_hint: None,
             errors: Vec::new(),
             const_locals: std::collections::HashSet::new(),
@@ -2153,6 +2167,14 @@ impl<'a, 'b> Checker<'a, 'b> {
         let mut inherent_matches: Vec<(usize, FnSig, HashMap<ParamId, Ty>)> = Vec::new();
         let mut trait_matches: Vec<(usize, FnSig, HashMap<ParamId, Ty>, String)> = Vec::new();
         for (idx, imp) in impls_snapshot.iter().enumerate() {
+            // Skip impls without this method before allocating inference
+            // variables or unifying. A rejected impl whose self type still
+            // unifies (for example `impl Eq for Map<K, V: Eq>`, which has no
+            // `set`) would otherwise leak its bounds onto the receiver's type
+            // variables.
+            let Some(msig) = imp.methods.get(name) else {
+                continue;
+            };
             // Substitute fresh vars for impl generics.
             let mut subst: HashMap<ParamId, Ty> = HashMap::new();
             for p in &imp.generics {
@@ -2168,10 +2190,6 @@ impl<'a, 'b> Checker<'a, 'b> {
             if probe.is_err() {
                 continue;
             }
-            // Method must exist on this impl.
-            let Some(msig) = imp.methods.get(name) else {
-                continue;
-            };
             if imp.trait_name.is_some() {
                 trait_matches.push((
                     idx,
@@ -2390,6 +2408,17 @@ impl<'a, 'b> Checker<'a, 'b> {
         let impls_snapshot = self.env.impls.clone();
         let mut matches: Vec<(FnSig, HashMap<ParamId, Ty>)> = Vec::new();
         for imp in impls_snapshot.iter() {
+            // Skip impls that do not provide this associated function before
+            // allocating inference variables or unifying. A rejected impl whose
+            // self type still unifies (for example `impl Eq for Map<K, V: Eq>`,
+            // which has no `new`) would otherwise leak its bounds onto the
+            // result's type variables.
+            let Some(msig) = imp.methods.get(name) else {
+                continue;
+            };
+            if msig.has_self {
+                continue;
+            }
             let mut subst: HashMap<ParamId, Ty> = HashMap::new();
             for p in &imp.generics {
                 let v = self.infer.fresh(span.clone());
@@ -2400,12 +2429,6 @@ impl<'a, 'b> Checker<'a, 'b> {
             }
             let impl_self = substitute(&imp.self_ty, &subst);
             if self.infer.unify(&impl_self, type_ty, span).is_err() {
-                continue;
-            }
-            let Some(msig) = imp.methods.get(name) else {
-                continue;
-            };
-            if msig.has_self {
                 continue;
             }
             matches.push((msig.clone(), subst));

--- a/src/tycheck/infer.rs
+++ b/src/tycheck/infer.rs
@@ -39,6 +39,11 @@ pub struct InferCtx {
     /// even though `T` appears only in the function's `S: Iterator<T>`
     /// bound and never in a parameter position.
     iterator_links: Vec<IteratorLink>,
+    /// Trait impls visible to this body as `(trait name, implementing type)`
+    /// pairs, so a pending bound can be verified the moment its variable
+    /// resolves to a simple concrete type (for example a `Map` key inferred to
+    /// a struct that has no `Hash` impl).
+    trait_impls: Vec<(String, Ty)>,
 }
 
 /// A deferred link from an iterator-typed variable to its element
@@ -83,6 +88,12 @@ impl InferCtx {
             span: Some(span),
         });
         InferVarId(id)
+    }
+
+    /// Record the trait impls in scope so a pending bound can be checked
+    /// against a concrete type as soon as its variable resolves.
+    pub fn set_trait_impls(&mut self, impls: Vec<(String, Ty)>) {
+        self.trait_impls = impls;
     }
 
     /// Attach a trait bound to a variable.
@@ -283,7 +294,7 @@ fn unify_inner(cx: &mut InferCtx, a: &Ty, b: &Ty, span: &Span) -> Result<(), Rav
             // Eagerly verify pending bounds now that we know the type.
             if let Some(bs) = cx.bounds.get(&root).cloned() {
                 for b in bs {
-                    check_bound_eager(other, &b, span)?;
+                    check_bound_eager(&cx.trait_impls, other, &b)?;
                 }
             }
             Ok(())
@@ -462,26 +473,48 @@ fn mismatch_named(a: &str, b: &str, span: &Span) -> RavenError {
 /// caller threads the environment when richer bound checking is needed;
 /// this eager path is conservative and prefers false positives only for
 /// concrete primitive shapes that obviously cannot satisfy a bound.
-fn check_bound_eager(ty: &Ty, bound: &PendingBound, span: &Span) -> Result<(), RavenError> {
-    if ty.is_error() {
+fn check_bound_eager(
+    impls: &[(String, Ty)],
+    ty: &Ty,
+    bound: &PendingBound,
+) -> Result<(), RavenError> {
+    // Only judge a *simple* concrete type whose impl can be matched exactly: a
+    // primitive or a monomorphic struct/enum. Inference variables and type
+    // parameters stay pending (a later resolution or the call site checks
+    // them); generic instantiations are deferred because matching a generic
+    // impl by structural equality would mis-fire. The matched cases are exactly
+    // those the declared-type well-formedness pass also judges, so the two
+    // checks stay consistent.
+    let simple = match ty {
+        Ty::Var(_) | Ty::Param(_) | Ty::Error => false,
+        Ty::Struct { args, .. } | Ty::Enum { args, .. } => args.is_empty(),
+        Ty::List(_) | Ty::Option(_) | Ty::Result(_, _) | Ty::Function { .. } | Ty::SelfTy(_) => {
+            false
+        }
+        _ => true,
+    };
+    if !simple {
         return Ok(());
     }
-    // Inference variables: the bound stays pending, no eager failure.
-    if matches!(ty, Ty::Var(_)) {
+    let satisfied = impls
+        .iter()
+        .any(|(t, self_ty)| t == &bound.trait_name && super::env::tys_equal(self_ty, ty));
+    if satisfied {
         return Ok(());
     }
-    // Declared parameters: defer; the call site that introduced the
-    // parameter is responsible for verifying against its bounds.
-    if matches!(ty, Ty::Param(_)) {
-        return Ok(());
-    }
-    // For other shapes (Struct, Enum, primitive) we can not verify the
-    // bound without the env; the call site of `unify` performs a
-    // second-stage walk after finalization to surface bound errors with
-    // full context. To avoid spurious early failures, simply succeed
-    // here and let the deferred check fire.
-    let _ = (bound, span);
-    Ok(())
+    let ty_name = format!("{}", ty);
+    Err(RavenError::ty(
+        TypeError::BoundNotSatisfied {
+            ty: ty_name.clone(),
+            trait_name: bound.trait_name.clone(),
+        },
+        bound.span.clone(),
+    )
+    .with_hint(format!(
+        "`{ty}` must implement `{tr}`; add `@derive({tr})` to its definition, or write an `impl {tr} for {ty}`",
+        ty = ty_name,
+        tr = bound.trait_name
+    )))
 }
 
 /// Substitute `subst` into `ty`. Walks recursively. `subst` maps each

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -86,6 +86,27 @@ fn generic_arg_violating_a_bound_is_rejected() {
 }
 
 #[test]
+fn inferred_type_violating_a_bound_is_rejected() {
+    // A call that infers a type argument violating the bound is rejected the
+    // moment the inference variable resolves to a concrete type, not deferred
+    // to the back end (issue #375).
+    let err = check(
+        "trait Keyed {}\nstruct Box<T: Keyed> { v: T }\nfun wrap<T: Keyed>(x: T) -> Box<T> {\n    return Box { v: x }\n}\nstruct Plain { x: Int }\nfun main() {\n    let b = wrap(Plain { x: 1 })\n}\n",
+    )
+    .unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => {
+            assert!(
+                matches!(*b, TypeError::BoundNotSatisfied { .. }),
+                "got: {:?}",
+                b
+            )
+        }
+        other => panic!("expected a bound error, got {:?}", other),
+    }
+}
+
+#[test]
 fn reassigning_a_const_local_is_rejected() {
     let err = check("fun f() {\n    const K: Int = 5\n    K = 7\n}\n").unwrap_err();
     match err {


### PR DESCRIPTION
**Closes #375.**

A binding whose generic type was fully **inferred** (no annotation) escaped bound checking: `let m = Map.new(); m.set(Key{}, 1)` where `Key` has no `Eq`/`Hash` reached the back end as an unresolved `Key$equals`/`Key$hash` callee. The declared-type well-formedness pass (#374) only sees *written* types.

## Fix
The inference context now verifies a pending bound the moment its variable resolves to a **simple concrete type** (primitive or monomorphic struct/enum), using the trait impls the checker hands it. `check_bound_eager` was a no-op for concrete shapes (no env access); it now matches the same simple types the WF pass judges, so the two stay consistent. The error points at the inference variable's origin (e.g. the `Map.new()` call).

## Latent bug this exposed
The associated-function and method candidate loops allocated inference variables and unified each impl's self type **before** checking the impl provides the called method. A rejected impl whose self type still unifies, e.g. `impl<K: Eq + Hash, V: Eq> Eq for Map<K, V>` (no `new`/`set`), leaked its `V: Eq` bound onto the result's **value** variable, wrongly demanding `Eq` of a map's value type (this broke `std/json`'s `Map<String, JsonValue>`). Both loops now skip an impl lacking the method before allocating or unifying.

## Verification
lib (522), codegen_smoke (72), and golden all pass. A `Map<String, Enum>` value with no `Eq` compiles again; an inferred bad **key** is rejected with a clear error. Regression test added.