### PR TITLE
fix(runtime): make defer frames per-goroutine root context state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.46] - 2026-06-10
+
+### Fixed
+
+- `defer` now works correctly across goroutines. The defer-frame stacks were thread-local, so a goroutine that suspended and resumed on a different worker thread lost or mixed up its deferred closures, and a deferred closure on a non-collecting worker could be freed before it ran. Defer frames now live in each goroutine's root context, so they travel with the goroutine and are marked by the collector through the same per-thread registry as the shadow-stack roots (#400).
+
 ## [2.18.45] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.45"
+version = "2.18.46"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.45"
+version = "2.18.46"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.45"
+version = "2.18.46"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -226,7 +226,7 @@ pub(crate) type RootSlot = *mut *mut u8;
 /// A saved root chain: the `ROOTS` and `FRAMES` vectors of a goroutine
 /// that is not currently running. The scheduler swaps these in and out of
 /// the thread-local cells on a context switch.
-pub(crate) type SavedRoots = (Vec<RootSlot>, Vec<usize>);
+pub(crate) type SavedRoots = (Vec<RootSlot>, Vec<usize>, Vec<Vec<*mut u8>>);
 
 /// Hook the scheduler installs so the mark phase can reach the roots of
 /// every parked goroutine and every buffered channel value. It is called
@@ -257,6 +257,7 @@ pub(crate) fn take_root_chain() -> SavedRoots {
         (
             std::mem::take(&mut ctx.roots),
             std::mem::take(&mut ctx.frames),
+            std::mem::take(&mut ctx.defer_frames),
         )
     })
 }
@@ -268,6 +269,7 @@ pub(crate) fn install_root_chain(saved: SavedRoots) {
     with_roots(|ctx| {
         ctx.roots = saved.0;
         ctx.frames = saved.1;
+        ctx.defer_frames = saved.2;
     });
 }
 
