### PR TITLE
fix(mir): cap generic instantiation depth so the monomorphizer cannot hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.5] - 2026-06-10
+
+### Fixed
+
+- The monomorphizer no longer hangs on a generic function that instantiates itself at an ever larger type (`fun f<T>(x: T) { f(wrap(x)) }`). It now stops at a nesting depth of 128 and reports a clear error instead of looping forever (#443).
+
 ## [2.18.4] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.4"
+version = "2.18.5"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.4"
+version = "2.18.5"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.4"
+version = "2.18.5"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/mir/mono.rs
+++ b/src/mir/mono.rs
@@ -20,7 +20,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::error::RavenError;
+use crate::error::{RavenError, TypeError};
 use crate::hir::{HirFn, HirItemKind, HirProgram, HirStruct};
 use crate::resolve::DeclId;
 use crate::tycheck::ty::ParamId;
@@ -74,6 +74,33 @@ struct MethodSymbolEntry {
     method_params: Vec<ParamId>,
 }
 
+/// The deepest a generic instantiation's type arguments may nest before the
+/// monomorphizer gives up. A hand written program stays far below this; going
+/// past it means a generic function is recursing into an ever larger type and
+/// will never reach a concrete one.
+const MONO_TYPE_DEPTH_LIMIT: usize = 128;
+
+/// The nesting depth of a type: how many constructors deep its deepest leaf
+/// sits. `Int` is 1, `List<Int>` is 2, `List<List<Int>>` is 3, and so on.
+fn ty_depth(ty: &Ty) -> usize {
+    match ty {
+        Ty::Struct { args, .. } | Ty::Enum { args, .. } => {
+            1 + args.iter().map(ty_depth).max().unwrap_or(0)
+        }
+        Ty::Option(t) | Ty::List(t) | Ty::SelfTy(t) => 1 + ty_depth(t),
+        Ty::Result(a, b) => 1 + ty_depth(a).max(ty_depth(b)),
+        Ty::Function { params, ret } => {
+            1 + params
+                .iter()
+                .map(ty_depth)
+                .max()
+                .unwrap_or(0)
+                .max(ty_depth(ret))
+        }
+        _ => 1,
+    }
+}
+
 /// Run the full monomorphization pass.
 pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
     let mut program = MirProgram::new();
@@ -103,6 +130,21 @@ pub fn monomorphize(hir: &HirProgram) -> Result<MirProgram, RavenError> {
             Some(f) => *f,
             None => continue,
         };
+        // Guard against a non-terminating generic recursion: a function that
+        // instantiates itself at an ever larger type (`fun f<T>(x: T) { f(wrap(x)) }`)
+        // produces a new, deeper key every time, so the worklist would grow
+        // without bound and the compiler would hang. Cap how deeply an
+        // instantiation's type arguments may nest and report it instead.
+        if let Some(depth) = subst.values().map(ty_depth).max() {
+            if depth > MONO_TYPE_DEPTH_LIMIT {
+                return Err(RavenError::ty(
+                    TypeError::Custom(format!(
+                        "generic instantiation nested too deeply ({depth} levels deep). This usually means a generic function instantiates itself at an ever larger type and never settles on a concrete one"
+                    )),
+                    hir_fn.span.clone(),
+                ));
+            }
+        }
         // A method's symbol is the concrete implementing type followed by
         // `$<method>`, computed by substituting the instantiation's type
         // arguments into the declared implementing type. This matches what

--- a/src/mir/tests.rs
+++ b/src/mir/tests.rs
@@ -61,6 +61,25 @@ fn compile_with_prelude(src: &str) -> MirProgram {
     lower_program(&hir).expect("mir")
 }
 
+#[test]
+fn recursive_generic_instantiation_is_rejected_not_hung() {
+    // A generic function that instantiates itself at an ever larger type would
+    // give the monomorphizer a new key every round and loop forever. It must
+    // instead report a clean depth-limit error.
+    let src = "struct Box<T> { value: T }\nfun deep<T>(x: T) {\n    deep(Box { value: x })\n}\nfun main() {\n    deep(0)\n}\n";
+    let tokens = Lexer::new(src.to_string(), PathBuf::from("t.rv"))
+        .tokenize()
+        .expect("lex");
+    let file = parse(&tokens).expect("parse");
+    let mut loader = NoLoader;
+    let resolved = resolve_file(&file, &mut loader).expect("resolve");
+    let typed = check_file(&resolved).expect("tycheck");
+    let hir = lower_file(&typed).expect("hir");
+    let err = lower_program(&hir).expect_err("expected a depth-limit error, not success");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("nested too deeply"), "got: {msg}");
+}
+
 fn find_fn<'a>(p: &'a MirProgram, name: &str) -> &'a MirFunction {
     p.functions
         .iter()


### PR DESCRIPTION
Closes #443.

A generic function that instantiates itself at an ever larger type (`fun deep<T>(x: T) { deep(Box { value: x }) }`) handed the worklist a new, deeper key every round. Nothing deduplicated, so the worklist grew without bound and the compiler hung with no diagnostic.

The worklist now measures the nesting depth of each instantiation's type arguments and stops at 128, reporting a clear error. A hand written program stays far below that. Added a mir test asserting the error instead of a hang. lib (525), codegen_smoke, and golden pass. Version 2.18.5.