### PR TITLE
fix(hir): stop inclusive range loops at end instead of overflowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.4] - 2026-06-10
+
+### Fixed
+
+- An inclusive range loop (`for i in a..=b`) to `i64::MAX` no longer runs forever. The counter was incremented past `end`, which wrapped to `i64::MIN`; the loop now stops once it reaches `end` (#444).
+
 ## [2.18.3] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.3"
+version = "2.18.4"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.3"
+version = "2.18.4"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.3"
+version = "2.18.4"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/inclusive_range.rv
+++ b/examples/v2/inclusive_range.rv
@@ -1,0 +1,27 @@
+// An inclusive range loop must stop after `end` instead of incrementing past
+// it. To `i64::MAX` that overflow used to wrap the counter and loop forever.
+import std/io { println }
+
+fun main() {
+    let sum = 0
+    for i in 1..=5 {
+        sum = sum + i
+    }
+    println("sum 1..=5: ${sum.to_string()}")
+
+    let count = 0
+    for i in 0..3 {
+        count = count + 1
+    }
+    println("count 0..3: ${count.to_string()}")
+
+    let max = 9223372036854775807
+    let near = 0
+    for i in (max - 2)..=max {
+        near = near + 1
+        if near > 10 {
+            break
+        }
+    }
+    println("count near max: ${near.to_string()}")
+}

--- a/examples/v2/inclusive_range.rv.out
+++ b/examples/v2/inclusive_range.rv.out
@@ -1,0 +1,3 @@
+sum 1..=5: 15
+count 0..3: 3
+count near max: 3

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -1219,11 +1219,55 @@ fn lower_counter_for(
         ),
         span.clone(),
     );
+    // For an inclusive range the counter must not be incremented past `end`:
+    // a loop to `i64::MAX` would wrap to `i64::MIN` and run forever. Once `__i`
+    // has reached `end`, break instead of incrementing. This sits in the
+    // advance step at the top of the loop, so it also holds when the body uses
+    // `continue`. An exclusive range stops at `end` before ever incrementing
+    // into it, so it keeps the plain increment.
+    let step_block = if inclusive {
+        let at_end = make_expr(
+            HirExprKind::Binary {
+                op: HirBinaryOp::Eq,
+                lhs: Box::new(ident_expr(&i_name, Ty::Int, span.clone())),
+                rhs: Box::new(ident_expr(&end_name, Ty::Int, span.clone())),
+            },
+            Ty::Bool,
+            span.clone(),
+        );
+        let break_at_end = HirStmt {
+            kind: HirStmtKind::Expr(make_expr(HirExprKind::Break(None), Ty::Error, span.clone())),
+            span: span.clone(),
+        };
+        let guarded = make_expr(
+            HirExprKind::If {
+                cond: Box::new(at_end),
+                then_block: HirBlock {
+                    stmts: vec![break_at_end],
+                    tail: None,
+                    ty: Ty::Unit,
+                    span: span.clone(),
+                },
+                else_block: Some(block_of_stmt(inc, span)),
+            },
+            Ty::Unit,
+            span.clone(),
+        );
+        block_of_stmt(
+            HirStmt {
+                kind: HirStmtKind::Expr(guarded),
+                span: span.clone(),
+            },
+            span,
+        )
+    } else {
+        block_of_stmt(inc, span)
+    };
     let advance = make_expr(
         HirExprKind::If {
             cond: Box::new(ident_expr(&first_name, Ty::Bool, span.clone())),
             then_block: block_of_stmt(set_first_false, span),
-            else_block: Some(block_of_stmt(inc, span)),
+            else_block: Some(step_block),
         },
         Ty::Unit,
         span.clone(),


### PR DESCRIPTION
Closes #444.

`for i in a..=b` advanced the counter and then checked `i > end`. At `b == i64::MAX` the body ran for MAX, the next increment wrapped to MIN, and MIN is not greater than MAX, so the loop ran forever.

For an inclusive range the advance step now breaks once the counter reaches `end` rather than incrementing past it. It sits at the top of the loop, so it also holds under `continue`. Exclusive ranges are untouched. Added `examples/v2/inclusive_range.rv` (normal loops plus the MAX edge). lib (524) and golden pass. Version 2.18.4.