### PR TITLE
fix(tycheck): a Self-returning method makes a trait not object-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.23] - 2026-06-10
+
+### Fixed
+
+- A trait with a method that returns `Self` is now correctly rejected as not object-safe when used as a `dyn` type, with a clear error, instead of being accepted and miscompiling (#412).
+
 ## [2.18.22] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.22"
+version = "2.18.23"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.22"
+version = "2.18.23"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.22"
+version = "2.18.23"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -544,6 +544,16 @@ pub fn object_safety_violation(sig: &TraitSig) -> Option<String> {
                 ));
             }
         }
+        // A method that returns `Self` is not object-safe: the concrete type is
+        // erased behind the trait object, so the result type would be unknown.
+        // Without this the call lowered a `Self`-typed result to a Unit slot and
+        // miscompiled downstream.
+        if ty_mentions_self(&m.ret) {
+            return Some(format!(
+                "method `{}` returns `Self`, which is not object-safe",
+                name
+            ));
+        }
     }
     None
 }

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -119,6 +119,15 @@ fn generic_method_return_only_param_is_grounded() {
 }
 
 #[test]
+fn dyn_over_self_returning_trait_is_rejected() {
+    // A trait with a `-> Self` method is not object-safe: building a `dyn`
+    // value of it must be a type error, not a downstream miscompile. Regression
+    // for #412.
+    let bad = "trait Cloner { fun dup(self) -> Self }\nstruct W { id: Int }\nimpl Cloner for W {\n    fun dup(self) -> W { return W { id: self.id } }\n}\nfun main() {\n    let w = W { id: 1 }\n    let d: dyn Cloner = w\n}\n";
+    assert!(check(bad).is_err());
+}
+
+#[test]
 fn cross_function_unresolved_var_does_not_panic() {
     // A body that leaves an unresolved inference variable must not crash a
     // later body's finalization. Each body resolves only its own type-map


### PR DESCRIPTION
Closes #412.

The object-safety check looked at a trait method's generics and by-value `Self` parameters but never its return type, so a method like `fun dup(self) -> Self` was accepted behind a `dyn`. The Self-typed result then lowered to a Unit slot and miscompiled.

A method that mentions `Self` in its return type now marks the trait as not object-safe, so building a `dyn` value of it is a clear type error (`method dup returns Self, which is not object-safe`). A normal trait stays usable as `dyn`. Added a tycheck test. lib (530) and golden pass. Version 2.18.23.