### PR TITLE
feat(rvpm): library-aware build/run, rvpm new, and a version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.54] - 2026-06-11
+
+### Added
+
+- `rvpm build` is now library-aware: a package with a `lib.rv` and no `src/main.rv` is type-checked (no binary), so a package author can verify the library compiles. `rvpm run` reports that a library has no executable instead of erroring on a missing entry.
+- `rvpm new <name>` scaffolds a package into a fresh `<name>/` directory (with `--lib` for a library), complementing `rvpm init`.
+- `rvpm --version` / `-V` / `version` prints the rvpm version (#505).
+
 ## [2.18.53] - 2026-06-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.53"
+version = "2.18.54"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/getting-started.md
+++ b/docs/v2/guide/getting-started.md
@@ -82,9 +82,14 @@ cd my_app
 ```
 my_app/
   rv.toml        # the package manifest
+  .gitignore     # ignores the generated target/ directory
   src/
     main.rv      # the entry point, defining fun main()
 ```
+
+To start a library instead (a package others import rather than run), use
+`rvpm init --lib`, which scaffolds `lib.rv` at the root in place of
+`src/main.rv`. `rvpm new <name>` does the same in a fresh directory.
 
 The generated `rv.toml`:
 

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -7,19 +7,24 @@ cache.
 
 ## Project layout
 
-A package has an `rv.toml` manifest at its root and an entry file at
-`src/main.rv`:
+A package has an `rv.toml` manifest at its root. Its entry file decides
+its kind: an application has `src/main.rv` (which defines `fun main()`)
+and a library has `lib.rv` at the root (the file other projects import).
 
 ```
-my_app/
-  rv.toml
-  rv.lock              # written by rvpm, pins resolved dependencies
-  src/
-    main.rv            # must define fun main()
+my_app/                  my_lib/
+  rv.toml                  rv.toml
+  rv.lock                  rv.lock
+  .gitignore               .gitignore
+  src/                     lib.rv         # the package API others import
+    main.rv
 ```
 
-`rvpm init [name]` scaffolds this. The built binary is written to
-`target/raven-out/<name>` (with a `.exe` extension on Windows).
+`rvpm init` scaffolds an application; `rvpm init --lib` scaffolds a
+library. Both also write a `.gitignore` that ignores the generated
+`target/` directory. An application's binary is written to
+`target/raven-out/<name>` (with a `.exe` extension on Windows); a library
+has no `main`, so it is type-checked rather than compiled to a binary.
 
 ## The rv.toml manifest
 
@@ -77,12 +82,24 @@ resolved version equals what you write.
 ### rvpm init
 
 ```bash
-rvpm init [name]
+rvpm init [name] [--lib]
 ```
 
-Scaffolds `rv.toml` and `src/main.rv` in the current directory. The name
-defaults to the directory name. It will not overwrite an existing
-`rv.toml`.
+Scaffolds a package in the current directory: `rv.toml`, a `.gitignore`,
+and an entry file. By default that is an application (`src/main.rv`); with
+`--lib` it is a library (`lib.rv` at the root). The name defaults to the
+directory name. It will not overwrite an existing `rv.toml`, and it leaves
+an existing `.gitignore` or entry file untouched.
+
+### rvpm new
+
+```bash
+rvpm new <name> [--lib]
+```
+
+Like `init`, but scaffolds into a fresh `<name>/` directory instead of the
+current one. The package name is the final path component. Use `--lib` for
+a library.
 
 ### rvpm add
 
@@ -124,9 +141,11 @@ bump a dependency, edit its ref in `rv.toml`, then run `update`.
 rvpm build
 ```
 
-Ensures dependencies are installed, builds the package context from the
-lock, then compiles `src/main.rv` to `target/raven-out/<name>` and
-reports the binary path.
+Ensures dependencies are installed and builds the package context from the
+lock. For an application it compiles `src/main.rv` to
+`target/raven-out/<name>` and reports the binary path. For a library it
+type-checks `lib.rv` (and its modules) without producing a binary, so a
+package author can verify the library compiles before publishing.
 
 ### rvpm run
 
@@ -134,9 +153,10 @@ reports the binary path.
 rvpm run [program arguments]
 ```
 
-Builds the package (the same path as `build`), then runs the produced
+Builds the application (the same path as `build`), then runs the produced
 binary, forwarding any arguments after `run` and exiting with the
-program's exit code.
+program's exit code. A library has no executable, so `run` reports that
+and exits non-zero; use `build` to type-check a library.
 
 ### rvpm fmt
 
@@ -145,6 +165,28 @@ rvpm fmt
 ```
 
 Formats the package sources using the `[fmt]` settings from `rv.toml`.
+
+### rvpm cache
+
+```bash
+rvpm cache dir                              # print the cache root
+rvpm cache list                             # list cached packages
+rvpm cache clean                            # remove the whole cache
+rvpm cache clean github.com/<user>/<repo>   # remove one package's versions
+```
+
+Inspects or clears the shared package cache. `clean` with no argument
+removes the entire cache; with a `github.com/<user>/<repo>` argument it
+removes every cached version of that one package. The cache is repopulated
+on the next `install` or `build`.
+
+### rvpm version
+
+```bash
+rvpm version          # also: rvpm --version, rvpm -V
+```
+
+Prints the rvpm version.
 
 ## The cache and rv.lock
 
@@ -159,6 +201,8 @@ The cache root is `$RVPM_CACHE_DIR` if set, otherwise
 `${HOME}/.rvpm/cache` (`%USERPROFILE%` on Windows). A populated entry is
 reused and never re-cloned. Cloning is shallow, and the `.git` directory
 is dropped after a clone, so the cache stores only working-tree content.
+Use `rvpm cache list` to see what is cached and `rvpm cache clean` to
+clear it.
 
 `rv.lock` pins every transitive dependency by `(source, version)` plus a
 SHA-256 tree content hash, sorted deterministically so the file is stable

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -41,7 +41,18 @@ fn dispatch() -> ExitCode {
             print_usage();
             ExitCode::SUCCESS
         }
+        Some("--version") | Some("-V") | Some("version") => {
+            println!("rvpm {}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
         Some("init") => match cmd_init(&args[1..]) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("rvpm: {}", e);
+                ExitCode::from(1)
+            }
+        },
+        Some("new") => match cmd_new(&args[1..]) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
                 eprintln!("rvpm: {}", e);
@@ -112,6 +123,42 @@ fn cmd_init(args: &[String]) -> Result<(), InitError> {
         ProjectKind::App => println!("  src/main.rv"),
         ProjectKind::Lib => println!("  lib.rv"),
     }
+    Ok(())
+}
+
+/// Scaffold a new package in a fresh `<name>/` directory (vs `init`, which
+/// scaffolds the current directory).
+fn cmd_new(args: &[String]) -> Result<(), String> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("{}", new_usage());
+        return Ok(());
+    }
+    let kind = if args.iter().any(|a| a == "--lib") {
+        ProjectKind::Lib
+    } else {
+        ProjectKind::App
+    };
+    let target = args
+        .iter()
+        .find(|a| !a.starts_with('-'))
+        .ok_or_else(|| format!("new needs a directory name\n{}", new_usage()))?;
+    let dir = PathBuf::from(target);
+    if dir.join("rv.toml").exists() {
+        return Err(format!("'{}' already contains an rv.toml", target));
+    }
+    // The package name is the final path component, so `rvpm new path/to/app`
+    // names the package `app`.
+    let name = Path::new(target)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(target.as_str());
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    init_project(&dir, name, kind).map_err(|e| e.to_string())?;
+    let label = match kind {
+        ProjectKind::App => "package",
+        ProjectKind::Lib => "library",
+    };
+    println!("Created {} '{}' in {}/", label, name, target);
     Ok(())
 }
 
@@ -477,6 +524,10 @@ fn init_usage() -> String {
     "Usage: rvpm init [name] [--lib]".to_string()
 }
 
+fn new_usage() -> String {
+    "Usage: rvpm new <name> [--lib]".to_string()
+}
+
 fn cache_usage() -> String {
     "Usage: rvpm cache <dir | list | clean [github.com/<user>/<repo>]>".to_string()
 }
@@ -513,16 +564,18 @@ fn print_usage() {
     println!();
     println!("Commands:");
     println!("  init [name]    Scaffold a new package here (--lib for a library, lib.rv)");
+    println!("  new <name>     Scaffold a new package in a fresh <name>/ directory (--lib)");
     println!("  add <pkg>      Add a dependency to rv.toml, then resolve and write rv.lock");
     println!("  install        Resolve rv.toml against rv.lock and fill the cache");
     println!("  update [pkg]   Re-resolve rv.toml and rewrite rv.lock for one package or all");
-    println!("  build          Compile src/main.rv to target/raven-out/<name>");
-    println!("  run [args]     Build the package then run it, forwarding args");
+    println!("  build          Compile src/main.rv to a binary, or type-check a lib.rv library");
+    println!("  run [args]     Build the application then run it, forwarding args");
     println!("  fmt [paths]    Format .rv files in place (--check to verify only)");
     println!("  fetch <pkg>    Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
     println!("  lock           Generate or validate rv.lock for the current package");
     println!("  cache <sub>    Inspect or clear the shared package cache (dir/list/clean)");
     println!("  help           Print this message");
+    println!("  version        Print the rvpm version (also --version, -V)");
     println!();
     println!("Package arguments use the 'github.com/<user>/<repo>' form.");
     println!("For 'add', append '@<version>' to pin a git tag or branch; without it");

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -119,6 +119,28 @@ pub fn build_binary(
     Ok(())
 }
 
+/// Type-check `source` and its modules without producing code. Runs the front
+/// end through type checking but stops before HIR/MIR/codegen, so it needs no
+/// `main` function and no runtime staticlib. `rvpm build` uses this for a
+/// library, which has no executable entry to compile to a binary.
+pub fn check(source: &str, input: &Path, ctx: Option<&PackageContext>) -> Result<(), DriverError> {
+    let tokens = Lexer::new(source.to_string(), input.to_path_buf())
+        .tokenize()
+        .map_err(|e| frontend_diag(e, input, source))?;
+    let macro_table =
+        crate::macros::collect_macro_table(&tokens).map_err(|e| frontend_diag(e, input, source))?;
+    let (tokens, macro_def_sites) = crate::macros::expand_tokens_hygienic(&tokens)
+        .map_err(|e| frontend_diag(e, input, source))?;
+    let file = parse_with_macros_all(&tokens, macro_table)
+        .map_err(|es| frontend_diags(es, input, source))?;
+    let file = expand_with_stdlib_ctx(&file, ctx).map_err(|e| frontend_diag(e, input, source))?;
+    let mut loader = FsLoader;
+    let resolved = resolve_file_ctx(&file, &mut loader, ctx, macro_def_sites)
+        .map_err(|e| frontend_diag(e, input, source))?;
+    check_file_all(&resolved).map_err(|es| frontend_diags(es, input, source))?;
+    Ok(())
+}
+
 /// Run the front and middle ends and Cranelift to produce a relocatable
 /// object for `source`. Threads `ctx` through expansion and resolution.
 pub fn compile_to_object(

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -50,8 +50,11 @@ pub enum OpError {
     Lock(LockError),
     /// `update` named a package that is not a dependency in `rv.toml`.
     UnknownPackage(String),
-    /// The package entry file (`src/main.rv`) was not found.
+    /// Neither entry file (`src/main.rv` for an application nor `lib.rv` for a
+    /// library) was found.
     MissingEntry(PathBuf),
+    /// `run` was asked to execute a library, which produces no binary.
+    NotRunnable,
     /// Compiling or linking the package failed.
     Build(DriverError),
     /// Running the produced binary failed to launch.
@@ -79,8 +82,23 @@ impl fmt::Display for OpError {
                 write!(f, "'{}' is not a dependency in rv.toml", p)
             }
             OpError::MissingEntry(p) => {
-                write!(f, "package entry file not found: '{}'", p.display())
+                let root = p.parent().and_then(|s| s.parent());
+                match root {
+                    Some(root) => write!(
+                        f,
+                        "no package entry in '{}': expected 'src/main.rv' (application) or 'lib.rv' (library)",
+                        root.display()
+                    ),
+                    None => write!(
+                        f,
+                        "no package entry: expected 'src/main.rv' (application) or 'lib.rv' (library)"
+                    ),
+                }
             }
+            OpError::NotRunnable => write!(
+                f,
+                "this package is a library (lib.rv) with no executable to run; use 'rvpm build' to type-check it"
+            ),
             OpError::Build(e) => write!(f, "{}", e),
             OpError::Run { binary, source } => {
                 write!(f, "cannot run '{}': {}", binary.display(), source)
@@ -333,19 +351,44 @@ pub fn update_in(
     }
 }
 
-/// The conventional package entry source, relative to the project root.
+/// The conventional application entry source, relative to the project root.
 pub const ENTRY_FILE: &str = "src/main.rv";
+
+/// The conventional library entry source, at the project root. This is the file
+/// other projects load for `import "github.com/<user>/<repo>"`.
+pub const LIB_ENTRY_FILE: &str = "lib.rv";
 
 /// The output directory for a built package binary, relative to the
 /// project root.
 pub const OUTPUT_DIR: &str = "target/raven-out";
 
-/// The result of a `build`: the path to the produced binary and the lines
-/// to report.
+/// The result of a `build`: the produced binary (`None` for a library, which is
+/// type-checked rather than compiled to a binary) and the lines to report.
 #[derive(Debug, Clone)]
 pub struct BuildReport {
-    pub binary: PathBuf,
+    pub binary: Option<PathBuf>,
     pub outcome_lines: Vec<String>,
+}
+
+/// A package's entry: an application compiled to a binary, or a library that is
+/// type-checked.
+enum Entry {
+    App(PathBuf),
+    Lib(PathBuf),
+}
+
+/// Find the package entry. `src/main.rv` (an application) takes precedence over
+/// `lib.rv` (a library) at the project root.
+fn resolve_entry(project_dir: &Path) -> Option<Entry> {
+    let app = project_dir.join(ENTRY_FILE);
+    if app.is_file() {
+        return Some(Entry::App(app));
+    }
+    let lib = project_dir.join(LIB_ENTRY_FILE);
+    if lib.is_file() {
+        return Some(Entry::Lib(lib));
+    }
+    None
 }
 
 /// Build the package under `project_dir`, using the default cache root.
@@ -381,30 +424,44 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
     };
     let ctx = PackageContext::new(cache_root.to_path_buf(), &lock);
 
-    let entry = project_dir.join(ENTRY_FILE);
-    if !entry.is_file() {
-        return Err(OpError::MissingEntry(entry));
+    match resolve_entry(project_dir) {
+        Some(Entry::App(entry)) => {
+            let binary = output_binary_path(project_dir, &manifest.package.name);
+            if let Some(parent) = binary.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| OpError::Io {
+                    action: "create output directory".to_string(),
+                    path: parent.to_path_buf(),
+                    source: e,
+                })?;
+            }
+            driver::build_binary(&entry, &binary, Some(&ctx))?;
+            Ok(BuildReport {
+                outcome_lines: vec![format!(
+                    "Compiled {} to {}",
+                    manifest.package.name,
+                    binary.display()
+                )],
+                binary: Some(binary),
+            })
+        }
+        Some(Entry::Lib(entry)) => {
+            // A library has no `main`, so it is type-checked, not linked.
+            let source = std::fs::read_to_string(&entry).map_err(|e| OpError::Io {
+                action: "read".to_string(),
+                path: entry.clone(),
+                source: e,
+            })?;
+            driver::check(&source, &entry, Some(&ctx))?;
+            Ok(BuildReport {
+                binary: None,
+                outcome_lines: vec![format!(
+                    "Checked library {} ({})",
+                    manifest.package.name, LIB_ENTRY_FILE
+                )],
+            })
+        }
+        None => Err(OpError::MissingEntry(project_dir.join(ENTRY_FILE))),
     }
-
-    let binary = output_binary_path(project_dir, &manifest.package.name);
-    if let Some(parent) = binary.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| OpError::Io {
-            action: "create output directory".to_string(),
-            path: parent.to_path_buf(),
-            source: e,
-        })?;
-    }
-
-    driver::build_binary(&entry, &binary, Some(&ctx))?;
-
-    Ok(BuildReport {
-        binary: binary.clone(),
-        outcome_lines: vec![format!(
-            "Compiled {} to {}",
-            manifest.package.name,
-            binary.display()
-        )],
-    })
 }
 
 /// Build the package then run the produced binary, forwarding `args` to it
@@ -420,12 +477,17 @@ pub fn run_package_in(
     args: &[String],
     cache_root: &Path,
 ) -> Result<i32, OpError> {
+    // A library has no executable; report that before building.
+    if let Some(Entry::Lib(_)) = resolve_entry(project_dir) {
+        return Err(OpError::NotRunnable);
+    }
     let report = build_in(project_dir, cache_root)?;
-    let status = std::process::Command::new(&report.binary)
+    let binary = report.binary.ok_or(OpError::NotRunnable)?;
+    let status = std::process::Command::new(&binary)
         .args(args)
         .status()
         .map_err(|e| OpError::Run {
-            binary: report.binary.clone(),
+            binary: binary.clone(),
             source: e,
         })?;
     Ok(status.code().unwrap_or(1))
@@ -811,6 +873,43 @@ mod tests {
             }
             other => panic!("expected MissingEntry, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn build_type_checks_a_library() {
+        // A package with a `lib.rv` and no `src/main.rv` is type-checked rather
+        // than compiled to a binary, so the report carries no binary path.
+        let proj = TempProject::new("lib");
+        proj.write_manifest("[package]\nname = \"mylib\"\nversion = \"0.1.0\"\n");
+        std::fs::write(
+            proj.root.join(LIB_ENTRY_FILE),
+            "fun add(a: Int, b: Int) -> Int {\n    return a + b\n}\n",
+        )
+        .expect("write lib.rv");
+        let cache = proj.cache_root();
+        std::fs::create_dir_all(&cache).expect("mkdir cache");
+        let report = build_in(&proj.root, &cache).expect("library type-checks");
+        assert!(report.binary.is_none(), "a library produces no binary");
+        assert!(report
+            .outcome_lines
+            .iter()
+            .any(|l| l.contains("Checked library")));
+    }
+
+    #[test]
+    fn run_rejects_a_library() {
+        // `run` has nothing to execute for a library.
+        let proj = TempProject::new("librun");
+        proj.write_manifest("[package]\nname = \"mylib\"\nversion = \"0.1.0\"\n");
+        std::fs::write(
+            proj.root.join(LIB_ENTRY_FILE),
+            "fun add(a: Int, b: Int) -> Int {\n    return a + b\n}\n",
+        )
+        .expect("write lib.rv");
+        let cache = proj.cache_root();
+        std::fs::create_dir_all(&cache).expect("mkdir cache");
+        let err = run_package_in(&proj.root, &[], &cache).unwrap_err();
+        assert!(matches!(err, OpError::NotRunnable), "got {:?}", err);
     }
 
     #[test]


### PR DESCRIPTION
Closes #505.

- **Library-aware `build`/`run`.** A package with `lib.rv` and no `src/main.rv` is type-checked through a new `driver::check` (front end + type checking, no codegen or link, so no `main` is required) instead of failing on a missing entry. `rvpm run` reports a library has no executable. `BuildReport.binary` is now `Option` to express "checked, nothing to run".
- **`rvpm new <name>`** scaffolds into a fresh `<name>/` directory (with `--lib`), complementing `init`.
- **`rvpm --version` / `-V` / `version`** prints the version.

Verified end to end: `rvpm new` (app + lib), a library `build` type-checks (`Checked library mylib (lib.rv)`), a library `run` gives a clean not-runnable error, and `version` prints. Docs (rvpm guide + getting-started) updated. lib (547, +2 ops tests), clippy clean. Version 2.18.54.