### PR TITLE
fix(stdlib): bound JSON nesting depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.14] - 2026-06-10
+
+### Fixed
+
+- The `std/json` parser bounds nesting depth (256 levels) and returns an error instead of overflowing the stack on deeply nested untrusted input (#425).
+
 ## [2.18.13] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.13"
+version = "2.18.14"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.13"
+version = "2.18.14"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.13"
+version = "2.18.14"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/json_depth.rv
+++ b/examples/v2/json_depth.rv
@@ -1,0 +1,38 @@
+// The JSON parser bounds nesting depth so untrusted input cannot overflow the
+// stack. Genuinely nested data still parses, and a flat collection of many
+// siblings is fine because depth is only counted while descending.
+import std/io { println }
+import std/json { parse, stringify }
+
+fun main() {
+    match parse("{\"a\": {\"b\": {\"c\": [1, 2, 3]}}}") {
+        Ok(v) -> println("nested ok: ${stringify(v)}"),
+        Err(e) -> println("nested err: ${e.message()}"),
+    }
+
+    let deep = ""
+    let i = 0
+    while i < 1000 {
+        deep = deep.concat("[")
+        i = i + 1
+    }
+    match parse(deep) {
+        Ok(v) -> println("deep ok (unexpected)"),
+        Err(e) -> println("deep rejected: ${e.message()}"),
+    }
+
+    let flat = "["
+    let j = 0
+    while j < 500 {
+        if j > 0 {
+            flat = flat.concat(",")
+        }
+        flat = flat.concat("{}")
+        j = j + 1
+    }
+    flat = flat.concat("]")
+    match parse(flat) {
+        Ok(v) -> println("flat ok (500 objects)"),
+        Err(e) -> println("flat err: ${e.message()}"),
+    }
+}

--- a/examples/v2/json_depth.rv.out
+++ b/examples/v2/json_depth.rv.out
@@ -1,0 +1,3 @@
+nested ok: {"a":{"b":{"c":[1,2,3]}}}
+deep rejected: maximum nesting depth exceeded
+flat ok (500 objects)

--- a/stdlib/std/json.rv
+++ b/stdlib/std/json.rv
@@ -39,6 +39,7 @@ fun json_error(msg: String) -> Error {
 struct Cursor {
     text: String,
     pos: Int,
+    depth: Int,
 }
 
 impl Cursor {
@@ -302,11 +303,27 @@ fun match_keyword(c: Cursor, word: String) -> Bool {
 fun parse_value(c: Cursor) -> Result<JsonValue, Error> {
     c.skip_ws()
     let b = c.peek()
+    // Containers recurse, so bound the nesting depth to keep untrusted input
+    // from overflowing the stack. Depth is incremented on the way into a
+    // container and decremented on the way out, so siblings at the same level
+    // do not accumulate; only genuine nesting counts.
     if b == 123 {
-        return parse_object(c)
+        c.depth = c.depth + 1
+        if c.depth > 256 {
+            return Err(json_error("maximum nesting depth exceeded"))
+        }
+        let v = parse_object(c)?
+        c.depth = c.depth - 1
+        return Ok(v)
     }
     if b == 91 {
-        return parse_array(c)
+        c.depth = c.depth + 1
+        if c.depth > 256 {
+            return Err(json_error("maximum nesting depth exceeded"))
+        }
+        let v = parse_array(c)?
+        c.depth = c.depth - 1
+        return Ok(v)
     }
     if b == 34 {
         c.advance()
@@ -418,7 +435,7 @@ fun offset_str(n: Int) -> String {
 // Parse `text` as a single JSON value. Trailing content other than
 // whitespace after the top-level value is rejected.
 fun parse(text: String) -> Result<JsonValue, Error> {
-    let c = Cursor { text: text, pos: 0 }
+    let c = Cursor { text: text, pos: 0, depth: 0 }
     let v = parse_value(c)?
     c.skip_ws()
     if !c.at_end() {


### PR DESCRIPTION
Closes #425.

`parse_value` recursed into `parse_array`/`parse_object` with no limit, so deeply nested input overflowed the stack and aborted the process.

The cursor now carries a depth counter, raised when descending into a container and lowered on the way out, so only genuine nesting counts and a flat collection of siblings does not. Past 256 levels the parser returns an error. Verified: normal nested data parses, 1000 open brackets is rejected cleanly, and a flat array of 500 objects is fine. lib (525) and golden pass. Version 2.18.14.