### PR TITLE
build: release 2.18.0, typed Request.json in std/http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.0] - 2026-06-08
+
+### Added
+
+- `Request.json<T: FromJson>()` in `std/http` decodes a request body straight into a struct: `req.json<User>()` or `let u: User = req.json()?`. It is enabled by the return-only generic method inference from 2.17.1 and is equivalent to the free `decode<User>(req.body)`.
+
+### Changed
+
+- `Request.json()` is now the typed decoder above. The ad-hoc form that parses the body into a `JsonValue` is now `Request.json_value()`. (The previous `Request.json() -> Result<JsonValue, Error>` shipped in 2.17.0.)
+
 ## [2.17.1] - 2026-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.17.1"
+version = "2.18.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.17.1"
+version = "2.18.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.17.1"
+version = "2.18.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
Minor release **2.18.0**.

## Since 2.17.1
- **#393** `Request.json<T: FromJson>()` decodes a request body into a struct (`req.json<User>()` / `let u: User = req.json()?`). The ad-hoc JsonValue form is now `Request.json_value()`.

## This PR
- Version -> 2.18.0; CHANGELOG 2.18.0 section.

After merge, tag `v2.18.0`.