### PR TITLE
fix(tycheck, mir): match constructors by variant name, not letter case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.7] - 2026-06-10
+
+### Fixed
+
+- A `match` arm now tells a constructor from a binding by the scrutinee's real variant names rather than by letter case. A lowercase enum variant is treated as a constructor (so omitting one is a non-exhaustive match instead of a silently accepted wrong dispatch), and an uppercase binding stays a binding. The int/bool/char match path also now binds a binding arm to the scrutinee value, which previously read a garbage slot (#410).
+
 ## [2.18.6] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.6"
+version = "2.18.7"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.6"
+version = "2.18.7"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.6"
+version = "2.18.7"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/enum_variant_case.rv
+++ b/examples/v2/enum_variant_case.rv
@@ -1,0 +1,30 @@
+// Match arms tell a constructor from a binding by the scrutinee's real variant
+// names, not by letter case. A lowercase enum variant is a constructor, so
+// leaving one out is a non-exhaustive match; an uppercase name that is not a
+// variant is a binding.
+import std/io { println }
+
+enum Sign { pos, zero, neg }
+
+fun describe(s: Sign) -> String {
+    return match s {
+        pos -> "positive",
+        zero -> "zero",
+        neg -> "negative",
+    }
+}
+
+fun pick(n: Int) -> Int {
+    return match n {
+        0 -> 100,
+        Other -> Other,
+    }
+}
+
+fun main() {
+    println(describe(Sign.pos))
+    println(describe(Sign.neg))
+    println(describe(Sign.zero))
+    println(pick(0).to_string())
+    println(pick(42).to_string())
+}

