### PR TITLE
fix(runtime): do not hold the net registry lock during a blocking syscall

### DIFF
--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -341,13 +341,11 @@ enum Method { Get, Post, Put, Delete, Patch, Head, Options, Unknown }
 model and never matches a registered route. The enum derives `Eq` and
 `ToString`, so you can compare it or print it.
 
-### Connections are served one at a time
+### A goroutine per connection
 
-`listen` accepts and serves connections sequentially: it reads a request,
-runs the handler, writes the response, and only then accepts the next
-connection. Handling each connection on its own goroutine is the natural next
-step, but is held by a scheduler issue, so a slow handler currently delays the
-clients behind it.
+`listen` hands each accepted connection to its own goroutine, so a slow handler
+only delays its own client. The goroutines run in parallel across the worker
+pool, and a connection waiting on a read or write does not hold up the others.
 
 ## See also
 

--- a/docs/v2/specs/std-http.md
+++ b/docs/v2/specs/std-http.md
@@ -189,10 +189,10 @@ to the first blank line, parses the request line and headers, reads the body up
 to `Content-Length`, routes, and writes the response framed with `Content-Length`
 and `Connection: close`. A malformed request is answered `400`.
 
-### Connections are served one at a time
+### A goroutine per connection
 
-`listen` accepts and serves connections sequentially. Handling each on its own
-goroutine is the natural next step, but a goroutine spawned just before the
-accept loop re-blocks is not scheduled promptly today (issue #377), so per-
-connection concurrency waits on that runtime fix. The server is otherwise a
-complete, correct HTTP/1.1 endpoint.
+`listen` accepts in a loop and hands each connection to its own goroutine, so a
+slow handler only delays its own client, not the ones behind it. The goroutines
+run in parallel across the worker pool, and a connection blocked in a read or
+write releases the shared net registry while it waits, so other connections are
+never serialized behind it.

--- a/examples/v2/http_server.rv
+++ b/examples/v2/http_server.rv
@@ -4,8 +4,9 @@
 //   curl localhost:8080/greet/raven
 //   curl "localhost:8080/search?q=birds"
 //   curl -X POST -d '{"name":"Ada"}' localhost:8080/users
-// Connections are served one at a time. Handlers are plain functions of
-// `Request -> Response`; routes may capture `:name` path segments.
+// Each connection is handled on its own goroutine, so one slow client does not
+// block the others. Handlers are plain functions of `Request -> Response`;
+// routes may capture `:name` path segments.
 
 import std/http { Server, Request, Response }
 

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1141,18 +1141,26 @@ pub extern "C" fn raven_net_listen(addr: *const object::String) -> i64 {
 /// slot set.
 #[no_mangle]
 pub extern "C" fn raven_net_accept(listener_id: i64) -> i64 {
-    // accept blocks until a connection arrives; run it outside the running set.
-    let accepted = crate::gc::blocking(|| {
+    // accept blocks until a connection arrives. Clone the listener handle under
+    // the registry lock, then accept without holding it, so a parked accept does
+    // not serialize every other goroutine's net operation on the shared
+    // registry. Run outside the running set so a slow accept never freezes a
+    // collection.
+    let listener = {
         let registry = net_registry().lock().unwrap();
         match registry.get(&listener_id) {
-            Some(Socket::Listener(l)) => l.accept().map(|(stream, _)| stream),
+            Some(Socket::Listener(l)) => l.try_clone(),
             Some(Socket::Stream(_)) => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "id is not a listener",
             )),
             None => Err(io::Error::new(io::ErrorKind::NotFound, "unknown socket id")),
         }
-    });
+    };
+    let accepted = match listener {
+        Ok(l) => crate::gc::blocking(|| l.accept().map(|(stream, _)| stream)),
+        Err(e) => Err(e),
+    };
     match accepted {
         Ok(stream) => net_insert(Socket::Stream(stream)),
         Err(e) => {
@@ -1169,25 +1177,32 @@ pub extern "C" fn raven_net_accept(listener_id: i64) -> i64 {
 #[no_mangle]
 pub extern "C" fn raven_net_read(stream_id: i64, max: i64) -> *mut object::String {
     let cap = max.max(0) as usize;
-    // Block outside the collector's running set: a slow read must not freeze a
-    // concurrent collection waiting for this worker to reach a safepoint.
-    let result = crate::gc::blocking(|| {
-        let mut registry = net_registry().lock().unwrap();
-        match registry.get_mut(&stream_id) {
-            Some(Socket::Stream(s)) => {
-                let mut buf = vec![0u8; cap];
-                s.read(&mut buf).map(|n| {
-                    buf.truncate(n);
-                    buf
-                })
-            }
+    // Clone the stream handle under the registry lock, then read without holding
+    // it, so a blocked read does not serialize other goroutines' net operations
+    // on the shared registry. Block outside the collector's running set so a slow
+    // read never freezes a concurrent collection waiting for this worker to reach
+    // a safepoint.
+    let stream = {
+        let registry = net_registry().lock().unwrap();
+        match registry.get(&stream_id) {
+            Some(Socket::Stream(s)) => s.try_clone(),
             Some(Socket::Listener(_)) => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "id is not a stream",
             )),
             None => Err(io::Error::new(io::ErrorKind::NotFound, "unknown socket id")),
         }
-    });
+    };
+    let result = match stream {
+        Ok(mut s) => crate::gc::blocking(|| {
+            let mut buf = vec![0u8; cap];
+            s.read(&mut buf).map(|n| {
+                buf.truncate(n);
+                buf
+            })
+        }),
+        Err(e) => Err(e),
+    };
     match result {
         Ok(bytes) => {
             net_clear_error();
@@ -1216,17 +1231,24 @@ pub extern "C" fn raven_net_write(stream_id: i64, data: *const object::String) -
         // SAFETY: a Raven String holds `len` initialized bytes.
         unsafe { slice::from_raw_parts(ptr, len) }
     };
-    let result = crate::gc::blocking(|| {
-        let mut registry = net_registry().lock().unwrap();
-        match registry.get_mut(&stream_id) {
-            Some(Socket::Stream(s)) => s.write_all(bytes).map(|()| bytes.len() as i64),
+    // Clone the stream handle under the registry lock, then write without
+    // holding it, so a blocked write does not serialize other goroutines' net
+    // operations on the shared registry.
+    let stream = {
+        let registry = net_registry().lock().unwrap();
+        match registry.get(&stream_id) {
+            Some(Socket::Stream(s)) => s.try_clone(),
             Some(Socket::Listener(_)) => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "id is not a stream",
             )),
             None => Err(io::Error::new(io::ErrorKind::NotFound, "unknown socket id")),
         }
-    });
+    };
+    let result = match stream {
+        Ok(mut s) => crate::gc::blocking(|| s.write_all(bytes).map(|()| bytes.len() as i64)),
+        Err(e) => Err(e),
+    };
     match result {
         Ok(n) => {
             net_clear_error();
@@ -1949,5 +1971,35 @@ mod tests {
         // Empty slices must not dereference the pointer.
         raven_print_str(std::ptr::null(), 0);
         raven_println_str(std::ptr::null(), 0);
+    }
+
+    fn rv_string(s: &str) -> *mut object::String {
+        object::raven_string_from_bytes(s.as_ptr(), s.len())
+    }
+
+    #[test]
+    fn parked_accept_does_not_hold_the_registry_lock() {
+        // A connection that has not yet arrived must not serialize other
+        // goroutines' net operations: accept clones its handle under the
+        // registry lock, then blocks without it (issue #377). With the lock
+        // held across the syscall, a worker reading another stream could not
+        // even acquire the registry while accept was parked.
+        let lid = raven_net_listen(rv_string("127.0.0.1:0"));
+        assert!(lid > 0, "listen failed");
+        let port = {
+            let reg = net_registry().lock().unwrap();
+            match reg.get(&lid) {
+                Some(Socket::Listener(l)) => l.local_addr().unwrap().port(),
+                _ => panic!("listener not registered"),
+            }
+        };
+        let handle = std::thread::spawn(move || raven_net_accept(lid));
+        // Let the accept reach the blocking syscall (no client yet).
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        let lock_free = net_registry().try_lock().is_ok();
+        // Unblock the accept with a client so the thread finishes, no leak.
+        let _client = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+        let _ = handle.join();
+        assert!(lock_free, "registry lock held while accept was parked");
     }
 }

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -315,15 +315,20 @@ impl Server {
         self.route(Method.Patch, pattern, handler)
     }
 
-    // Bind `addr` ("host:port") and serve connections forever, one at a time.
-    // Blocks until the process ends; a failed bind is reported and returns.
+    // Bind `addr` ("host:port") and serve forever, handling each connection on
+    // its own goroutine so a slow client never blocks the others. Blocks until
+    // the process ends; a failed bind is reported and returns.
     fun listen(self, addr: String) {
         match listen(addr) {
             Ok(socket) -> {
                 let routes = self.routes
                 while true {
                     match socket.accept() {
-                        Ok(stream) -> serve_connection(routes, stream),
+                        Ok(stream) -> {
+                            spawn(fun() -> Unit {
+                                serve_connection(routes, stream)
+                            })
+                        }
                         Err(_) -> {}
                     }
                 }


### PR DESCRIPTION
**Closes #377.**

`raven_net_accept`/`read`/`write` held the **global net registry mutex for the entire blocking syscall**. A goroutine parked in `accept` thus held the lock until a connection arrived, so every other goroutine's net op blocked acquiring the registry rather than on its own IO. In an accept-and-spawn server this serialized everything: a handler goroutine could not read its request while the accept loop was parked, so a **lone or spaced request hung** while a rapid burst mostly worked (each new connection briefly freed the lock). This is the bug that forced `std/http` to serve connections one at a time.

## Fix
Each op now clones the socket handle under the lock (`try_clone`), releases the lock, then runs the blocking syscall on the clone. The registry is held only for the lookup, so net ops on different sockets run concurrently. Regression test added (the registry lock must be free while an `accept` is parked).

`std/http`'s `Server.listen` handles each connection on its own goroutine again.

## Verification
A spawn-per-connection server now answers **single, spaced, and parallel** requests reliably (spaced singles were 0/N before; now 15/15, and 30/30 parallel). Runtime (122), lib (522), and golden pass. Example and docs drop the "served one at a time" note.