### PR TITLE
fix(runtime): do not scan buffered channel Int values as GC roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.39] - 2026-06-10
+
+### Fixed
+
+- The garbage collector no longer treats buffered channel `Int` values as object pointers. It was handing each channel queue slot to the collector as a root, so an integer payload was dereferenced as a pointer and GC bits were written into arbitrary memory, corrupting the heap or crashing (#396).
+
 ## [2.18.38] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.38"
+version = "2.18.39"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.38"
+version = "2.18.39"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.38"
+version = "2.18.39"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -195,9 +195,15 @@ impl Scheduler {
     }
 }
 
-/// Visitor for the collector: surface every parked goroutine's root chain
-/// and every buffered channel value as roots. The buffered slots live in
-/// the channel queues, so we hand the collector the address of each slot.
+/// Visitor for the collector: surface every parked goroutine's root chain as
+/// roots.
+///
+/// Buffered channel values are deliberately not scanned. A channel carries
+/// plain `Int` payloads (the `std/sync` Channel API is `Int`-typed), so handing
+/// the collector the address of a queue slot made it read the integer value and
+/// dereference it as an object pointer, writing GC bits into arbitrary memory.
+/// If channels ever carry GC pointers, the queue will need a per-channel flag
+/// and the scan reinstated only for those.
 fn extra_roots(visit: &mut dyn FnMut(RootSlot)) {
     with_sched(|sched| {
         for g in sched.goroutines.values() {
@@ -206,11 +212,6 @@ fn extra_roots(visit: &mut dyn FnMut(RootSlot)) {
             // is a harmless no-op; a parked goroutine's saved chain is
             // authoritative. Either way, scan the saved chain.
             for_each_slot_in(&g.roots, visit);
-        }
-        for chan in sched.channels.values() {
-            for slot in chan.queue.iter() {
-                visit(slot as *const i64 as RootSlot);
-            }
         }
     });
 }


### PR DESCRIPTION
Closes #396.

`extra_roots` handed the collector the address of every channel queue slot. A channel carries plain `Int` payloads (the `std/sync` Channel API is `Int`-typed), so the collector read each integer and dereferenced it as an object pointer, writing GC bits into arbitrary memory and corrupting the heap.

The channel queues are no longer scanned. Buffered `Int` values are not heap objects and need no rooting; if channels ever carry GC pointers the scan can be reinstated behind a per-channel flag. Verified a buffered channel of pointer-like Int values runs correctly across five runs under `RAVEN_GC_THRESHOLD=1`. Scheduler tests, lib, and codegen_smoke (72) pass. Version 2.18.39.