### PR TITLE
fix(codegen): keep a heap return value rooted across an allocating defer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.29] - 2026-06-10
+
+### Fixed
+
+- A heap return value is now kept rooted across an allocating `defer`. A function that returned a heap value (a String, list, struct, ...) and had a `defer` that allocated could have its return value collected by the defer's allocation, a use-after-free at the return (#438).
+
 ## [2.18.28] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.28"
+version = "2.18.29"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.28"
+version = "2.18.29"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.28"
+version = "2.18.29"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -195,6 +195,7 @@ impl<'cx, 'func> FunctionLowering<'cx, 'func> {
                 &blocks,
                 root_frame,
                 self.func.has_defer,
+                layout::is_gc_pointer(&self.func.ret_ty),
             )?;
         }
 
@@ -284,6 +285,7 @@ fn lower_block(
     blocks: &[cranelift_codegen::ir::Block],
     root_frame: Option<RootFrame>,
     has_defer: bool,
+    ret_is_gc: bool,
 ) -> Result<(), CodegenError> {
     for stmt in &mir_block.statements {
         lower_stmt(cx, builder, stmt, slots)?;
@@ -296,6 +298,7 @@ fn lower_block(
         blocks,
         root_frame,
         has_defer,
+        ret_is_gc,
     )?;
     Ok(())
 }
@@ -2951,6 +2954,7 @@ fn lower_terminator(
     blocks: &[cranelift_codegen::ir::Block],
     root_frame: Option<RootFrame>,
     has_defer: bool,
+    ret_is_gc: bool,
 ) -> Result<(), CodegenError> {
     match term {
         MirTerminator::Goto(target) => {
@@ -2991,9 +2995,22 @@ fn lower_terminator(
             // already-computed result (they are Unit-typed and cannot
             // change it). Defers run before leaving the GC frame, so they
             // may still touch rooted GC locals.
-            let v = lower_operand(cx, builder, op, slots)?;
+            let mut v = lower_operand(cx, builder, op, slots)?;
             if has_defer {
-                run_defer_frame(cx, builder);
+                // A deferred thunk may allocate and trigger a collection. A
+                // heap return value computed just above lives in an unrooted
+                // register, so root it across the defer run or the collector
+                // could free it (a use-after-free at the return). The GC does
+                // not move objects, so the reloaded pointer is the same value.
+                match v {
+                    Some(value) if ret_is_gc => {
+                        let ptr = cx.pointer_type();
+                        let slot = push_temp_root(cx, builder, value, ptr);
+                        run_defer_frame(cx, builder);
+                        v = Some(pop_temp_root(cx, builder, slot, ptr));
+                    }
+                    _ => run_defer_frame(cx, builder),
+                }
             }
             leave_root_frame(cx, builder, root_frame);
             match v {


### PR DESCRIPTION
Closes #438.

A function that returns a heap value evaluates it into an unrooted register, then runs its defer frame before returning. A deferred thunk that allocates can trigger a collection, which had no root for the return value and could free it, a use-after-free observed at the return.

When the function returns a GC pointer and has defers, the return value is now pushed as a temporary GC root for the defer run and reloaded afterward (the collector does not move objects, so the pointer is unchanged). Verified six runs under `RAVEN_GC_THRESHOLD=1` all return the correct value. lib (534), codegen_smoke (72), golden pass. Version 2.18.29.