### PR TITLE
fix(rvpm): reject path traversal in dependency path and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.28] - 2026-06-10
+
+### Fixed
+
+- `rvpm` rejects a dependency path or version that contains `..`, a path separator, or a `.` segment, closing a cache path-traversal gap before any directory is created (#431).
+
 ## [2.18.27] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.27"
+version = "2.18.28"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.27"
+version = "2.18.28"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.27"
+version = "2.18.28"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -70,6 +70,9 @@ pub enum LockError {
     },
     /// A dependency constraint was not a usable git ref (empty).
     EmptyConstraint { source: String },
+    /// A dependency constraint held a path separator or `..`, which could
+    /// escape the cache directory when used as a directory name.
+    InvalidConstraint { source: String, value: String },
     /// A pinned tree hash did not match the fetched tree.
     HashMismatch {
         source: String,
@@ -101,6 +104,11 @@ impl fmt::Display for LockError {
                 f,
                 "dependency '{}' has an empty version, expected a git tag or branch",
                 source
+            ),
+            LockError::InvalidConstraint { source, value } => write!(
+                f,
+                "dependency '{}' has an invalid version '{}': a version may not contain a path separator or '..'",
+                source, value
             ),
             LockError::HashMismatch {
                 source,
@@ -388,6 +396,15 @@ fn resolved_ref(dep: &crate::manifest::Dependency) -> Result<String, LockError> 
     if r.is_empty() {
         return Err(LockError::EmptyConstraint {
             source: dep_source(&dep.path),
+        });
+    }
+    // The version becomes a directory name under the cache, so reject anything
+    // that could climb out of it. A real version never holds a separator or a
+    // parent reference.
+    if r.contains('/') || r.contains('\\') || r.contains("..") {
+        return Err(LockError::InvalidConstraint {
+            source: dep_source(&dep.path),
+            value: r.to_string(),
         });
     }
     Ok(r.to_string())

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -222,7 +222,13 @@ impl GithubPath {
         let user = parts.next()?.to_string();
         let repo = parts.next()?.to_string();
         let subpath: Vec<String> = parts.map(|s| s.to_string()).collect();
-        if user.is_empty() || repo.is_empty() || subpath.iter().any(|s| s.is_empty()) {
+        // Every segment becomes a directory name under the cache, so reject an
+        // empty, `.`, `..`, or backslash-bearing segment that could escape it.
+        let unsafe_segment = |s: &str| s.is_empty() || s == "." || s == ".." || s.contains('\\');
+        if unsafe_segment(&user)
+            || unsafe_segment(&repo)
+            || subpath.iter().any(|s| unsafe_segment(s))
+        {
             return None;
         }
         Some(GithubPath {
@@ -468,6 +474,15 @@ mod tests {
     use crate::parser::parse;
 
     use super::super::scope::ScopeStack;
+
+    #[test]
+    fn github_path_rejects_traversal_segments() {
+        use super::GithubPath;
+        assert!(GithubPath::parse("github.com/user/repo").is_some());
+        assert!(GithubPath::parse("github.com/../etc/passwd").is_none());
+        assert!(GithubPath::parse("github.com/user/repo/../..").is_none());
+        assert!(GithubPath::parse("github.com/user/..").is_none());
+    }
     use super::*;
 
     /// In memory loader keyed by relative target path (already


### PR DESCRIPTION
Closes #431.

A GitHub import path and a dependency version both become directory names under the package cache, but neither was checked for `..` or a path separator, so a crafted dependency could aim the cache path outside its root.

`GithubPath::parse` now rejects an empty, `.`, `..`, or backslash-bearing segment, and `resolved_ref` rejects a version holding a separator or `..`. Both fail before any directory is created. Added a parse test. lib (534) passes. Version 2.18.28.