### PR TITLE
feat(rvpm): gitignore on init, init --lib, and a cache command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.53] - 2026-06-11
+
+### Added
+
+- `rvpm init` now writes a `.gitignore` (ignoring the generated `/target/`) alongside the manifest and entry file, leaving an existing `.gitignore` untouched.
+- `rvpm init --lib` scaffolds a library: `lib.rv` at the repo root (the entry point other projects import via `import "github.com/<user>/<repo>"`) instead of `src/main.rv`.
+- `rvpm cache` to inspect and clear the shared package cache: `cache dir` prints the cache root, `cache list` lists cached packages, and `cache clean [github.com/<user>/<repo>]` removes the whole cache or one package's cached versions (#503).
+
 ## [2.18.52] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.52"
+version = "2.18.53"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.52"
+version = "2.18.53"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.52"
+version = "2.18.53"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -5,12 +5,12 @@
 //! library code in `raven::manifest`, `raven::pkg`, `raven::lock`, and
 //! `raven::ops`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use raven::format::format_source_with;
 use raven::lock::{self, LockFile, LOCK_FILE_NAME};
-use raven::manifest::init::{init_project, name_from_dir, InitError};
+use raven::manifest::init::{init_project, name_from_dir, InitError, ProjectKind};
 use raven::manifest::Manifest;
 use raven::ops;
 use raven::pkg;
@@ -68,6 +68,13 @@ fn dispatch() -> ExitCode {
         Some("build") => run(cmd_build(&args[1..])),
         Some("run") => cmd_run(&args[1..]),
         Some("fmt") => cmd_fmt(&args[1..]),
+        Some("cache") => match cmd_cache(&args[1..]) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("rvpm: {}", e);
+                ExitCode::from(1)
+            }
+        },
         Some(other) => {
             eprintln!("rvpm: unknown subcommand '{}'", other);
             eprintln!("Run 'rvpm help' for usage.");
@@ -77,17 +84,134 @@ fn dispatch() -> ExitCode {
 }
 
 fn cmd_init(args: &[String]) -> Result<(), InitError> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("{}", init_usage());
+        return Ok(());
+    }
     let cwd = std::env::current_dir().map_err(InitError::Io)?;
