### PR TITLE
fix(runtime): feed process stdin on a separate thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.37] - 2026-06-10
+
+### Fixed
+
+- `process.run_with_input` no longer deadlocks when a child produces a lot of output while still reading stdin. Stdin is now fed on a separate thread while the parent drains stdout and stderr (#404).
+
 ## [2.18.36] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.36"
+version = "2.18.37"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.36"
+version = "2.18.37"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.36"
+version = "2.18.37"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1842,21 +1842,31 @@ pub extern "C" fn raven_process_run(
         }
     };
 
-    if let Some(mut stdin) = child.stdin.take() {
-        // Ignore a broken pipe: a child that exits without reading still
-        // produced a valid result. Dropping stdin closes it.
-        let _ = stdin.write_all(stdin_data.as_bytes());
-    }
+    // Feed stdin on a separate thread while the main thread drains stdout and
+    // stderr. Writing all of stdin before reading the output deadlocks when the
+    // child fills its output pipe buffer faster than we consume it: the child
+    // blocks writing stdout and we block writing stdin.
+    let stdin_pipe = child.stdin.take();
+    let stdin_bytes = stdin_data.as_bytes().to_vec();
+    let writer = std::thread::spawn(move || {
+        if let Some(mut pipe) = stdin_pipe {
+            // A broken pipe is fine: a child that exits without reading still
+            // produced a valid result. Dropping the pipe closes stdin (EOF).
+            let _ = pipe.write_all(&stdin_bytes);
+        }
+    });
 
-    // Feeding stdin and waiting for the child to exit block for the child's
-    // whole lifetime; run them outside the collector's running set.
+    // Waiting for the child to exit blocks for its whole lifetime; run it
+    // outside the collector's running set.
     let output = match crate::gc::blocking(|| child.wait_with_output()) {
         Ok(o) => o,
         Err(e) => {
+            let _ = writer.join();
             process_set_error(e.to_string());
             return 0;
         }
     };
+    let _ = writer.join();
 
     // A child terminated by a signal with no exit code maps to -1.
     let code = output.status.code().map(|c| c as i64).unwrap_or(-1);


### PR DESCRIPTION
Closes #404.

`raven_process_run` wrote all of stdin before calling `wait_with_output`, which reads stdout and stderr. A child that fills its output pipe buffer while still reading stdin blocks, and so does the parent: a classic pipe deadlock.

Stdin is now written on a separate thread while the main thread drains the child's output, and the writer is joined after the child exits. Verified a 268 KB round-trip through `sort` completes instead of hanging. lib (536), codegen_smoke (72) pass. Version 2.18.37.