### PR TITLE
feat(stdlib): typed JSON and static file serving in std/http

### DIFF
--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -219,7 +219,7 @@ fun main() {
     let app = Server.new()
     app.get("/", fun(req: Request) -> Response = Response.html("<h1>Raven</h1>"))
     app.get("/hello/:name", hello)
-    app.post("/echo", fun(req: Request) -> Response = Response.json(req.body))
+    app.post("/echo", fun(req: Request) -> Response = Response.json_raw(req.body))
     app.listen("127.0.0.1:8080")
 }
 ```
@@ -250,7 +250,7 @@ one-liner:
 ```rust
 fun show_user(req: Request) -> Response {
     let id = req.param("id")
-    return Response.json("{\"id\": \"${id}\"}")
+    return Response.text("user ${id}")
 }
 
 app.get("/users/:id", show_user)
@@ -284,7 +284,7 @@ unwrapping an `Option`:
 fun search(req: Request) -> Response {
     let q = req.query_value("q")       // /search?q=birds -> "birds"
     let auth = req.header("authorization")
-    return Response.json("{\"q\": \"${q}\"}")
+    return Response.text("query: ${q}")
 }
 ```
 
@@ -304,7 +304,9 @@ struct Response {
 |-------------|--------|--------------|
 | `Response.ok(body)` / `Response.text(body)` | 200 | `text/plain` |
 | `Response.html(body)` | 200 | `text/html` |
-| `Response.json(body)` | 200 | `application/json` |
+| `Response.json(value)` | 200 | `application/json` (serializes a `ToJson` value, see below) |
+| `Response.json_raw(body)` | 200 | `application/json` (body is already JSON text) |
+| `Response.file(path)` | 200 / 404 | from the file extension (see below) |
 | `Response.created(body)` | 201 | `text/plain` |
 | `Response.no_content()` | 204 | none |
 | `Response.not_found()` | 404 | `text/plain` |
@@ -330,6 +332,62 @@ fun create(req: Request) -> Response {
 
 `listen` adds `Content-Length` and `Connection: close` for you when it writes
 the response.
+
+### Working with JSON
+
+`Response.json(value)` serializes any value whose type implements
+[`ToJson`](json.md), so a `@derive(ToJson)` struct or enum, a `List`, an
+`Option`, or a scalar, and sets `application/json`. No string-building, no manual
+escaping:
+
+```rust
+@derive(ToJson, FromJson)
+struct User { name: String, age: Int }
+
+fun show_user(req: Request) -> Response {
+    return Response.json(User { name: "Ada", age: 36 })   // {"name":"Ada","age":36}
+}
+```
+
+To read a JSON request body into a struct, use `decode<T>` from
+[std/json](json.md). Decoding failures (bad JSON, a missing or mistyped field)
+come back as an `Error`:
+
+```rust
+import std/json { decode }
+
+fun create_user(req: Request) -> Response {
+    return match decode<User>(req.body) {
+        Ok(user) -> Response.json(user).status_code(201),
+        Err(e) -> Response.bad_request(e.message()),
+    }
+}
+```
+
+`req.json()` returns the body as a `JsonValue` for ad-hoc inspection when a
+struct is overkill. (The fully-typed method `req.json<User>()` is not available
+yet; method-call generics do not infer the type parameter. Use `decode<User>`.)
+
+### Serving files
+
+`Response.file(path)` reads a file and serves it with a `Content-Type` chosen
+from its extension (`html`, `css`, `js`, `json`, `svg`, `txt`; otherwise
+`application/octet-stream`); a missing file is a 404.
+
+`Server.static(prefix, dir)` mounts a directory: it serves
+`GET <prefix>/<file>` from `<dir>/<file>`. The file name is a single path
+segment, so a request cannot escape `dir` with a slash.
+
+```rust
+fun main() {
+    let app = Server.new()
+    app.static("/static", "public")     // GET /static/style.css -> public/style.css
+    app.get("/", fun(req: Request) -> Response = Response.file("public/index.html"))
+    app.listen("127.0.0.1:8080")
+}
+```
+
+Paths are relative to the process's working directory.
 
 ### `enum Method`
 

--- a/docs/v2/specs/std-http-dx.md
+++ b/docs/v2/specs/std-http-dx.md
@@ -1,0 +1,105 @@
+# std/http developer experience: JSON and static files
+
+A `std/http` server today makes the application write boilerplate the library
+should own: building JSON by hand with string concatenation and backslash
+escaping, and reading static files with manual content-type guessing. This
+design folds that work into the library so a handler is a few lines of intent.
+
+## Goal
+
+Take the notes example from this:
+
+```rust
+fun escape(s: String) -> String { /* backslash, quote, newline ... */ }
+fun note_json(id, text) -> String { /* "{\"id\":\"" .concat ... */ }
+fun notes_json(filter) -> String { /* loop building "[ ... ]" */ }
+fun content_type_for(name) -> String { /* .html -> text/html ... */ }
+fun serve_file(path, ctype) -> Response { /* fs.read, 404 ... */ }
+```
+
+to this:
+
+```rust
+@derive(ToJson, FromJson)
+struct Note { id: String, text: String }
+
+fun list_notes(req: Request) -> Response { return Response.json(all_notes()) }
+fun add_note(req: Request) -> Response {
+    return match decode<Note>(req.body) {
+        Ok(note) -> { store(note); Response.json(note).status_code(201) },
+        Err(e) -> Response.bad_request(e.message()),
+    }
+}
+fun main() {
+    let app = Server.new()
+    app.static("/static", "public")    // serve a whole directory
+    app.get("/notes", list_notes)
+    app.post("/notes", add_note)
+    app.listen("127.0.0.1:8080")
+}
+```
+
+## What ships
+
+`std/http` gains a dependency on `std/json`, `std/string`, and `std/fs`, and the
+following surface. Every item below was verified to compile and run against the
+current toolchain.
+
+### JSON responses
+
+- `Response.json(value)`: `fun json<T: ToJson>(value: T) -> Response`. Serializes
+  `value` through `std/json`'s `ToJson` (so `@derive(ToJson)` structs/enums,
+  lists, options, and scalars all work), sets `Content-Type: application/json`,
+  status 200. Chain `.status_code(201)` for Created, etc. This replaces every
+  hand-built JSON string and all manual escaping.
+
+### JSON request bodies
+
+- `decode<T: FromJson>(body: String) -> Result<T, Error>` in `std/json`: parse
+  and decode a JSON string into a `T` in one call (`from_json_value(parse(body)?)`).
+  A handler writes `match decode<Note>(req.body) { Ok(n) -> ..., Err(e) -> ... }`.
+  Decoding errors (bad JSON, missing/mistyped fields) come back as an `Error`.
+- `Request.json(self) -> Result<JsonValue, Error>`: parse the body to a
+  `JsonValue` for ad-hoc access when a struct is overkill.
+
+### Static and HTML file serving
+
+- `Response.file(path: String) -> Response`: read a file from disk and serve it
+  with a `Content-Type` chosen from its extension (html, css, js, json, txt,
+  svg, png, ... ; `application/octet-stream` otherwise). A missing file is a 404.
+- `Server.static(self, prefix: String, dir: String)`: mount a directory. Adds a
+  `GET <prefix>/:file` route that serves `<dir>/<file>` via `Response.file`. The
+  `:file` capture is a single path segment, so it cannot escape `dir` with a
+  slash. (Nested subdirectories under one mount are a later addition.)
+- An internal `content_type_for(path)` helper backs both.
+
+## Prerequisite compiler fix (already implemented)
+
+While verifying the generic JSON helpers, a pre-existing type-checker crash
+surfaced: `finalize_types` resolved the *shared* type map with the current
+body's inference context and panicked (`index out of bounds`) on a variable a
+different body owned. It now resolves only the entries each body recorded, and
+`find`/`resolve` are bounds-guarded. This turns the crash into ordinary
+type-errors and is independent of the std/http work; it shipped as its own fix (#385, merged).
+
+## Known limitation (filed separately)
+
+The fully-typed method form `req.json<Note>()` is intentionally *not* part of
+this design. Method-call generic instantiation does not propagate the expected
+or explicit type to the method's type parameter, so `T` collapses to `Unit`
+(`Unit$from_json`). That is a broader language gap, not specific to JSON; the
+request decoder is the free function `decode<T>` until it is fixed. Tracked in #384.
+
+## Testing app refactor
+
+`testing/martian-testing` is rewritten on the new surface as the worked example:
+`Note` derives `ToJson`/`FromJson`; handlers use `Response.json` and `app.static`
+plus `Response.file`; and `escape`, `note_json`, `notes_json`, `content_type_for`,
+`serve_file`, and `static_file` are deleted (roughly 60 lines removed).
+
+## Verification
+
+Each new function gets a golden example (a single end-to-end program that prints
+a JSON round-trip and a file-serve result) plus the refactored server example,
+and the lib/golden suites must stay green. The server is exercised by hand with
+curl for the file and JSON routes.

--- a/docs/v2/specs/std-http.md
+++ b/docs/v2/specs/std-http.md
@@ -155,22 +155,30 @@ struct Request {
     query: Map<String, String>,     // decoded query string
     body: String,
 }
-fun Request.header(name) -> String        // "" if absent
-fun Request.param(name) -> String         // path capture, "" if absent
-fun Request.query_value(name) -> String   // "" if absent
+fun Request.header(name) -> String          // "" if absent
+fun Request.param(name) -> String           // path capture, "" if absent
+fun Request.query_value(name) -> String     // "" if absent
+fun Request.json(self) -> Result<JsonValue, Error>   // parse the body
 
 struct Response { status: Int, headers: Map<String, String>, body: String }
 // constructors
-Response.text/ok/html/json/created/no_content/not_found/bad_request/server_error/redirect/with_body
+fun Response.json<T: ToJson>(value) -> Response       // serialize, application/json
+fun Response.json_raw(body) -> Response               // body is already JSON text
+fun Response.file(path) -> Response                   // serve a file, 404 if missing
+Response.text/ok/html/created/no_content/not_found/bad_request/server_error/redirect/with_body
 // chaining builders (return self)
 fun Response.header(name, value) -> Response
 fun Response.content_type(value) -> Response
 fun Response.status_code(code) -> Response
 
+// decode a request body into a struct (std/json)
+fun decode<T: FromJson>(body: String) -> Result<T, Error>
+
 struct Server { routes: List<Route> }
 fun Server.new() -> Server
 fun Server.route(method, pattern, handler)            // handler: fun(Request) -> Response
 fun Server.get/post/put/delete/patch(pattern, handler)
+fun Server.static(prefix, dir)                        // mount a directory
 fun Server.listen(addr)                               // binds and blocks
 ```
 

