### PR TITLE
fix(lexer, parser): handle char literals inside string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.30] - 2026-06-10
+
+### Fixed
+
+- A char literal inside a `${...}` interpolation can now hold a brace or a quote (`"${f('}')}"`). The lexer and the interpolation splitter both skip a char literal, so its contents are no longer read as interpolation structure (#419).
+
 ## [2.18.29] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.29"
+version = "2.18.30"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.29"
+version = "2.18.30"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.29"
+version = "2.18.30"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/char_in_interpolation.rv
+++ b/examples/v2/char_in_interpolation.rv
@@ -1,0 +1,11 @@
+// A char literal inside a `${...}` interpolation can hold a brace or a quote.
+// Those must not be read as interpolation structure and close it early.
+import std/io { println }
+
+fun code(c: Char) -> Int = 1
+
+fun main() {
+    println("close=${code('}')}")
+    println("open=${code('{')}")
+    println("quote=${code('"')}")
+}

--- a/examples/v2/char_in_interpolation.rv.out
+++ b/examples/v2/char_in_interpolation.rv.out
@@ -1,0 +1,3 @@
+close=1
+open=1
+quote=1

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -650,6 +650,28 @@ impl Lexer {
                     out.push(self.bump().unwrap()); // {
                     interp_depth += 1;
                 }
+                // Inside an interpolation a char literal is copied verbatim, so
+                // a `{`, `}`, `"`, or `$` inside it (`${'}'.debug()}`) is not
+                // mistaken for interpolation structure.
+                Some('\'') if interp_depth > 0 => {
+                    out.push(self.bump().unwrap()); // opening '
+                    loop {
+                        match self.peek() {
+                            None | Some('\n') | Some('\r') => break,
+                            Some('\\') => {
+                                out.push(self.bump().unwrap()); // backslash
+                                if self.peek().is_some() {
+                                    out.push(self.bump().unwrap()); // escaped char
+                                }
+                            }
+                            Some('\'') => {
+                                out.push(self.bump().unwrap()); // closing '
+                                break;
+                            }
+                            Some(_) => out.push(self.bump().unwrap()),
+                        }
+                    }
+                }
                 Some('{') if interp_depth > 0 => {
                     interp_depth += 1;
                     out.push(self.bump().unwrap());

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1368,6 +1368,22 @@ fn split_interpolation(
                         }
                         continue;
                     }
+                    b'\'' => {
+                        // Skip a char literal for the same reason: a `{`, `}`,
+                        // or `"` inside `'...'` must not affect the brace depth.
+                        j += 1;
+                        while j < bytes.len() {
+                            match bytes[j] {
+                                b'\\' => j += 2,
+                                b'\'' => {
+                                    j += 1;
+                                    break;
+                                }
+                                _ => j += 1,
+                            }
+                        }
+                        continue;
+                    }
                     b'{' => depth += 1,
                     b'}' => {
                         depth -= 1;


### PR DESCRIPTION
Closes #419.

Inside a `${...}` interpolation only nested string literals were skipped, so a char literal holding a brace or quote (`"${f('}')}"`) had its contents read as interpolation structure: the `}` in `'}'` closed the interpolation early.

The lexer now copies a char literal verbatim while scanning an interpolation, and the splitter skips a char literal the same way it skips a string. Verified `'}'`, `'{'`, and `'"'` inside interpolation all work. Added `examples/v2/char_in_interpolation.rv`. lib (534) and golden pass. Version 2.18.30.