### PR TITLE
fix(tycheck): reject unsupported nested constructor patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.36] - 2026-06-10
+
+### Fixed
+
+- A nested constructor pattern (`Some(Ok(x))`, `Some(0)`) is now rejected with a clear error instead of being accepted and mis-bound. Only one level of constructor binding is lowered today; nesting an inner constructor, literal, or range silently miscompiled (#409).
+
 ## [2.18.35] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.35"
+version = "2.18.36"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.35"
+version = "2.18.36"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.35"
+version = "2.18.36"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -2967,6 +2967,18 @@ impl<'a, 'b> Checker<'a, 'b> {
         let mut pattern_names: Vec<super::match_check::PatternHead> = Vec::new();
 
         for arm in arms {
+            // A constructor pattern whose element is itself a constructor,
+            // literal, or range (`Some(Ok(x))`, `Some(0)`) is not supported:
+            // the lowering binds only one level and would miscompile. Reject it
+            // rather than silently mis-binding.
+            if let Some(nested) = unsupported_nesting_span(&arm.pattern) {
+                return Err(RavenError::ty(
+                    TypeError::Custom(
+                        "a nested pattern inside a constructor is not supported yet; bind the inner value and match it separately".into(),
+                    ),
+                    nested,
+                ));
+            }
             // Each arm gets its own pattern bindings.
             let mut arm_locals = self.locals.clone();
             pattern::bind(&arm.pattern, &scrut_stripped, self.env, &mut arm_locals)?;
@@ -3380,6 +3392,28 @@ fn compound_binary_op(op: AssignOp) -> BinaryOp {
         AssignOp::Shl => BinaryOp::Shl,
         AssignOp::Shr => BinaryOp::Shr,
         AssignOp::Assign => BinaryOp::Add, // unreachable in callers
+    }
+}
+
+/// The span of the first constructor-pattern element that is itself a
+/// constructor, literal, or range (an unsupported nested pattern), or `None`
+/// when the pattern nests only wildcards and bindings. A bare identifier is
+/// allowed because it lowers to a simple binding.
+fn unsupported_nesting_span(pat: &crate::ast::Pattern) -> Option<Span> {
+    use crate::ast::PatternKind;
+    let trivial =
+        |p: &crate::ast::Pattern| matches!(p.kind, PatternKind::Wildcard | PatternKind::Ident(_));
+    match &pat.kind {
+        PatternKind::Tuple { elements, .. } => elements
+            .iter()
+            .find(|e| !trivial(e))
+            .map(|e| e.span.clone()),
+        PatternKind::Struct { fields, .. } => fields
+            .iter()
+            .filter_map(|f| f.pattern.as_ref())
+            .find(|p| !trivial(p))
+            .map(|p| p.span.clone()),
+        _ => None,
     }
 }
 

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -107,6 +107,15 @@ fn inferred_type_violating_a_bound_is_rejected() {
 }
 
 #[test]
+fn nested_constructor_pattern_is_rejected() {
+    // A constructor pattern whose element is itself a constructor is not
+    // supported and must be a clean type error, not a silent miscompile.
+    // Regression for #409.
+    let bad = "fun f(x: Option<Result<Int, Int>>) -> Int {\n    return match x {\n        Some(Ok(n)) -> n,\n        Some(Err(e)) -> 0 - e,\n        None -> 0,\n    }\n}\nfun main() {}\n";
+    assert!(check(bad).is_err());
+}
+
+#[test]
 fn generic_method_return_only_param_is_grounded() {
     // A method whose generic parameter appears only in the return type
     // type-checks both via an annotation (the expected type) and via an


### PR DESCRIPTION
Closes #409.

A constructor pattern whose element is itself a constructor, literal, or range (`Some(Ok(x))`, `Some(0)`) was accepted, but the lowering binds only one level and emitted a Nop for the inner pattern, so the inner value was neither matched nor bound and the match silently miscompiled.

Such a pattern is now a clear type error pointing at the nested element. A bare identifier element stays allowed (it lowers to a simple binding). Full nested-pattern support would be a separate feature. Verified the nested case errors and ordinary one-level patterns still work. lib (536), codegen_smoke (72), golden pass. Version 2.18.36.