### PR TITLE
fix(mir, tycheck): lower match arm guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.35] - 2026-06-10
+
+### Fixed
+
+- `match` arm guards now work. They were parsed and type-checked but silently dropped at MIR lowering, so a guarded arm ran unconditionally and the wrong arm could execute. A guarded match now lowers to a sequential fall-through, and exhaustiveness no longer counts a guarded arm as covering its pattern (#408).
+
 ## [2.18.34] - 2026-06-10
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.34"
+version = "2.18.35"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.34"
+version = "2.18.35"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.34"
+version = "2.18.35"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/match_guards.rv
+++ b/examples/v2/match_guards.rv
@@ -1,0 +1,31 @@
+// A guard runs after the pattern matches: the arm is taken only when the guard
+// is true, otherwise the match falls through to the next arm. Several arms may
+// share a pattern with different guards.
+import std/io { println }
+
+fun classify(n: Int) -> String {
+    return match n {
+        x if x > 10 -> "big",
+        x if x > 0 -> "small",
+        _ -> "non-positive",
+    }
+}
+
+fun sign(o: Option<Int>) -> String {
+    return match o {
+        Some(n) if n > 0 -> "positive",
+        Some(n) if n < 0 -> "negative",
+        Some(n) -> "zero",
+        None -> "none",
+    }
+}
+
+fun main() {
+    println(classify(20))
+    println(classify(5))
+    println(classify(0 - 1))
+    println(sign(Some(7)))
+    println(sign(Some(0 - 3)))
+    println(sign(Some(0)))
+    println(sign(None))
+}

--- a/examples/v2/match_guards.rv.out
+++ b/examples/v2/match_guards.rv.out
@@ -1,0 +1,7 @@
+big
+small
+non-positive
+positive
+negative
+zero
+none

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -46,7 +46,12 @@ pub fn lower_match(
     let result_local = cx.builder.fresh_temp("match", result_ty);
     let cont = cx.builder.new_block();
 
-    if is_enum_like(&scrut_ty) {
+    // A guard needs sequential fall-through, which the switch-based paths
+    // cannot express, so any match with a guarded arm takes the sequential
+    // lowering regardless of scrutinee type.
+    if arms.iter().any(|a| a.guard.is_some()) {
+        lower_sequential_match(cx, scrut_op, &scrut_ty, arms, result_local, cont);
+    } else if is_enum_like(&scrut_ty) {
         lower_enum_match(cx, scrut_op, &scrut_ty, arms, result_local, cont);
     } else if matches!(scrut_ty, Ty::Int | Ty::Bool | Ty::Char) {
         lower_int_match(cx, scrut_op, &scrut_ty, arms, result_local, cont);
@@ -256,6 +261,122 @@ fn lower_fallback_match(
     }
     // Trailing chain: if no arm matched, fall through to continuation
     // with whatever placeholder the result local already holds.
+    if !cx.builder.is_closed(next_test) {
+        cx.builder.close_block(next_test, MirTerminator::Goto(cont));
+    }
+}
+
+/// Lower a match where at least one arm has a guard. Guards need a sequential
+/// fall-through that a `SwitchEnum`/`SwitchInt` cannot express: an arm whose
+/// pattern matches but whose guard is false must drop through to the next arm,
+/// and two arms may share a pattern with different guards. Each arm is tested in
+/// order (a per-arm `SwitchEnum`/`SwitchInt` for a constructor or literal, an
+/// unconditional jump for a binding or wildcard); on a match the pattern is
+/// bound and the guard, if any, is evaluated, falling through to the next arm
+/// when it is false.
+fn lower_sequential_match(
+    cx: &mut LowerCx<'_>,
+    scrut: MirOperand,
+    scrut_ty: &Ty,
+    arms: &[HirArm],
+    result: super::super::ir::MirLocal,
+    cont: MirBlockId,
+) {
+    let mut next_test = cx.current;
+    for arm in arms {
+        let arm_block = cx.builder.new_block();
+        let test_next = cx.builder.new_block();
+
+        match &arm.pattern.kind {
+            HirPatternKind::Wildcard | HirPatternKind::Binding(_) => {
+                if !cx.builder.is_closed(next_test) {
+                    cx.builder
+                        .close_block(next_test, MirTerminator::Goto(arm_block));
+                }
+            }
+            HirPatternKind::Literal(lit) => {
+                let cmp_local = cx
+                    .builder
+                    .fresh_temp("cmp", super::super::ty::MirType::Bool);
+                let test = if let HirLiteralPat::Str(s) = lit {
+                    MirRvalue::Call {
+                        callee: super::super::ir::MirFnRef {
+                            mangled: super::super::intrinsics::STR_EQ.into(),
+                            origin: None,
+                        },
+                        args: vec![
+                            scrut.clone(),
+                            MirOperand::Const(MirConstant::Str(s.clone())),
+                        ],
+                    }
+                } else {
+                    MirRvalue::BinaryOp(
+                        super::super::ir::MirBinOp::Eq,
+                        scrut.clone(),
+                        MirOperand::Const(literal_to_const(lit)),
+                    )
+                };
+                cx.builder.assign(next_test, cmp_local, test);
+                cx.builder.close_block(
+                    next_test,
+                    MirTerminator::SwitchInt {
+                        discriminant: MirOperand::Copy(cmp_local),
+                        targets: vec![(1, arm_block)],
+                        otherwise: test_next,
+                    },
+                );
+            }
+            HirPatternKind::Constructor { .. } | HirPatternKind::Struct { .. } => {
+                match variant_index_of(&arm.pattern, scrut_ty, cx) {
+                    Some(idx) => cx.builder.close_block(
+                        next_test,
+                        MirTerminator::SwitchEnum {
+                            discriminant: scrut.clone(),
+                            targets: vec![(idx, arm_block)],
+                            otherwise: Some(test_next),
+                        },
+                    ),
+                    None => {
+                        if !cx.builder.is_closed(next_test) {
+                            cx.builder
+                                .close_block(next_test, MirTerminator::Goto(arm_block));
+                        }
+                    }
+                }
+            }
+            _ => {
+                if !cx.builder.is_closed(next_test) {
+                    cx.builder
+                        .close_block(next_test, MirTerminator::Goto(arm_block));
+                }
+            }
+        }
+
+        cx.current = arm_block;
+        bind_pattern(cx, &arm.pattern, scrut_ty, &scrut);
+        // A false guard drops through to the next arm's test.
+        if let Some(guard) = &arm.guard {
+            let g = super::expr::lower_expr(cx, guard);
+            let run = cx.builder.new_block();
+            cx.builder.close_block(
+                cx.current,
+                MirTerminator::SwitchInt {
+                    discriminant: g,
+                    targets: vec![(1, run)],
+                    otherwise: test_next,
+                },
+            );
+            cx.current = run;
+        }
+        let v = super::expr::lower_expr(cx, &arm.body);
+        cx.builder.assign(cx.current, result, MirRvalue::Use(v));
+        if !cx.builder.is_closed(cx.current) {
+            cx.builder
+                .close_block(cx.current, MirTerminator::Goto(cont));
+        }
+
+        next_test = test_next;
+    }
     if !cx.builder.is_closed(next_test) {
         cx.builder.close_block(next_test, MirTerminator::Goto(cont));
     }

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -2987,7 +2987,15 @@ impl<'a, 'b> Checker<'a, 'b> {
                     self.infer.resolve(&prev)
                 }
             });
-            pattern_names.push(super::match_check::pattern_head(&arm.pattern));
+            // A guarded arm only matches when its guard holds, so it neither
+            // covers its pattern for exhaustiveness nor shadows a later arm with
+            // the same pattern. Treat it as a non-covering specific head.
+            let head = if arm.guard.is_some() {
+                super::match_check::PatternHead::Other
+            } else {
+                super::match_check::pattern_head(&arm.pattern)
+            };
+            pattern_names.push(head);
         }
 
         super::match_check::check(&scrut_stripped, &pattern_names, span, self.env)?;


### PR DESCRIPTION
Closes #408.

Guards were parsed and type-checked but never read at MIR lowering: every match went through a `SwitchEnum`/`SwitchInt` straight to the arm body, so a guarded arm ran unconditionally. Exhaustiveness also counted a guarded arm as covering its pattern.

A match with any guarded arm now takes a sequential lowering: each arm is tested in order, and on a pattern match the guard is evaluated, falling through to the next arm when false (so several arms may share a pattern with different guards). Unguarded matches keep the efficient switch. Exhaustiveness treats a guarded arm as non-covering, so a fully guarded match needs a catch-all.

Verified guarded int and Option matches dispatch correctly and a non-exhaustive guarded match is rejected. Added `examples/v2/match_guards.rv`. lib (535), codegen_smoke (72), golden pass. Version 2.18.35.