### PR TITLE
fix(format): keep comments inside bracketed expressions in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.49] - 2026-06-10
+
+### Fixed
+
+- The formatter no longer relocates a comment that sits inside a bracketed expression to the end of the file. A call, array, or tuple that contains an interior comment is now laid out multi-line with each comment kept beside its element; a comment-free bracketed expression still collapses to one line (#426).
+
 ## [2.18.48] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.48"
+version = "2.18.49"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.48"
+version = "2.18.49"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.48"
+version = "2.18.49"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -401,7 +401,6 @@ pub extern "C" fn raven_defer_run_frame() {
     });
 }
 
-
 /// Default collection floor in bytes (1 MiB) when no override is set.
 const INITIAL_THRESHOLD: usize = 1024 * 1024;
 
@@ -703,7 +702,8 @@ fn mark() {
     if hook_addr != 0 {
         // SAFETY: the address was stored by `set_extra_roots_hook` from a valid
         // `ExtraRootsHook` function pointer, which lives for the whole program.
-        let hook: ExtraRootsHook = unsafe { std::mem::transmute::<usize, ExtraRootsHook>(hook_addr) };
+        let hook: ExtraRootsHook =
+            unsafe { std::mem::transmute::<usize, ExtraRootsHook>(hook_addr) };
         let mut visit = |slot: RootSlot| {
             if slot.is_null() {
                 return;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -909,10 +909,20 @@ impl Printer<'_> {
                 s
             }
             ExprKind::Array(items) => {
+                if let Some(first) = items.first() {
+                    if self.pending_comment_within(first.span.start, e.span.end) {
+                        return self.bracketed_multiline("[", "]", items, e.span.end, base);
+                    }
+                }
                 let parts = self.expr_list(items, base);
                 format!("[{}]", parts.join(", "))
             }
             ExprKind::Tuple(items) => {
+                if let Some(first) = items.first() {
+                    if self.pending_comment_within(first.span.start, e.span.end) {
+                        return self.bracketed_multiline("(", ")", items, e.span.end, base);
+                    }
+                }
                 let parts = self.expr_list(items, base);
                 format!("({})", parts.join(", "))
             }
@@ -962,6 +972,12 @@ impl Printer<'_> {
             }
             ExprKind::Call { callee, args } => {
                 let callee = self.expr_at(callee, base);
+                if let Some(first) = args.first() {
+                    if self.pending_comment_within(first.span.start, e.span.end) {
+                        let list = self.bracketed_multiline("(", ")", args, e.span.end, base);
+                        return format!("{}{}", callee, list);
+                    }
+                }
                 let parts = self.expr_list(args, base);
                 format!("{}({})", callee, parts.join(", "))
             }
@@ -976,6 +992,13 @@ impl Printer<'_> {
                 s.push_str(name);
                 if !generics.is_empty() {
                     s.push_str(&render_type_args(generics));
+                }
+                if let Some(first) = args.first() {
+                    if self.pending_comment_within(first.span.start, e.span.end) {
+                        let list = self.bracketed_multiline("(", ")", args, e.span.end, base);
+                        s.push_str(&list);
+                        return s;
+                    }
                 }
                 let parts = self.expr_list(args, base);
                 let _ = write!(s, "({})", parts.join(", "));
@@ -1034,6 +1057,74 @@ impl Printer<'_> {
             parts.push(self.expr_at(it, base));
         }
         parts
+    }
+
+    /// Whether the next pending comment begins within `[start, end)`. Used to
+    /// decide whether a bracketed expression must be laid out multi-line to
+    /// keep an interior comment with its element instead of dropping it.
+    fn pending_comment_within(&self, start: usize, end: usize) -> bool {
+        self.comments
+            .get(self.next_comment)
+            .is_some_and(|c| c.start >= start && c.start < end)
+    }
+
+    /// Render `items` as a multi-line bracketed list (`open` .. `close`) with
+    /// interior comments emitted at their source positions: own-line comments
+    /// before an element sit on their own lines, and a same-line comment after
+    /// an element trails it. `close_byte` is the source position of the closing
+    /// bracket, so comments between the last element and it are kept too.
+    fn bracketed_multiline(
+        &mut self,
+        open: &str,
+        close: &str,
+        items: &[Expr],
+        close_byte: usize,
+        base: usize,
+    ) -> String {
+        let mut s = String::from(open);
+        s.push('\n');
+        for it in items {
+            // Own-line comments that precede this element.
+            while let Some(c) = self.comments.get(self.next_comment) {
+                if c.start >= it.span.start || !c.own_line {
+                    break;
+                }
+                let text = c.text.clone();
+                self.push_indent(&mut s, base + 1);
+                s.push_str(&text);
+                s.push('\n');
+                self.next_comment += 1;
+            }
+            self.push_indent(&mut s, base + 1);
+            let part = self.expr_at(it, base + 1);
+            s.push_str(&part);
+            s.push(',');
+            if let Some(t) = self.take_trailing_comment(self.line_of(it.span.end)) {
+                s.push(' ');
+                s.push_str(&t);
+            }
+            s.push('\n');
+        }
+        // Own-line comments between the last element and the closing bracket.
+        while let Some(c) = self.comments.get(self.next_comment) {
+            if c.start >= close_byte || !c.own_line {
+                break;
+            }
+            let text = c.text.clone();
+            self.push_indent(&mut s, base + 1);
+            s.push_str(&text);
+            s.push('\n');
+            self.next_comment += 1;
+        }
+        self.push_indent(&mut s, base);
+        s.push_str(close);
+        s
+    }
+
+    fn push_indent(&self, s: &mut String, level: usize) {
+        for _ in 0..level {
+            s.push_str(&self.indent_unit);
+        }
     }
 
     fn field_value(&mut self, f: &crate::ast::FieldInit) -> String {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -43,6 +43,34 @@ fn function_block_body() {
 }
 
 #[test]
+fn comment_inside_call_args_stays_in_place() {
+    // A comment interior to a call must stay with its argument and a later
+    // standalone comment must keep its place, not be relocated to end of file.
+    // Regression for #426.
+    let src = "fun main() {\n    let r = foo(\n        1, // first arg comment\n        2,\n    )\n    print(r)\n    // trailing standalone comment\n    bar()\n}\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("1, // first arg comment"),
+        "interior call comment was lost or moved: {out:?}"
+    );
+    let comment_pos = out.find("// trailing standalone comment").unwrap();
+    let bar_pos = out.find("bar()").unwrap();
+    assert!(
+        comment_pos < bar_pos,
+        "standalone comment was relocated past its code: {out:?}"
+    );
+}
+
+#[test]
+fn call_without_comments_stays_single_line() {
+    let out = fmt("fun main() {\n    let r = foo(\n        1,\n        2,\n    )\n}\n");
+    assert!(
+        out.contains("foo(1, 2)"),
+        "a comment-free call should collapse to one line: {out:?}"
+    );
+}
+
+#[test]
 fn function_expr_body() {
     let out = fmt("fun double(x:Int)->Int=x*2");
     assert_eq!(out, "fun double(x: Int) -> Int = x * 2\n");


### PR DESCRIPTION
Closes #426.

Call arguments, array, and tuple literals always rendered single-line and never consulted the comment cursor, so a comment interior to one was skipped and, at `finish`, dumped at the end of the file along with everything blocked behind it. That silently moved comments across function boundaries.

A bracketed expression that contains an interior comment is now laid out multi-line with own-line comments on their own lines and same-line comments trailing their element; a comment-free one still collapses to a single line. Verified the issue's reproduction keeps both comments in place and is idempotent, a comment-free call still collapses to `foo(1, 2)`, and arrays/tuples behave the same. Also reflows two stray lines in the runtime GC module so the tree stays fmt-clean. lib (538, including two new format tests) passes. Version 2.18.49.