### PR TITLE
fix(rvpm): keep existing src/main.rv on init; hash symlinks in the lock tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.27] - 2026-06-10
+
+### Fixed
+
+- `rvpm init` no longer overwrites an existing `src/main.rv`; it adds the manifest and keeps the source. The lock file's tree hash now also covers symlinks (a regular-file tree hashes the same as before, so existing lock files stay valid) (#435).
+
 ## [2.18.26] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.26"
+version = "2.18.27"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.26"
+version = "2.18.27"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.26"
+version = "2.18.27"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -322,45 +322,60 @@ pub fn validate_lock_in(lock: &LockFile, cache_root: &Path) -> Result<(), LockEr
 /// file mode or timestamp is included, so the same tree hashes identically
 /// across platforms.
 pub fn tree_hash(dir: &Path) -> std::io::Result<String> {
-    let mut files: Vec<(String, PathBuf)> = Vec::new();
+    let mut files: Vec<(String, PathBuf, bool)> = Vec::new();
     collect_files(dir, dir, &mut files)?;
     files.sort_by(|a, b| a.0.cmp(&b.0));
 
     let mut hasher = Sha256::new();
-    for (rel, abs) in &files {
-        let bytes = std::fs::read(abs)?;
+    for (rel, abs, is_symlink) in &files {
         hasher.update(rel.as_bytes());
         hasher.update([0u8]);
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update(&bytes);
+        if *is_symlink {
+            // Record the link's target so a symlink is not silently dropped
+            // from the tree. A tree of regular files hashes exactly as before,
+            // so existing lockfiles stay valid.
+            let target = std::fs::read_link(abs)?;
+            hasher.update(b"symlink:");
+            hasher.update(target.to_string_lossy().as_bytes());
+        } else {
+            let bytes = std::fs::read(abs)?;
+            hasher.update((bytes.len() as u64).to_le_bytes());
+            hasher.update(&bytes);
+        }
     }
     let digest = hasher.finalize();
     Ok(format!("sha256:{:x}", digest))
 }
 
+fn rel_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 fn collect_files(
     root: &Path,
     current: &Path,
-    out: &mut Vec<(String, PathBuf)>,
+    out: &mut Vec<(String, PathBuf, bool)>,
 ) -> std::io::Result<()> {
     for entry in std::fs::read_dir(current)? {
         let entry = entry?;
         let path = entry.path();
         let file_type = entry.file_type()?;
-        if file_type.is_dir() {
+        // Check symlink first: a symlink's own file type is neither directory
+        // nor file, so it would otherwise be dropped from the tree entirely.
+        if file_type.is_symlink() {
+            out.push((rel_path(root, &path), path, true));
+        } else if file_type.is_dir() {
             if entry.file_name() == ".git" {
                 continue;
             }
             collect_files(root, &path, out)?;
         } else if file_type.is_file() {
-            let rel = path
-                .strip_prefix(root)
-                .unwrap_or(&path)
-                .components()
-                .map(|c| c.as_os_str().to_string_lossy())
-                .collect::<Vec<_>>()
-                .join("/");
-            out.push((rel, path));
+            out.push((rel_path(root, &path), path, false));
         }
     }
     Ok(())

--- a/src/manifest/init.rs
+++ b/src/manifest/init.rs
@@ -66,7 +66,13 @@ pub fn init_project(dir: &Path, name: &str) -> Result<(), InitError> {
     let src_dir = dir.join("src");
     std::fs::create_dir_all(&src_dir)?;
     std::fs::write(&manifest_path, manifest_template(name))?;
-    std::fs::write(src_dir.join("main.rv"), main_rv_template(name))?;
+    // Do not clobber an existing entry point. A directory can already hold
+    // `src/main.rv` (a project that lost its manifest, or one laid out by hand),
+    // and `init` should add the manifest without throwing that source away.
+    let main_path = src_dir.join("main.rv");
+    if !main_path.exists() {
+        std::fs::write(main_path, main_rv_template(name))?;
+    }
     Ok(())
 }
 
@@ -125,6 +131,22 @@ mod tests {
         .unwrap();
         let err = init_project(&dir, "x").unwrap_err();
         assert!(matches!(err, InitError::ManifestExists));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn init_keeps_an_existing_main_rv() {
+        let dir = temp_dir("keepmain");
+        let src = dir.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("main.rv"), "fun main() { print(\"mine\") }\n").unwrap();
+        init_project(&dir, "x").unwrap();
+        let main_rv = std::fs::read_to_string(src.join("main.rv")).unwrap();
+        assert!(
+            main_rv.contains("mine"),
+            "init clobbered the existing source"
+        );
+        assert!(dir.join("rv.toml").exists());
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
Closes #435.

`init` wrote `src/main.rv` unconditionally, so running it in a directory that already had source threw that source away. It now writes the entry point only when one does not already exist (the `rv.toml` guard is unchanged), verified that an existing `main.rv` survives.

The lock file's tree hash also skipped symlinks entirely (a symlink's file type is neither file nor directory), so a tree differing only by a symlink hashed the same. Symlinks are now recorded by their target; a tree of regular files hashes exactly as before, so existing lock files stay valid. File modes are intentionally left out of the hash to keep it portable across platforms. Added an init test. lib (533) passes. Version 2.18.27.