### PR TITLE
fix(runtime): make the extra-roots hook process-global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.44] - 2026-06-10
+
+### Fixed
+
+- The collector's extra-roots hook, which marks the roots of every parked goroutine, is now process-global instead of thread-local. It was installed only on the thread that first spawned a goroutine, so a collection on any other worker thread skipped parked goroutines and freed their live roots (#398).
+
 ## [2.18.43] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.43"
+version = "2.18.44"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.43"
+version = "2.18.44"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.43"
+version = "2.18.44"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -27,7 +27,7 @@ use crate::stw::StopTheWorld;
 use crate::{raven_alloc, raven_dealloc};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 /// Registry of every live thread's shadow-stack [`RootContext`]. A collection
 /// scans every registered context, so an object one thread holds survives a
@@ -235,14 +235,18 @@ pub(crate) type SavedRoots = (Vec<RootSlot>, Vec<usize>);
 /// program with no goroutines marks exactly the thread-local chain.
 type ExtraRootsHook = fn(&mut dyn FnMut(RootSlot));
 
-thread_local! {
-    static EXTRA_ROOTS_HOOK: Cell<Option<ExtraRootsHook>> = const { Cell::new(None) };
-}
+/// The scheduler's extra-roots hook, as the function pointer's address (0 means
+/// unset). This is process-global, not thread-local: the scheduler installs it
+/// on the thread that first spawns a goroutine, but a collection on any worker
+/// thread must run it to mark parked-goroutine roots. A thread-local cell left
+/// worker collections with no hook, so a parked goroutine's live roots were
+/// swept. A `fn` pointer is a plain address, valid for the whole program.
+static EXTRA_ROOTS_HOOK: AtomicUsize = AtomicUsize::new(0);
 
 /// Install the scheduler's extra-roots hook. Idempotent; the scheduler
 /// installs it the first time a goroutine is spawned.
 pub(crate) fn set_extra_roots_hook(hook: ExtraRootsHook) {
-    EXTRA_ROOTS_HOOK.with(|h| h.set(Some(hook)));
+    EXTRA_ROOTS_HOOK.store(hook as usize, Ordering::Release);
 }
 
 /// Move the live thread-local root chain out, leaving it empty, and
@@ -707,7 +711,11 @@ fn mark() {
     // Roots of every parked goroutine and every buffered channel value.
     // The hook is set only after a scheduler starts, so a program with no
     // goroutines visits nothing extra here.
-    if let Some(hook) = EXTRA_ROOTS_HOOK.with(|h| h.get()) {
+    let hook_addr = EXTRA_ROOTS_HOOK.load(Ordering::Acquire);
+    if hook_addr != 0 {
+        // SAFETY: the address was stored by `set_extra_roots_hook` from a valid
+        // `ExtraRootsHook` function pointer, which lives for the whole program.
+        let hook: ExtraRootsHook = unsafe { std::mem::transmute::<usize, ExtraRootsHook>(hook_addr) };
         let mut visit = |slot: RootSlot| {
             if slot.is_null() {
                 return;

--- a/raven-runtime/src/reflect.rs
+++ b/raven-runtime/src/reflect.rs
@@ -447,10 +447,13 @@ mod tests {
             };
             use crate::object::{raven_string_new, raven_struct_new};
             let _keep = register_point();
-            // Point has a scalar slot 0 and (pretend) a GC pointer slot 1.
-            raven_struct_register(3, 0b10);
+            // A scalar slot 0 and a GC pointer slot 1. This uses its own struct
+            // id, not Point's (3): the descriptor table is process-global, so
+            // reusing id 3 with this fake mask would race the other tests that
+            // register the real Point mask for id 3.
+            raven_struct_register(40, 0b10);
             let name = raven_string_new(3);
-            let s = raven_struct_new(2, 3);
+            let s = raven_struct_new(2, 40);
             // SAFETY: slot 0 scalar, slot 1 the String pointer.
             unsafe {
                 let fields = raven_struct_fields(s) as *mut u64;
@@ -460,7 +463,7 @@ mod tests {
             // Box the struct into an Any with the GC-pointer flag set, then
             // root only the Any. The struct and string are reachable solely
             // through the Any now.
-            let a = raven_any_new(s as u64, 3, 1);
+            let a = raven_any_new(s as u64, 40, 1);
             // Root the Any through the frame ABI codegen emits: the local
             // holding the Any lives in `root`, and the registered array entry
             // is the *address* of that slot.


### PR DESCRIPTION
Closes #398.

The scheduler's extra-roots hook marks the roots of every parked goroutine, but it lived in a thread-local cell and was installed only on the thread that first spawned a goroutine. A collection on any other worker thread found no hook and skipped the parked goroutines, freeing their live roots while suspended.

The hook is now a process-global atomic function pointer, so every worker collection runs it. Verified a String held by a goroutine parked on a channel survives heavy allocation by another goroutine across six runs under `RAVEN_GC_THRESHOLD=1`.

Also gives the one reflection test that registers a deliberately fake struct descriptor its own type id: the descriptor table became global in 2.18.42, so sharing id 3 with the real Point tests raced under the parallel test runner (122 runtime tests now green across repeated runs). lib, codegen_smoke (72) pass. Version 2.18.44.