### PR TITLE
fix(lexer): make the full 64-bit integer range writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.32] - 2026-06-10
+
+### Fixed
+
+- The full 64-bit integer range is now writable. A hex or binary literal reinterprets its bits, so `0xFFFFFFFFFFFFFFFF` is `-1` and `0x8000000000000000` is `i64::MIN`, and the decimal `-9223372036854775808` is accepted as `i64::MIN`. A value beyond 64 bits still errors (#420).
+
 ## [2.18.31] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.31"
+version = "2.18.32"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.31"
+version = "2.18.32"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.31"
+version = "2.18.32"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -511,6 +511,13 @@ impl Lexer {
                     TokenKind::IntLit(v),
                     self.make_span(start, line, col),
                 )),
+                // `9223372036854775808` is the magnitude of `i64::MIN`, valid only
+                // as `-9223372036854775808`. Accept it as that bit pattern so the
+                // unary minus yields `i64::MIN`; any larger decimal is out of range.
+                Err(_) if cleaned == "9223372036854775808" => Ok(Token::new(
+                    TokenKind::IntLit(i64::MIN),
+                    self.make_span(start, line, col),
+                )),
                 Err(_) => Err(self.err(LexError::InvalidNumber(lexeme.into()), start, line, col)),
             }
         }
@@ -551,9 +558,13 @@ impl Lexer {
         }
         let raw = &self.source[digits_start..self.pos];
         let cleaned: String = raw.chars().filter(|c| *c != '_').collect();
-        match i64::from_str_radix(&cleaned, radix) {
+        // A hex or binary literal names a 64-bit pattern, so parse it as `u64`
+        // and reinterpret the bits as `i64`. This lets the full width be written
+        // (`0xFFFFFFFFFFFFFFFF` is -1, `0x8000000000000000` is i64::MIN), which a
+        // signed parse would reject for any value with bit 63 set.
+        match u64::from_str_radix(&cleaned, radix) {
             Ok(v) => Ok(Token::new(
-                TokenKind::IntLit(v),
+                TokenKind::IntLit(v as i64),
                 self.make_span(start, line, col),
             )),
             Err(_) => {

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -23,6 +23,24 @@ fn empty_source_yields_eof_only() {
 }
 
 #[test]
+fn full_width_integer_literals_are_writable() {
+    // i64::MIN's decimal magnitude is accepted as the bit pattern (valid with a
+    // leading minus), and a full-width hex pattern reinterprets its bits.
+    assert_eq!(
+        lex("9223372036854775808")[0].kind,
+        TokenKind::IntLit(i64::MIN)
+    );
+    assert_eq!(lex("0xFFFFFFFFFFFFFFFF")[0].kind, TokenKind::IntLit(-1));
+    assert_eq!(
+        lex("0x8000000000000000")[0].kind,
+        TokenKind::IntLit(i64::MIN)
+    );
+    // A value beyond the 64-bit range still errors.
+    lex_err("0x1FFFFFFFFFFFFFFFF");
+    lex_err("99999999999999999999999");
+}
+
+#[test]
 fn malformed_numeric_literal_is_an_error_not_a_split() {
     // A digit invalid for the base, or a letter right after a number, is a
     // single malformed literal, not a valid number followed by a second token.


### PR DESCRIPTION
Closes #420.

A hex or binary literal was parsed as a signed `i64`, so any pattern with bit 63 set (`0xFFFFFFFFFFFFFFFF`, `0x8000000000000000`) overflowed and was rejected. And `i64::MIN` had no decimal form, since its magnitude `9223372036854775808` does not fit a positive `i64`.

Hex and binary literals are now parsed as `u64` and reinterpreted as `i64`, so the full width is writable, and the decimal magnitude is accepted as the `i64::MIN` bit pattern (valid as `-9223372036854775808`). A value beyond 64 bits still errors. Added a lexer test. lib (535) and golden pass. Version 2.18.32.