--- a/examples/v2/enum_variant_case.rv.out
+++ b/examples/v2/enum_variant_case.rv.out
@@ -1,0 +1,5 @@
+positive
+negative
+zero
+100
+42

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -49,7 +49,7 @@ pub fn lower_match(
     if is_enum_like(&scrut_ty) {
         lower_enum_match(cx, scrut_op, &scrut_ty, arms, result_local, cont);
     } else if matches!(scrut_ty, Ty::Int | Ty::Bool | Ty::Char) {
-        lower_int_match(cx, scrut_op, arms, result_local, cont);
+        lower_int_match(cx, scrut_op, &scrut_ty, arms, result_local, cont);
     } else {
         lower_fallback_match(cx, scrut_op, &scrut_ty, arms, result_local, cont);
     }
@@ -113,6 +113,7 @@ fn lower_enum_match(
 fn lower_int_match(
     cx: &mut LowerCx<'_>,
     scrut: MirOperand,
+    scrut_ty: &Ty,
     arms: &[HirArm],
     result: super::super::ir::MirLocal,
     cont: MirBlockId,
@@ -133,7 +134,7 @@ fn lower_int_match(
     cx.builder.close_block(
         cx.current,
         MirTerminator::SwitchInt {
-            discriminant: scrut,
+            discriminant: scrut.clone(),
             targets,
             otherwise,
         },
@@ -141,6 +142,17 @@ fn lower_int_match(
 
     for (arm, block) in arms.iter().zip(arm_blocks.iter()) {
         cx.current = *block;
+        // A binding arm (`other -> ...`) over an int/bool/char scrutinee binds
+        // the name to the scrutinee value. Without this the name was unbound in
+        // the arm body and read a garbage slot.
+        if let HirPatternKind::Binding(name) = &arm.pattern.kind {
+            let local = cx
+                .builder
+                .named_local(name.clone(), super::super::ty::MirType::from_ty(scrut_ty));
+            cx.builder
+                .assign(*block, local, MirRvalue::Use(scrut.clone()));
+            cx.bind(name.clone(), local);
+        }
         let v = super::expr::lower_expr(cx, &arm.body);
         cx.builder.assign(cx.current, result, MirRvalue::Use(v));
         if !cx.builder.is_closed(cx.current) {

--- a/src/tycheck/match_check.rs
+++ b/src/tycheck/match_check.rs
@@ -88,10 +88,22 @@ pub fn check(
         ));
     }
 
-    // Redundancy: first wildcard renders every subsequent arm
-    // unreachable. We use the existence of a wildcard or a catch all
-    // binding ident later to count for exhaustiveness.
-    if let Some(idx) = arms.iter().position(is_catch_all) {
+    // The constructor names this scrutinee actually has. A bare identifier
+    // pattern is a constructor only when it names one of these; any other
+    // identifier is a binding that matches everything. Deciding this by the
+    // real variant set, rather than by the identifier's letter case, is what
+    // lets a lowercase enum variant (`pos`) stay a constructor and an
+    // uppercase binding (`Found`) stay a binding.
+    let ctors = scrutinee_ctors(scrut, env);
+    let is_catch_all = |h: &PatternHead| match h {
+        PatternHead::Wildcard => true,
+        PatternHead::Ctor(name) => !ctors.iter().any(|c| c == name),
+        _ => false,
+    };
+
+    // Redundancy: a catch-all arm renders every arm after it unreachable. A
+    // catch-all anywhere also makes the match exhaustive.
+    if let Some(idx) = arms.iter().position(&is_catch_all) {
         if idx + 1 < arms.len() {
             return Err(RavenError::ty(TypeError::RedundantPattern, span.clone()));
         }
@@ -176,21 +188,18 @@ fn check_variant_set(
     }
 }
 
-/// True when the head matches everything: a wildcard, or a bare
-/// identifier we recognized as a binding (the body checker already
-/// resolved any constructor identifier semantics; what remains here as
-/// `Ctor` may still be a binding). To stay sound for exhaustiveness,
-/// we treat a `Ctor(name)` that contains lower case ascii as a
-/// catch all, mirroring Rust's convention. Constructor names in
-/// Raven are upper case (`Some`, `Ok`, enum variants).
-fn is_catch_all(h: &PatternHead) -> bool {
-    match h {
-        PatternHead::Wildcard => true,
-        PatternHead::Ctor(name) => name
-            .chars()
-            .next()
-            .map(|c| c.is_lowercase())
-            .unwrap_or(false),
-        _ => false,
+/// The constructor names a scrutinee type offers, used to tell a real
+/// constructor pattern from a binding. An open type (`Int`, `String`, a
+/// struct, ...) has none, so any bare identifier over it is a binding.
+fn scrutinee_ctors(scrut: &Ty, env: &TypeEnv) -> Vec<String> {
+    match scrut.strip_self() {
+        Ty::Option(_) => vec!["None".to_string(), "Some".to_string()],
+        Ty::Result(_, _) => vec!["Ok".to_string(), "Err".to_string()],
+        Ty::Enum { id, .. } => env
+            .enums
+            .get(id)
+            .map(|esig| esig.variants.iter().map(|v| v.name.clone()).collect())
+            .unwrap_or_default(),
+        _ => Vec::new(),
     }
 }


### PR DESCRIPTION
Closes #410.

Exhaustiveness decided whether a bare identifier pattern was a constructor or a binding by its first letter (lowercase meant a catch-all). So a lowercase enum variant (`enum Sign { pos, neg }`) was treated as a catch-all: a match on only `pos` was accepted and `Sign.neg` ran the `pos` arm. The reverse also bit, an uppercase binding raised a spurious non-exhaustive error.

The check now uses the scrutinee's real variant set. A bare identifier is a constructor only when it names one of those variants; anything else is a binding.

That fix exposed a second bug: the int/bool/char match path never bound a binding arm, so the name read a garbage slot (returned -2 in testing). It now binds the name to the scrutinee value like the other paths. Verified lowercase-variant dispatch, the non-exhaustive rejection, and the binding value. Added `examples/v2/enum_variant_case.rv`. lib (525), codegen_smoke (72), golden pass. Version 2.18.7.