### PR TITLE
fix(runtime): report an operation on an unknown channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.38] - 2026-06-10
+
+### Fixed
+
+- A send, receive, or select on a channel id that does not exist now reports a clear panic instead of busy-spinning forever (receive/select) or silently dropping the value (send) (#406).
+
 ## [2.18.37] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.37"
+version = "2.18.38"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.37"
+version = "2.18.38"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.37"
+version = "2.18.38"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -510,6 +510,16 @@ fn deadlock_panic() -> ! {
     std::process::exit(101);
 }
 
+/// A send or receive named a channel id with no registered channel (a freed or
+/// invalid handle). Report and exit rather than busy-spinning on a receive or
+/// silently dropping a send.
+fn unknown_channel_panic(id: i64) -> ! {
+    eprintln!(
+        "raven panic: operation on unknown channel {id} (it may have been freed or never created)"
+    );
+    std::process::exit(101);
+}
+
 // ----- channels -----
 
 /// Create a channel with capacity `cap` and return its id. `cap == 0` is
@@ -577,6 +587,9 @@ pub extern "C" fn raven_channel_send(id: i64, value: i64) {
         // slip between the check and the register (a lost wakeup) or let two
         // senders both deposit past the bound.
         let waiter = with_sched(|sched| {
+            if !sched.channels.contains_key(&id) {
+                unknown_channel_panic(id);
+            }
             if can_send_now(sched, id) {
                 return match sched.channels.get_mut(&id) {
                     Some(ch) => {
@@ -627,7 +640,7 @@ pub extern "C" fn raven_channel_recv(id: i64) -> i64 {
         }
         let outcome = with_sched(|sched| {
             let Some(ch) = sched.channels.get_mut(&id) else {
-                return Recv::Block(None);
+                unknown_channel_panic(id);
             };
             if let Some(v) = ch.queue.pop_front() {
                 return Recv::Got(v, ch.send_waiters.pop_front());
@@ -778,6 +791,13 @@ pub extern "C" fn raven_select_recv(set_id: i64) -> i64 {
             let ids = sched.select_sets.get(&set_id)?.clone();
             if ids.is_empty() {
                 return None;
+            }
+            // A select over a channel that does not exist would otherwise be
+            // silently skipped and could block forever; report it instead.
+            for &cid in &ids {
+                if !sched.channels.contains_key(&cid) {
+                    unknown_channel_panic(cid);
+                }
             }
             // Clear any registration from a previous iteration so re-registering
             // below cannot duplicate this waiter on a channel's list.


### PR DESCRIPTION
Closes #406.

A receive on a channel id with no registered channel returned a block outcome without registering the goroutine, so `park` returned at once and the receive loop spun forever. A send dropped the value silently, and a select skipped the channel and could block forever.

All three now report a clear panic naming the channel id. A valid channel is unaffected (the case only arises from a freed or invalid handle); verified normal channels and the scheduler tests still pass. lib (536), codegen_smoke (72), runtime tests pass. Version 2.18.38.