### PR TITLE
fix(mir): type a match arm payload by its variant, not the slot index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.58] - 2026-06-11
+
+### Fixed
+
+- A `match` arm that binds an enum payload (`Ok(x)`, `Err(e)`, `Some(x)`) is now typed by its variant rather than the positional index. Previously `Err(e)` was typed as the `Ok` payload, which only worked when both shared the i64 slot; once they differed (for example `Result<Bool, MyError>` or `Result<Float, MyError>` with a struct error) the payload was narrowed to the wrong machine type, producing a Cranelift verifier error or a runtime segfault. This unblocks the idiomatic `fun f() -> Result<T, MyError>` pattern with `?` (#513).
+
 ## [2.18.57] - 2026-06-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.57"
+version = "2.18.58"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/result_struct_error.rv
+++ b/examples/v2/result_struct_error.rv
@@ -1,0 +1,34 @@
+// Regression for #513: a struct error payload carried through `Result` whose
+// Ok type has a different machine representation than the error (here `Bool`).
+// The match arm binding `Err(e)` must be typed as the error struct, not the Ok
+// payload; getting that wrong corrupted the pointer and crashed at runtime.
+import std/io { println }
+import std/string
+
+struct Fail {
+    code: Int,
+    message: String,
+}
+
+fun check(n: Int) -> Result<Bool, Fail> {
+    if n < 0 {
+        return Err(Fail { code: 1, message: "negative" })
+    }
+    return Ok(true)
+}
+
+fun run(n: Int) -> Result<Int, Fail> {
+    let _ok = check(n)?
+    return Ok(n * 2)
+}
+
+fun main() {
+    match run(5) {
+        Ok(v) -> println(v.to_string()),
+        Err(e) -> println(e.message),
+    }
+    match run(0 - 3) {
+        Ok(v) -> println(v.to_string()),
+        Err(e) -> println(e.message.concat(" code=").concat(e.code.to_string())),
+    }
+}

--- a/examples/v2/result_struct_error.rv.out
+++ b/examples/v2/result_struct_error.rv.out
@@ -1,0 +1,2 @@
+10
+negative code=1

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -493,9 +493,15 @@ fn bind_pattern(cx: &mut LowerCx<'_>, pat: &HirPattern, scrut_ty: &Ty, scrut: &M
 
 fn payload_type_at(scrut_ty: &Ty, variant: Option<&str>, index: usize, cx: &LowerCx<'_>) -> Ty {
     match scrut_ty {
-        Ty::Option(inner) if index == 0 => (**inner).clone(),
-        Ty::Result(t, _) if index == 0 => (**t).clone(),
-        Ty::Result(_, e) if index == 1 => (**e).clone(),
+        // `Some(x)`, `Ok(x)`, and `Err(e)` each bind their single payload at
+        // index 0 of their own pattern, so the binding type is selected by the
+        // variant, not the positional index. (Selecting by index alone typed
+        // `Err(e)` as the `Ok` payload; it only worked while both payloads
+        // shared the i64 slot, and produced a bad cast, a Cranelift verifier
+        // error, or a segfault once they differed, e.g. `Result<Bool, E>`.)
+        Ty::Option(inner) if variant == Some("Some") && index == 0 => (**inner).clone(),
+        Ty::Result(t, _) if variant == Some("Ok") && index == 0 => (**t).clone(),
+        Ty::Result(_, e) if variant == Some("Err") && index == 0 => (**e).clone(),
         Ty::Enum { name, .. } => {
             let Some(vname) = variant else {
                 return Ty::Error;

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -31,6 +31,17 @@ fn hello_world_compiles_and_runs() {
 }
 
 #[test]
+fn result_struct_error_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Regression for #513: a struct error payload in `Result<Bool, _>` carried
+    // through `?` and matched. The `Err(e)` binding must be typed as the error
+    // struct, not the `Ok` payload, or the program crashes at runtime.
+    compile_link_run_and_check("result_struct_error.rv", "10\nnegative code=1\n", &runtime);
+}
+
+#[test]
 fn declarative_macros_compile_and_run() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Closes #513.

A `match` arm binding an enum payload (`Ok(x)`, `Err(e)`, `Some(x)`) was typed by the **positional index** of the binding, so `Err(e)` (payload at index 0 of the `Err` pattern) was given the **Ok** payload type. This only worked when the Ok and Err payloads shared the i64 slot; once they differed, the Err payload was narrowed to the wrong machine type:

- `Result<Float, E>` (struct error) produced a Cranelift verifier error at compile time.
- `Result<Bool, E>` (struct error) with `?` segfaulted at runtime.

This broke the idiomatic `fun f() -> Result<T, MyError>` pattern whenever the error was a struct with a different representation than the Ok type.

`payload_type_at` (src/mir/lower/pattern.rs) now selects the binding type by the **variant name** (`Ok`/`Err`/`Some`), matching how `variant_index_of` builds the switch.

Verified: every minimal repro from the issue now runs correctly, raven-dotenv (a real library using struct errors + `?`) passes its 14 tests, and no regression (lib 555, codegen_smoke 73, golden green). Adds `examples/v2/result_struct_error.rv` exercising `Result<Bool, struct>` + `?` (run by golden and a codegen smoke test). Version 2.18.58.