### PR TITLE
fix(runtime): root a spawned goroutine's closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.45] - 2026-06-10
+
+### Fixed
+
+- A spawned goroutine's closure is now rooted for the goroutine's whole life. It was referenced only as a raw integer address, so a collection between the spawn and the goroutine running, or during its run, could free the closure and the values it captured (#399).
+
 ## [2.18.44] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.44"
+version = "2.18.45"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.44"
+version = "2.18.45"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.44"
+version = "2.18.45"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -46,6 +46,13 @@ type GoYielder = Yielder<(), Suspend>;
 struct Goroutine {
     coro: Option<Coroutine<(), Suspend, ()>>,
     roots: SavedRoots,
+    /// The closure this goroutine runs, kept as a root for the goroutine's
+    /// whole life. The spawned closure (and its capture buffer) is otherwise
+    /// referenced only as a raw integer address inside `coro`, so a collection
+    /// between the spawn and the goroutine first running, or during its run,
+    /// would free it and the values it captured. Null for goroutine 0 (main),
+    /// which has no spawn closure.
+    spawn_root: *mut u8,
 }
 
 /// A channel: a bounded queue of pointer-width value slots plus the wait
@@ -175,6 +182,7 @@ impl Scheduler {
             Goroutine {
                 coro: None,
                 roots: (Vec::new(), Vec::new()),
+                spawn_root: std::ptr::null_mut(),
             },
         );
         Scheduler {
@@ -206,12 +214,16 @@ impl Scheduler {
 /// and the scan reinstated only for those.
 fn extra_roots(visit: &mut dyn FnMut(RootSlot)) {
     with_sched(|sched| {
-        for g in sched.goroutines.values() {
+        for g in sched.goroutines.values_mut() {
             // A running goroutine's saved chain is empty (taken into its worker's
             // registered context, scanned via the registry), so scanning it here
             // is a harmless no-op; a parked goroutine's saved chain is
             // authoritative. Either way, scan the saved chain.
             for_each_slot_in(&g.roots, visit);
+            // The goroutine's own closure, rooted from spawn until it finishes.
+            if !g.spawn_root.is_null() {
+                visit(&mut g.spawn_root as *mut *mut u8);
+            }
         }
     });
 }
@@ -261,6 +273,9 @@ pub extern "C" fn raven_go_spawn(closure: *mut Closure) {
             Goroutine {
                 coro: Some(coro),
                 roots: (Vec::new(), Vec::new()),
+                // Root the closure so it and its captures survive until and
+                // while the goroutine runs.
+                spawn_root: closure as *mut u8,
             },
         );
         sched.ready.push_back(id);


### PR DESCRIPTION
Closes #399.

`raven_go_spawn` pulled the function pointer and capture-env address out of the closure as raw integers and kept nothing else referencing the closure. Between the spawn and the goroutine first running (and while it ran, since the body reads the env throughout), a collection could free the closure and its capture buffer, so the goroutine read freed memory and the values it captured were lost.

The goroutine now holds its closure in a `spawn_root` slot that the extra-roots hook marks, keeping the closure and its captures alive until the goroutine finishes and is removed. Verified a String captured by a spawned closure survives six runs under `RAVEN_GC_THRESHOLD=1`. Full runtime suite (122), codegen_smoke (72) pass. Version 2.18.45.