-    let name = match args.first() {
+    let kind = if args.iter().any(|a| a == "--lib") {
+        ProjectKind::Lib
+    } else {
+        ProjectKind::App
+    };
+    // The name is the first non-flag argument; default to the directory name.
+    let name = match args.iter().find(|a| !a.starts_with('-')) {
         Some(n) => n.clone(),
         None => name_from_dir(&cwd),
     };
     let dir = PathBuf::from(".");
-    init_project(&dir, &name)?;
-    println!("Created package '{}'", name);
+    init_project(&dir, &name, kind)?;
+    let label = match kind {
+        ProjectKind::App => "package",
+        ProjectKind::Lib => "library",
+    };
+    println!("Created {} '{}'", label, name);
     println!("  rv.toml");
-    println!("  src/main.rv");
+    println!("  .gitignore");
+    match kind {
+        ProjectKind::App => println!("  src/main.rv"),
+        ProjectKind::Lib => println!("  lib.rv"),
+    }
     Ok(())
+}
+
+/// Inspect or clear the shared package cache.
+fn cmd_cache(args: &[String]) -> Result<(), String> {
+    match args.first().map(String::as_str) {
+        None | Some("--help") | Some("-h") => {
+            println!("{}", cache_usage());
+            Ok(())
+        }
+        Some("dir") => {
+            println!("{}", pkg::cache_root().display());
+            Ok(())
+        }
+        Some("list") => cache_list(),
+        Some("clean") => cache_clean(&args[1..]),
+        Some(other) => Err(format!(
+            "unknown cache subcommand '{}'\n{}",
+            other,
+            cache_usage()
+        )),
+    }
+}
+
+/// List every cached `<host>/<user>/<repo>@<version>` directory.
+fn cache_list() -> Result<(), String> {
+    let root = pkg::cache_root();
+    if !root.exists() {
+        println!("cache is empty ({})", root.display());
+        return Ok(());
+    }
+    let mut entries = Vec::new();
+    for host in dir_names(&root)? {
+        let host_dir = root.join(&host);
+        for user in dir_names(&host_dir)? {
+            let user_dir = host_dir.join(&user);
+            for pkg_ver in dir_names(&user_dir)? {
+                entries.push(format!("{}/{}/{}", host, user, pkg_ver));
+            }
+        }
+    }
+    if entries.is_empty() {
+        println!("cache is empty ({})", root.display());
+    } else {
+        entries.sort();
+        for e in &entries {
+            println!("{}", e);
+        }
+    }
+    Ok(())
+}
+
+/// Remove the whole cache, or every cached version of one package given as a
+/// `github.com/<user>/<repo>` argument.
+fn cache_clean(args: &[String]) -> Result<(), String> {
+    let root = pkg::cache_root();
+    match args.iter().find(|a| !a.starts_with('-')) {
+        Some(spec) => {
+            let gh = GithubPath::parse(spec)
+                .ok_or_else(|| format!("'{}' is not a 'github.com/<user>/<repo>' path", spec))?;
+            let user_dir = root.join(&gh.host).join(&gh.user);
+            if !user_dir.exists() {
+                println!("nothing cached for {}", spec);
+                return Ok(());
+            }
+            let prefix = format!("{}@", gh.repo);
+            let mut removed = 0;
+            for name in dir_names(&user_dir)? {
+                if name == gh.repo || name.starts_with(&prefix) {
+                    std::fs::remove_dir_all(user_dir.join(&name)).map_err(|e| e.to_string())?;
+                    removed += 1;
+                }
+            }
+            println!("removed {} cached version(s) of {}", removed, spec);
+            Ok(())
+        }
+        None => {
+            if !root.exists() {
+                println!("cache is already empty ({})", root.display());
+                return Ok(());
+            }
+            std::fs::remove_dir_all(&root).map_err(|e| e.to_string())?;
+            println!("removed the package cache ({})", root.display());
+            Ok(())
+        }
+    }
+}
+
+/// The names of the immediate subdirectories of `dir`, ignoring files.
+fn dir_names(dir: &Path) -> Result<Vec<String>, String> {
+    let mut names = Vec::new();
+    for entry in std::fs::read_dir(dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        if entry.path().is_dir() {
+            if let Some(n) = entry.file_name().to_str() {
+                names.push(n.to_string());
+            }
+        }
+    }
+    Ok(names)
 }
 
 fn cmd_fetch(args: &[String]) -> Result<(), String> {
@@ -349,6 +473,14 @@ fn collect_rv_files(dir: PathBuf) -> Result<Vec<PathBuf>, String> {
     Ok(out)
 }
 
+fn init_usage() -> String {
+    "Usage: rvpm init [name] [--lib]".to_string()
+}
+
+fn cache_usage() -> String {
+    "Usage: rvpm cache <dir | list | clean [github.com/<user>/<repo>]>".to_string()
+}
+
 fn fmt_usage() -> String {
     "Usage: rvpm fmt [--check] [paths...]".to_string()
 }
@@ -380,7 +512,7 @@ fn print_usage() {
     println!("  rvpm <command> [arguments]");
     println!();
     println!("Commands:");
-    println!("  init [name]    Scaffold a new package in the current directory");
+    println!("  init [name]    Scaffold a new package here (--lib for a library, lib.rv)");
     println!("  add <pkg>      Add a dependency to rv.toml, then resolve and write rv.lock");
     println!("  install        Resolve rv.toml against rv.lock and fill the cache");
     println!("  update [pkg]   Re-resolve rv.toml and rewrite rv.lock for one package or all");
@@ -389,6 +521,7 @@ fn print_usage() {
     println!("  fmt [paths]    Format .rv files in place (--check to verify only)");
     println!("  fetch <pkg>    Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
     println!("  lock           Generate or validate rv.lock for the current package");
+    println!("  cache <sub>    Inspect or clear the shared package cache (dir/list/clean)");
     println!("  help           Print this message");
     println!();
     println!("Package arguments use the 'github.com/<user>/<repo>' form.");

--- a/src/manifest/init.rs
+++ b/src/manifest/init.rs
@@ -1,14 +1,25 @@
 //! Project scaffolding for `rvpm init`.
 //!
-//! Writes a starter `rv.toml` and `src/main.rv` into a target directory.
-//! The generated manifest round-trips through [`super::Manifest`] and the
-//! generated program compiles under the `raven` build.
+//! Writes a starter manifest, a `.gitignore`, and an entry file into a target
+//! directory: `src/main.rv` for an application, or `lib.rv` at the root for a
+//! library (the entry point other projects import). The generated manifest
+//! round-trips through [`super::Manifest`] and the generated source compiles
+//! under the `raven` build.
 
 use std::io;
 use std::path::Path;
 
 /// The starter version stamped into a new manifest.
 pub const STARTER_VERSION: &str = "0.1.0";
+
+/// What `init` scaffolds: an application (an executable entered through
+/// `src/main.rv`) or a library (a package exposing `lib.rv` at its root, the
+/// file other projects load via `import "github.com/<user>/<repo>"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectKind {
+    App,
+    Lib,
+}
 
 /// Reasons `init` could not scaffold a project.
 #[derive(Debug)]
@@ -55,23 +66,69 @@ pub fn main_rv_template(name: &str) -> String {
     format!("fun main() {{\n    print(\"hello from {name}\")\n}}\n")
 }
 
-/// Scaffold a new project named `name` rooted at `dir`. Writes
-/// `<dir>/rv.toml` and `<dir>/src/main.rv`. Fails without writing
-/// anything if `<dir>/rv.toml` already exists.
-pub fn init_project(dir: &Path, name: &str) -> Result<(), InitError> {
+/// Render the starter `lib.rv` for a library named `name`. The declarations
+/// here are what other projects import via `import "github.com/<user>/<repo>"`.
+pub fn lib_rv_template(name: &str) -> String {
+    format!(
+        "// lib.rv is the entry point of the `{name}` package: the items declared\n\
+         // here are what other projects import, for example:\n\
+         //   import \"github.com/<user>/{name}\" {{ greet, Greeting }}\n\
+         //\n\
+         // A sub-path import like `github.com/<user>/{name}/util` loads `util.rv`\n\
+         // next to this file.\n\
+         \n\
+         import std/string\n\
+         \n\
+         struct Greeting {{\n    who: String,\n}}\n\
+         \n\
+         fun greet(who: String) -> String {{\n    return \"hello, \".concat(who)\n}}\n"
+    )
+}
+
+/// The starter `.gitignore`: ignore the build output. `rvpm build` writes the
+/// binary under `target/raven-out/`, and the runtime staticlib is staged in
+/// `target/` too, so the whole directory is generated.
+pub fn gitignore_template() -> &'static str {
+    "# Raven build output\n/target/\n"
+}
+
+/// Scaffold a new project named `name` rooted at `dir`. Writes `<dir>/rv.toml`,
+/// a `<dir>/.gitignore`, and the entry file: `<dir>/src/main.rv` for
+/// [`ProjectKind::App`] or `<dir>/lib.rv` for [`ProjectKind::Lib`]. Fails
+/// without writing anything if `<dir>/rv.toml` already exists; an existing
+/// `.gitignore` or entry file is left untouched.
+pub fn init_project(dir: &Path, name: &str, kind: ProjectKind) -> Result<(), InitError> {
     let manifest_path = dir.join("rv.toml");
     if manifest_path.exists() {
         return Err(InitError::ManifestExists);
     }
-    let src_dir = dir.join("src");
-    std::fs::create_dir_all(&src_dir)?;
     std::fs::write(&manifest_path, manifest_template(name))?;
-    // Do not clobber an existing entry point. A directory can already hold
-    // `src/main.rv` (a project that lost its manifest, or one laid out by hand),
+
+    // A `.gitignore` for the generated build output. Do not clobber one the
+    // user already wrote.
+    let gitignore_path = dir.join(".gitignore");
+    if !gitignore_path.exists() {
+        std::fs::write(gitignore_path, gitignore_template())?;
+    }
+
+    // The entry file. Do not clobber an existing one: a directory can already
+    // hold source (a project that lost its manifest, or one laid out by hand),
     // and `init` should add the manifest without throwing that source away.
-    let main_path = src_dir.join("main.rv");
-    if !main_path.exists() {
-        std::fs::write(main_path, main_rv_template(name))?;
+    match kind {
+        ProjectKind::App => {
+            let src_dir = dir.join("src");
+            std::fs::create_dir_all(&src_dir)?;
+            let main_path = src_dir.join("main.rv");
+            if !main_path.exists() {
+                std::fs::write(main_path, main_rv_template(name))?;
+            }
+        }
+        ProjectKind::Lib => {
+            let lib_path = dir.join("lib.rv");
+            if !lib_path.exists() {
+                std::fs::write(lib_path, lib_rv_template(name))?;
+            }
+        }
     }
     Ok(())
 }
@@ -105,7 +162,7 @@ mod tests {
     #[test]
     fn init_writes_files_that_parse() {
         let dir = temp_dir("ok");
-        init_project(&dir, "demo_pkg").expect("init");
+        init_project(&dir, "demo_pkg", ProjectKind::App).expect("init");
 
         let manifest_text = std::fs::read_to_string(dir.join("rv.toml")).unwrap();
         let m = Manifest::from_toml_str(&manifest_text).expect("generated manifest parses");
@@ -118,6 +175,35 @@ mod tests {
         assert!(main_rv.contains("fun main()"));
         assert!(main_rv.contains("hello from demo_pkg"));
 
+        // A .gitignore is written that ignores the build output.
+        let gitignore = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+        assert!(gitignore.contains("/target/"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn init_lib_writes_lib_rv_at_root() {
+        let dir = temp_dir("lib");
+        init_project(&dir, "mylib", ProjectKind::Lib).expect("init lib");
+
+        // The entry point is `lib.rv` at the root, not `src/main.rv`.
+        let lib_rv = std::fs::read_to_string(dir.join("lib.rv")).unwrap();
+        assert!(lib_rv.contains("fun greet"));
+        assert!(!dir.join("src").join("main.rv").exists());
+        assert!(dir.join(".gitignore").exists());
+        assert!(dir.join("rv.toml").exists());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn init_keeps_an_existing_gitignore() {
+        let dir = temp_dir("keepignore");
+        std::fs::write(dir.join(".gitignore"), "custom\n").unwrap();
+        init_project(&dir, "x", ProjectKind::App).unwrap();
+        let gi = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+        assert_eq!(gi, "custom\n", "init clobbered an existing .gitignore");
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -129,7 +215,7 @@ mod tests {
             "[package]\nname=\"a\"\nversion=\"0.1.0\"\n",
         )
         .unwrap();
-        let err = init_project(&dir, "x").unwrap_err();
+        let err = init_project(&dir, "x", ProjectKind::App).unwrap_err();
         assert!(matches!(err, InitError::ManifestExists));
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -140,7 +226,7 @@ mod tests {
         let src = dir.join("src");
         std::fs::create_dir_all(&src).unwrap();
         std::fs::write(src.join("main.rv"), "fun main() { print(\"mine\") }\n").unwrap();
-        init_project(&dir, "x").unwrap();
+        init_project(&dir, "x", ProjectKind::App).unwrap();
         let main_rv = std::fs::read_to_string(src.join("main.rv")).unwrap();
         assert!(
             main_rv.contains("mine"),


### PR DESCRIPTION
Closes #503.

Three packaging-workflow improvements:

- **`init` writes a `.gitignore`** (ignoring `/target/`) next to the manifest and entry file, without clobbering an existing one.
- **`init --lib`** scaffolds a library: a sample `lib.rv` at the repo root, which is the file other projects load for `import "github.com/<user>/<repo>"` (confirmed against `external_source_path`), instead of `src/main.rv`. `init_project` now takes a `ProjectKind`.
- **`cache`** inspects and clears the shared package cache: `cache dir` prints the root, `cache list` lists cached `<host>/<user>/<repo>@<version>` entries, and `cache clean [github.com/<user>/<repo>]` removes everything or one package's cached versions.

Verified end to end: `init` (app + lib + .gitignore), the generated `lib.rv` compiles via a local consumer, and `cache dir/list/clean` (whole + per-package, with a clean error for a bad subcommand). lib (545, +2 tests), clippy clean. Version 2.18.53.

Note: a true `rvpm build` of a library (a check-only mode, since a lib has no `main`) is a sensible follow-up; this PR covers scaffolding + cache.