### PR TITLE
fix(parser): strip the escaped-dollar sentinel in c-strings and patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.25] - 2026-06-10
+
+### Fixed
+
+- An escaped `\$` now stays a plain `$` in a c-string and in a string match pattern. The internal escape sentinel was leaking into both because neither runs through the interpolation splitter (#418).
+
 ## [2.18.24] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.24"
+version = "2.18.25"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.24"
+version = "2.18.25"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.24"
+version = "2.18.25"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/escaped_dollar.rv
+++ b/examples/v2/escaped_dollar.rv
@@ -1,0 +1,17 @@
+// An escaped `\$` is a literal dollar sign. It must survive as a plain `$` in a
+// c-string (which is not interpolated) and in a string match pattern, not leak
+// the internal escape sentinel.
+import std/io { println }
+
+extern "C" {
+    fun strlen(s: CStr) -> Int
+}
+
+fun main() {
+    println(strlen(c"price\$5").to_string())
+    let s = "\$"
+    match s {
+        "\$" -> println("matched dollar"),
+        other -> println("no match"),
+    }
+}

--- a/examples/v2/escaped_dollar.rv.out
+++ b/examples/v2/escaped_dollar.rv.out
@@ -1,0 +1,2 @@
+7
+matched dollar

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -421,6 +421,10 @@ impl Parser {
             }
             TokenKind::CStringLit(s) => {
                 self.advance();
+                // A c-string is not interpolated, so the splitter never runs on
+                // it. Strip the escaped-dollar sentinel here, leaving the plain
+                // `$`, instead of letting U+E000 leak into the C string.
+                let s = s.replace(ESCAPED_DOLLAR_SENTINEL, "");
                 Ok(Expr {
                     kind: ExprKind::CStr(s),
                     span: tok.span,

--- a/src/parser/pattern.rs
+++ b/src/parser/pattern.rs
@@ -2,7 +2,7 @@
 
 use crate::ast::{FieldPattern, LiteralPattern, Pattern, PatternKind};
 use crate::error::ParseError;
-use crate::lexer::TokenKind;
+use crate::lexer::{TokenKind, ESCAPED_DOLLAR_SENTINEL};
 
 use super::{merge_spans, ParseResult, Parser};
 
@@ -69,7 +69,11 @@ impl Parser {
                 })
             }
             TokenKind::StringLit(ref s) => {
-                let s = s.clone();
+                // A pattern's string is matched against a value's bytes, so the
+                // escaped-dollar sentinel must be stripped to the plain `$`
+                // here; the interpolation splitter that normally does this never
+                // runs on a pattern.
+                let s = s.replace(ESCAPED_DOLLAR_SENTINEL, "");
                 let tok = self.advance();
                 Ok(Pattern {
                     kind: PatternKind::Literal(LiteralPattern::String(s)),


### PR DESCRIPTION
Closes #418.

The lexer marks an escaped `\$` with a private-use sentinel so the interpolation splitter can tell it from a real `$`. A c-string and a string match pattern do not run through that splitter, so the sentinel leaked into the C string's bytes (making `strlen` too long) and into the pattern (so it never matched a real `$`).

Both now strip the sentinel to the plain `$` at parse time. Verified `strlen(c"price\")` is 7 and a `"\$"` pattern matches. Added `examples/v2/escaped_dollar.rv`. lib (531) and golden pass. Version 2.18.25.