### PR TITLE
fix(rvpm): run the compiler on a generous-stack worker thread

### DIFF
--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -16,7 +16,25 @@ use raven::ops;
 use raven::pkg;
 use raven::resolve::GithubPath;
 
+/// `rvpm build`/`run` invoke the compiler, which recurses deeply (derive
+/// expansion, type checking), enough to overflow the default main-thread stack
+/// in debug builds. Run the work on a thread with a generous stack, the same as
+/// the `raven` CLI. The reservation is virtual address space; the OS commits
+/// pages only as they are touched.
+const COMPILER_STACK_SIZE: usize = 512 * 1024 * 1024;
+
 fn main() -> ExitCode {
+    let worker = std::thread::Builder::new()
+        .stack_size(COMPILER_STACK_SIZE)
+        .spawn(dispatch)
+        .expect("spawn rvpm worker thread");
+    match worker.join() {
+        Ok(code) => code,
+        Err(_) => ExitCode::from(101),
+    }
+}
+
+fn dispatch() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match args.first().map(String::as_str) {
         None | Some("help") | Some("--help") | Some("-h") => {


### PR DESCRIPTION
**Closes #388.**

`rvpm build`/`run` invoked the compiler on rvpm's **main thread** (default 8 MB stack), while the `raven` CLI runs it on a worker thread with a **512 MB** stack (`COMPILER_STACK_SIZE`). Deep compiler recursion, e.g. a program using `@derive(ToJson)`, overflowed under rvpm (`thread 'main' has overflowed its stack`, exit 127) even though `raven build` of the same source succeeded.

rvpm now runs its work on the same generous-stack worker thread as the CLI. Verified: an rvpm project using `@derive(ToJson)` (the std/http JSON DX from #386) now builds and runs.