### PR TITLE
fix(stdlib): length-prefix regex list results instead of joining on newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.33] - 2026-06-10
+
+### Fixed
+
+- `regex` `find_all`, `captures`, and `split` no longer corrupt a result that contains a newline. List results now cross the runtime boundary length-prefixed instead of newline-joined, which also distinguishes an empty list from a one-element list holding the empty string (#430).
+
 ## [2.18.32] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.32"
+version = "2.18.33"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.32"
+version = "2.18.33"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.32"
+version = "2.18.33"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/regex_newline.rv
+++ b/examples/v2/regex_newline.rv
@@ -1,0 +1,17 @@
+// A regex result may contain a newline. find_all of a dot-all pattern over text
+// with a newline returns one match, not one per line, because the list crosses
+// the runtime boundary length-prefixed rather than newline-joined.
+import std/io { println }
+import std/regex
+
+fun main() {
+    match regex.compile("(?s).+") {
+        Ok(re) -> {
+            let ms = re.find_all("a\nb\nc")
+            println("matches: ${ms.len().to_string()}")
+            println("has newline: ${ms.get(0).contains("\n").to_string()}")
+            re.free()
+        },
+        Err(e) -> println("compile failed"),
+    }
+}

--- a/examples/v2/regex_newline.rv.out
+++ b/examples/v2/regex_newline.rv.out
@@ -1,0 +1,2 @@
+matches: 1
+has newline: true

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1676,16 +1676,26 @@ pub extern "C" fn raven_regex_find_all(
         .map(|text| {
             let registry = regex_registry().lock().unwrap();
             match registry.get(&id) {
-                Some(re) => re
-                    .find_iter(text)
-                    .map(|m| m.as_str())
-                    .collect::<Vec<&str>>()
-                    .join("\n"),
+                Some(re) => encode_str_list(re.find_iter(text).map(|m| m.as_str())),
                 None => std::string::String::new(),
             }
         })
         .unwrap_or_default();
     object::raven_string_from_bytes(value.as_ptr(), value.len())
+}
+
+/// Encode a list of strings for transport to Raven as one `String`: each
+/// element is its byte length in decimal, then a `:`, then its bytes. This is
+/// unambiguous even when an element contains a newline or a colon, which the
+/// previous newline join was not. `std/regex` decodes it.
+fn encode_str_list<'a>(elems: impl IntoIterator<Item = &'a str>) -> std::string::String {
+    let mut out = std::string::String::new();
+    for e in elems {
+        out.push_str(&e.len().to_string());
+        out.push(':');
+        out.push_str(e);
+    }
+    out
 }
 
 /// The capture groups of the first match of the compiled pattern `id` in
@@ -1706,10 +1716,7 @@ pub extern "C" fn raven_regex_captures(
             let registry = regex_registry().lock().unwrap();
             registry.get(&id).and_then(|re| {
                 re.captures(text).map(|caps| {
-                    caps.iter()
-                        .map(|g| g.map(|m| m.as_str()).unwrap_or(""))
-                        .collect::<Vec<&str>>()
-                        .join("\n")
+                    encode_str_list(caps.iter().map(|g| g.map(|m| m.as_str()).unwrap_or("")))
                 })
             })
         })
@@ -1757,8 +1764,9 @@ pub extern "C" fn raven_regex_split(id: i64, text: *const object::String) -> *mu
         .map(|text| {
             let registry = regex_registry().lock().unwrap();
             match registry.get(&id) {
-                Some(re) => re.split(text).collect::<Vec<&str>>().join("\n"),
-                None => text.to_string(),
+                Some(re) => encode_str_list(re.split(text)),
+                // Unknown id: the text unsplit, as a single encoded element.
+                None => encode_str_list(std::iter::once(text)),
             }
         })
         .unwrap_or_default();

--- a/stdlib/std/regex.rv
+++ b/stdlib/std/regex.rv
@@ -4,8 +4,9 @@
 // registry keyed by an opaque integer id and hands Raven that id; the
 // Regex struct wraps the id. compile is fallible and returns
 // Result<Regex, Error> tagged with kind "regex" via the runtime's
-// thread-local last-error slot. List results cross the FFI as `\n`-joined
-// Strings split back into a List in Raven. There is no destructor, so a
+// thread-local last-error slot. List results cross the FFI as a single
+// length-prefixed String decoded back into a List in Raven, so an element may
+// contain any byte (a newline included). There is no destructor, so a
 // caller should `free` a pattern when done; not freeing leaks the
 // registry entry for the life of the process. See
 // docs/v2/specs/std-regex.md.
@@ -57,7 +58,7 @@ impl Regex {
     // Every non-overlapping match in `text`. No matches yields an empty
     // list.
     fun find_all(self, text: String) -> List<String> {
-        return split_lines(raven_regex_find_all(self.id, text))
+        return decode_list(raven_regex_find_all(self.id, text))
     }
 
     // The capture groups of the first match: group 0 (the whole match)
@@ -65,7 +66,7 @@ impl Regex {
     // an empty string. No match yields an empty list.
     fun captures(self, text: String) -> List<String> {
         if raven_regex_has_match(self.id, text) {
-            return split_lines(raven_regex_captures(self.id, text))
+            return decode_list(raven_regex_captures(self.id, text))
         }
         let empty: List<String> = []
         return empty
@@ -79,7 +80,7 @@ impl Regex {
 
     // Split `text` on the pattern.
     fun split(self, text: String) -> List<String> {
-        return split_lines(raven_regex_split(self.id, text))
+        return decode_list(raven_regex_split(self.id, text))
     }
 
     // Release the compiled pattern. There is no destructor, so call this
@@ -89,24 +90,29 @@ impl Regex {
     }
 }
 
-// Split `s` on `\n` into a list. An empty string yields an empty list (not
-// a one-element list of ""), so an empty runtime result maps to an empty
-// list.
-fun split_lines(s: String) -> List<String> {
+// Decode a length-prefixed list emitted by the runtime: repeated
+// `<len>:<bytes>` where `len` is the element's byte length in decimal. This is
+// unambiguous even when an element contains a newline or a colon, which a
+// newline-joined encoding was not, and it distinguishes an empty list (no
+// elements) from a one-element list holding the empty string. An empty input
+// decodes to an empty list.
+fun decode_list(s: String) -> List<String> {
     let out: List<String> = []
-    if s.length() == 0 {
-        return out
-    }
-    let n = s.length()
-    let start = 0
+    let n = __str_len(s)
     let i = 0
     while i < n {
-        if s.char_at(i).starts_with("\n") {
-            out.push(s.substring(start, i))
-            start = i + 1
+        let len = 0
+        while i < n {
+            let b = __str_byte_at(s, i)
+            if b == 58 {
+                i = i + 1
+                break
+            }
+            len = len * 10 + (b - 48)
+            i = i + 1
         }
-        i = i + 1
+        out.push(s.substring(i, i + len))
+        i = i + len
     }
-    out.push(s.substring(start, n))
     return out
 }


### PR DESCRIPTION
Closes #430.

`find_all`, `captures`, and `split` returned their list by joining elements with a newline, which the Raven side split back on a newline. A match or split piece that itself contained a newline was torn into several entries, and an empty result could not be told from a single empty string.

The runtime now encodes the list length-prefixed (each element is its byte length, a colon, then its bytes), and `std/regex` decodes that. Verified `find_all` of `(?s).+` over `a\nb\nc` returns one match containing the newlines, and `split` keeps a newline inside a piece. lib (535), codegen_smoke (72), golden pass. Version 2.18.33.