### PR TITLE
fix(parser): continue a method chain when a dot leads the next line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.20] - 2026-06-10
+
+### Fixed
+
+- A method chain can now break across lines with the dot leading the next line (`s\n    .trim()\n    .to_lower()`). The postfix parser continues across a newline when a `.` or `?` follows it (#416).
+
 ## [2.18.19] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.19"
+version = "2.18.20"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.19"
+version = "2.18.20"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.19"
+version = "2.18.20"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/leading_dot_chain.rv
+++ b/examples/v2/leading_dot_chain.rv
@@ -1,0 +1,15 @@
+// A method chain can break across lines with the dot leading the next line.
+// Only a `.` or `?` continues the chain; any other line stands on its own.
+import std/io { println }
+import std/string
+
+fun main() {
+    let cleaned = "  Hello World  "
+        .trim()
+        .to_lower()
+    println(cleaned)
+
+    let n = "  42  "
+        .trim()
+    println(n)
+}

--- a/examples/v2/leading_dot_chain.rv.out
+++ b/examples/v2/leading_dot_chain.rv.out
@@ -1,0 +1,2 @@
+hello world
+42

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -245,6 +245,18 @@ impl Parser {
     fn parse_postfix(&mut self) -> ParseResult<Expr> {
         let mut expr = self.parse_primary()?;
         loop {
+            // A method or try chain may continue on the next line: skip a
+            // newline only when a `.` or `?` follows it, so `s\n    .trim()`
+            // keeps chaining. Anything else after the newline ends this
+            // expression and the newline stays as a statement separator.
+            if matches!(self.peek_kind(), TokenKind::Newline) {
+                let saved = self.checkpoint();
+                self.skip_newlines();
+                if !matches!(self.peek_kind(), TokenKind::Dot | TokenKind::Question) {
+                    self.rewind(saved);
+                    break;
+                }
+            }
             match self.peek_kind() {
                 TokenKind::Dot => {
                     self.advance();


### PR DESCRIPTION
Closes #416.

The postfix parser stopped at a newline, so a chain written with the dot at the start of the next line (`s\n    .trim()`) failed to parse. The newline before the dot was even consumed by the binary ladder, leaving the dot orphaned.

The postfix loop now looks past a newline and keeps chaining only when a `.` or `?` follows it; any other token ends the expression and leaves the newline as a statement separator. Added `examples/v2/leading_dot_chain.rv`. lib (526), codegen_smoke (72), golden pass with no regressions. Version 2.18.20.