### PR TITLE
fix(runtime): unblock readers on net.close; free channels and wait groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.41] - 2026-06-10
+
+### Fixed
+
+- `net.close` on a stream now shuts the underlying socket down, so a goroutine parked in a blocking read returns instead of hanging forever (the read had cloned the handle, so dropping the registry copy alone did not close the socket).
+
+### Added
+
+- `Channel.free()` and `WaitGroup.free()` release a channel's or wait group's runtime registry entry, which otherwise leaked for the life of the process (#407).
+
 ## [2.18.40] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.40"
+version = "2.18.41"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.40"
+version = "2.18.41"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.40"
+version = "2.18.41"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1292,7 +1292,15 @@ pub extern "C" fn raven_net_write(stream_id: i64, data: *const object::String) -
 /// unknown id is a no-op.
 #[no_mangle]
 pub extern "C" fn raven_net_close(stream_id: i64) {
-    net_registry().lock().unwrap().remove(&stream_id);
+    let sock = net_registry().lock().unwrap().remove(&stream_id);
+    // Accept/read clone the handle for their blocking syscall, so dropping the
+    // registry's copy alone leaves the underlying socket open and a parked
+    // reader hung. Shut a stream down so that read returns at once. (A listener
+    // has no portable shutdown; dropping its registry copy is the best we can
+    // do here.)
+    if let Some(Socket::Stream(stream)) = sock {
+        let _ = stream.shutdown(std::net::Shutdown::Both);
+    }
 }
 
 /// Set the read timeout of the stream `stream_id` to `ms` milliseconds. A

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -855,6 +855,24 @@ pub extern "C" fn raven_select_free(set_id: i64) {
     });
 }
 
+/// Free a channel's registry entry. The id becomes invalid; a later operation
+/// on it panics (see `unknown_channel_panic`). Free only when no goroutine is
+/// still using the channel.
+#[no_mangle]
+pub extern "C" fn raven_channel_free(id: i64) {
+    with_sched(|sched| {
+        sched.channels.remove(&id);
+    });
+}
+
+/// Free a wait group's registry entry.
+#[no_mangle]
+pub extern "C" fn raven_waitgroup_free(id: i64) {
+    with_sched(|sched| {
+        sched.wait_groups.remove(&id);
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/stdlib/std/sync.rv
+++ b/stdlib/std/sync.rv
@@ -20,6 +20,8 @@ extern "C" {
     fun raven_select_recv(set_id: Int) -> Int
     fun raven_select_value() -> Int
     fun raven_select_free(set_id: Int)
+    fun raven_channel_free(id: Int)
+    fun raven_waitgroup_free(id: Int)
 }
 
 // A channel of Int values. The id keys the runtime's channel registry.
@@ -46,6 +48,13 @@ impl Channel {
     // Receive a value, blocking until one is available.
     fun recv(self) -> Int {
         return raven_channel_recv(self.id)
+    }
+
+    // Release the channel's runtime registry entry. The channel must not be
+    // used afterward. Call this when done to avoid leaking the entry; there is
+    // no destructor.
+    fun free(self) {
+        raven_channel_free(self.id)
     }
 }
 
@@ -111,6 +120,12 @@ impl WaitGroup {
     // Block until the count reaches zero.
     fun wait(self) {
         raven_waitgroup_wait(self.id)
+    }
+
+    // Release the wait group's runtime registry entry. Call when done to avoid
+    // leaking the entry; there is no destructor.
+    fun free(self) {
+        raven_waitgroup_free(self.id)
     }
 }
 


### PR DESCRIPTION
Closes #407.

`net.close` only removed the stream from the registry, but accept and read clone the handle for their blocking syscall, so the underlying socket stayed open and a parked reader hung forever. Close now shuts a stream down (`shutdown(Both)`) so a blocked read returns at once. (A listener has no portable shutdown, so accept is unchanged.)

Channels and wait groups also leaked their registry entry for the life of the process; only select had a free. Adds `raven_channel_free`/`raven_waitgroup_free` with `Channel.free()` and `WaitGroup.free()` wrappers. Verified free works and normal channel/goroutine use is unaffected. lib, codegen_smoke (72), runtime tests pass. Version 2.18.41.