### PR TITLE
fix(mir): keep the value in a match binding arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.2] - 2026-06-10
+
+### Fixed
+
+- A binding arm in a `match` over a `String`, `Float`, or struct scrutinee no longer loses the value. The bound name was stored in a Unit slot, so it came back empty inside the arm; it now keeps the scrutinee's real type (#442).
+
 ## [2.18.1] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.1"
+version = "2.18.2"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.1"
+version = "2.18.2"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.1"
+version = "2.18.2"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/match_binding.rv
+++ b/examples/v2/match_binding.rv
@@ -1,0 +1,25 @@
+// A binding arm in a match must hand the arm the scrutinee's value at its real
+// type. For a String, Float, or struct scrutinee the bound name was coming back
+// empty because the binding slot was typed Unit.
+import std/io { println }
+
+struct Point { x: Int, y: Int }
+
+fun classify(s: String) -> String {
+    return match s {
+        "hello" -> "greeting",
+        other -> other,
+    }
+}
+
+fun first_coord(p: Point) -> Int {
+    return match p {
+        pt -> pt.x,
+    }
+}
+
+fun main() {
+    println(classify("hello"))
+    println(classify("world"))
+    println(first_coord(Point { x: 7, y: 9 }).to_string())
+}

--- a/examples/v2/match_binding.rv.out
+++ b/examples/v2/match_binding.rv.out
@@ -1,0 +1,3 @@
+greeting
+world
+7

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -51,7 +51,7 @@ pub fn lower_match(
     } else if matches!(scrut_ty, Ty::Int | Ty::Bool | Ty::Char) {
         lower_int_match(cx, scrut_op, arms, result_local, cont);
     } else {
-        lower_fallback_match(cx, scrut_op, arms, result_local, cont);
+        lower_fallback_match(cx, scrut_op, &scrut_ty, arms, result_local, cont);
     }
 
     cx.current = cont;
@@ -153,6 +153,7 @@ fn lower_int_match(
 fn lower_fallback_match(
     cx: &mut LowerCx<'_>,
     scrut: MirOperand,
+    scrut_ty: &Ty,
     arms: &[HirArm],
     result: super::super::ir::MirLocal,
     cont: MirBlockId,
@@ -222,13 +223,12 @@ fn lower_fallback_match(
         cx.current = arm_block;
         // Bind name for `Binding` patterns.
         if let HirPatternKind::Binding(name) = &arm.pattern.kind {
-            // We do not know the scrutinee type here at MIR level
-            // beyond what is in HIR; rely on the type checker having
-            // recorded it on the arm body's binding instead.
-            // Materialize the binding as a Use of the scrutinee.
+            // Bind the name to the scrutinee value at its real type. Using a
+            // Unit slot here dropped the value: a `String`, `Float`, or struct
+            // scrutinee came back empty inside the arm body.
             let local = cx
                 .builder
-                .named_local(name.clone(), super::super::ty::MirType::Unit);
+                .named_local(name.clone(), super::super::ty::MirType::from_ty(scrut_ty));
             cx.builder
                 .assign(arm_block, local, MirRvalue::Use(scrut.clone()));
             cx.bind(name.clone(), local);


### PR DESCRIPTION
Closes #442.

A binding arm in a `match` over a non-enum scrutinee (`match s { "x" -> ..., other -> other }`) stored the bound name in a Unit slot, so the value was lost: a String, Float, or struct came back empty inside the arm.

The fallback match path now types the binding local from the scrutinee type, the same way the enum path already does. Added `examples/v2/match_binding.rv`. lib (524) and codegen_smoke (72) pass. Version 2.18.2.