### PR TITLE
fix(tycheck): clear error for an un-inferable module-level let

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.51] - 2026-06-11
+
+### Fixed
+
+- A module-level `let` with an unannotated, non-literal initializer (for example `let lock = mutex()`) now reports a clear type error pointing at the binding, asking for a type annotation, instead of crashing in codegen with `unresolved callee: Unit$<method>`. An annotated global (`let lock: Mutex = mutex()`) works as before, and literal globals are still inferred (#497).
+
 ## [2.18.50] - 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.50"
+version = "2.18.51"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.50"
+version = "2.18.51"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.50"
+version = "2.18.51"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -168,11 +168,25 @@ pub fn collect_declarations(
                 let scope = GenericScope::new();
                 let ty = match &l.ty {
                     Some(t) => resolve_ty(t, resolved, env, None, &scope)?,
-                    // Infer an unannotated module-level `let` from a literal
-                    // initializer so references type-check (HIR inlines the
-                    // literal at each use; module-level bindings have no
-                    // runtime storage yet).
-                    None => l.init.as_ref().and_then(literal_ty_of).unwrap_or(Ty::Error),
+                    // An unannotated module-level `let` is inferred from a
+                    // literal initializer. A non-literal initializer (a call,
+                    // for example) cannot be typed at signature-collection time
+                    // without running the body checker, so require an
+                    // annotation instead of leaving the binding typed `Error`,
+                    // which previously surfaced only as an opaque codegen
+                    // failure (`unresolved callee: Unit$<method>`) at each use.
+                    None => match l.init.as_ref().and_then(literal_ty_of) {
+                        Some(t) => t,
+                        None => {
+                            return Err(RavenError::ty(
+                                TypeError::Custom(format!(
+                                    "cannot infer the type of module-level `let {0}` from a non-literal initializer; add a type annotation, for example `let {0}: SomeType = ...`",
+                                    l.name
+                                )),
+                                l.span.clone(),
+                            ));
+                        }
+                    },
                 };
                 env.statics.insert(id, ty);
             }

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -107,6 +107,20 @@ fn inferred_type_violating_a_bound_is_rejected() {
 }
 
 #[test]
+fn module_level_let_non_literal_needs_annotation() {
+    // An unannotated module-level `let` with a non-literal initializer is a
+    // clean type error rather than an opaque codegen failure. Regression for
+    // #497.
+    assert!(check("fun make() -> Int { return 5 }\nlet g = make()\nfun main() {}\n").is_err());
+}
+
+#[test]
+fn module_level_let_literal_is_inferred() {
+    // An unannotated literal global is still inferred. Companion to #497.
+    assert!(check("let n = 42\nlet s = \"hi\"\nfun main() {}\n").is_ok());
+}
+
+#[test]
 fn module_level_empty_list_adopts_annotation() {
     // A top-level `let xs: List<Int> = []` must adopt its annotated element
     // type, the same as a local binding does, rather than reporting that the


### PR DESCRIPTION
Closes #497.

An unannotated module-level `let` whose initializer is not a literal (a call, for example `let lock = mutex()`) was typed `Error` at signature-collection time, which surfaced only as an opaque codegen failure (`unresolved callee: Unit$<method>`) at every use of the binding.

Such a binding now reports a clear type error at the binding asking for a type annotation. A literal initializer is still inferred, and an annotated global (`let lock: Mutex = mutex()`) compiles and runs as before.

Inferring the type of a non-literal global *without* an annotation would require running the body checker at signature-collection time with a mutable environment, which the current pipeline does not expose at that phase; that is left as a separate enhancement. The immediate fix removes the codegen crash and gives actionable guidance. lib (541, +2 tests), clippy clean. Version 2.18.51.