### PR TITLE
feat(rvpm): add a test runner (rvpm test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.55] - 2026-06-11
+
+### Added
+
+- `rvpm test` runs a package's tests: zero-argument `test_*` functions in `*_test.rv` files. Each test runs in its own process (so a failed assertion's panic fails only that test), and the command prints a per-test `ok`/`FAIL` summary and exits non-zero if any test fails. Works for libraries too. The tests assert with `std/test` (#507).
+
 ## [2.18.54] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.53"
+version = "2.18.54"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.53"
+version = "2.18.54"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.54"
+version = "2.18.55"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -158,6 +158,42 @@ binary, forwarding any arguments after `run` and exiting with the
 program's exit code. A library has no executable, so `run` reports that
 and exits non-zero; use `build` to type-check a library.
 
+### rvpm test
+
+```bash
+rvpm test
+```
+
+Discovers and runs the package's tests. A test is a zero-argument function
+named `test_*` in a `*_test.rv` file anywhere in the package (commonly
+under `src/` or a `tests/` directory). It asserts with `std/test`; a failed
+assertion panics, which the runner reports as a failure.
+
+```rust
+// src/math_test.rv
+import std/test { assert_eq_int }
+import "./main" { add }
+
+fun test_add() {
+    assert_eq_int(add(2, 3), 5)
+}
+```
+
+Each test runs in its own process, so a panic from one failed assertion
+fails only that test. The command prints a per-test `ok`/`FAIL` line and a
+summary, and exits non-zero if any test fails:
+
+```
+running 2 tests
+  ok   test_add
+  FAIL test_add_wrong (raven panic: assertion failed: 4 != 5)
+test result: FAILED. 1 passed; 1 failed
+```
+
+Test function names must be unique within a file. Libraries are supported:
+a `*_test.rv` at the package root that imports `./lib` works without a
+`src/main.rv`.
+
 ### rvpm fmt
 
 ```bash

--- a/docs/v2/specs/std-test.md
+++ b/docs/v2/specs/std-test.md
@@ -6,9 +6,29 @@ program whose assertions all hold runs to completion and exits zero.
 
 ## Test model
 
-Raven has no attributes or reflection yet, so there is no test discovery
-or registration framework. A test is an ordinary Raven program whose
-`main` calls these assertions:
+Raven has no attributes or reflection yet, so a test is an ordinary
+function or program that calls these assertions; a failed assertion panics
+with a message and a nonzero exit. There are two ways to run them.
+
+`rvpm test` discovers zero-argument `test_*` functions in `*_test.rv`
+files, runs each in its own process (so one failed assertion fails only
+that test), and reports a per-test summary. The assertions here are what
+those `test_*` functions call. See the
+[rvpm guide](../guide/rvpm.md#rvpm-test).
+
+```rust
+// src/math_test.rv
+import std/test { assert, assert_eq_int }
+
+fun test_arithmetic() {
+    assert(1 + 1 == 2)
+    assert_eq_int(6 * 7, 42)
+}
+```
+
+A test can also be a standalone program whose `main` asserts, run by
+anything that checks its exit code (a shell loop or CI step). Exit zero
+means every assertion held:
 
 ```rust
 import std/test { assert, assert_eq_int }
@@ -20,11 +40,6 @@ fun main() {
     println("all passed")
 }
 ```
-
-Build and run the program. Exit zero means every assertion held; a
-nonzero exit means an assertion failed, and the panic message names the
-failure. A test runner is just whatever invokes the compiled program and
-checks its exit code (for example a shell loop or CI step).
 
 ## Import
 

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -78,6 +78,7 @@ fn dispatch() -> ExitCode {
         Some("update") => run(cmd_update(&args[1..])),
         Some("build") => run(cmd_build(&args[1..])),
         Some("run") => cmd_run(&args[1..]),
+        Some("test") => cmd_test(&args[1..]),
         Some("fmt") => cmd_fmt(&args[1..]),
         Some("cache") => match cmd_cache(&args[1..]) {
             Ok(()) => ExitCode::SUCCESS,
@@ -397,6 +398,38 @@ fn cmd_run(args: &[String]) -> ExitCode {
     }
 }
 
+/// Discover and run the package's `fun test_*()` tests, printing per-test
+/// results and a summary. Exits non-zero if any test fails.
+fn cmd_test(args: &[String]) -> ExitCode {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("{}", test_usage());
+        return ExitCode::SUCCESS;
+    }
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("rvpm: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+    match ops::test(&cwd) {
+        Ok(report) => {
+            for line in &report.outcome_lines {
+                println!("{}", line);
+            }
+            if report.failed == 0 {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(e) => {
+            eprintln!("rvpm: {}", e);
+            ExitCode::from(1)
+        }
+    }
+}
+
 /// Format Raven sources in place, or check formatting with `--check`.
 ///
 /// With no path arguments, formats every `.rv` file under the project
@@ -544,6 +577,10 @@ fn run_usage() -> String {
     "Usage: rvpm run [program arguments]".to_string()
 }
 
+fn test_usage() -> String {
+    "Usage: rvpm test".to_string()
+}
+
 fn add_usage() -> String {
     "Usage: rvpm add github.com/<user>/<repo>[@<version>]".to_string()
 }
@@ -570,6 +607,7 @@ fn print_usage() {
     println!("  update [pkg]   Re-resolve rv.toml and rewrite rv.lock for one package or all");
     println!("  build          Compile src/main.rv to a binary, or type-check a lib.rv library");
     println!("  run [args]     Build the application then run it, forwarding args");
+    println!("  test           Run fun test_*() tests in *_test.rv files");
     println!("  fmt [paths]    Format .rv files in place (--check to verify only)");
     println!("  fetch <pkg>    Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
     println!("  lock           Generate or validate rv.lock for the current package");

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -55,6 +55,8 @@ pub enum OpError {
     MissingEntry(PathBuf),
     /// `run` was asked to execute a library, which produces no binary.
     NotRunnable,
+    /// A `*_test.rv` file could not be lexed or parsed during test discovery.
+    TestParse { file: PathBuf, message: String },
     /// Compiling or linking the package failed.
     Build(DriverError),
     /// Running the produced binary failed to launch.
@@ -99,6 +101,9 @@ impl fmt::Display for OpError {
                 f,
                 "this package is a library (lib.rv) with no executable to run; use 'rvpm build' to type-check it"
             ),
+            OpError::TestParse { file, message } => {
+                write!(f, "cannot read test file '{}': {}", file.display(), message)
+            }
             OpError::Build(e) => write!(f, "{}", e),
             OpError::Run { binary, source } => {
                 write!(f, "cannot run '{}': {}", binary.display(), source)
@@ -503,6 +508,231 @@ fn output_binary_path(project_dir: &Path, name: &str) -> PathBuf {
         p.push(name);
     }
     p
+}
+
+/// The generated test-runner entry written to the project root while a test
+/// run compiles, then removed.
+const TEST_MAIN_FILE: &str = ".rvpm-test-main.rv";
+
+/// The name of the compiled test-runner binary under `target/raven-out`.
+const TEST_BINARY_NAME: &str = ".rvpm-test";
+
+/// The result of a `test` run.
+#[derive(Debug, Clone)]
+pub struct TestReport {
+    pub passed: usize,
+    pub failed: usize,
+    pub outcome_lines: Vec<String>,
+}
+
+/// Discover, compile, and run the package's tests under the default cache.
+pub fn test(project_dir: &Path) -> Result<TestReport, OpError> {
+    test_in(project_dir, &pkg::cache_root())
+}
+
+/// Run every `fun test_*()` found in the package's `*_test.rv` files. Each test
+/// runs in its own process (a small generated dispatcher selects the test by
+/// name) so a panic from a failed assertion fails only that test, not the run.
+pub fn test_in(project_dir: &Path, cache_root: &Path) -> Result<TestReport, OpError> {
+    Manifest::load(project_dir.join(MANIFEST_FILE_NAME))?;
+    let (_outcome, _report) = install_in(project_dir, cache_root)?;
+    let lock_path = project_dir.join(LOCK_FILE_NAME);
+    let lock = if lock_path.exists() {
+        LockFile::load(&lock_path)?
+    } else {
+        LockFile {
+            version: lock::LOCK_VERSION,
+            packages: Vec::new(),
+        }
+    };
+    let ctx = PackageContext::new(cache_root.to_path_buf(), &lock);
+
+    // Each suite is (relative import path of the test file, test function names).
+    let mut suites: Vec<(String, Vec<String>)> = Vec::new();
+    for file in discover_test_files(project_dir)? {
+        let names = test_functions_in(&file)?;
+        if !names.is_empty() {
+            suites.push((test_import_path(project_dir, &file), names));
+        }
+    }
+
+    let total: usize = suites.iter().map(|s| s.1.len()).sum();
+    let mut lines = vec![format!(
+        "running {} test{}",
+        total,
+        if total == 1 { "" } else { "s" }
+    )];
+    if total == 0 {
+        lines.push("no tests found (looked for `fun test_*` in `*_test.rv` files)".to_string());
+        return Ok(TestReport {
+            passed: 0,
+            failed: 0,
+            outcome_lines: lines,
+        });
+    }
+
+    let main_path = project_dir.join(TEST_MAIN_FILE);
+    let binary = output_binary_path(project_dir, TEST_BINARY_NAME);
+    if let Some(parent) = binary.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| OpError::Io {
+            action: "create output directory".to_string(),
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
+
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+    // Compile one dispatcher per file, then run each of its tests in isolation.
+    // The closure lets the generated entry be removed whether the run succeeds
+    // or fails.
+    let run = (|| -> Result<(), OpError> {
+        for (import, names) in &suites {
+            std::fs::write(&main_path, generate_test_dispatcher(import, names)).map_err(|e| {
+                OpError::Io {
+                    action: "write".to_string(),
+                    path: main_path.clone(),
+                    source: e,
+                }
+            })?;
+            driver::build_binary(&main_path, &binary, Some(&ctx))?;
+            for name in names {
+                let output = std::process::Command::new(&binary)
+                    .arg(name)
+                    .output()
+                    .map_err(|e| OpError::Run {
+                        binary: binary.clone(),
+                        source: e,
+                    })?;
+                if output.status.success() {
+                    passed += 1;
+                    lines.push(format!("  ok   {}", name));
+                } else {
+                    failed += 1;
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    let reason = stderr.lines().next().unwrap_or("").trim();
+                    if reason.is_empty() {
+                        lines.push(format!("  FAIL {}", name));
+                    } else {
+                        lines.push(format!("  FAIL {} ({})", name, reason));
+                    }
+                }
+            }
+        }
+        Ok(())
+    })();
+    let _ = std::fs::remove_file(&main_path);
+    run?;
+
+    lines.push(format!(
+        "test result: {}. {} passed; {} failed",
+        if failed == 0 { "ok" } else { "FAILED" },
+        passed,
+        failed
+    ));
+    Ok(TestReport {
+        passed,
+        failed,
+        outcome_lines: lines,
+    })
+}
+
+/// Collect every `*_test.rv` file under `project_dir`, skipping the build
+/// output and hidden or VCS directories.
+fn discover_test_files(project_dir: &Path) -> Result<Vec<PathBuf>, OpError> {
+    let mut out = Vec::new();
+    collect_test_files(project_dir, &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+fn collect_test_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), OpError> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return Ok(()),
+    };
+    for entry in entries {
+        let entry = entry.map_err(|e| OpError::Io {
+            action: "read directory".to_string(),
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if name == "target" || name.starts_with('.') {
+                continue;
+            }
+            collect_test_files(&path, out)?;
+        } else if name.ends_with("_test.rv") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Parse `file` and return the names of its zero-argument `test_*` functions.
+fn test_functions_in(file: &Path) -> Result<Vec<String>, OpError> {
+    let source = std::fs::read_to_string(file).map_err(|e| OpError::Io {
+        action: "read".to_string(),
+        path: file.to_path_buf(),
+        source: e,
+    })?;
+    let tokens = crate::lexer::Lexer::new(source, file.to_path_buf())
+        .tokenize()
+        .map_err(|e| OpError::TestParse {
+            file: file.to_path_buf(),
+            message: format!("{}", e),
+        })?;
+    let parsed = crate::parser::parse(&tokens).map_err(|e| OpError::TestParse {
+        file: file.to_path_buf(),
+        message: format!("{}", e),
+    })?;
+    let mut names = Vec::new();
+    for item in &parsed.items {
+        if let crate::ast::DeclKind::Function(func) = &item.kind {
+            if func.name.starts_with("test_") && func.params.is_empty() {
+                names.push(func.name.clone());
+            }
+        }
+    }
+    Ok(names)
+}
+
+/// The `import` path the generated dispatcher uses to reach `file` from the
+/// project root: a `./`-prefixed, forward-slashed path with the `.rv`
+/// extension dropped.
+fn test_import_path(project_dir: &Path, file: &Path) -> String {
+    let rel = file.strip_prefix(project_dir).unwrap_or(file);
+    let rel = rel.with_extension("");
+    let joined = rel
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+    format!("./{}", joined)
+}
+
+/// Render a runner that imports a test file's functions and calls the one named
+/// by the first process argument. Running it per test name isolates panics.
+fn generate_test_dispatcher(import: &str, names: &[String]) -> String {
+    let mut src = String::from("import std/env { arg_at }\n");
+    src.push_str(&format!(
+        "import \"{}\" {{ {} }}\n\n",
+        import,
+        names.join(", ")
+    ));
+    src.push_str("fun main() {\n    let name = arg_at(1)\n");
+    for (i, name) in names.iter().enumerate() {
+        let kw = if i == 0 { "if" } else { "} else if" };
+        src.push_str(&format!(
+            "    {} name.equals(\"{}\") {{\n        {}()\n",
+            kw, name, name
+        ));
+    }
+    src.push_str("    }\n}\n");
+    src
 }
 
 /// Build a manifest carrying only the one dependency `key`, reusing the
@@ -910,6 +1140,52 @@ mod tests {
         std::fs::create_dir_all(&cache).expect("mkdir cache");
         let err = run_package_in(&proj.root, &[], &cache).unwrap_err();
         assert!(matches!(err, OpError::NotRunnable), "got {:?}", err);
+    }
+
+    #[test]
+    fn discovers_test_files_and_skips_target() {
+        let proj = TempProject::new("disc");
+        std::fs::create_dir_all(proj.root.join("src")).unwrap();
+        std::fs::create_dir_all(proj.root.join("target")).unwrap();
+        std::fs::write(proj.root.join("src").join("math_test.rv"), "").unwrap();
+        std::fs::write(proj.root.join("src").join("helper.rv"), "").unwrap();
+        std::fs::write(proj.root.join("target").join("stale_test.rv"), "").unwrap();
+        let found = discover_test_files(&proj.root).unwrap();
+        assert_eq!(found.len(), 1, "found: {:?}", found);
+        assert!(found[0].ends_with("math_test.rv"));
+    }
+
+    #[test]
+    fn collects_zero_arg_test_functions() {
+        let proj = TempProject::new("fns");
+        let f = proj.root.join("a_test.rv");
+        std::fs::write(
+            &f,
+            "fun test_a() {}\nfun test_b(x: Int) {}\nfun helper() {}\nfun test_c() {}\n",
+        )
+        .unwrap();
+        let names = test_functions_in(&f).unwrap();
+        assert_eq!(names, vec!["test_a".to_string(), "test_c".to_string()]);
+    }
+
+    #[test]
+    fn dispatcher_imports_and_calls_by_name() {
+        let src = generate_test_dispatcher(
+            "./src/a_test",
+            &["test_a".to_string(), "test_b".to_string()],
+        );
+        assert!(src.contains("import \"./src/a_test\" { test_a, test_b }"));
+        assert!(src.contains("if name.equals(\"test_a\") {"));
+        assert!(src.contains("} else if name.equals(\"test_b\") {"));
+        assert!(src.contains("test_a()"));
+        assert!(src.contains("test_b()"));
+    }
+
+    #[test]
+    fn import_path_is_relative_and_forward_slashed() {
+        let proj = TempProject::new("imp");
+        let f = proj.root.join("src").join("math_test.rv");
+        assert_eq!(test_import_path(&proj.root, &f), "./src/math_test");
     }
 
     #[test]


### PR DESCRIPTION
Closes #507.

`std/test` provides assertions that panic on failure, but running tests meant invoking each program by hand. `rvpm test` discovers and runs them.

- A test is a zero-argument `test_*` function in a `*_test.rv` file anywhere in the package.
- The runner parses each test file for `test_*` functions, generates a small dispatcher that imports them and calls the one named by the first process argument (`std/env.arg_at`), compiles it once per file, and runs each test in its **own process** so a failed assertion's panic fails only that test.
- It prints a per-test `ok`/`FAIL` line and a summary, exiting non-zero when any test fails. Libraries are supported (no `src/main.rv` required).

Verified end to end: a 3-test file reports `2 passed; 1 failed` with the panic message and exit 1; all-pass exits 0; a no-tests project reports cleanly; a library (`lib.rv`, test at root importing `./lib`) passes. The generated runner file is removed after the run. Docs (rvpm guide + std/test spec) updated. lib (551, +4 ops tests), clippy clean. Version 2.18.55.