--- a/examples/v2/http_server.rv
+++ b/examples/v2/http_server.rv
@@ -1,17 +1,30 @@
-// An HTTP server built on std/http. golden:skip (a server blocks forever, so
-// it has no fixed stdout to diff). Run it, then from another shell:
+// An HTTP server built on std/http: typed JSON with @derive(ToJson)/decode, and
+// static file serving. golden:skip (a server blocks forever, so it has no fixed
+// stdout to diff). Run it, then from another shell:
 //   curl localhost:8080/
 //   curl localhost:8080/greet/raven
-//   curl "localhost:8080/search?q=birds"
-//   curl -X POST -d '{"name":"Ada"}' localhost:8080/users
-// Each connection is handled on its own goroutine, so one slow client does not
-// block the others. Handlers are plain functions of `Request -> Response`;
-// routes may capture `:name` path segments.
+//   curl "localhost:8080/search?q=birds"            # JSON, serialized from a struct
+//   curl -X POST -d '{"name":"Ada","age":36}' localhost:8080/users
+//   curl localhost:8080/static/style.css            # any file under public/
+// Each connection is handled on its own goroutine.
 
 import std/http { Server, Request, Response }
+import std/json { decode }
+
+@derive(ToJson)
+struct SearchResult {
+    query: String,
+    results: List<String>,
+}
+
+@derive(ToJson, FromJson)
+struct User {
+    name: String,
+    age: Int,
+}
 
 fun home(req: Request) -> Response {
-    return Response.html("<h1>Raven HTTP</h1><p>It works.</p>")
+    return Response.html("<h1>Raven HTTP</h1><p>/search for JSON, /static for files.</p>")
 }
 
 fun greet(req: Request) -> Response {
@@ -19,16 +32,20 @@ fun greet(req: Request) -> Response {
 }
 
 fun search(req: Request) -> Response {
-    let q = req.query_value("q")
-    return Response.json("{\"query\": \"${q}\", \"results\": []}")
+    let results: List<String> = []
+    return Response.json(SearchResult { query: req.query_value("q"), results: results })
 }
 
 fun create_user(req: Request) -> Response {
-    return Response.created(req.body).header("X-Created-By", "raven")
+    return match decode<User>(req.body) {
+        Ok(user) -> Response.json(user).status_code(201),
+        Err(e) -> Response.bad_request(e.message()),
+    }
 }
 
 fun main() {
     let app = Server.new()
+    app.static("/static", "public")     // serve files under ./public
     app.get("/", home)
     app.get("/greet/:name", greet)
     app.get("/search", search)

--- a/examples/v2/stdlib_json_decode.rv
+++ b/examples/v2/stdlib_json_decode.rv
@@ -1,0 +1,20 @@
+// Decode a JSON string into a struct with std/json's `decode`, then re-serialize
+// it with the `@derive(ToJson)` impl. The two derives synthesize the conversions.
+import std/json { decode, stringify, ToJson }
+import std/io { println }
+
+@derive(ToJson, FromJson)
+struct User {
+    name: String,
+    age: Int,
+}
+
+fun main() {
+    match decode<User>("{\"name\":\"Ada\",\"age\":36}") {
+        Ok(u) -> {
+            println("name=${u.name} age=${u.age}")
+            println(stringify(u.to_json()))
+        }
+        Err(e) -> println("decode error"),
+    }
+}

--- a/examples/v2/stdlib_json_decode.rv.out
+++ b/examples/v2/stdlib_json_decode.rv.out
@@ -1,0 +1,2 @@
+name=Ada age=36
+{"name":"Ada","age":36}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -12,6 +12,8 @@ import std/error { error_kind }
 import std/net { listen, TcpStream }
 import std/string
 import std/collections
+import std/json { JsonValue, ToJson, stringify, parse }
+import std/fs { read }
 
 struct HttpResponse {
     status_code: Int,
@@ -177,6 +179,13 @@ impl Request {
     fun query_value(self, name: String) -> String {
         return self.query.get_or(name, "")
     }
+
+    // Parse the request body as JSON, returning a `JsonValue` to inspect, or an
+    // Err for malformed JSON. To decode straight into a struct, prefer
+    // `std/json`'s `decode<T>(req.body)`.
+    fun json(self) -> Result<JsonValue, Error> {
+        return parse(self.body)
+    }
 }
 
 // One HTTP response: a status code, response headers, and a body. Build one
@@ -195,6 +204,22 @@ impl Response {
         return Response { status: status, headers: h, body: body }
     }
 
+    // 200 with `value` serialized to JSON via its `ToJson` impl (a `@derive(
+    // ToJson)` struct or enum, a List, an Option, or a scalar), with
+    // `Content-Type: application/json`. Chain `.status_code(201)` for Created.
+    fun json<T: ToJson>(value: T) -> Response {
+        return Response.with_body(200, stringify(value.to_json())).content_type("application/json")
+    }
+
+    // 200 serving the file at `path` from disk, with a `Content-Type` chosen
+    // from its extension. A missing or unreadable file is a 404.
+    fun file(path: String) -> Response {
+        return match read(path) {
+            Ok(body) -> Response.with_body(200, body).content_type(content_type_for(path)),
+            Err(_) -> Response.not_found(),
+        }
+    }
+
     // 200 with a `text/plain` body.
     fun text(body: String) -> Response {
         return Response.with_body(200, body).content_type("text/plain; charset=utf-8")
@@ -210,8 +235,10 @@ impl Response {
         return Response.with_body(200, body).content_type("text/html; charset=utf-8")
     }
 
-    // 200 with an `application/json` body. `body` must already be JSON text.
-    fun json(body: String) -> Response {
+    // 200 with `body` (already JSON text) and an `application/json` type. Use
+    // `Response.json(value)` instead to serialize a value; this is for a body
+    // you have already rendered.
+    fun json_raw(body: String) -> Response {
         return Response.with_body(200, body).content_type("application/json")
     }
 
@@ -313,6 +340,15 @@ impl Server {
     // Register a handler for PATCH `pattern`.
     fun patch(self, pattern: String, handler: fun(Request) -> Response) {
         self.route(Method.Patch, pattern, handler)
+    }
+
+    // Serve files under directory `dir` for GET requests whose path is `prefix`
+    // followed by a file name, for example `app.static("/static", "public")`
+    // serves `GET /static/style.css` from `public/style.css`. The file name is a
+    // single path segment, so it cannot escape `dir` with a slash. A missing
+    // file is a 404 (see `Response.file`).
+    fun static(self, prefix: String, dir: String) {
+        self.route(Method.Get, prefix.concat("/:file"), fun(req: Request) -> Response = serve_from(dir, req))
     }
 
     // Bind `addr` ("host:port") and serve forever, handling each connection on
@@ -552,4 +588,32 @@ fun reason_phrase(status: Int) -> String {
         return "Internal Server Error"
     }
     return "OK"
+}
+
+// Serve the `:file` capture of a `Server.static` route from its directory.
+fun serve_from(dir: String, req: Request) -> Response {
+    return Response.file(dir.concat("/").concat(req.param("file")))
+}
+
+// A `Content-Type` for a file path, chosen from its extension.
+fun content_type_for(path: String) -> String {
+    if path.ends_with(".html") {
+        return "text/html; charset=utf-8"
+    }
+    if path.ends_with(".css") {
+        return "text/css; charset=utf-8"
+    }
+    if path.ends_with(".js") {
+        return "application/javascript"
+    }
+    if path.ends_with(".json") {
+        return "application/json"
+    }
+    if path.ends_with(".svg") {
+        return "image/svg+xml"
+    }
+    if path.ends_with(".txt") {
+        return "text/plain; charset=utf-8"
+    }
+    return "application/octet-stream"
 }

--- a/stdlib/std/json.rv
+++ b/stdlib/std/json.rv
@@ -782,6 +782,14 @@ fun from_json_value<T: FromJson>(j: JsonValue) -> Result<T, Error> {
     return T.from_json(j)
 }
 
+// Parse a JSON string and decode it into a `T` in one step. The element type is
+// chosen by the call, so `decode<Point>(text)` or a `Result<Point, Error>`
+// annotation selects the impl. Returns an Err for malformed JSON or a shape that
+// does not match `T`.
+fun decode<T: FromJson>(s: String) -> Result<T, Error> {
+    return from_json_value(parse(s)?)
+}
+
 // Read object member `key`, or an Err when `j` is not an object or the key
 // is absent. Useful in a hand-written `from_json` to fetch a field before
 // decoding it (`@derive(FromJson)` emits its own equivalent helper).


### PR DESCRIPTION
**Closes #386.** Design: `docs/v2/specs/std-http-dx.md`.

Moves the boilerplate a `std/http` app used to write into the library, on top of `std/json`'s `ToJson`/`FromJson`.

## JSON
- **`Response.json(value)`** — serialize any `ToJson` value (a `@derive(ToJson)` struct/enum, `List`, `Option`, scalar). Kills hand-built JSON strings and all manual escaping. (The old `Response.json(String)` is renamed **`json_raw`** for pre-rendered bodies.)
- **`std/json.decode<T: FromJson>(body)`** — parse + decode a request body into a struct in one call. **`Request.json()`** returns a `JsonValue`.

## Static files
- **`Response.file(path)`** — serve a file with content-type by extension, 404 if missing.
- **`Server.static(prefix, dir)`** — mount a directory (single path segment).

## This PR
- The `http_server` example is rewritten on the new surface; a new `stdlib_json_decode` golden covers `decode` + `ToJson` round-trip; spec + guide updated.
- **lib (523)** and **golden** pass; clippy clean.

## Out of scope
The fully-typed method `req.json<Note>()` needs the method-generic-instantiation fix (**#384**); the free `decode<T>` gives the same handler ergonomics today. The prerequisite type-checker panic was fixed separately in #385.