### PR TITLE
fix(stdlib): stop fs.walk from following symlinked directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.16] - 2026-06-10
+
+### Fixed
+
+- `std/fs.walk` no longer follows symlinked directories, so a link that points back up the tree can no longer send it into endless recursion. Adds `fs.is_symlink` (#436).
+
 ## [2.18.15] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.15"
+version = "2.18.16"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.15"
+version = "2.18.16"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.15"
+version = "2.18.16"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -942,6 +942,20 @@ pub extern "C" fn raven_fs_is_dir(path: *const object::String) -> bool {
     env_name(path).is_some_and(|p| std::path::Path::new(p).is_dir())
 }
 
+/// Whether `path` itself is a symbolic link. Unlike `is_dir`, this does not
+/// follow the link: it reads the link's own metadata. A missing path is
+/// `false`. Used by `fs.walk` to avoid descending through a symlinked
+/// directory, which could form a cycle.
+///
+/// # Safety
+///
+/// `path` must be a valid `raven_string_from_bytes`-built `String`.
+#[no_mangle]
+pub extern "C" fn raven_fs_is_symlink(path: *const object::String) -> bool {
+    env_name(path)
+        .is_some_and(|p| std::fs::symlink_metadata(p).is_ok_and(|m| m.file_type().is_symlink()))
+}
+
 /// The message of the most recent fallible time op (parsing), empty when
 /// it succeeded. The std/time wrapper reads this to build an `Err` only
 /// when it is non-empty.

--- a/stdlib/std/fs.rv
+++ b/stdlib/std/fs.rv
@@ -24,6 +24,7 @@ extern "C" {
     fun raven_fs_exists(path: String) -> Bool
     fun raven_fs_is_file(path: String) -> Bool
     fun raven_fs_is_dir(path: String) -> Bool
+    fun raven_fs_is_symlink(path: String) -> Bool
 }
 
 // An Error tagged with kind "io" (the IoError realization), its message a
@@ -124,6 +125,12 @@ fun is_dir(path: String) -> Bool {
     return raven_fs_is_dir(path)
 }
 
+// True when `path` itself is a symbolic link. This does not follow the link, so
+// unlike `is_dir` it reports on the link rather than its target.
+fun is_symlink(path: String) -> Bool {
+    return raven_fs_is_symlink(path)
+}
+
 // Create `path` and every missing parent directory, like `mkdir -p`. An
 // already-existing directory in the chain is not an error.
 fun create_dir_all(path: String) -> Result<Bool, Error> {
@@ -169,7 +176,10 @@ fun walk(path: String) -> Result<List<String>, Error> {
     while i < entries.len() {
         let full = join(path, entries.get(i))
         out.push(full)
-        if is_dir(full) {
+        // Descend into real subdirectories only. A symlinked directory is
+        // listed but not followed, so a link that points back up the tree
+        // cannot send the walk into an endless loop.
+        if is_dir(full) && !is_symlink(full) {
             let sub = walk(full)?
             let j = 0
             while j < sub.len() {


### PR DESCRIPTION
Closes #436.

`walk` recursed into any entry that `is_dir` reported as a directory, and `is_dir` follows symlinks. A directory symlink pointing back up the tree therefore sent `walk` into endless recursion.

Adds `raven_fs_is_symlink` (reads the link's own metadata via `symlink_metadata`, so it does not follow the link) and an `fs.is_symlink` wrapper. `walk` now lists a symlinked directory but does not descend into it, so a cycle cannot form. Verified a normal tree walks correctly. lib (525), codegen_smoke (72), golden pass. Version 2.18.16.