### PR TITLE
fix(lexer): reject a malformed numeric literal instead of splitting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.21] - 2026-06-10
+
+### Fixed
+
+- A numeric literal with a digit invalid for its base or a trailing letter (`0b12`, `0o78`, `123abc`) is now a single malformed-literal error rather than being silently split into two tokens (#421).
+
 ## [2.18.20] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.20"
+version = "2.18.21"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.20"
+version = "2.18.21"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.20"
+version = "2.18.21"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -476,6 +476,23 @@ impl Lexer {
             }
         }
 
+        // A letter right after a decimal number is a malformed literal
+        // (`123abc`, `1.0f`), not a number followed by an identifier. Consume
+        // the run so the error covers the whole token.
+        if self
+            .peek()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        {
+            while self
+                .peek()
+                .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                self.bump();
+            }
+            let lexeme = self.source[start..self.pos].to_string();
+            return Err(self.err(LexError::InvalidNumber(lexeme), start, line, col));
+        }
+
         let lexeme = &self.source[start..self.pos];
         let cleaned: String = lexeme.chars().filter(|c| *c != '_').collect();
 
@@ -515,6 +532,20 @@ impl Lexer {
             }
         }
         if self.pos == digits_start {
+            let lexeme = self.source[start..self.pos].to_string();
+            return Err(self.err(LexError::InvalidNumber(lexeme), start, line, col));
+        }
+        // A letter or further digit right after the digits is an invalid digit
+        // for this base (`0b12`, `0xZ`), not the start of a new token. Consume
+        // the rest of the run so the error covers the whole bad literal instead
+        // of silently splitting it in two.
+        if self.peek().is_some_and(|c| c.is_ascii_alphanumeric()) {
+            while self
+                .peek()
+                .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                self.bump();
+            }
             let lexeme = self.source[start..self.pos].to_string();
             return Err(self.err(LexError::InvalidNumber(lexeme), start, line, col));
         }

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -23,6 +23,17 @@ fn empty_source_yields_eof_only() {
 }
 
 #[test]
+fn malformed_numeric_literal_is_an_error_not_a_split() {
+    // A digit invalid for the base, or a letter right after a number, is a
+    // single malformed literal, not a valid number followed by a second token.
+    lex_err("0b12");
+    lex_err("0o78");
+    lex_err("123abc");
+    // A valid number followed by a method call still lexes fine.
+    lex("1.method()");
+}
+
+#[test]
 fn leading_utf8_bom_is_ignored() {
     // A UTF-8 BOM at the start of the source is dropped rather than lexed as an
     // unexpected character, so a BOM-prefixed file tokenizes like a clean one.


### PR DESCRIPTION
Closes #421.

The number scanners stopped at the first character invalid for the base and left it to lex separately, so `0b12` became `0b1` then `2` and `123abc` became `123` then `abc`, silently changing the program.

Both the radix and decimal paths now treat a digit invalid for the base, or a letter right after a number, as one malformed literal and report it. A valid number followed by `.method()` still lexes as before. Added a lexer test. lib (527) and golden pass. Version 2.18.21.