### PR TITLE
fix(stdlib): cap the http request body size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.12] - 2026-06-10
+
+### Fixed
+
+- The `std/http` server caps the request body at 10 MiB and rejects a negative or oversized `Content-Length` with a 400 before reading, so a client can no longer make it buffer unbounded memory (#428).
+
 ## [2.18.11] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.11"
+version = "2.18.12"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.11"
+version = "2.18.12"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.11"
+version = "2.18.12"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -510,6 +510,16 @@ fun read_request(stream: TcpStream) -> Result<Request, Error> {
             None -> {}
         }
     }
+    // Reject a negative or oversized declared body before reading it, so a
+    // client cannot make the server buffer unbounded memory. 10 MiB is a
+    // generous default for a simple server.
+    if want < 0 {
+        return Err(error_kind("http", "negative Content-Length"))
+    }
+    let max_body = 10485760
+    if want > max_body {
+        return Err(error_kind("http", "request body too large"))
+    }
     while body.length() < want {
         let chunk = stream.read(4096)?
         if chunk.length() == 0 {


### PR DESCRIPTION
Closes #428.

`read_request` read the body up to the client's `Content-Length` with no upper bound, so a request declaring a huge length made the server buffer that much memory.

It now rejects a negative or over-10-MiB `Content-Length` with a 400 before reading any body. Verified: a normal POST still works, and a forged `Content-Length: 20000000` gets an immediate 400 with no buffering. lib (525) and golden pass. Version 2.18.12.