### PR TITLE
fix(tycheck): resolve the match scrutinee type before checking arms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.59] - 2026-06-11
+
+### Fixed
+
+- A `match` whose arm is itself a `match` returning `Option`/`Result` no longer fails to infer an inner `None`/`Err` when the outer match also has one. The match scrutinee type is now resolved before the arms are bound and checked, so a nested match whose scrutinee is an inference variable (the inner `v` of `match opt { Some(v) -> match v { ... } }`) binds its payloads correctly and is not wrongly flagged as having an unreachable, shadowed arm (#515).
+
 ## [2.18.58] - 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.57"
+version = "2.18.58"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.57"
+version = "2.18.58"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.58"
+version = "2.18.59"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/nested_match_option.rv
+++ b/examples/v2/nested_match_option.rv
@@ -1,0 +1,34 @@
+// Regression for #515: a nested match where the inner match returns Option and
+// both the inner and outer matches have a None arm. The inner None arms must
+// infer their Option<String> type from the sibling Some arm.
+import std/io { println }
+
+enum V {
+    Str(String),
+    Int(Int),
+    Bool(Bool),
+}
+
+fun as_string(o: Option<V>) -> Option<String> {
+    return match o {
+        Some(v) -> match v {
+            Str(s) -> Some(s),
+            Int(n) -> None,
+            Bool(b) -> None,
+        },
+        None -> None,
+    }
+}
+
+fun show(o: Option<String>) -> String {
+    return match o {
+        Some(s) -> s,
+        None -> "(none)",
+    }
+}
+
+fun main() {
+    println(show(as_string(Some(V.Str("hello")))))
+    println(show(as_string(Some(V.Int(5)))))
+    println(show(as_string(None)))
+}

--- a/examples/v2/nested_match_option.rv.out
+++ b/examples/v2/nested_match_option.rv.out
@@ -1,0 +1,3 @@
+hello
+(none)
+(none)

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -2966,7 +2966,15 @@ impl<'a, 'b> Checker<'a, 'b> {
         span: &Span,
     ) -> Result<Ty, RavenError> {
         let scrut_ty = self.check_expr(scrutinee)?;
-        let scrut_stripped = scrut_ty.strip_self().clone();
+        // Resolve the scrutinee type up front. A nested match binds its
+        // scrutinee to an inference variable that is already solved by the time
+        // the inner match runs (the inner `v` of `match opt { Some(v) -> match v
+        // { ... } }`). Without resolving, the patterns are bound against the
+        // bare variable, so a payload binding like `Str(s)` gets a fresh
+        // variable instead of its real type and the arms fail to infer, and the
+        // exhaustiveness check finds no constructors and wrongly flags the first
+        // arm as a catch-all that shadows the rest.
+        let scrut_stripped = self.infer.resolve(scrut_ty.strip_self());
 
         let mut result_ty: Option<Ty> = None;
         let mut pattern_names: Vec<super::match_check::PatternHead> = Vec::new();

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -107,6 +107,27 @@ fn inferred_type_violating_a_bound_is_rejected() {
 }
 
 #[test]
+fn nested_match_none_arm_infers() {
+    // A match arm that is itself a match returning Option, where both the inner
+    // and outer matches have a None arm. The inner scrutinee is an inference
+    // variable solved during checking; resolving it up front lets the inner
+    // None infer and keeps exhaustiveness from flagging a false catch-all.
+    // Regression for #515.
+    let src = "enum V { Str(String), Int(Int) }\n\
+               fun f(o: Option<V>) -> Option<String> {\n\
+               return match o {\n\
+               Some(v) -> match v {\n\
+               Str(s) -> Some(s),\n\
+               Int(n) -> None,\n\
+               },\n\
+               None -> None,\n\
+               }\n\
+               }\n\
+               fun main() {}\n";
+    assert!(check(src).is_ok());
+}
+
+#[test]
 fn derive_ord_struct_and_enum_check() {
     // `@derive(Ord)` synthesizes a `compare` method that type-checks for a
     // struct and a tuple enum. Feature for #499.


### PR DESCRIPTION
Closes #515.

A nested `match` (an arm that is itself a `match` returning `Option`/`Result`, where the outer match also has a `None`/`Err` arm) failed with *the type here cannot be inferred* plus a bogus *unreachable pattern, shadowed by an earlier arm*.

The inner match's scrutinee is an inference variable (the `v` bound by the outer `Some(v)`), already solved by the time the inner match runs. But `check_match` bound the arm patterns and ran the exhaustiveness check against the **unresolved** variable, so `Str(s)` got a fresh variable instead of `String` (breaking the sibling `None` inference), and the exhaustiveness check found no constructors and flagged the first arm as a catch-all.

`check_match` now resolves the scrutinee type once, up front, and uses it for both pattern binding and exhaustiveness. Verified the issue repro and a real consumer (raven-toml's typed getters) compile; added a tycheck regression test and a golden example. lib 556, clippy + golden green. Version 2.18.59.