### PR TITLE
fix(parser): undo a split >> token when a type-argument trial backtracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.31] - 2026-06-10
+
+### Fixed
+
+- `a < b >> c` is no longer wrongly rejected as a chained comparison. A failed attempt to read `<...>` as type arguments used to leave the `>>` token split into a single `>`; that rewrite is now undone on backtrack. Nested generics like `Map<K, Map<K, V>>` still close on `>>` (#413).
+
 ## [2.18.30] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.30"
+version = "2.18.31"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.30"
+version = "2.18.31"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.30"
+version = "2.18.31"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/angle_shift_disambiguation.rv
+++ b/examples/v2/angle_shift_disambiguation.rv
@@ -1,0 +1,16 @@
+// `a < b >> c` is a comparison of `a` with `b >> c`, not a generic. A failed
+// attempt to read `<...>` as type arguments must not leave the `>>` token split
+// into a single `>`. Nested generics like Map<K, Map<K, V>> still close on `>>`.
+import std/io { println }
+import std/collections
+
+fun main() {
+    let a = 1
+    let b = 8
+    let c = 1
+    println((a < b >> c).to_string())
+
+    let nested: Map<String, Map<String, Int>> = Map.new()
+    nested.set("k", Map.new())
+    println("nested generics ok")
+}

--- a/examples/v2/angle_shift_disambiguation.rv.out
+++ b/examples/v2/angle_shift_disambiguation.rv.out
@@ -1,0 +1,2 @@
+true
+nested generics ok

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -63,6 +63,11 @@ pub struct Parser {
     recovering: bool,
     /// Diagnostics accumulated during recovery (statement and item level).
     errors: Vec<RavenError>,
+    /// Log of in-place token rewrites (currently only `consume_close_angle`
+    /// splitting a `>>` into `>`), as `(index, original token)`. `rewind`
+    /// replays it so a failed speculative parse does not leave a split `>>`
+    /// behind.
+    token_edits: Vec<(usize, Token)>,
 }
 
 impl Parser {
@@ -78,6 +83,7 @@ impl Parser {
             macros: crate::macros::MacroTable::default(),
             recovering: false,
             errors: Vec::new(),
+            token_edits: Vec::new(),
         }
     }
 
@@ -93,6 +99,7 @@ impl Parser {
             macros,
             recovering: false,
             errors: Vec::new(),
+            token_edits: Vec::new(),
         }
     }
 
@@ -253,6 +260,19 @@ impl Parser {
 
     /// Rewind to a previously saved cursor.
     pub(crate) fn rewind(&mut self, pos: usize) {
+        // Undo any in-place token rewrite at or after the rewind point so a
+        // failed speculative parse does not leave a `>>` split into a single
+        // `>`. Edits before the rewind point were part of already-committed
+        // parsing and stay.
+        let mut i = 0;
+        while i < self.token_edits.len() {
+            if self.token_edits[i].0 >= pos {
+                let (idx, original) = self.token_edits.remove(i);
+                self.tokens[idx] = original;
+            } else {
+                i += 1;
+            }
+        }
         self.pos = pos;
     }
 

--- a/src/parser/ty.rs
+++ b/src/parser/ty.rs
@@ -183,6 +183,10 @@ impl Parser {
                 // Replace the `>>` token in place with a single `>`
                 // representing the second half. The cursor stays at
                 // the same position so the outer call sees that `>`.
+                // Record the original so `rewind` can restore it: a failed
+                // speculative parse must not leave the `>>` collapsed to `>`.
+                self.token_edits
+                    .push((self.pos, self.tokens[self.pos].clone()));
                 self.tokens[self.pos] = Token {
                     kind: TokenKind::Gt,
                     span: second_half,


### PR DESCRIPTION
Closes #413.

Closing nested generics rewrites a `>>` token in place into a single `>`. A speculative attempt to read `<...>` as type arguments could perform that rewrite and then backtrack on `pos` only, leaving the `>>` collapsed, so `a < b >> c` saw a stray `>` and was rejected as a chained comparison.

The parser now logs each in-place token rewrite, and `rewind` restores any rewrite at or after the backtrack point. Nested generics that genuinely close on `>>` (`Map<K, Map<K, V>>`) are unaffected. Verified both. lib (534) and golden pass. Version 2.18.31.