### PR TITLE
fix(stdlib): strip CR and LF from response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.11] - 2026-06-10
+
+### Fixed
+
+- `std/http` strips CR and LF from response header names and values, closing a header-injection / response-splitting hole when a handler sets a header from untrusted input (#424).
+
 ## [2.18.10] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.10"
+version = "2.18.11"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.10"
+version = "2.18.11"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.10"
+version = "2.18.11"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -278,9 +278,14 @@ impl Response {
         return Response.with_body(302, "").header("Location", location)
     }
 
-    // Set a response header, returning self so calls chain.
+    // Set a response header, returning self so calls chain. A header name or
+    // value must never contain CR or LF: those characters frame the header
+    // block, so an untrusted value carrying them could inject extra headers or
+    // split the response. Strip them before storing.
     fun header(self, name: String, value: String) -> Response {
-        self.headers.set(name, value)
+        let clean_name = name.replace("\r", "").replace("\n", "")
+        let clean_value = value.replace("\r", "").replace("\n", "")
+        self.headers.set(clean_name, clean_value)
         return self
     }
 


### PR DESCRIPTION
Closes #424.

`Response.header` stored the name and value verbatim and the writer emitted them followed by CRLF, so a handler that set a header from untrusted input could embed a CRLF and inject extra headers or split the response.

The setter now strips CR and LF from both the name and the value. Every header setter (`content_type`, `redirect`, ...) routes through it, so the whole response side is covered. Verified end to end: a header value containing a raw CRLF now serializes as a single header with no injected line. lib (525) and golden pass. Version 2.18.11.