### PR TITLE
ci: re-enable CI on pull requests to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,20 @@
 name: Raven CI
 
-# CI is paused while we work through the bug backlog (issues #396-#444) to keep
-# Actions usage down. Only manual runs fire for now.
-#
-# To turn it back on, drop the workflow_dispatch line and uncomment the
-# pull_request block. We run on pull requests to main only, never on push or
-# merge to main, so a change is not built twice.
+# We run on pull requests to main only, never on push or merge to main, so a
+# change is not built twice.
 on:
-  workflow_dispatch:
-  # pull_request:
-  #   branches: [ "main" ]
-  #   paths:
-  #     - "src/**"
-  #     - "lib/**"
-  #     - "examples/**"
-  #     - "tests/**"
-  #     - "raven-runtime/**"
-  #     - "benchmarks/**"
-  #     - "Cargo.toml"
-  #     - "Cargo.lock"
-  #     - ".github/workflows/ci.yml"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "src/**"
+      - "lib/**"
+      - "examples/**"
+      - "tests/**"
+      - "raven-runtime/**"
+      - "benchmarks/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The backlog of issues #396-#444 is cleared, so restore the `pull_request` trigger that was paused to save Actions minutes. CI runs only on PRs to main, never on push or merge to main, so a change is not built twice.