### PR TITLE
ci: pause Actions, run on pull requests to main only when re-enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,30 +1,25 @@
 name: Raven CI
 
+# CI is paused while we work through the bug backlog (issues #396-#444) to keep
+# Actions usage down. Only manual runs fire for now.
+#
+# To turn it back on, drop the workflow_dispatch line and uncomment the
+# pull_request block. We run on pull requests to main only, never on push or
+# merge to main, so a change is not built twice.
 on:
-  push:
-    branches: [ "main", "v1.x-maintenance", "v2.x" ]
-    paths:
-      - "src/**"
-      - "lib/**"
-      - "examples/**"
-      - "tests/**"
-      - "raven-runtime/**"
-      - "benchmarks/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/ci.yml"
-  pull_request:
-    branches: [ "main", "v1.x-maintenance", "v2.x" ]
-    paths:
-      - "src/**"
-      - "lib/**"
-      - "examples/**"
-      - "tests/**"
-      - "raven-runtime/**"
-      - "benchmarks/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/ci.yml"
+  workflow_dispatch:
+  # pull_request:
+  #   branches: [ "main" ]
+  #   paths:
+  #     - "src/**"
+  #     - "lib/**"
+  #     - "examples/**"
+  #     - "tests/**"
+  #     - "raven-runtime/**"
+  #     - "benchmarks/**"
+  #     - "Cargo.toml"
+  #     - "Cargo.lock"
+  #     - ".github/workflows/ci.yml"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Turning CI off for now while we clear the bug backlog (#396-#444) so we are not paying for Actions on every push.

The workflow stays in the repo behind `workflow_dispatch`. When we switch it back on it runs on pull requests to main only, not on merges to main, so a commit is not built twice. The re-enable steps are at the top of the file.