### PR TITLE
feat(stdlib): typed Request.json<T: FromJson>() in std/http

### DIFF
--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -349,24 +349,23 @@ fun show_user(req: Request) -> Response {
 }
 ```
 
-To read a JSON request body into a struct, use `decode<T>` from
-[std/json](json.md). Decoding failures (bad JSON, a missing or mistyped field)
-come back as an `Error`:
+To read a JSON request body into a struct, use `req.json<T>()`, which decodes
+the body through the type's `FromJson` impl. Decoding failures (bad JSON, a
+missing or mistyped field) come back as an `Error`:
 
 ```rust
-import std/json { decode }
-
 fun create_user(req: Request) -> Response {
-    return match decode<User>(req.body) {
+    return match req.json<User>() {
         Ok(user) -> Response.json(user).status_code(201),
         Err(e) -> Response.bad_request(e.message()),
     }
 }
 ```
 
-`req.json()` returns the body as a `JsonValue` for ad-hoc inspection when a
-struct is overkill. For a typed struct, decode the body with
-`decode<User>(req.body)`.
+The type can also come from an annotation, `let user: User = req.json()?`, and
+`decode<User>(req.body)` from [std/json](json.md) does the same thing without a
+request. For ad-hoc access when a struct is overkill, `req.json_value()` returns
+the body as a `JsonValue`.
 
 ### Serving files
 

--- a/docs/v2/specs/std-http.md
+++ b/docs/v2/specs/std-http.md
@@ -158,7 +158,8 @@ struct Request {
 fun Request.header(name) -> String          // "" if absent
 fun Request.param(name) -> String           // path capture, "" if absent
 fun Request.query_value(name) -> String     // "" if absent
-fun Request.json(self) -> Result<JsonValue, Error>   // parse the body
+fun Request.json<T: FromJson>(self) -> Result<T, Error>  // decode the body into a struct
+fun Request.json_value(self) -> Result<JsonValue, Error> // parse the body to a JsonValue
 
 struct Response { status: Int, headers: Map<String, String>, body: String }
 // constructors

--- a/examples/v2/http_server.rv
+++ b/examples/v2/http_server.rv
@@ -9,7 +9,6 @@
 // Each connection is handled on its own goroutine.
 
 import std/http { Server, Request, Response }
-import std/json { decode }
 
 @derive(ToJson)
 struct SearchResult {
@@ -37,7 +36,7 @@ fun search(req: Request) -> Response {
 }
 
 fun create_user(req: Request) -> Response {
-    return match decode<User>(req.body) {
+    return match req.json<User>() {
         Ok(user) -> Response.json(user).status_code(201),
         Err(e) -> Response.bad_request(e.message()),
     }

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -12,7 +12,7 @@ import std/error { error_kind }
 import std/net { listen, TcpStream }
 import std/string
 import std/collections
-import std/json { JsonValue, ToJson, stringify, parse }
+import std/json { JsonValue, ToJson, FromJson, stringify, parse, decode }
 import std/fs { read }
 
 struct HttpResponse {
@@ -180,10 +180,16 @@ impl Request {
         return self.query.get_or(name, "")
     }
 
-    // Parse the request body as JSON, returning a `JsonValue` to inspect, or an
-    // Err for malformed JSON. To decode straight into a struct, prefer
-    // `std/json`'s `decode<T>(req.body)`.
-    fun json(self) -> Result<JsonValue, Error> {
+    // Decode the request body into a `T` via its `FromJson` impl, for example
+    // `req.json<User>()` or `let u: User = req.json()?`. Returns an Err for
+    // malformed JSON or a body that does not match `T`.
+    fun json<T: FromJson>(self) -> Result<T, Error> {
+        return decode(self.body)
+    }
+
+    // Parse the request body as JSON to a `JsonValue` for ad-hoc inspection,
+    // when a struct is overkill. Returns an Err for malformed JSON.
+    fun json_value(self) -> Result<JsonValue, Error> {
         return parse(self.body)
     }
 }


### PR DESCRIPTION
**Closes #393.** Enabled by #384 (return-only generic method inference).

Adds a typed request decoder so a handler writes:
```rust
match req.json<User>() { Ok(user) -> ..., Err(e) -> Response.bad_request(e.message()) }
// or: let user: User = req.json()?
```
instead of the free `decode<User>(req.body)` (which still exists).

## Breaking refinement
`Request.json()` previously returned a `JsonValue` (shipped one day ago in 2.17.0). It is now the typed decoder; the ad-hoc JsonValue form is **`Request.json_value()`**. The `http_server` example and the std/http guide/spec are updated.

## Verification
The notes test app and the example use `req.json<T>()` and decode correctly (bad JSON -> 400). lib (524), golden, codegen_smoke (72) pass; clippy clean.