### PR TITLE
fix(mir): short-circuit && and ||

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.1] - 2026-06-10
+
+### Fixed
+
+- `&&` and `||` now short-circuit. The right operand is only evaluated when the left does not already decide the result, so a guard like `i < xs.len() && xs[i] == x` no longer runs the index when the bounds check fails (#441).
+
 ## [2.18.0] - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.0"
+version = "2.18.1"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.0"
+version = "2.18.1"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.0"
+version = "2.18.1"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/short_circuit.rv
+++ b/examples/v2/short_circuit.rv
@@ -1,0 +1,23 @@
+// `&&` and `||` only evaluate the right operand when the left does not already
+// decide the answer. The classic case is a bounds guard: if the length check
+// fails, the index must never run, or the program crashes.
+import std/io { println }
+import std/collections
+
+fun main() {
+    let xs: List<Int> = [10, 20, 30]
+    let out_of_range = 5
+
+    if out_of_range < xs.len() && xs[out_of_range] == 20 {
+        println("entered (wrong)")
+    } else {
+        println("guard held, index skipped")
+    }
+
+    let zero = 0
+    if zero == 0 || xs[99] == 1 {
+        println("or short-circuited")
+    } else {
+        println("entered else (wrong)")
+    }
+}

--- a/examples/v2/short_circuit.rv.out
+++ b/examples/v2/short_circuit.rv.out
@@ -1,0 +1,2 @@
+guard held, index skipped
+or short-circuited

--- a/src/mir/lower/expr.rs
+++ b/src/mir/lower/expr.rs
@@ -93,6 +93,14 @@ pub fn lower_expr(cx: &mut LowerCx<'_>, expr: &HirExpr) -> MirOperand {
             MirOperand::Copy(dst)
         }
         HirExprKind::Binary { op, lhs, rhs } => {
+            // `&&` and `||` short-circuit: the right operand only runs when the
+            // left does not already decide the result. Lower them to branches
+            // rather than a plain binary op so a guard like
+            // `i < xs.len() && xs[i] == x` never evaluates the index when the
+            // bound check fails.
+            if matches!(op, HirBinaryOp::And | HirBinaryOp::Or) {
+                return lower_short_circuit(cx, matches!(op, HirBinaryOp::And), lhs, rhs, ty);
+            }
             // `==`/`!=` on `String` compare contents, not object identity,
             // so route them through the runtime byte-equality intrinsic.
             // `!=` negates the equality result. Every other operand type
@@ -849,6 +857,65 @@ pub fn lower_block(cx: &mut LowerCx<'_>, block: &HirBlock) -> MirOperand {
     };
     cx.pop_scope();
     result
+}
+
+/// Lower `lhs && rhs` (`is_and`) or `lhs || rhs` with short-circuit semantics.
+/// The left operand is evaluated first; the right operand runs only when the
+/// left does not settle the answer (left true for `&&`, left false for `||`).
+/// Otherwise the result is the short-circuit constant (`false` for `&&`,
+/// `true` for `||`) and the right operand is never touched.
+fn lower_short_circuit(
+    cx: &mut LowerCx<'_>,
+    is_and: bool,
+    lhs: &HirExpr,
+    rhs: &HirExpr,
+    ty: MirType,
+) -> MirOperand {
+    let discr = lower_expr(cx, lhs);
+    let rhs_bb = cx.builder.new_block();
+    let short_bb = cx.builder.new_block();
+    let cont_bb = cx.builder.new_block();
+    let result = cx.builder.fresh_temp(if is_and { "and" } else { "or" }, ty);
+
+    // For `&&`, a true left falls through to the right operand and a false left
+    // takes the short-circuit block. For `||` it is the other way round.
+    let (then_target, else_target) = if is_and {
+        (rhs_bb, short_bb)
+    } else {
+        (short_bb, rhs_bb)
+    };
+    cx.builder.close_block(
+        cx.current,
+        MirTerminator::SwitchInt {
+            discriminant: discr,
+            targets: vec![(1, then_target)],
+            otherwise: else_target,
+        },
+    );
+
+    cx.current = rhs_bb;
+    let rv = lower_expr(cx, rhs);
+    cx.builder.assign(cx.current, result, MirRvalue::Use(rv));
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, MirTerminator::Goto(cont_bb));
+    }
+
+    cx.current = short_bb;
+    cx.builder.assign(
+        cx.current,
+        result,
+        MirRvalue::Use(MirOperand::Const(MirConstant::Bool(!is_and))),
+    );
+    if !cx.builder.is_closed(cx.current) {
+        cx.builder
+            .close_block(cx.current, MirTerminator::Goto(cont_bb));
+    }
+
+    cx.current = cont_bb;
+    // The merge block is reachable even if the right operand diverged.
+    cx.diverged = false;
+    MirOperand::Copy(result)
 }
 
 fn lower_if(


### PR DESCRIPTION
Closes #441.

`&&` and `||` were lowered to a plain binary op, so both operands always ran. That breaks the everyday bounds guard: in `i < xs.len() && xs[i] == x` the index runs even when the length check fails, and the program panics out of bounds.

They now lower to branches. For `&&` the right operand runs only when the left is true; for `||` only when the left is false. Otherwise the result is the short-circuit constant and the right side is never evaluated.

Added `examples/v2/short_circuit.rv`, which crashes without the fix and prints a clean result with it. lib (524) and codegen_smoke (72) pass. Version bumped to 2.18.1.