### PR TITLE
build: release 2.17.1, return-only generic method inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.17.1] - 2026-06-08
+
+### Fixed
+
+- A generic method whose type parameter appears only in the return type (for example `fun decode<T: FromJson>(self) -> Result<T, Error>`) can now be called. The explicit form `recv.decode<T>()` was ignoring the type argument, and the annotated form `let n: T = recv.decode()` was monomorphizing the parameter to `Unit`. The type checker now applies a method call's explicit type arguments, and MIR lowering matches the declared return type against the call's resolved result type so the parameter is recovered for monomorphization (#384).
+
 ## [2.17.0] - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.17.0"
+version = "2.17.1"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.17.0"
+version = "2.17.1"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.17.0"
+version = "2.17.1"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
Patch release **2.17.1**.

## Since 2.17.0
- **#384** A generic method whose type parameter appears only in the return type (e.g. `fun decode<T: FromJson>(self) -> Result<T, Error>`) can now be called, both `recv.decode<T>()` and `let n: T = recv.decode()`.

## This PR
- Version -> 2.17.1; CHANGELOG 2.17.1 section.

After merge, tag `v2.17.1`.