### PR TITLE
build: release 2.17.0, std/http JSON and static files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.17.0] - 2026-06-08
+
+### Added
+
+- JSON and static file serving in `std/http`. `Response.json(value)` serializes any value whose type implements `ToJson` (a `@derive(ToJson)` struct or enum, a `List`, an `Option`, a scalar) with `Content-Type: application/json`, replacing hand-built JSON strings and manual escaping; `Response.json_raw(body)` keeps the pre-rendered-JSON form. `std/json.decode<T: FromJson>(body)` parses and decodes a request body into a struct in one call, and `Request.json()` returns the body as a `JsonValue`. `Response.file(path)` serves a file with a `Content-Type` chosen from its extension (404 if missing), and `Server.static(prefix, dir)` mounts a directory of files (#386).
+
+### Fixed
+
+- The type checker no longer panics when it finalizes a function body after an earlier body left an unresolved inference variable. It shared one type map across all bodies but resolved the whole map with the current body's inference context, crashing on a variable another body owned. It now resolves only each body's own entries, so a generic call whose type argument cannot be inferred reports a clear error instead.
+- `rvpm build` and `rvpm run` no longer overflow the stack on deeply recursive compilation, for example a program that uses `@derive(ToJson)`. rvpm runs the compiler on a worker thread with a generous stack, matching the `raven` CLI (#388).
+
 ## [2.16.0] - 2026-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.16.0"
+version = "2.17.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.16.0"
+version = "2.17.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.16.0"
+version = "2.17.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
Release prep for **2.17.0**.

## Since 2.16.0
- **#386** std/http developer experience: `Response.json(value)` / `json_raw` / `Request.json`, `std/json.decode<T>`, and `Response.file` / `Server.static` for static files.
- **#385** tycheck no longer panics finalizing a body after an earlier one left an unresolved inference variable.
- **#388** rvpm no longer overflows the stack on deep compilation (`@derive(ToJson)`); runs on a generous-stack worker like the raven CLI.

## This PR
- Version -> 2.17.0; CHANGELOG 2.17.0 section.

After merge, tag `v2.17.0`.