### PR TITLE
feat(derive): support @derive(Ord) for structs and enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.52] - 2026-06-11
+
+### Added
+
+- `@derive(Ord)` for structs and enums. It synthesizes `compare(self, other) -> Int`: a struct compares its fields in declaration order (first non-zero wins), and an enum compares variant order first, then payload slots for the same variant. A derived type can be sorted with `std/cmp` (`sort`, `sorted_by`) without a hand-written comparator (#499).
+
 ## [2.18.51] - 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.51"
+version = "2.18.52"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.51"
+version = "2.18.52"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.51"
+version = "2.18.52"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/derive.md
+++ b/docs/v2/specs/derive.md
@@ -31,8 +31,8 @@ and attaches the trait list to the following struct or enum as a
 than `derive`, is a parse error. A type with no attribute carries an empty
 derive list and is unaffected.
 
-The supported traits are `Eq`, `Hash`, `ToString`, `Debug`, `ToJson`, and
-`FromJson`. Naming any other trait (for example `Ord`) is a compile error.
+The supported traits are `Eq`, `Ord`, `Hash`, `ToString`, `Debug`, `ToJson`, and
+`FromJson`. Naming any other trait (for example `Clone`) is a compile error.
 `ToJson` and `FromJson` provide JSON serialization on top of `std/json`; see
 their section below and the [std/json spec](std-json.md).
 
@@ -89,6 +89,27 @@ The built-in generic types `Option<T>`, `Result<T, E>`, and `List<T>` implement
 `Eq` in `std/core`, and `Set<T>` and `Map<K, V>` in `std/collections` (these
 two compare order-independently), so `==`/`!=` work on them by value when the
 element type implements `Eq`.
+
+### Ord
+
+```rust
+fun compare(self, other: Self) -> Int
+```
+
+Returns a negative number when `self < other`, zero when equal, and a positive
+number when `self > other`, matching `std/core`'s `Ord`. Each field or payload
+type must itself implement `Ord`.
+
+* Struct: compare fields in declaration order, returning the first non-zero
+  field `compare` and `0` when every field is equal. `Point { x, y }` orders by
+  `x` first, then `y`.
+* Enum: compare the variant's declaration order first (an earlier variant sorts
+  before a later one), then, for two values of the same variant, compare the
+  payload slots in order. `Shape.Dot` sorts before `Shape.Circle(_)`, and
+  `Circle(2)` before `Circle(5)`.
+
+`Ord` pairs with `std/cmp` (`sort`, `sorted_by`, `min`, `max`) so a derived type
+can be sorted without a hand-written comparator.
 
 ### Hash
 
@@ -217,8 +238,8 @@ The bound is required because `equals` on a field of type `A` needs
 
 ## Limitations
 
-* Only `Eq`, `Hash`, `ToString`, `Debug`, `ToJson`, and `FromJson` are
-  supported. `Ord` and other traits are not derivable yet.
+* Only `Eq`, `Ord`, `Hash`, `ToString`, `Debug`, `ToJson`, and `FromJson` are
+  supported. Other traits are not derivable yet.
 * Enum variants with struct-style (named-field) payloads, for example
   `V(a: Int)`, are rejected with a clear error. Unit and tuple variants are
   fully supported.

--- a/examples/v2/derive_ord.rv
+++ b/examples/v2/derive_ord.rv
@@ -1,0 +1,26 @@
+// @derive(Ord) gives a type a `compare(self, other) -> Int` method: structs
+// compare field by field in declaration order, enums by variant order and then
+// by payload. That is enough to sort a list of either with std/cmp.
+import std/io { println }
+import std/cmp { sort }
+
+@derive(Ord, ToString)
+struct Version { major: Int, minor: Int, patch: Int }
+
+@derive(Ord)
+enum Level { Low, Mid(Int), High(Int, Int) }
+
+fun main() {
+    let vs = sort([
+        Version { major: 1, minor: 2, patch: 0 },
+        Version { major: 1, minor: 0, patch: 9 },
+        Version { major: 0, minor: 9, patch: 9 },
+        Version { major: 1, minor: 2, patch: 0 },
+    ])
+    for v in vs {
+        println(v.to_string())
+    }
+    println(Level.Low.compare(Level.High(1, 1)).to_string())
+    println(Level.High(2, 1).compare(Level.High(2, 5)).to_string())
+    println(Level.Mid(7).compare(Level.Mid(7)).to_string())
+}

