### PR TITLE
fix(parser): allow a struct literal in a call argument inside a condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.18] - 2026-06-10
+
+### Fixed
+
+- A struct literal is now accepted inside a call argument within an `if`/`while`/`for`/`match` head (`if check(Point { x: 1 }) {`). The no-struct-literal rule that keeps the condition unambiguous is lifted inside the call's parentheses (#417).
+
 ## [2.18.17] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.17"
+version = "2.18.18"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.17"
+version = "2.18.18"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.17"
+version = "2.18.18"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/struct_lit_in_condition.rv
+++ b/examples/v2/struct_lit_in_condition.rv
@@ -1,0 +1,21 @@
+// A struct literal is allowed inside a call argument in an if/while/match head.
+// The condition itself still forbids a bare struct literal (which would clash
+// with the block brace), but inside the call's parentheses it is unambiguous.
+import std/io { println }
+
+struct Point { x: Int, y: Int }
+
+fun positive(p: Point) -> Bool = p.x > 0
+
+fun main() {
+    if positive(Point { x: 1, y: 2 }) {
+        println("if ok")
+    }
+    while positive(Point { x: 0, y: 0 }) {
+        println("never runs")
+    }
+    match positive(Point { x: 5, y: 5 }) {
+        true -> println("match ok"),
+        false -> println("no"),
+    }
+}

--- a/examples/v2/struct_lit_in_condition.rv.out
+++ b/examples/v2/struct_lit_in_condition.rv.out
@@ -1,0 +1,2 @@
+if ok
+match ok

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -326,6 +326,18 @@ impl Parser {
     /// Parse the contents of an argument list (after `(`) and consume
     /// the closing `)`. Returns the args and the span of the closer.
     fn parse_arg_list(&mut self) -> ParseResult<(Vec<Expr>, Span)> {
+        // Inside a call's parentheses a struct literal is unambiguous: the `)`
+        // closes the argument list, so there is no `if cond {` ambiguity. Lift
+        // the no-struct-literal restriction an enclosing if/while/for/match head
+        // imposes for the duration of the arguments, then restore it.
+        let saved = self.no_struct_literal;
+        self.no_struct_literal = false;
+        let result = self.parse_arg_list_body();
+        self.no_struct_literal = saved;
+        result
+    }
+
+    fn parse_arg_list_body(&mut self) -> ParseResult<(Vec<Expr>, Span)> {
         let mut args = Vec::new();
         self.skip_newlines();
         if !matches!(self.peek_kind(), TokenKind::RParen) {


### PR DESCRIPTION
Closes #417.

An `if`/`while`/`for`/`match` head sets a flag that forbids a bare struct literal so the block brace is not mistaken for the literal's brace. That flag leaked into a call's argument list, so `if check(Point { x: 1 }) {` failed to parse with `expected )`.

The argument list now clears the flag while parsing arguments and restores it after; inside the parentheses a struct literal is unambiguous. Added `examples/v2/struct_lit_in_condition.rv`. lib (526) and golden pass. Version 2.18.18.