### PR TITLE
fix(stdlib): encoding decoders report malformed input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.34] - 2026-06-10
+
+### Changed
+
+- `std/encoding`'s `hex_decode`, `base64_decode`, and `base32_decode` now return `Result<String, Error>` and reject malformed input (an odd or wrong length, or a non-alphabet byte) instead of silently dropping or zeroing it (#434).
+
 ## [2.18.33] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.33"
+version = "2.18.34"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.33"
+version = "2.18.34"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.33"
+version = "2.18.34"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/std-encoding.md
+++ b/docs/v2/specs/std-encoding.md
@@ -8,7 +8,8 @@ encode a `String`'s raw bytes to text and decode the inverse.
 A Raven `String` is a byte buffer. These functions treat the input as raw
 bytes (`__str_byte_at` reads byte values 0..255), so they work on arbitrary
 binary data carried in a `String`, not only valid UTF-8 text. A decoder
-likewise returns the decoded bytes as a `String`.
+returns `Result<String, Error>`: the decoded bytes on success, or an `Error`
+tagged `"encoding"` when the input is malformed.
 
 ## Import
 
@@ -20,7 +21,7 @@ import std/encoding { hex_encode, hex_decode, base64_encode, base64_decode }
 fun main() {
     let h = hex_encode("abc")          // "616263"
     let b = base64_encode("abc")       // "YWJj"
-    let back = base64_decode(b)        // "abc"
+    let back = base64_decode(b)        // Ok("abc")
 }
 ```
 
@@ -29,9 +30,10 @@ fun main() {
 | Function | Result | Notes |
 |---|---|---|
 | `hex_encode(s: String)` | `String` | each input byte to two lowercase hex digits |
-| `hex_decode(s: String)` | `String` | inverse; accepts lowercase, uppercase, or mixed |
+| `hex_decode(s: String)` | `Result<String, Error>` | inverse; accepts lower, upper, or mixed; Err on an odd length or a non-hex byte |
 | `base64_encode(s: String)` | `String` | standard alphabet (`A-Z a-z 0-9 + /`), `=` padding |
-| `base64_decode(s: String)` | `String` | inverse; honors `=` padding |
+| `base64_decode(s: String)` | `Result<String, Error>` | inverse; honors `=` padding; Err on a bad length or a non-alphabet byte |
+| `base32_decode(s: String)` | `Result<String, Error>` | inverse; honors `=` padding; Err on a non-alphabet byte |
 
 ## Known vectors
 
@@ -42,14 +44,14 @@ decode round-trips: `base64_decode(base64_encode(s)) == s`.
 
 ## Invalid input
 
-The decoders favor a simple, total mapping over rejecting input:
+The decoders reject malformed input with an `Err` rather than silently
+producing wrong bytes:
 
-- `hex_decode`: digits outside `0-9 a-f A-F` map to nibble `0`. An odd final
-  digit is read as the high nibble of a zero-padded byte.
-- `base64_decode`: bytes outside the alphabet (other than `=` padding) map to
-  sextet `0`. Trailing `=` padding sets how many bytes the final group
-  yields. Input whose length is not a multiple of four decodes the leading
-  whole groups and drops a trailing partial group.
+- `hex_decode`: an odd length, or any byte outside `0-9 a-f A-F`, is an `Err`.
+- `base64_decode`: a length that is not a multiple of four, or any byte outside
+  the alphabet other than `=` padding, is an `Err`.
+- `base32_decode`: any byte outside the alphabet other than `=` padding is an
+  `Err`.
 
 ## Out of scope
 

--- a/examples/v2/stdlib_encoding.rv
+++ b/examples/v2/stdlib_encoding.rv
@@ -15,7 +15,10 @@ fun main() {
     print(url_encode("a b/c"))              // a%20b%2Fc
     print(url_decode("a%20b%2Fc"))          // a b/c
     print(base32_encode("foobar"))          // MZXW6YTBOI======
-    print(base32_decode("MZXW6YTBOI======"))  // foobar
+    match base32_decode("MZXW6YTBOI======") {
+        Ok(d) -> print(d),
+        Err(e) -> print("err"),
+    }
     print(normalize("/a/b/../c/./d"))       // /a/c/d
     print(with_extension("report.txt", "md"))  // report.md
     print(crc32("123456789"))               // 3421780262

--- a/examples/v2/use_encoding.rv
+++ b/examples/v2/use_encoding.rv
@@ -8,7 +8,16 @@ fun main() {
     println(base64_encode("Man"))
     println(base64_encode("Ma"))
     println(base64_encode("M"))
-    print(hex_decode("616263") == "abc")
-    print(base64_decode("YWJj") == "abc")
-    print(base64_decode(base64_encode("hello, world")) == "hello, world")
+    match hex_decode("616263") {
+        Ok(d) -> println((d == "abc").to_string()),
+        Err(e) -> println("err"),
+    }
+    match base64_decode("YWJj") {
+        Ok(d) -> println((d == "abc").to_string()),
+        Err(e) -> println("err"),
+    }
+    match base64_decode(base64_encode("hello, world")) {
+        Ok(d) -> println((d == "hello, world").to_string()),
+        Err(e) -> println("err"),
+    }
 }

--- a/stdlib/std/encoding.rv
+++ b/stdlib/std/encoding.rv
@@ -2,6 +2,14 @@
 // Raven String is a byte buffer; input is treated as raw bytes. See
 // docs/v2/specs/std-encoding.md.
 
+import std/error
+
+// An Error tagged with kind "encoding". The struct literal is built directly:
+// a bundled module cannot call another bundled module's free helpers.
+fun encoding_error(msg: String) -> Error {
+    return Error { kind: "encoding", message: msg }
+}
+
 // Map a 0..15 nibble to its lowercase hex digit byte.
 fun hex_digit(v: Int) -> Int {
     if v < 10 {
@@ -28,7 +36,7 @@ fun hex_value(b: Int) -> Int {
             return b - 55
         }
     }
-    return 0
+    return -1
 }
 
 fun hex_encode(s: String) -> String {
@@ -44,23 +52,25 @@ fun hex_encode(s: String) -> String {
     return out
 }
 
-// Inverse of hex_encode. Assumes even length; a trailing odd byte is
-// ignored. Non-hex bytes decode as 0.
-fun hex_decode(s: String) -> String {
+// Inverse of hex_encode. An odd length, or any non-hex byte, is an Err rather
+// than silently producing wrong output.
+fun hex_decode(s: String) -> Result<String, Error> {
     let n = __str_len(s)
+    if n % 2 != 0 {
+        return Err(encoding_error("hex input has an odd length"))
+    }
     let out = ""
     let i = 0
-    while i + 1 < n {
+    while i < n {
         let hi = hex_value(__str_byte_at(s, i))
         let lo = hex_value(__str_byte_at(s, i + 1))
+        if hi < 0 || lo < 0 {
+            return Err(encoding_error("hex input has a non-hex character"))
+        }
         out = __str_concat(out, __str_from_byte((hi << 4) | lo))
         i = i + 2
     }
-    if i < n {
-        // Lone final digit: treat as the high nibble of a zero-padded byte.
-        out = __str_concat(out, __str_from_byte(hex_value(__str_byte_at(s, i)) << 4))
-    }
-    return out
+    return Ok(out)
 }
 
 // Map a 0..63 sextet to its standard base64 alphabet byte (A-Z, a-z,
@@ -105,7 +115,7 @@ fun b64_value(b: Int) -> Int {
     if b == 47 {
         return 63
     }
-    return 0
+    return -1
 }
 
 fun base64_encode(s: String) -> String {
@@ -140,11 +150,14 @@ fun base64_encode(s: String) -> String {
     return out
 }
 
-// Inverse of base64_encode. Trailing `=` padding sets how many bytes the
-// final group yields. Input length not a multiple of 4 decodes what it
-// can; stray non-alphabet bytes contribute 0.
-fun base64_decode(s: String) -> String {
+// Inverse of base64_encode. The length must be a multiple of 4, trailing `=`
+// is padding, and any other non-alphabet byte is an Err rather than silently
+// contributing a wrong value.
+fun base64_decode(s: String) -> Result<String, Error> {
     let n = __str_len(s)
+    if n % 4 != 0 {
+        return Err(encoding_error("base64 input length is not a multiple of 4"))
+    }
     let out = ""
     let i = 0
     while i + 4 <= n {
@@ -156,6 +169,16 @@ fun base64_decode(s: String) -> String {
         let v1 = b64_value(c1)
         let v2 = b64_value(c2)
         let v3 = b64_value(c3)
+        // The first two bytes must be alphabet; the last two may be `=` padding.
+        if v0 < 0 || v1 < 0 {
+            return Err(encoding_error("base64 input has a non-alphabet character"))
+        }
+        if c2 != 61 && v2 < 0 {
+            return Err(encoding_error("base64 input has a non-alphabet character"))
+        }
+        if c3 != 61 && v3 < 0 {
+            return Err(encoding_error("base64 input has a non-alphabet character"))
+        }
         let o0 = ((v0 << 2) | (v1 >> 4)) & 255
         out = __str_concat(out, __str_from_byte(o0))
         if c2 != 61 {
@@ -170,7 +193,7 @@ fun base64_decode(s: String) -> String {
         }
         i = i + 4
     }
-    return out
+    return Ok(out)
 }
 
 // Map a 0..15 nibble to its uppercase hex digit byte (for percent-encoding).
@@ -245,8 +268,14 @@ fun url_decode(s: String) -> String {
             if i + 2 < n {
                 let hi = hex_value(__str_byte_at(s, i + 1))
                 let lo = hex_value(__str_byte_at(s, i + 2))
-                out = __str_concat(out, __str_from_byte(hi * 16 + lo))
-                i = i + 3
+                if hi < 0 || lo < 0 {
+                    // Not a valid `%XX` escape: keep the `%` as a literal byte.
+                    out = __str_concat(out, __str_from_byte(b))
+                    i = i + 1
+                } else {
+                    out = __str_concat(out, __str_from_byte(hi * 16 + lo))
+                    i = i + 3
+                }
             } else {
                 out = __str_concat(out, __str_from_byte(b))
                 i = i + 1
@@ -335,7 +364,9 @@ fun base32_encode(s: String) -> String {
 
 // Decode an RFC 4648 base32 string. Padding and non-alphabet bytes are
 // skipped. The inverse of `base32_encode`.
-fun base32_decode(s: String) -> String {
+// Inverse of base32_encode. Trailing `=` is padding; any other non-alphabet
+// byte is an Err rather than being silently skipped.
+fun base32_decode(s: String) -> Result<String, Error> {
     let n = __str_len(s)
     let out = ""
     let acc = 0
@@ -343,8 +374,14 @@ fun base32_decode(s: String) -> String {
     let i = 0
     while i < n {
         let b = __str_byte_at(s, i)
-        let v = base32_value(b)
-        if v >= 0 {
+        if b == 61 {
+            // `=` padding: no more data bits follow.
+            i = i + 1
+        } else {
+            let v = base32_value(b)
+            if v < 0 {
+                return Err(encoding_error("base32 input has a non-alphabet character"))
+            }
             acc = (acc << 5) | v
             bits = bits + 5
             if bits >= 8 {
@@ -352,8 +389,8 @@ fun base32_decode(s: String) -> String {
                 let byte = (acc >> bits) & 255
                 out = __str_concat(out, __str_from_byte(byte))
             }
+            i = i + 1
         }
-        i = i + 1
     }
-    return out
+    return Ok(out)
 }


### PR DESCRIPTION
Closes #434.

`hex_decode`, `base64_decode`, and `base32_decode` returned a `String` and mapped a bad byte to zero, dropped a partial tail, or skipped a stray byte, so malformed input silently produced wrong output.

They now return `Result<String, Error>` and reject malformed input: an odd hex length or non-hex byte, a base64 length not a multiple of four or a non-alphabet byte, and a non-alphabet base32 byte (each other than `=` padding). Verified valid inputs still round-trip and each malformed case returns a clear error. This is a breaking API change; the examples and spec are updated. lib (535) and golden pass. Version 2.18.34.