### PR TITLE
fix(stdlib): block path traversal in the http static file server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.13] - 2026-06-10
+
+### Fixed
+
+- The `std/http` static file server rejects a requested file name that contains a path separator (including a Windows backslash), a parent reference, or a drive marker, closing a path-traversal hole that could escape the served directory (#423).
+
 ## [2.18.12] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.12"
+version = "2.18.13"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.12"
+version = "2.18.13"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.12"
+version = "2.18.13"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -613,7 +613,27 @@ fun reason_phrase(status: Int) -> String {
 
 // Serve the `:file` capture of a `Server.static` route from its directory.
 fun serve_from(dir: String, req: Request) -> Response {
-    return Response.file(dir.concat("/").concat(req.param("file")))
+    let name = req.param("file")
+    // The captured name must be a single, ordinary file name inside `dir`.
+    // Reject anything that could climb out: a path separator (note that `\` is
+    // one on Windows), a parent reference, a drive or stream marker, or an
+    // empty name. Without this a request like `..\..\secret` would escape.
+    if name.length() == 0 {
+        return Response.with_body(404, "Not Found")
+    }
+    if name.contains("/") {
+        return Response.with_body(404, "Not Found")
+    }
+    if name.contains("\\") {
+        return Response.with_body(404, "Not Found")
+    }
+    if name.contains("..") {
+        return Response.with_body(404, "Not Found")
+    }
+    if name.contains(":") {
+        return Response.with_body(404, "Not Found")
+    }
+    return Response.file(dir.concat("/").concat(name))
 }
 
 // A `Content-Type` for a file path, chosen from its extension.


### PR DESCRIPTION
Closes #423.

`serve_from` joined the captured `:file` segment onto the served directory and read it. The router treats the segment as opaque, so a Windows backslash slipped through and a name like `..\..\secret` climbed out of the directory.

The captured name is now rejected when it contains a path separator (forward or back slash), a parent reference, a drive/stream colon, or is empty. Verified end to end: a legit file serves with 200, while both `..%5c..%5csecret.txt` and `..%2f..%2fsecret.txt` return 404. lib (525) and golden pass. Version 2.18.13.