### PR TITLE
fix(formatter,rvpm): keep doc comments on derived items; fmt the whole package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.57] - 2026-06-11
+
+### Fixed
+
+- The formatter no longer inserts a blank line between a doc comment and a following `@derive`/`@repr` attribute, so a comment stays attached to the item it documents (and `rvpm doc` keeps picking it up). The blank-line gap calculation now accounts for the attribute lines, which are not part of the item's span (#511).
+- `rvpm fmt` with no arguments now formats every `.rv` file in the package (skipping the build output and hidden directories) instead of assuming a `src/` directory, so it works for a library (`lib.rv` at the root) as well as an application (#511).
+
 ## [2.18.56] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.55"
+version = "2.18.57"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.55"
+version = "2.18.57"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.56"
+version = "2.18.57"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -197,10 +197,15 @@ a `*_test.rv` at the package root that imports `./lib` works without a
 ### rvpm fmt
 
 ```bash
-rvpm fmt
+rvpm fmt [--check] [paths...]
 ```
 
-Formats the package sources using the `[fmt]` settings from `rv.toml`.
+Formats Raven sources using the `[fmt]` settings from `rv.toml`. With no
+paths it formats every `.rv` file in the package (the build output and
+hidden directories are skipped), so it works for both an application
+(`src/main.rv`) and a library (`lib.rv` at the root). Pass explicit files
+or directories to format only those, and `--check` to verify formatting
+without writing (it lists unformatted files and exits non-zero).
 
 ### rvpm doc
 

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -455,7 +455,7 @@ fn cmd_fmt(args: &[String]) -> ExitCode {
     let paths: Vec<&String> = args.iter().filter(|a| !a.starts_with('-')).collect();
 
     let files = if paths.is_empty() {
-        match collect_rv_files(PathBuf::from("src")) {
+        match collect_package_rv_files() {
             Ok(f) => f,
             Err(e) => {
                 eprintln!("rvpm: {}", e);
@@ -542,6 +542,36 @@ fn cmd_fmt(args: &[String]) -> ExitCode {
 
 /// Recursively collect `.rv` files under `dir`, sorted for deterministic
 /// output.
+/// Collect the `.rv` files to format by default: every `.rv` under the current
+/// directory, skipping the build output and hidden or VCS directories. This
+/// covers an application (`src/main.rv`) and a library (`lib.rv` at the root)
+/// alike, plus any test and example sources.
+fn collect_package_rv_files() -> Result<Vec<PathBuf>, String> {
+    let mut out = Vec::new();
+    collect_rv_excluding(Path::new("."), &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+fn collect_rv_excluding(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries = std::fs::read_dir(dir).map_err(|e| format!("{}: {}", dir.display(), e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if name == "target" || name.starts_with('.') {
+                continue;
+            }
+            collect_rv_excluding(&path, out)?;
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rv") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
 fn collect_rv_files(dir: PathBuf) -> Result<Vec<PathBuf>, String> {
     if !dir.exists() {
         return Err(format!("'{}' does not exist", dir.display()));

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -196,7 +196,13 @@ impl<'a> Printer<'a> {
             // Emit any own-line comments that precede this item, each with a
             // gap-preserving blank, then the item itself.
             prev_end_line = self.emit_toplevel_comments(item.span.start, prev_end_line);
-            self.maybe_blank(prev_end_line, item.span.start);
+            // A struct/enum's `@derive`/`@repr` attributes are emitted by
+            // `decl()` but are not covered by `item.span`, so the source lines
+            // they occupy are discounted here. Otherwise a doc comment sitting
+            // directly above `@derive` would be split from its item by a
+            // spurious blank line.
+            let attr_lines = leading_attr_lines(&item.kind);
+            self.maybe_blank(prev_end_line.map(|p| p + attr_lines), item.span.start);
             let trailing = self.decl(item);
             if let Some(t) = trailing {
                 self.attach_trailing(&t);
@@ -1458,6 +1464,18 @@ fn macro_space_before(prev: &TokenKind, cur: &TokenKind) -> bool {
         return false;
     }
     true
+}
+
+/// The number of `@derive`/`@repr` attribute lines a declaration emits before
+/// its keyword. These attributes are not covered by the declaration's span, so
+/// the top-level blank-line logic discounts them when deciding whether a real
+/// blank line preceded the item.
+fn leading_attr_lines(kind: &DeclKind) -> usize {
+    match kind {
+        DeclKind::Struct(s) => (s.repr_c as usize) + (!s.derives.is_empty() as usize),
+        DeclKind::Enum(e) => !e.derives.is_empty() as usize,
+        _ => 0,
+    }
 }
 
 fn render_type(ty: &Type) -> String {

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -62,6 +62,30 @@ fn comment_inside_call_args_stays_in_place() {
 }
 
 #[test]
+fn doc_comment_stays_attached_to_derived_item() {
+    // A comment directly above `@derive` documents the item, so the formatter
+    // must not split them with a blank line (which `rvpm doc` would read as the
+    // comment no longer documenting the item).
+    let src = "// A point.\n@derive(Eq, Ord)\nstruct Point {\n    x: Int,\n}\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("// A point.\n@derive(Eq, Ord)"),
+        "comment was split from @derive: {out:?}"
+    );
+}
+
+#[test]
+fn intentional_blank_above_derived_item_is_preserved() {
+    // A real blank line between a comment and a derived item is kept.
+    let src = "// not the doc\n\n@derive(Eq)\nenum E {\n    A,\n}\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("// not the doc\n\n@derive(Eq)"),
+        "intentional blank line was dropped: {out:?}"
+    );
+}
+
+#[test]
 fn call_without_comments_stays_single_line() {
     let out = fmt("fun main() {\n    let r = foo(\n        1,\n        2,\n    )\n}\n");
     assert!(


### PR DESCRIPTION
Closes #511.

Two formatting fixes found while building an external library.

- **Doc comment detached from `@derive`.** The formatter inserted a blank line between a `//` comment and a following `@derive`/`@repr` attribute, splitting the comment from the item it documents (and dropping it from `rvpm doc`, which treats only a comment directly above an item as its docs). The top-level blank-line logic compared the comment line against the declaration keyword, but the attribute lines in between are not part of the declaration's span, so a contiguous comment looked like it had a gap. The gap calculation now discounts those attribute lines; an intentional blank line is still preserved.
- **`rvpm fmt` assumed `src/`.** With no arguments it now formats every `.rv` file in the package (skipping the build output and hidden directories), so it works for a library (`lib.rv` at the root) as well as an application.

Verified: a comment above `@derive` stays attached and `rvpm doc` keeps the docs; `rvpm fmt --check` with no args works in both a library and an application. Two formatter regression tests added (attach + preserve-intentional-blank). lib (555, +2 tests), clippy and golden clean. Version 2.18.57.