### PR TITLE
fix(benchmarks): use trailing-operator line continuation in the corpus

### DIFF
--- a/benchmarks/compile-time/corpus/modules/mod0.rv
+++ b/benchmarks/compile-time/corpus/modules/mod0.rv
@@ -152,8 +152,8 @@ fun compute_0(seed: Int) -> Int {
     let g = grade_points_0(grade_0(seed))
     let r = ranked_0(tagged) + ranked_0(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_0(doubled)
-        + m + g + r + accumulate_0(1) + sweep_0(1)
-        + fib_0(8) + classify_0(Shape_0.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_0(doubled) +
+        m + g + r + accumulate_0(1) + sweep_0(1) +
+        fib_0(8) + classify_0(Shape_0.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod1.rv
+++ b/benchmarks/compile-time/corpus/modules/mod1.rv
@@ -152,8 +152,8 @@ fun compute_1(seed: Int) -> Int {
     let g = grade_points_1(grade_1(seed))
     let r = ranked_1(tagged) + ranked_1(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_1(doubled)
-        + m + g + r + accumulate_1(8) + sweep_1(8)
-        + fib_1(8) + classify_1(Shape_1.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_1(doubled) +
+        m + g + r + accumulate_1(8) + sweep_1(8) +
+        fib_1(8) + classify_1(Shape_1.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod10.rv
+++ b/benchmarks/compile-time/corpus/modules/mod10.rv
@@ -152,8 +152,8 @@ fun compute_10(seed: Int) -> Int {
     let g = grade_points_10(grade_10(seed))
     let r = ranked_10(tagged) + ranked_10(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_10(doubled)
-        + m + g + r + accumulate_10(2) + sweep_10(2)
-        + fib_10(8) + classify_10(Shape_10.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_10(doubled) +
+        m + g + r + accumulate_10(2) + sweep_10(2) +
+        fib_10(8) + classify_10(Shape_10.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod11.rv
+++ b/benchmarks/compile-time/corpus/modules/mod11.rv
@@ -152,8 +152,8 @@ fun compute_11(seed: Int) -> Int {
     let g = grade_points_11(grade_11(seed))
     let r = ranked_11(tagged) + ranked_11(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_11(doubled)
-        + m + g + r + accumulate_11(9) + sweep_11(9)
-        + fib_11(8) + classify_11(Shape_11.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_11(doubled) +
+        m + g + r + accumulate_11(9) + sweep_11(9) +
+        fib_11(8) + classify_11(Shape_11.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod12.rv
+++ b/benchmarks/compile-time/corpus/modules/mod12.rv
@@ -152,8 +152,8 @@ fun compute_12(seed: Int) -> Int {
     let g = grade_points_12(grade_12(seed))
     let r = ranked_12(tagged) + ranked_12(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_12(doubled)
-        + m + g + r + accumulate_12(16) + sweep_12(16)
-        + fib_12(8) + classify_12(Shape_12.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_12(doubled) +
+        m + g + r + accumulate_12(16) + sweep_12(16) +
+        fib_12(8) + classify_12(Shape_12.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod13.rv
+++ b/benchmarks/compile-time/corpus/modules/mod13.rv
@@ -152,8 +152,8 @@ fun compute_13(seed: Int) -> Int {
     let g = grade_points_13(grade_13(seed))
     let r = ranked_13(tagged) + ranked_13(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_13(doubled)
-        + m + g + r + accumulate_13(23) + sweep_13(23)
-        + fib_13(8) + classify_13(Shape_13.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_13(doubled) +
+        m + g + r + accumulate_13(23) + sweep_13(23) +
+        fib_13(8) + classify_13(Shape_13.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod14.rv
+++ b/benchmarks/compile-time/corpus/modules/mod14.rv
@@ -152,8 +152,8 @@ fun compute_14(seed: Int) -> Int {
     let g = grade_points_14(grade_14(seed))
     let r = ranked_14(tagged) + ranked_14(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_14(doubled)
-        + m + g + r + accumulate_14(7) + sweep_14(7)
-        + fib_14(8) + classify_14(Shape_14.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_14(doubled) +
+        m + g + r + accumulate_14(7) + sweep_14(7) +
+        fib_14(8) + classify_14(Shape_14.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod15.rv
+++ b/benchmarks/compile-time/corpus/modules/mod15.rv
@@ -152,8 +152,8 @@ fun compute_15(seed: Int) -> Int {
     let g = grade_points_15(grade_15(seed))
     let r = ranked_15(tagged) + ranked_15(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_15(doubled)
-        + m + g + r + accumulate_15(14) + sweep_15(14)
-        + fib_15(8) + classify_15(Shape_15.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_15(doubled) +
+        m + g + r + accumulate_15(14) + sweep_15(14) +
+        fib_15(8) + classify_15(Shape_15.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod16.rv
+++ b/benchmarks/compile-time/corpus/modules/mod16.rv
@@ -152,8 +152,8 @@ fun compute_16(seed: Int) -> Int {
     let g = grade_points_16(grade_16(seed))
     let r = ranked_16(tagged) + ranked_16(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_16(doubled)
-        + m + g + r + accumulate_16(21) + sweep_16(21)
-        + fib_16(8) + classify_16(Shape_16.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_16(doubled) +
+        m + g + r + accumulate_16(21) + sweep_16(21) +
+        fib_16(8) + classify_16(Shape_16.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod17.rv
+++ b/benchmarks/compile-time/corpus/modules/mod17.rv
@@ -152,8 +152,8 @@ fun compute_17(seed: Int) -> Int {
     let g = grade_points_17(grade_17(seed))
     let r = ranked_17(tagged) + ranked_17(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_17(doubled)
-        + m + g + r + accumulate_17(5) + sweep_17(5)
-        + fib_17(8) + classify_17(Shape_17.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_17(doubled) +
+        m + g + r + accumulate_17(5) + sweep_17(5) +
+        fib_17(8) + classify_17(Shape_17.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod18.rv
+++ b/benchmarks/compile-time/corpus/modules/mod18.rv
@@ -152,8 +152,8 @@ fun compute_18(seed: Int) -> Int {
     let g = grade_points_18(grade_18(seed))
     let r = ranked_18(tagged) + ranked_18(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_18(doubled)
-        + m + g + r + accumulate_18(12) + sweep_18(12)
-        + fib_18(8) + classify_18(Shape_18.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_18(doubled) +
+        m + g + r + accumulate_18(12) + sweep_18(12) +
+        fib_18(8) + classify_18(Shape_18.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod19.rv
+++ b/benchmarks/compile-time/corpus/modules/mod19.rv
@@ -152,8 +152,8 @@ fun compute_19(seed: Int) -> Int {
     let g = grade_points_19(grade_19(seed))
     let r = ranked_19(tagged) + ranked_19(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_19(doubled)
-        + m + g + r + accumulate_19(19) + sweep_19(19)
-        + fib_19(8) + classify_19(Shape_19.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_19(doubled) +
+        m + g + r + accumulate_19(19) + sweep_19(19) +
+        fib_19(8) + classify_19(Shape_19.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod2.rv
+++ b/benchmarks/compile-time/corpus/modules/mod2.rv
@@ -152,8 +152,8 @@ fun compute_2(seed: Int) -> Int {
     let g = grade_points_2(grade_2(seed))
     let r = ranked_2(tagged) + ranked_2(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_2(doubled)
-        + m + g + r + accumulate_2(15) + sweep_2(15)
-        + fib_2(8) + classify_2(Shape_2.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_2(doubled) +
+        m + g + r + accumulate_2(15) + sweep_2(15) +
+        fib_2(8) + classify_2(Shape_2.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod20.rv
+++ b/benchmarks/compile-time/corpus/modules/mod20.rv
@@ -152,8 +152,8 @@ fun compute_20(seed: Int) -> Int {
     let g = grade_points_20(grade_20(seed))
     let r = ranked_20(tagged) + ranked_20(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_20(doubled)
-        + m + g + r + accumulate_20(3) + sweep_20(3)
-        + fib_20(8) + classify_20(Shape_20.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_20(doubled) +
+        m + g + r + accumulate_20(3) + sweep_20(3) +
+        fib_20(8) + classify_20(Shape_20.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod21.rv
+++ b/benchmarks/compile-time/corpus/modules/mod21.rv
@@ -152,8 +152,8 @@ fun compute_21(seed: Int) -> Int {
     let g = grade_points_21(grade_21(seed))
     let r = ranked_21(tagged) + ranked_21(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_21(doubled)
-        + m + g + r + accumulate_21(10) + sweep_21(10)
-        + fib_21(8) + classify_21(Shape_21.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_21(doubled) +
+        m + g + r + accumulate_21(10) + sweep_21(10) +
+        fib_21(8) + classify_21(Shape_21.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod22.rv
+++ b/benchmarks/compile-time/corpus/modules/mod22.rv
@@ -152,8 +152,8 @@ fun compute_22(seed: Int) -> Int {
     let g = grade_points_22(grade_22(seed))
     let r = ranked_22(tagged) + ranked_22(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_22(doubled)
-        + m + g + r + accumulate_22(17) + sweep_22(17)
-        + fib_22(8) + classify_22(Shape_22.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_22(doubled) +
+        m + g + r + accumulate_22(17) + sweep_22(17) +
+        fib_22(8) + classify_22(Shape_22.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod23.rv
+++ b/benchmarks/compile-time/corpus/modules/mod23.rv
@@ -152,8 +152,8 @@ fun compute_23(seed: Int) -> Int {
     let g = grade_points_23(grade_23(seed))
     let r = ranked_23(tagged) + ranked_23(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_23(doubled)
-        + m + g + r + accumulate_23(1) + sweep_23(1)
-        + fib_23(8) + classify_23(Shape_23.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_23(doubled) +
+        m + g + r + accumulate_23(1) + sweep_23(1) +
+        fib_23(8) + classify_23(Shape_23.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod24.rv
+++ b/benchmarks/compile-time/corpus/modules/mod24.rv
@@ -152,8 +152,8 @@ fun compute_24(seed: Int) -> Int {
     let g = grade_points_24(grade_24(seed))
     let r = ranked_24(tagged) + ranked_24(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_24(doubled)
-        + m + g + r + accumulate_24(8) + sweep_24(8)
-        + fib_24(8) + classify_24(Shape_24.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_24(doubled) +
+        m + g + r + accumulate_24(8) + sweep_24(8) +
+        fib_24(8) + classify_24(Shape_24.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod25.rv
+++ b/benchmarks/compile-time/corpus/modules/mod25.rv
@@ -152,8 +152,8 @@ fun compute_25(seed: Int) -> Int {
     let g = grade_points_25(grade_25(seed))
     let r = ranked_25(tagged) + ranked_25(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_25(doubled)
-        + m + g + r + accumulate_25(15) + sweep_25(15)
-        + fib_25(8) + classify_25(Shape_25.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_25(doubled) +
+        m + g + r + accumulate_25(15) + sweep_25(15) +
+        fib_25(8) + classify_25(Shape_25.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod26.rv
+++ b/benchmarks/compile-time/corpus/modules/mod26.rv
@@ -152,8 +152,8 @@ fun compute_26(seed: Int) -> Int {
     let g = grade_points_26(grade_26(seed))
     let r = ranked_26(tagged) + ranked_26(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_26(doubled)
-        + m + g + r + accumulate_26(22) + sweep_26(22)
-        + fib_26(8) + classify_26(Shape_26.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_26(doubled) +
+        m + g + r + accumulate_26(22) + sweep_26(22) +
+        fib_26(8) + classify_26(Shape_26.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod27.rv
+++ b/benchmarks/compile-time/corpus/modules/mod27.rv
@@ -152,8 +152,8 @@ fun compute_27(seed: Int) -> Int {
     let g = grade_points_27(grade_27(seed))
     let r = ranked_27(tagged) + ranked_27(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_27(doubled)
-        + m + g + r + accumulate_27(6) + sweep_27(6)
-        + fib_27(8) + classify_27(Shape_27.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_27(doubled) +
+        m + g + r + accumulate_27(6) + sweep_27(6) +
+        fib_27(8) + classify_27(Shape_27.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod28.rv
+++ b/benchmarks/compile-time/corpus/modules/mod28.rv
@@ -152,8 +152,8 @@ fun compute_28(seed: Int) -> Int {
     let g = grade_points_28(grade_28(seed))
     let r = ranked_28(tagged) + ranked_28(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_28(doubled)
-        + m + g + r + accumulate_28(13) + sweep_28(13)
-        + fib_28(8) + classify_28(Shape_28.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_28(doubled) +
+        m + g + r + accumulate_28(13) + sweep_28(13) +
+        fib_28(8) + classify_28(Shape_28.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod29.rv
+++ b/benchmarks/compile-time/corpus/modules/mod29.rv
@@ -152,8 +152,8 @@ fun compute_29(seed: Int) -> Int {
     let g = grade_points_29(grade_29(seed))
     let r = ranked_29(tagged) + ranked_29(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_29(doubled)
-        + m + g + r + accumulate_29(20) + sweep_29(20)
-        + fib_29(8) + classify_29(Shape_29.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_29(doubled) +
+        m + g + r + accumulate_29(20) + sweep_29(20) +
+        fib_29(8) + classify_29(Shape_29.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod3.rv
+++ b/benchmarks/compile-time/corpus/modules/mod3.rv
@@ -152,8 +152,8 @@ fun compute_3(seed: Int) -> Int {
     let g = grade_points_3(grade_3(seed))
     let r = ranked_3(tagged) + ranked_3(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_3(doubled)
-        + m + g + r + accumulate_3(22) + sweep_3(22)
-        + fib_3(8) + classify_3(Shape_3.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_3(doubled) +
+        m + g + r + accumulate_3(22) + sweep_3(22) +
+        fib_3(8) + classify_3(Shape_3.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod30.rv
+++ b/benchmarks/compile-time/corpus/modules/mod30.rv
@@ -152,8 +152,8 @@ fun compute_30(seed: Int) -> Int {
     let g = grade_points_30(grade_30(seed))
     let r = ranked_30(tagged) + ranked_30(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_30(doubled)
-        + m + g + r + accumulate_30(4) + sweep_30(4)
-        + fib_30(8) + classify_30(Shape_30.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_30(doubled) +
+        m + g + r + accumulate_30(4) + sweep_30(4) +
+        fib_30(8) + classify_30(Shape_30.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod31.rv
+++ b/benchmarks/compile-time/corpus/modules/mod31.rv
@@ -152,8 +152,8 @@ fun compute_31(seed: Int) -> Int {
     let g = grade_points_31(grade_31(seed))
     let r = ranked_31(tagged) + ranked_31(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_31(doubled)
-        + m + g + r + accumulate_31(11) + sweep_31(11)
-        + fib_31(8) + classify_31(Shape_31.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_31(doubled) +
+        m + g + r + accumulate_31(11) + sweep_31(11) +
+        fib_31(8) + classify_31(Shape_31.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod32.rv
+++ b/benchmarks/compile-time/corpus/modules/mod32.rv
@@ -152,8 +152,8 @@ fun compute_32(seed: Int) -> Int {
     let g = grade_points_32(grade_32(seed))
     let r = ranked_32(tagged) + ranked_32(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_32(doubled)
-        + m + g + r + accumulate_32(18) + sweep_32(18)
-        + fib_32(8) + classify_32(Shape_32.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_32(doubled) +
+        m + g + r + accumulate_32(18) + sweep_32(18) +
+        fib_32(8) + classify_32(Shape_32.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod33.rv
+++ b/benchmarks/compile-time/corpus/modules/mod33.rv
@@ -152,8 +152,8 @@ fun compute_33(seed: Int) -> Int {
     let g = grade_points_33(grade_33(seed))
     let r = ranked_33(tagged) + ranked_33(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_33(doubled)
-        + m + g + r + accumulate_33(2) + sweep_33(2)
-        + fib_33(8) + classify_33(Shape_33.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_33(doubled) +
+        m + g + r + accumulate_33(2) + sweep_33(2) +
+        fib_33(8) + classify_33(Shape_33.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod34.rv
+++ b/benchmarks/compile-time/corpus/modules/mod34.rv
@@ -152,8 +152,8 @@ fun compute_34(seed: Int) -> Int {
     let g = grade_points_34(grade_34(seed))
     let r = ranked_34(tagged) + ranked_34(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_34(doubled)
-        + m + g + r + accumulate_34(9) + sweep_34(9)
-        + fib_34(8) + classify_34(Shape_34.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_34(doubled) +
+        m + g + r + accumulate_34(9) + sweep_34(9) +
+        fib_34(8) + classify_34(Shape_34.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod35.rv
+++ b/benchmarks/compile-time/corpus/modules/mod35.rv
@@ -152,8 +152,8 @@ fun compute_35(seed: Int) -> Int {
     let g = grade_points_35(grade_35(seed))
     let r = ranked_35(tagged) + ranked_35(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_35(doubled)
-        + m + g + r + accumulate_35(16) + sweep_35(16)
-        + fib_35(8) + classify_35(Shape_35.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_35(doubled) +
+        m + g + r + accumulate_35(16) + sweep_35(16) +
+        fib_35(8) + classify_35(Shape_35.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod36.rv
+++ b/benchmarks/compile-time/corpus/modules/mod36.rv
@@ -152,8 +152,8 @@ fun compute_36(seed: Int) -> Int {
     let g = grade_points_36(grade_36(seed))
     let r = ranked_36(tagged) + ranked_36(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_36(doubled)
-        + m + g + r + accumulate_36(23) + sweep_36(23)
-        + fib_36(8) + classify_36(Shape_36.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_36(doubled) +
+        m + g + r + accumulate_36(23) + sweep_36(23) +
+        fib_36(8) + classify_36(Shape_36.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod37.rv
+++ b/benchmarks/compile-time/corpus/modules/mod37.rv
@@ -152,8 +152,8 @@ fun compute_37(seed: Int) -> Int {
     let g = grade_points_37(grade_37(seed))
     let r = ranked_37(tagged) + ranked_37(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_37(doubled)
-        + m + g + r + accumulate_37(7) + sweep_37(7)
-        + fib_37(8) + classify_37(Shape_37.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_37(doubled) +
+        m + g + r + accumulate_37(7) + sweep_37(7) +
+        fib_37(8) + classify_37(Shape_37.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod38.rv
+++ b/benchmarks/compile-time/corpus/modules/mod38.rv
@@ -152,8 +152,8 @@ fun compute_38(seed: Int) -> Int {
     let g = grade_points_38(grade_38(seed))
     let r = ranked_38(tagged) + ranked_38(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_38(doubled)
-        + m + g + r + accumulate_38(14) + sweep_38(14)
-        + fib_38(8) + classify_38(Shape_38.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_38(doubled) +
+        m + g + r + accumulate_38(14) + sweep_38(14) +
+        fib_38(8) + classify_38(Shape_38.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod39.rv
+++ b/benchmarks/compile-time/corpus/modules/mod39.rv
@@ -152,8 +152,8 @@ fun compute_39(seed: Int) -> Int {
     let g = grade_points_39(grade_39(seed))
     let r = ranked_39(tagged) + ranked_39(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_39(doubled)
-        + m + g + r + accumulate_39(21) + sweep_39(21)
-        + fib_39(8) + classify_39(Shape_39.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_39(doubled) +
+        m + g + r + accumulate_39(21) + sweep_39(21) +
+        fib_39(8) + classify_39(Shape_39.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod4.rv
+++ b/benchmarks/compile-time/corpus/modules/mod4.rv
@@ -152,8 +152,8 @@ fun compute_4(seed: Int) -> Int {
     let g = grade_points_4(grade_4(seed))
     let r = ranked_4(tagged) + ranked_4(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_4(doubled)
-        + m + g + r + accumulate_4(6) + sweep_4(6)
-        + fib_4(8) + classify_4(Shape_4.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_4(doubled) +
+        m + g + r + accumulate_4(6) + sweep_4(6) +
+        fib_4(8) + classify_4(Shape_4.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod40.rv
+++ b/benchmarks/compile-time/corpus/modules/mod40.rv
@@ -152,8 +152,8 @@ fun compute_40(seed: Int) -> Int {
     let g = grade_points_40(grade_40(seed))
     let r = ranked_40(tagged) + ranked_40(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_40(doubled)
-        + m + g + r + accumulate_40(5) + sweep_40(5)
-        + fib_40(8) + classify_40(Shape_40.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_40(doubled) +
+        m + g + r + accumulate_40(5) + sweep_40(5) +
+        fib_40(8) + classify_40(Shape_40.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod41.rv
+++ b/benchmarks/compile-time/corpus/modules/mod41.rv
@@ -152,8 +152,8 @@ fun compute_41(seed: Int) -> Int {
     let g = grade_points_41(grade_41(seed))
     let r = ranked_41(tagged) + ranked_41(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_41(doubled)
-        + m + g + r + accumulate_41(12) + sweep_41(12)
-        + fib_41(8) + classify_41(Shape_41.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_41(doubled) +
+        m + g + r + accumulate_41(12) + sweep_41(12) +
+        fib_41(8) + classify_41(Shape_41.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod42.rv
+++ b/benchmarks/compile-time/corpus/modules/mod42.rv
@@ -152,8 +152,8 @@ fun compute_42(seed: Int) -> Int {
     let g = grade_points_42(grade_42(seed))
     let r = ranked_42(tagged) + ranked_42(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_42(doubled)
-        + m + g + r + accumulate_42(19) + sweep_42(19)
-        + fib_42(8) + classify_42(Shape_42.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_42(doubled) +
+        m + g + r + accumulate_42(19) + sweep_42(19) +
+        fib_42(8) + classify_42(Shape_42.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod43.rv
+++ b/benchmarks/compile-time/corpus/modules/mod43.rv
@@ -152,8 +152,8 @@ fun compute_43(seed: Int) -> Int {
     let g = grade_points_43(grade_43(seed))
     let r = ranked_43(tagged) + ranked_43(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_43(doubled)
-        + m + g + r + accumulate_43(3) + sweep_43(3)
-        + fib_43(8) + classify_43(Shape_43.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_43(doubled) +
+        m + g + r + accumulate_43(3) + sweep_43(3) +
+        fib_43(8) + classify_43(Shape_43.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod44.rv
+++ b/benchmarks/compile-time/corpus/modules/mod44.rv
@@ -152,8 +152,8 @@ fun compute_44(seed: Int) -> Int {
     let g = grade_points_44(grade_44(seed))
     let r = ranked_44(tagged) + ranked_44(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_44(doubled)
-        + m + g + r + accumulate_44(10) + sweep_44(10)
-        + fib_44(8) + classify_44(Shape_44.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_44(doubled) +
+        m + g + r + accumulate_44(10) + sweep_44(10) +
+        fib_44(8) + classify_44(Shape_44.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod45.rv
+++ b/benchmarks/compile-time/corpus/modules/mod45.rv
@@ -152,8 +152,8 @@ fun compute_45(seed: Int) -> Int {
     let g = grade_points_45(grade_45(seed))
     let r = ranked_45(tagged) + ranked_45(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_45(doubled)
-        + m + g + r + accumulate_45(17) + sweep_45(17)
-        + fib_45(8) + classify_45(Shape_45.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_45(doubled) +
+        m + g + r + accumulate_45(17) + sweep_45(17) +
+        fib_45(8) + classify_45(Shape_45.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod46.rv
+++ b/benchmarks/compile-time/corpus/modules/mod46.rv
@@ -152,8 +152,8 @@ fun compute_46(seed: Int) -> Int {
     let g = grade_points_46(grade_46(seed))
     let r = ranked_46(tagged) + ranked_46(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_46(doubled)
-        + m + g + r + accumulate_46(1) + sweep_46(1)
-        + fib_46(8) + classify_46(Shape_46.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_46(doubled) +
+        m + g + r + accumulate_46(1) + sweep_46(1) +
+        fib_46(8) + classify_46(Shape_46.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod47.rv
+++ b/benchmarks/compile-time/corpus/modules/mod47.rv
@@ -152,8 +152,8 @@ fun compute_47(seed: Int) -> Int {
     let g = grade_points_47(grade_47(seed))
     let r = ranked_47(tagged) + ranked_47(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_47(doubled)
-        + m + g + r + accumulate_47(8) + sweep_47(8)
-        + fib_47(8) + classify_47(Shape_47.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_47(doubled) +
+        m + g + r + accumulate_47(8) + sweep_47(8) +
+        fib_47(8) + classify_47(Shape_47.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod48.rv
+++ b/benchmarks/compile-time/corpus/modules/mod48.rv
@@ -152,8 +152,8 @@ fun compute_48(seed: Int) -> Int {
     let g = grade_points_48(grade_48(seed))
     let r = ranked_48(tagged) + ranked_48(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_48(doubled)
-        + m + g + r + accumulate_48(15) + sweep_48(15)
-        + fib_48(8) + classify_48(Shape_48.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_48(doubled) +
+        m + g + r + accumulate_48(15) + sweep_48(15) +
+        fib_48(8) + classify_48(Shape_48.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod49.rv
+++ b/benchmarks/compile-time/corpus/modules/mod49.rv
@@ -152,8 +152,8 @@ fun compute_49(seed: Int) -> Int {
     let g = grade_points_49(grade_49(seed))
     let r = ranked_49(tagged) + ranked_49(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_49(doubled)
-        + m + g + r + accumulate_49(22) + sweep_49(22)
-        + fib_49(8) + classify_49(Shape_49.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_49(doubled) +
+        m + g + r + accumulate_49(22) + sweep_49(22) +
+        fib_49(8) + classify_49(Shape_49.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod5.rv
+++ b/benchmarks/compile-time/corpus/modules/mod5.rv
@@ -152,8 +152,8 @@ fun compute_5(seed: Int) -> Int {
     let g = grade_points_5(grade_5(seed))
     let r = ranked_5(tagged) + ranked_5(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_5(doubled)
-        + m + g + r + accumulate_5(13) + sweep_5(13)
-        + fib_5(8) + classify_5(Shape_5.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_5(doubled) +
+        m + g + r + accumulate_5(13) + sweep_5(13) +
+        fib_5(8) + classify_5(Shape_5.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod50.rv
+++ b/benchmarks/compile-time/corpus/modules/mod50.rv
@@ -152,8 +152,8 @@ fun compute_50(seed: Int) -> Int {
     let g = grade_points_50(grade_50(seed))
     let r = ranked_50(tagged) + ranked_50(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_50(doubled)
-        + m + g + r + accumulate_50(6) + sweep_50(6)
-        + fib_50(8) + classify_50(Shape_50.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_50(doubled) +
+        m + g + r + accumulate_50(6) + sweep_50(6) +
+        fib_50(8) + classify_50(Shape_50.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod51.rv
+++ b/benchmarks/compile-time/corpus/modules/mod51.rv
@@ -152,8 +152,8 @@ fun compute_51(seed: Int) -> Int {
     let g = grade_points_51(grade_51(seed))
     let r = ranked_51(tagged) + ranked_51(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_51(doubled)
-        + m + g + r + accumulate_51(13) + sweep_51(13)
-        + fib_51(8) + classify_51(Shape_51.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_51(doubled) +
+        m + g + r + accumulate_51(13) + sweep_51(13) +
+        fib_51(8) + classify_51(Shape_51.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod52.rv
+++ b/benchmarks/compile-time/corpus/modules/mod52.rv
@@ -152,8 +152,8 @@ fun compute_52(seed: Int) -> Int {
     let g = grade_points_52(grade_52(seed))
     let r = ranked_52(tagged) + ranked_52(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_52(doubled)
-        + m + g + r + accumulate_52(20) + sweep_52(20)
-        + fib_52(8) + classify_52(Shape_52.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_52(doubled) +
+        m + g + r + accumulate_52(20) + sweep_52(20) +
+        fib_52(8) + classify_52(Shape_52.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod53.rv
+++ b/benchmarks/compile-time/corpus/modules/mod53.rv
@@ -152,8 +152,8 @@ fun compute_53(seed: Int) -> Int {
     let g = grade_points_53(grade_53(seed))
     let r = ranked_53(tagged) + ranked_53(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_53(doubled)
-        + m + g + r + accumulate_53(4) + sweep_53(4)
-        + fib_53(8) + classify_53(Shape_53.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_53(doubled) +
+        m + g + r + accumulate_53(4) + sweep_53(4) +
+        fib_53(8) + classify_53(Shape_53.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod54.rv
+++ b/benchmarks/compile-time/corpus/modules/mod54.rv
@@ -152,8 +152,8 @@ fun compute_54(seed: Int) -> Int {
     let g = grade_points_54(grade_54(seed))
     let r = ranked_54(tagged) + ranked_54(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_54(doubled)
-        + m + g + r + accumulate_54(11) + sweep_54(11)
-        + fib_54(8) + classify_54(Shape_54.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_54(doubled) +
+        m + g + r + accumulate_54(11) + sweep_54(11) +
+        fib_54(8) + classify_54(Shape_54.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod55.rv
+++ b/benchmarks/compile-time/corpus/modules/mod55.rv
@@ -152,8 +152,8 @@ fun compute_55(seed: Int) -> Int {
     let g = grade_points_55(grade_55(seed))
     let r = ranked_55(tagged) + ranked_55(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_55(doubled)
-        + m + g + r + accumulate_55(18) + sweep_55(18)
-        + fib_55(8) + classify_55(Shape_55.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_55(doubled) +
+        m + g + r + accumulate_55(18) + sweep_55(18) +
+        fib_55(8) + classify_55(Shape_55.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod56.rv
+++ b/benchmarks/compile-time/corpus/modules/mod56.rv
@@ -152,8 +152,8 @@ fun compute_56(seed: Int) -> Int {
     let g = grade_points_56(grade_56(seed))
     let r = ranked_56(tagged) + ranked_56(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_56(doubled)
-        + m + g + r + accumulate_56(2) + sweep_56(2)
-        + fib_56(8) + classify_56(Shape_56.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_56(doubled) +
+        m + g + r + accumulate_56(2) + sweep_56(2) +
+        fib_56(8) + classify_56(Shape_56.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod57.rv
+++ b/benchmarks/compile-time/corpus/modules/mod57.rv
@@ -152,8 +152,8 @@ fun compute_57(seed: Int) -> Int {
     let g = grade_points_57(grade_57(seed))
     let r = ranked_57(tagged) + ranked_57(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_57(doubled)
-        + m + g + r + accumulate_57(9) + sweep_57(9)
-        + fib_57(8) + classify_57(Shape_57.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_57(doubled) +
+        m + g + r + accumulate_57(9) + sweep_57(9) +
+        fib_57(8) + classify_57(Shape_57.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod58.rv
+++ b/benchmarks/compile-time/corpus/modules/mod58.rv
@@ -152,8 +152,8 @@ fun compute_58(seed: Int) -> Int {
     let g = grade_points_58(grade_58(seed))
     let r = ranked_58(tagged) + ranked_58(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_58(doubled)
-        + m + g + r + accumulate_58(16) + sweep_58(16)
-        + fib_58(8) + classify_58(Shape_58.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_58(doubled) +
+        m + g + r + accumulate_58(16) + sweep_58(16) +
+        fib_58(8) + classify_58(Shape_58.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod59.rv
+++ b/benchmarks/compile-time/corpus/modules/mod59.rv
@@ -152,8 +152,8 @@ fun compute_59(seed: Int) -> Int {
     let g = grade_points_59(grade_59(seed))
     let r = ranked_59(tagged) + ranked_59(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_59(doubled)
-        + m + g + r + accumulate_59(23) + sweep_59(23)
-        + fib_59(8) + classify_59(Shape_59.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_59(doubled) +
+        m + g + r + accumulate_59(23) + sweep_59(23) +
+        fib_59(8) + classify_59(Shape_59.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod6.rv
+++ b/benchmarks/compile-time/corpus/modules/mod6.rv
@@ -152,8 +152,8 @@ fun compute_6(seed: Int) -> Int {
     let g = grade_points_6(grade_6(seed))
     let r = ranked_6(tagged) + ranked_6(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_6(doubled)
-        + m + g + r + accumulate_6(20) + sweep_6(20)
-        + fib_6(8) + classify_6(Shape_6.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_6(doubled) +
+        m + g + r + accumulate_6(20) + sweep_6(20) +
+        fib_6(8) + classify_6(Shape_6.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod60.rv
+++ b/benchmarks/compile-time/corpus/modules/mod60.rv
@@ -152,8 +152,8 @@ fun compute_60(seed: Int) -> Int {
     let g = grade_points_60(grade_60(seed))
     let r = ranked_60(tagged) + ranked_60(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_60(doubled)
-        + m + g + r + accumulate_60(7) + sweep_60(7)
-        + fib_60(8) + classify_60(Shape_60.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_60(doubled) +
+        m + g + r + accumulate_60(7) + sweep_60(7) +
+        fib_60(8) + classify_60(Shape_60.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod61.rv
+++ b/benchmarks/compile-time/corpus/modules/mod61.rv
@@ -152,8 +152,8 @@ fun compute_61(seed: Int) -> Int {
     let g = grade_points_61(grade_61(seed))
     let r = ranked_61(tagged) + ranked_61(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_61(doubled)
-        + m + g + r + accumulate_61(14) + sweep_61(14)
-        + fib_61(8) + classify_61(Shape_61.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_61(doubled) +
+        m + g + r + accumulate_61(14) + sweep_61(14) +
+        fib_61(8) + classify_61(Shape_61.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod7.rv
+++ b/benchmarks/compile-time/corpus/modules/mod7.rv
@@ -152,8 +152,8 @@ fun compute_7(seed: Int) -> Int {
     let g = grade_points_7(grade_7(seed))
     let r = ranked_7(tagged) + ranked_7(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_7(doubled)
-        + m + g + r + accumulate_7(4) + sweep_7(4)
-        + fib_7(8) + classify_7(Shape_7.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_7(doubled) +
+        m + g + r + accumulate_7(4) + sweep_7(4) +
+        fib_7(8) + classify_7(Shape_7.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod8.rv
+++ b/benchmarks/compile-time/corpus/modules/mod8.rv
@@ -152,8 +152,8 @@ fun compute_8(seed: Int) -> Int {
     let g = grade_points_8(grade_8(seed))
     let r = ranked_8(tagged) + ranked_8(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_8(doubled)
-        + m + g + r + accumulate_8(11) + sweep_8(11)
-        + fib_8(8) + classify_8(Shape_8.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_8(doubled) +
+        m + g + r + accumulate_8(11) + sweep_8(11) +
+        fib_8(8) + classify_8(Shape_8.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/corpus/modules/mod9.rv
+++ b/benchmarks/compile-time/corpus/modules/mod9.rv
@@ -152,8 +152,8 @@ fun compute_9(seed: Int) -> Int {
     let g = grade_points_9(grade_9(seed))
     let r = ranked_9(tagged) + ranked_9(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_9(doubled)
-        + m + g + r + accumulate_9(18) + sweep_9(18)
-        + fib_9(8) + classify_9(Shape_9.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_9(doubled) +
+        m + g + r + accumulate_9(18) + sweep_9(18) +
+        fib_9(8) + classify_9(Shape_9.Hexagon) + extra +
+        q.left().length()
 }

--- a/benchmarks/compile-time/generate.sh
+++ b/benchmarks/compile-time/generate.sh
@@ -180,10 +180,10 @@ fun compute_${i}(seed: Int) -> Int {
     let g = grade_points_${i}(grade_${i}(seed))
     let r = ranked_${i}(tagged) + ranked_${i}(v)
     let extra = if big { 1 } else { 0 }
-    return p.left() + p.right() + w.magnitude_sq() + identity_${i}(doubled)
-        + m + g + r + accumulate_${i}(${base}) + sweep_${i}(${base})
-        + fib_${i}(8) + classify_${i}(Shape_${i}.Hexagon) + extra
-        + q.left().length()
+    return p.left() + p.right() + w.magnitude_sq() + identity_${i}(doubled) +
+        m + g + r + accumulate_${i}(${base}) + sweep_${i}(${base}) +
+        fib_${i}(8) + classify_${i}(Shape_${i}.Hexagon) + extra +
+        q.left().length()
 }
 EOF
 }


### PR DESCRIPTION
## Why CI failed

The benchmark job (`bash benchmarks/compile-time/run.sh`) failed verifying the corpus compiles:

```
error: cannot resolve import .../mod61.rv
  help: parse: mod61.rv:156:9: expected expression, found `+`
```

The corpus generator emitted a long `+` chain with each continuation line **starting** with the operator:

```raven
return p.left() + p.right() + w.magnitude_sq() + identity_61(doubled)
    + m + g + r + accumulate_61(14) + sweep_61(14)
    ...
```

Since #414, a newline *before* an infix operator no longer continues the previous expression: a line that starts with `+`/`-` is a new statement (that was the silent statement-merge footgun #414 fixed). So the generated modules no longer parse.

## Fix

Move the `+` to the **end** of the previous line, the supported trailing-operator continuation, in `generate.sh`, and regenerate all 62 modules. Generation stays deterministic (re-running reproduces the same output) and the corpus compiles again. No compiler change, so no version bump.