### PR TITLE
fix(tycheck): adopt the annotation for a module-level empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.50] - 2026-06-11
+
+### Fixed
+
+- A module-level `let x: List<T> = []` now adopts its annotated element type instead of rejecting the empty array with "empty array literals require a context type". The top-level initializer check now threads the declared `List<T>` element type as the array hint, the same as a local `let` (#498).
+
 ## [2.18.49] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.49"
+version = "2.18.50"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.49"
+version = "2.18.50"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.49"
+version = "2.18.50"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -155,6 +155,11 @@ fn check_decl_body(
             if let Some(init) = &l.init {
                 let mut cx = Checker::new(resolved, env, types, None, expected.clone());
                 cx.errors = std::mem::take(&mut errors);
+                // Expose a declared `List<T>` element type so an empty `[]`
+                // initializer can adopt it, the same as a local `let` does.
+                if let Ty::List(elem) = &expected {
+                    cx.array_hint = Some((**elem).clone());
+                }
                 let actual = cx.check_expr_recover(init);
                 if !matches!(expected, Ty::Error) {
                     cx.unify_recover(&expected, &actual, &init.span);

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -107,6 +107,14 @@ fn inferred_type_violating_a_bound_is_rejected() {
 }
 
 #[test]
+fn module_level_empty_list_adopts_annotation() {
+    // A top-level `let xs: List<Int> = []` must adopt its annotated element
+    // type, the same as a local binding does, rather than reporting that the
+    // empty array needs a context type. Regression for #498.
+    assert!(check("let xs: List<Int> = []\nfun main() {}\n").is_ok());
+}
+
+#[test]
 fn nested_constructor_pattern_is_rejected() {
     // A constructor pattern whose element is itself a constructor is not
     // supported and must be a clean type error, not a silent miscompile.


### PR DESCRIPTION
Closes #498.

A top-level `let xs: List<Int> = []` was rejected with "empty array literals require a context type" even though the binding was annotated, while the same statement inside a function compiled. The local `let` path sets the array element hint from a declared `List<T>` before checking the initializer; the top-level path created the checker with the expected type but never set the hint.

The top-level initializer check now sets the same array hint from the declared `List<T>`. Verified an annotated empty-list global type-checks, runs, and mutates, and the local case is unaffected. lib (539, +1 regression test), clippy clean. Version 2.18.50.