### PR TITLE
fix(lexer): handle CRLF inside string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.22] - 2026-06-10
+
+### Fixed
+
+- CRLF line endings no longer corrupt string literals. A CRLF inside a single-line string is now reported as unterminated (it was folded to a stray carriage return), and a block string normalizes CRLF to LF so its content is the same on any platform (#415).
+
 ## [2.18.21] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.21"
+version = "2.18.22"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.21"
+version = "2.18.22"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.21"
+version = "2.18.22"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -616,7 +616,7 @@ impl Lexer {
                     out.push(self.bump().unwrap()); // opening "
                     loop {
                         match self.peek() {
-                            None | Some('\n') => {
+                            None | Some('\n') | Some('\r') => {
                                 return Err(self.err(
                                     LexError::UnterminatedString,
                                     start,
@@ -638,7 +638,11 @@ impl Lexer {
                         }
                     }
                 }
-                Some('\n') => {
+                // A raw line break (LF, or a CR that `bump` would fold a
+                // following LF into) cannot appear in a single-line string, so
+                // it terminates the literal as unterminated rather than being
+                // copied in as a stray carriage return.
+                Some('\n') | Some('\r') => {
                     return Err(self.err(LexError::UnterminatedString, start, line, col));
                 }
                 Some('$') if self.peek_at(1) == Some('{') => {
@@ -691,7 +695,15 @@ impl Lexer {
                 }
                 Some(_) => {
                     let ch = self.bump().unwrap();
-                    out.push(ch);
+                    // A block string may span lines. `bump` returns a lone CR
+                    // for a CRLF (or a bare CR); normalize it to LF so the
+                    // content has consistent newlines regardless of the file's
+                    // line endings.
+                    if ch == '\r' {
+                        out.push('\n');
+                    } else {
+                        out.push(ch);
+                    }
                 }
             }
         }

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -34,6 +34,26 @@ fn malformed_numeric_literal_is_an_error_not_a_split() {
 }
 
 #[test]
+fn crlf_in_regular_string_is_unterminated() {
+    // A CRLF inside a single-line string used to be folded to a stray CR and
+    // copied in; it now terminates the literal as unterminated.
+    lex_err("\"abc\r\ndef\"");
+}
+
+#[test]
+fn crlf_in_block_string_normalizes_to_lf() {
+    let toks = lex("\"\"\"\r\nx\r\ny\r\n\"\"\"");
+    let body = toks
+        .iter()
+        .find_map(|t| match &t.kind {
+            TokenKind::BlockStringLit(s) => Some(s.clone()),
+            _ => None,
+        })
+        .expect("block string literal");
+    assert!(!body.contains('\r'), "block string kept a CR: {body:?}");
+}
+
+#[test]
 fn leading_utf8_bom_is_ignored() {
     // A UTF-8 BOM at the start of the source is dropped rather than lexed as an
     // unexpected character, so a BOM-prefixed file tokenizes like a clean one.


### PR DESCRIPTION
Closes #415.

`bump` returns a lone CR for a CRLF (it consumes the following LF for line tracking). Inside a string that meant a CRLF was copied in as a stray carriage return, and because the loop only watched for LF, a single-line string with a CRLF was not even caught as unterminated.

A single-line string now treats a CR like an LF and reports it as unterminated, and a block string normalizes a CR to LF so its content is the same regardless of the file's line endings. Verified with CRLF-encoded files and added lexer tests. lib (529) and golden pass. Version 2.18.22.