--- a/examples/v2/derive_ord.rv.out
+++ b/examples/v2/derive_ord.rv.out
@@ -1,0 +1,7 @@
+Version { major: 0, minor: 9, patch: 9 }
+Version { major: 1, minor: 0, patch: 9 }
+Version { major: 1, minor: 2, patch: 0 }
+Version { major: 1, minor: 2, patch: 0 }
+-1
+-1
+0

--- a/src/resolve/derive.rs
+++ b/src/resolve/derive.rs
@@ -27,7 +27,9 @@ use crate::lexer::Lexer;
 use crate::parser::parse;
 
 /// The traits this pass can derive.
-const SUPPORTED: &[&str] = &["Eq", "Hash", "ToString", "Debug", "ToJson", "FromJson"];
+const SUPPORTED: &[&str] = &[
+    "Eq", "Ord", "Hash", "ToString", "Debug", "ToJson", "FromJson",
+];
 
 /// Whether a derive of `trait_name` is present on any type in `file`.
 fn any_derive(file: &File, trait_name: &str) -> bool {
@@ -110,7 +112,7 @@ fn check_supported(trait_name: &str, span: &crate::span::Span) -> Result<(), Rav
     } else {
         Err(RavenError::resolve(
             ResolveError::Other(format!(
-                "cannot derive `{trait_name}`: supported traits are Eq, Hash, ToString, Debug, ToJson, FromJson"
+                "cannot derive `{trait_name}`: supported traits are Eq, Ord, Hash, ToString, Debug, ToJson, FromJson"
             )),
             span.clone(),
         ))
@@ -139,6 +141,7 @@ fn struct_impl(s: &Struct, trait_name: &str) -> String {
     let (gen, self_ty) = impl_head(&s.name, &s.generics, trait_name);
     let body = match trait_name {
         "Eq" => struct_eq_body(s, &self_ty),
+        "Ord" => struct_ord_body(s, &self_ty),
         "Hash" => struct_hash_body(s),
         "ToString" => struct_to_string_body(s, "to_string"),
         "Debug" => struct_to_string_body(s, "debug"),
@@ -165,6 +168,25 @@ fn struct_eq_body(s: &Struct, self_ty: &str) -> String {
         "    fun equals(self, other: {self_ty}) -> Bool {{ return {} }}\n",
         parts.join(" && ")
     )
+}
+
+/// Compare a struct field by field in declaration order, returning the first
+/// non-zero field comparison and 0 when every field is equal. Each field type
+/// must implement `Ord`.
+fn struct_ord_body(s: &Struct, self_ty: &str) -> String {
+    if s.fields.is_empty() {
+        return format!("    fun compare(self, other: {self_ty}) -> Int {{ return 0 }}\n");
+    }
+    let mut body = format!("    fun compare(self, other: {self_ty}) -> Int {{\n");
+    for (i, f) in s.fields.iter().enumerate() {
+        let decl = if i == 0 { "let c" } else { "c" };
+        body.push_str(&format!(
+            "        {decl} = self.{0}.compare(other.{0})\n        if c != 0 {{ return c }}\n",
+            f.name
+        ));
+    }
+    body.push_str("        return 0\n    }\n");
+    body
 }
 
 fn struct_hash_body(s: &Struct) -> String {
@@ -221,6 +243,7 @@ fn enum_impl(e: &Enum, trait_name: &str, span: &crate::span::Span) -> Result<Str
     let (gen, self_ty) = impl_head(&e.name, &e.generics, trait_name);
     let body = match trait_name {
         "Eq" => enum_eq_body(e, &self_ty),
+        "Ord" => enum_ord_body(e, &self_ty),
         "Hash" => enum_hash_body(e),
         "ToString" => enum_to_string_body(e, "to_string"),
         "Debug" => enum_to_string_body(e, "debug"),
@@ -265,6 +288,59 @@ fn enum_eq_body(e: &Enum, self_ty: &str) -> String {
                 cmp.join(" && ")
             ));
         }
+    }
+    body.push_str("        }\n    }\n");
+    body
+}
+
+/// Compare an enum by variant order first, then by payload for the same
+/// variant: a variant declared earlier sorts before a later one, and two values
+/// of the same variant compare their payload slots in order. Each payload type
+/// must implement `Ord`. The inner `match` lists every variant explicitly so it
+/// stays exhaustive.
+fn enum_ord_body(e: &Enum, self_ty: &str) -> String {
+    let mut body = format!(
+        "    fun compare(self, other: {self_ty}) -> Int {{\n        return match self {{\n"
+    );
+    for (i, v) in e.variants.iter().enumerate() {
+        let n = variant_arity(v);
+        let self_pat = if n == 0 {
+            v.name.clone()
+        } else {
+            let binds: Vec<String> = (0..n).map(|k| format!("a{k}")).collect();
+            format!("{}({})", v.name, binds.join(", "))
+        };
+        body.push_str(&format!("            {self_pat} -> match other {{\n"));
+        for (j, w) in e.variants.iter().enumerate() {
+            let m = variant_arity(w);
+            let other_pat = if m == 0 {
+                w.name.clone()
+            } else if j == i {
+                let binds: Vec<String> = (0..m).map(|k| format!("b{k}")).collect();
+                format!("{}({})", w.name, binds.join(", "))
+            } else {
+                let wilds: Vec<String> = (0..m).map(|_| "_".to_string()).collect();
+                format!("{}({})", w.name, wilds.join(", "))
+            };
+            if j < i {
+                body.push_str(&format!("                {other_pat} -> 1,\n"));
+            } else if j > i {
+                body.push_str(&format!("                {other_pat} -> -1,\n"));
+            } else if n == 0 {
+                body.push_str(&format!("                {other_pat} -> 0,\n"));
+            } else {
+                let mut blk = String::from("{\n");
+                for k in 0..n {
+                    let decl = if k == 0 { "let c" } else { "c" };
+                    blk.push_str(&format!(
+                        "                    {decl} = a{k}.compare(b{k})\n                    if c != 0 {{ return c }}\n"
+                    ));
+                }
+                blk.push_str("                    0\n                }");
+                body.push_str(&format!("                {other_pat} -> {blk},\n"));
+            }
+        }
+        body.push_str("            },\n");
     }
     body.push_str("        }\n    }\n");
     body
@@ -619,10 +695,23 @@ mod tests {
 
     #[test]
     fn unsupported_trait_is_rejected() {
-        let file = parse_src("@derive(Ord)\nstruct Point { x: Int }\n");
+        let file = parse_src("@derive(Clone)\nstruct Point { x: Int }\n");
         let mut out = Vec::new();
-        let err = expand_derives(&file.items, &mut out).expect_err("Ord is not derivable");
-        assert!(format!("{err}").contains("Ord"), "got: {err}");
+        let err = expand_derives(&file.items, &mut out).expect_err("Clone is not derivable");
+        assert!(format!("{err}").contains("Clone"), "got: {err}");
+    }
+
+    #[test]
+    fn ord_is_derivable() {
+        let impls = derived_impls("@derive(Ord)\nstruct P { x: Int, y: Int }\n");
+        let traits: Vec<String> = impls
+            .iter()
+            .map(|i| i.trait_or_type.segments[0].name.clone())
+            .collect();
+        assert!(
+            traits.contains(&"Ord".to_string()),
+            "expected a derived Ord impl, got: {traits:?}"
+        );
     }
 
     #[test]

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -107,6 +107,14 @@ fn inferred_type_violating_a_bound_is_rejected() {
 }
 
 #[test]
+fn derive_ord_struct_and_enum_check() {
+    // `@derive(Ord)` synthesizes a `compare` method that type-checks for a
+    // struct and a tuple enum. Feature for #499.
+    assert!(check("@derive(Ord)\nstruct P { x: Int, y: Int }\nfun main() {}\n").is_ok());
+    assert!(check("@derive(Ord)\nenum E { A, B(Int), C(Int, Int) }\nfun main() {}\n").is_ok());
+}
+
+#[test]
 fn module_level_let_non_literal_needs_annotation() {
     // An unannotated module-level `let` with a non-literal initializer is a
     // clean type error rather than an opaque codegen failure. Regression for


### PR DESCRIPTION
Closes #499.

Adds `Ord` to the set of derivable traits. The synthesized impl provides `compare(self, other) -> Int`:

- **Struct**: compares fields in declaration order, returning the first non-zero field comparison and 0 when every field is equal.
- **Enum**: compares variant declaration order first (an earlier variant sorts before a later one), then, for the same variant, compares payload slots in order. The generated inner `match` lists every variant so it stays exhaustive.

Each field or payload type must implement `Ord`, the same way the derived `Eq` requires `Eq`. A derived type now sorts with `std/cmp` (`sort`, `sorted_by`) without a hand-written comparator.

Verified end to end: a `Version` struct and a `Level` enum sort correctly and compare as expected (`examples/v2/derive_ord.rv`). Updates `docs/v2/specs/derive.md`. Per the maintainer's instruction this ships as a patch bump (2.18.52), not a minor. lib (543, +2 tests), codegen_smoke (72), golden pass.