### PR TITLE
fix(lexer): ignore a leading UTF-8 BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.17] - 2026-06-10
+
+### Fixed
+
+- A leading UTF-8 byte-order mark is ignored instead of failing with an "unexpected character" error, so a source file saved with a BOM compiles (#422).
+
 ## [2.18.16] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.16"
+version = "2.18.17"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.16"
+version = "2.18.17"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.16"
+version = "2.18.17"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -166,8 +166,15 @@ pub struct Lexer {
 impl Lexer {
     /// Build a lexer over `source` annotated as coming from `file`.
     pub fn new(source: impl Into<String>, file: impl Into<PathBuf>) -> Self {
+        let mut source: String = source.into();
+        // A UTF-8 byte-order mark is well-formed but is not part of the
+        // program. Drop a single leading BOM so it does not lex as an
+        // unexpected character. Editors on Windows add it routinely.
+        if let Some(stripped) = source.strip_prefix('\u{FEFF}') {
+            source = stripped.to_string();
+        }
         Lexer {
-            source: source.into(),
+            source,
             pos: 0,
             line: 1,
             col: 1,

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -23,6 +23,14 @@ fn empty_source_yields_eof_only() {
 }
 
 #[test]
+fn leading_utf8_bom_is_ignored() {
+    // A UTF-8 BOM at the start of the source is dropped rather than lexed as an
+    // unexpected character, so a BOM-prefixed file tokenizes like a clean one.
+    let toks = lex("\u{FEFF}let x = 1");
+    assert_eq!(toks[0].kind, TokenKind::Let);
+}
+
+#[test]
 fn all_keywords_are_recognized() {
     let src = "let const fun return if else while for loop in break continue match struct trait impl enum import as extern defer true false self Self";
     let toks = lex(src);


### PR DESCRIPTION
Closes #422.

A source file saved with a byte-order mark failed to compile: the BOM fell through the whitespace handling and lexed as an unexpected character. The lexer now drops a single leading BOM before tokenizing. Added a lexer test. lib (526) passes. Version 2.18.17.