### PR TITLE
fix(rvpm): honor [fmt].indent_width when formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.26] - 2026-06-10
+
+### Fixed
+
+- `rvpm fmt` now honors `[fmt].indent_width` from `rv.toml` (it previously loaded no manifest and always used four spaces). `wrap_width` is still read but has no effect, because the formatter does not reflow long lines yet (#432).
+
 ## [2.18.25] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.25"
+version = "2.18.26"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.25"
+version = "2.18.26"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.25"
+version = "2.18.26"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use raven::format::format_source;
+use raven::format::format_source_with;
 use raven::lock::{self, LockFile, LOCK_FILE_NAME};
 use raven::manifest::init::{init_project, name_from_dir, InitError};
 use raven::manifest::Manifest;
@@ -271,6 +271,12 @@ fn cmd_fmt(args: &[String]) -> ExitCode {
         return ExitCode::from(1);
     }
 
+    // Honor `[fmt].indent_width` from the project manifest when there is one;
+    // fall back to the default outside a project.
+    let indent_width = Manifest::load("rv.toml")
+        .map(|m| m.fmt.indent_width)
+        .unwrap_or(4);
+
     let mut changed: Vec<PathBuf> = Vec::new();
     let mut errored = false;
     for path in &files {
@@ -282,7 +288,7 @@ fn cmd_fmt(args: &[String]) -> ExitCode {
                 continue;
             }
         };
-        let formatted = match format_source(&src) {
+        let formatted = match format_source_with(&src, indent_width) {
             Ok(f) => f,
             Err(e) => {
                 eprintln!("rvpm: {}: {}", path.display(), e);

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -25,7 +25,8 @@ mod comments;
 
 use comments::Comment;
 
-const INDENT: &str = "    ";
+/// The indent width used when no manifest `[fmt].indent_width` applies.
+const DEFAULT_INDENT_WIDTH: u32 = 4;
 
 /// A formatting failure. The only way to fail is to be handed source that
 /// does not lex or parse: the formatter cannot canonicalize what it cannot
@@ -49,6 +50,12 @@ impl std::error::Error for FormatError {}
 
 /// Format Raven source text into its canonical form.
 pub fn format_source(src: &str) -> Result<String, FormatError> {
+    format_source_with(src, DEFAULT_INDENT_WIDTH)
+}
+
+/// Format `src` using `indent_width` spaces per level. `rvpm fmt` passes the
+/// width from the manifest's `[fmt].indent_width`.
+pub fn format_source_with(src: &str, indent_width: u32) -> Result<String, FormatError> {
     let tokens = Lexer::new(src, "<fmt>")
         .tokenize()
         .map_err(|e| FormatError::Parse(e.to_string()))?;
@@ -59,7 +66,8 @@ pub fn format_source(src: &str) -> Result<String, FormatError> {
     // `MacroCall` expression arm.
     let file = parse(&tokens).map_err(|e| FormatError::Parse(e.to_string()))?;
     let comments = comments::scan(src);
-    let mut p = Printer::new(src, comments);
+    let indent_unit = " ".repeat(indent_width as usize);
+    let mut p = Printer::new(src, comments, indent_unit);
     p.file(&file);
     Ok(p.finish())
 }
@@ -69,6 +77,8 @@ pub fn format_source(src: &str) -> Result<String, FormatError> {
 struct Printer<'a> {
     out: String,
     indent: usize,
+    /// The string emitted for one indent level (`indent_width` spaces).
+    indent_unit: String,
     src: &'a str,
     comments: Vec<Comment>,
     /// Index of the next comment not yet emitted.
@@ -76,10 +86,11 @@ struct Printer<'a> {
 }
 
 impl<'a> Printer<'a> {
-    fn new(src: &'a str, comments: Vec<Comment>) -> Self {
+    fn new(src: &'a str, comments: Vec<Comment>, indent_unit: String) -> Self {
         Printer {
             out: String::new(),
             indent: 0,
+            indent_unit,
             src,
             comments,
             next_comment: 0,
@@ -111,7 +122,7 @@ impl<'a> Printer<'a> {
             return;
         }
         for _ in 0..self.indent {
-            self.out.push_str(INDENT);
+            self.out.push_str(&self.indent_unit);
         }
         self.out.push_str(text);
         self.out.push('\n');
@@ -798,7 +809,7 @@ impl Printer<'_> {
                 continue;
             }
             for _ in 0..self.indent {
-                self.out.push_str(INDENT);
+                self.out.push_str(&self.indent_unit);
             }
             self.out.push_str(part);
         }
@@ -868,7 +879,7 @@ impl Printer<'_> {
                     s.push_str(" {\n");
                     for f in fields {
                         for _ in 0..base + 1 {
-                            s.push_str(INDENT);
+                            s.push_str(&self.indent_unit);
                         }
                         let value = self.field_value(f);
                         if is_field_shorthand(&f.name, &f.value) {
@@ -878,7 +889,7 @@ impl Printer<'_> {
                         }
                     }
                     for _ in 0..base {
-                        s.push_str(INDENT);
+                        s.push_str(&self.indent_unit);
                     }
                     s.push('}');
                 } else {
@@ -1071,7 +1082,7 @@ impl Printer<'_> {
         s.push_str(&inner);
         s.push('\n');
         for _ in 0..base {
-            s.push_str(INDENT);
+            s.push_str(&self.indent_unit);
         }
         s.push('}');
         s
@@ -1112,7 +1123,7 @@ impl Printer<'_> {
             let guard = arm.guard.as_ref().map(|g| self.expr_at(g, base + 1));
             let body = self.expr_at(&arm.body, base + 1);
             for _ in 0..base + 1 {
-                s.push_str(INDENT);
+                s.push_str(&self.indent_unit);
             }
             s.push_str(&pat);
             if let Some(g) = guard {
@@ -1124,7 +1135,7 @@ impl Printer<'_> {
             s.push_str(",\n");
         }
         for _ in 0..base {
-            s.push_str(INDENT);
+            s.push_str(&self.indent_unit);
         }
         s.push('}');
         s
@@ -1171,7 +1182,7 @@ impl Printer<'_> {
                 s.push_str(&inner);
                 s.push('\n');
                 for _ in 0..base {
-                    s.push_str(INDENT);
+                    s.push_str(&self.indent_unit);
                 }
                 s.push('}');
                 s

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -1,5 +1,19 @@
-use super::format_source;
+use super::{format_source, format_source_with};
 use crate::ast::pretty_file;
+
+#[test]
+fn indent_width_is_configurable() {
+    let out = format_source_with("fun main() {\nlet x = 1\n}\n", 2).unwrap();
+    assert!(
+        out.contains("\n  let x = 1"),
+        "expected a two-space indent, got: {out:?}"
+    );
+    let four = format_source_with("fun main() {\nlet x = 1\n}\n", 4).unwrap();
+    assert!(
+        four.contains("\n    let x = 1"),
+        "expected a four-space indent"
+    );
+}
 use crate::lexer::Lexer;
 use crate::parser::parse;
 


### PR DESCRIPTION
Closes #432.

`rvpm fmt` never loaded the manifest, and the formatter's indent was a hardcoded four-space constant, so `[fmt].indent_width` in `rv.toml` was parsed but ignored.

The formatter now takes the indent width as a parameter (`format_source_with`), and `rvpm fmt` reads `[fmt].indent_width`, falling back to four spaces outside a project. Verified `indent_width = 2` produces two-space indents and the default stays four. Added a formatter test.

Note: `wrap_width` is read but not yet applied, because the formatter does not reflow long lines (that would be a separate feature). lib (532) and golden pass. Version 2.18.26.