### PR TITLE
fix(tycheck): finalize only each body's own type-map entries

### DIFF
--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -298,6 +298,10 @@ struct Checker<'a, 'b> {
     /// Binding keys of `const` locals in this body, used to reject a
     /// reassignment of an immutable local.
     const_locals: std::collections::HashSet<BindingKey>,
+    /// Type-map keys this body recorded. Finalization resolves only these, not
+    /// the whole shared map, so a later body never tries to resolve an earlier
+    /// body's variable against its own (foreign) inference context.
+    recorded: Vec<UseKey>,
 }
 
 /// Keys used by the locals map. Mirrors the resolver's `Binding`
@@ -361,6 +365,7 @@ impl<'a, 'b> Checker<'a, 'b> {
             array_hint: None,
             errors: Vec::new(),
             const_locals: std::collections::HashSet::new(),
+            recorded: Vec::new(),
         }
     }
 
@@ -593,10 +598,11 @@ impl<'a, 'b> Checker<'a, 'b> {
         let elem_of = move |ty: &Ty| -> Option<Ty> { iterator_elem_concrete(&impls, ty) };
         self.infer.solve_iterator_links(&elem_of)?;
 
-        // Resolve every entry in the type map. We do this in place by
-        // replacing each entry's value with its resolved form, raising
-        // CannotInferType if a variable remains.
-        let keys: Vec<crate::resolve::UseKey> = self.types.types.keys().cloned().collect();
+        // Resolve only the entries this body recorded, replacing each value
+        // with its resolved form and raising CannotInferType if a variable
+        // remains. Resolving the whole shared map would try this body's
+        // inference context against another body's variables.
+        let keys: Vec<crate::resolve::UseKey> = self.recorded.clone();
         let infer = &self.infer;
         let mut first_err: Option<RavenError> = None;
         for k in keys {
@@ -3098,7 +3104,9 @@ impl<'a, 'b> Checker<'a, 'b> {
     }
 
     fn record(&mut self, span: &Span, ty: Ty) {
-        self.types.types.insert(UseKey::from_span(span), ty);
+        let key = UseKey::from_span(span);
+        self.recorded.push(key.clone());
+        self.types.types.insert(key, ty);
     }
 
     fn record_type_args(&mut self, span: &Span, args: Vec<Ty>) {

--- a/src/tycheck/infer.rs
+++ b/src/tycheck/infer.rs
@@ -146,9 +146,12 @@ impl InferCtx {
 
     /// Return the union-find root for `v`. Performs path compression.
     pub fn find(&self, v: InferVarId) -> InferVarId {
-        // Iterative path traversal.
+        // Iterative path traversal. The bounds guard tolerates a variable from a
+        // different inference context (one not allocated here): it is returned
+        // unchanged rather than panicking. Each body owns its own variables, so
+        // this only matters as defense in depth.
         let mut cur = v.0 as usize;
-        while self.slots[cur].parent != cur as u32 {
+        while cur < self.slots.len() && self.slots[cur].parent != cur as u32 {
             cur = self.slots[cur].parent as usize;
         }
         InferVarId(cur as u32)
@@ -156,7 +159,7 @@ impl InferCtx {
 
     fn find_mut(&mut self, v: InferVarId) -> InferVarId {
         let mut cur = v.0 as usize;
-        while self.slots[cur].parent != cur as u32 {
+        while cur < self.slots.len() && self.slots[cur].parent != cur as u32 {
             let next = self.slots[cur].parent as usize;
             self.slots[cur].parent = self.slots[next].parent;
             cur = next;
@@ -171,7 +174,11 @@ impl InferCtx {
         match ty {
             Ty::Var(v) => {
                 let root = self.find(*v);
-                match &self.slots[root.0 as usize].solved {
+                match self
+                    .slots
+                    .get(root.0 as usize)
+                    .and_then(|s| s.solved.as_ref())
+                {
                     Some(t) => self.resolve(t),
                     None => Ty::Var(root),
                 }

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -107,6 +107,17 @@ fn inferred_type_violating_a_bound_is_rejected() {
 }
 
 #[test]
+fn cross_function_unresolved_var_does_not_panic() {
+    // A body that leaves an unresolved inference variable must not crash a
+    // later body's finalization. Each body resolves only its own type-map
+    // entries, so `later` no longer tries to resolve `consumer`'s variable
+    // against its own inference context. This must return a clean type error,
+    // not panic.
+    let src = "fun ambiguous<T>() -> List<T> {\n    let xs: List<T> = []\n    return xs\n}\nfun consumer() {\n    let a = ambiguous()\n}\nfun later() {\n    let b = 1\n}\n";
+    assert!(check(src).is_err());
+}
+
+#[test]
 fn reassigning_a_const_local_is_rejected() {
     let err = check("fun f() {\n    const K: Int = 5\n    K = 7\n}\n").unwrap_err();
     match err {


### PR DESCRIPTION
The type checker shares one TypeMap across all function bodies but gives each body a fresh inference context. `finalize_types` resolved the **whole shared map** with the current body's context, so once an earlier body left an unresolved inference variable, a later body's finalization looked it up in a context that never allocated it and **panicked** (`index out of bounds`). A generic call whose type argument can't be inferred (e.g. a return-type-only generic used without an annotation) triggered it.

## Fix
Finalization now resolves only the entries the current body **recorded** (tracked as they're inserted), so it never touches another body's variable. `find`/`resolve` are also bounds-guarded (a foreign variable is returned unchanged, not indexed out of range). The crash becomes an ordinary `cannot infer type` error.

## Verification
Regression test added (a cross-body unresolved-variable program that panicked before, errors cleanly now). lib (522), codegen_smoke (72), and golden pass. Found while building the std/http JSON DX (docs/v2/specs/std-http-dx.md).