### PR TITLE
fix(mir): capture self in closures, defer, and spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.3] - 2026-06-10
+
+### Fixed
+
+- A closure, `defer`, or `spawn` body inside a method can now refer to `self`. It was not captured, so the lifted body had no `self` and the build failed (#440).
+
 ## [2.18.2] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.2"
+version = "2.18.3"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.2"
+version = "2.18.3"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.2"
+version = "2.18.3"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/closure_captures_self.rv
+++ b/examples/v2/closure_captures_self.rv
@@ -1,0 +1,23 @@
+// A closure, defer, or spawn body inside a method can refer to `self`. It is
+// captured from the method like any other local; before, the lifted body had no
+// `self` and the build failed.
+import std/io { println }
+
+struct Counter { value: Int }
+
+impl Counter {
+    fun getter(self) -> fun() -> Int {
+        return fun() -> Int = self.value
+    }
+    fun announce(self) {
+        defer println("done with ${self.value.to_string()}")
+        println("working on ${self.value.to_string()}")
+    }
+}
+
+fun main() {
+    let c = Counter { value: 42 }
+    let g = c.getter()
+    println(g().to_string())
+    c.announce()
+}

--- a/examples/v2/closure_captures_self.rv.out
+++ b/examples/v2/closure_captures_self.rv.out
@@ -1,0 +1,3 @@
+42
+working on 42
+done with 42

--- a/src/mir/lower/closure.rs
+++ b/src/mir/lower/closure.rs
@@ -434,7 +434,6 @@ fn collect_free_expr(
         | HirExprKind::Char(_)
         | HirExprKind::CStr(_)
         | HirExprKind::Unit
-        | HirExprKind::SelfValue
         | HirExprKind::GlobalGet(_)
         | HirExprKind::NoneCtor
         | HirExprKind::TypeName(_)
@@ -443,6 +442,11 @@ fn collect_free_expr(
         | HirExprKind::VariantNames(_)
         | HirExprKind::VariantFieldTypes(_)
         | HirExprKind::Continue => {}
+        // `self` inside a closure/defer/spawn body is a free variable: it must
+        // be captured from the enclosing method like any other local, or the
+        // lifted body has no `self` and reads a Unit. It is bound under the name
+        // "self", which is exactly what `SelfValue` looks up when lowered.
+        HirExprKind::SelfValue => record_use("self", bound, seen, out),
         HirExprKind::Ident(name) => record_use(name, bound, seen, out),
         HirExprKind::Array(items) => {
             for it in items {


### PR DESCRIPTION
Closes #440.

A closure, `defer`, or `spawn` body inside a method that referred to `self` did not capture it, so the lifted body had no `self` in scope and the build failed with `field base used a Unit value`.

`self` is now collected as a free variable and captured like any other local. The lifted body binds it under the name `self`, which is exactly what `SelfValue` looks up, so all three forms work. Verified closures, `defer`, and `spawn` over `self`. Added `examples/v2/closure_captures_self.rv`. lib (524) and codegen_smoke (72) pass. Version 2.18.3.