@@ -277,6 +279,12 @@ pub(crate) fn install_root_chain(saved: SavedRoots) {
 pub(crate) fn for_each_slot_in(saved: &SavedRoots, visit: &mut dyn FnMut(RootSlot)) {
     for &slot in &saved.0 {
         visit(slot);
+    }
+    // A parked goroutine's deferred closures are roots too.
+    for frame in &saved.2 {
+        for closure_slot in frame.iter() {
+            visit(closure_slot as *const *mut u8 as RootSlot);
+        }
     }
 }
 
@@ -298,14 +306,6 @@ thread_local! {
     /// Initialised from `collection_floor()`, which honours the
     /// `RAVEN_GC_THRESHOLD` override.
     static THRESHOLD: Cell<usize> = Cell::new(collection_floor());
-
-    /// Per-call-frame stacks of deferred closures, one inner vector per
-    /// open call frame. A `defer expr` pushes its thunk closure onto the
-    /// top frame; the function epilogue runs and pops the top frame at
-    /// every return. Parked closures stay GC-reachable through `mark`,
-    /// which visits every pointer in every open defer frame.
-    static DEFER_FRAMES: RefCell<Vec<Vec<*mut crate::object::Closure>>> =
-        const { RefCell::new(Vec::new()) };
 }
 
 /// ABI of a deferred thunk: the runtime calls the closure's lifted body
@@ -318,7 +318,7 @@ type DeferThunk = extern "C" fn(env: *mut u8);
 /// must pair it with one `raven_defer_run_frame`.
 #[no_mangle]
 pub extern "C" fn raven_defer_enter_frame() {
-    DEFER_FRAMES.with(|f| f.borrow_mut().push(Vec::new()));
+    with_roots(|ctx| ctx.defer_frames.push(Vec::new()));
 }
 
 /// Register a deferred thunk on the current defer frame.
@@ -338,9 +338,9 @@ pub extern "C" fn raven_defer_push(closure: *mut crate::object::Closure) {
     if closure.is_null() {
         return;
     }
-    DEFER_FRAMES.with(|f| {
-        if let Some(top) = f.borrow_mut().last_mut() {
-            top.push(closure);
+    with_roots(|ctx| {
+        if let Some(top) = ctx.defer_frames.last_mut() {
+            top.push(closure as *mut u8);
         }
     });
 }
@@ -356,20 +356,20 @@ pub extern "C" fn raven_defer_push(closure: *mut crate::object::Closure) {
 pub extern "C" fn raven_defer_run_frame() {
     // Take ownership of the top frame so a thunk that pushes a new defer
     // grows the still-open frame; we keep draining until it is empty.
-    let mut frame = match DEFER_FRAMES.with(|f| f.borrow_mut().pop()) {
+    let mut frame = match with_roots(|ctx| ctx.defer_frames.pop()) {
         Some(frame) => frame,
         None => return,
     };
     // Re-open the frame while draining so any defer scheduled by a thunk
     // lands here and runs too. Pop the placeholder afterwards.
-    DEFER_FRAMES.with(|f| f.borrow_mut().push(Vec::new()));
+    with_roots(|ctx| ctx.defer_frames.push(Vec::new()));
     loop {
         let closure = match frame.pop() {
             Some(c) => c,
             None => {
                 // Pull in any defers a thunk scheduled while draining.
-                let scheduled = DEFER_FRAMES.with(|f| {
-                    f.borrow_mut()
+                let scheduled = with_roots(|ctx| {
+                    ctx.defer_frames
                         .last_mut()
                         .map(std::mem::take)
                         .unwrap_or_default()
@@ -384,6 +384,7 @@ pub extern "C" fn raven_defer_run_frame() {
         if closure.is_null() {
             continue;
         }
+        let closure = closure as *mut crate::object::Closure;
         // SAFETY: a parked closure is a live Closure; its lifted body is a
         // `fn(env)` and its capture buffer is the env argument.
         unsafe {
@@ -395,25 +396,11 @@ pub extern "C" fn raven_defer_run_frame() {
             }
         }
     }
-    DEFER_FRAMES.with(|f| {
-        f.borrow_mut().pop();
+    with_roots(|ctx| {
+        ctx.defer_frames.pop();
     });
 }
 
-/// Visit every parked deferred closure across all open defer frames,
-/// marking each so the collector keeps it (and the values it captures)
-/// alive while it waits to run.
-fn for_each_defer_root(work: &mut Vec<*mut ObjectHeader>) {
-    DEFER_FRAMES.with(|f| {
-        for frame in f.borrow().iter() {
-            for &closure in frame.iter() {
-                if mark_object(closure as *mut ObjectHeader) {
-                    work.push(closure as *mut ObjectHeader);
-                }
-            }
-        }
-    });
-}
 
 /// Default collection floor in bytes (1 MiB) when no override is set.
 const INITIAL_THRESHOLD: usize = 1024 * 1024;
@@ -705,9 +692,10 @@ fn mark() {
             work.push(object);
         }
     });
-    // Closures parked in open defer frames are roots too: they must
-    // survive until the function epilogue runs them.
-    for_each_defer_root(&mut work);
+    // Closures parked in open defer frames are roots too. The running
+    // goroutine's frames live in its registered root context (marked above by
+    // `for_each_root`); a parked goroutine's are surfaced by the extra-roots
+    // hook below.
     // Roots of every parked goroutine and every buffered channel value.
     // The hook is set only after a scheduler starts, so a program with no
     // goroutines visits nothing extra here.

--- a/raven-runtime/src/roots.rs
+++ b/raven-runtime/src/roots.rs
@@ -31,6 +31,13 @@ pub struct RootContext {
     /// `roots` length at each open frame's entry; leaving a frame truncates
     /// `roots` back to the recorded length.
     pub frames: Vec<usize>,
+    /// Deferred-closure addresses, one inner vector per open call frame. Stored
+    /// here, alongside the shadow-stack roots, so the collector marks a
+    /// goroutine's parked defers through the same per-thread registry that
+    /// covers every worker, and so the defers travel with the goroutine when it
+    /// migrates worker threads. Held as `*mut u8` to keep this module free of
+    /// object-layout types.
+    pub defer_frames: Vec<Vec<*mut u8>>,
 }
 
 impl RootContext {
@@ -38,6 +45,7 @@ impl RootContext {
         RootContext {
             roots: Vec::new(),
             frames: Vec::new(),
+            defer_frames: Vec::new(),
         }
     }
 }
@@ -99,6 +107,13 @@ impl RootRegistry {
                     visit(slot);
                 }
             }
+            // Parked deferred closures are roots too: hand the collector the
+            // address of each slot holding a closure pointer.
+            for frame in &ctx.defer_frames {
+                for closure_slot in frame.iter() {
+                    visit(closure_slot as *const *mut u8 as RootSlot);
+                }
+            }
         }
     }
 }
@@ -124,10 +139,12 @@ mod tests {
         let mut ctx_a = RootContext {
             roots: vec![&mut obj_a as *mut *mut u8],
             frames: vec![],
+            defer_frames: vec![],
         };
         let mut ctx_b = RootContext {
             roots: vec![&mut obj_b as *mut *mut u8],
             frames: vec![],
+            defer_frames: vec![],
         };
         reg.register(&mut ctx_a);
         reg.register(&mut ctx_b);
@@ -153,6 +170,7 @@ mod tests {
         let mut ctx = RootContext {
             roots: vec![std::ptr::null_mut(), &mut obj as *mut *mut u8],
             frames: vec![],
+            defer_frames: vec![],
         };
         reg.register(&mut ctx);
 
@@ -173,6 +191,7 @@ mod tests {
         let mut ctx = RootContext {
             roots: vec![&mut obj as *mut *mut u8],
             frames: vec![],
+            defer_frames: vec![],
         };
         reg.register(&mut ctx);
         reg.deregister(&mut ctx);

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -181,7 +181,7 @@ impl Scheduler {
             0,
             Goroutine {
                 coro: None,
-                roots: (Vec::new(), Vec::new()),
+                roots: (Vec::new(), Vec::new(), Vec::new()),
                 spawn_root: std::ptr::null_mut(),
             },
         );
@@ -272,7 +272,7 @@ pub extern "C" fn raven_go_spawn(closure: *mut Closure) {
             id,
             Goroutine {
                 coro: Some(coro),
-                roots: (Vec::new(), Vec::new()),
+                roots: (Vec::new(), Vec::new(), Vec::new()),
                 // Root the closure so it and its captures survive until and
                 // while the goroutine runs.
                 spawn_root: closure as *mut u8,


### PR DESCRIPTION
Closes #400.

The defer-frame stacks lived in a thread-local cell. With the M:N scheduler a goroutine can suspend on one worker thread and resume on another, so its open defer frames were left behind or mixed with another goroutine's, and a deferred closure parked on a non-collecting worker was not marked and could be freed before it ran.

Defer frames now live in each thread's `RootContext` alongside the shadow-stack roots. They are saved and restored with the root chain on a context switch (so they travel with the goroutine) and are marked through the same per-thread registry for a running goroutine and the extra-roots hook for a parked one. The separate thread-local table and its bespoke marking are removed.

Verified a deferred closure that captures a String runs correctly after the goroutine parks and resumes, across six runs under `RAVEN_GC_THRESHOLD=1`. Full runtime suite (122, stable across repeated runs), codegen_smoke (72), and golden (including the defer examples) pass. Version 2.18.46.