### PR TITLE
feat(resolve): import selector renames and module-alias qualified calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.61] - 2026-06-11
+
+### Added
+
+- Import selector renames: `import "..." { name as local }` binds the import under `local`, so two packages that export the same free function (for example several config parsers that each expose `parse`) can be used in one file without wrapper modules. Works for functions and types, across std, local, and external imports.
+- Module-alias qualified calls: `import "..." as m` then `m.func(...)` now resolves for local and external packages, not just std modules. The call targets the same namespaced function a selective import would bind. Type access through an alias (`m.Type`) is not included; import types with a selector (optionally renamed) instead.
+
 ## [2.18.60] - 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.58"
+version = "2.18.60"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.58"
+version = "2.18.60"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.60"
+version = "2.18.61"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/import_aliasing.rv
+++ b/examples/v2/import_aliasing.rv
@@ -1,0 +1,14 @@
+// Selector renames ({ name as local }) and module-alias qualified calls
+// (alias.func()). Both let an importer dodge name collisions without wrapper
+// modules.
+import std/io { println }
+import std/string
+import "./import_aliasing_lib" { parse as decode, Wrapper as Box }
+import "./import_aliasing_lib" as lib
+
+fun main() {
+    println(decode("hi"))
+    println(lib.shout("loud"))
+    let b = Box { value: 7 }
+    println(b.value.to_string())
+}

--- a/examples/v2/import_aliasing.rv.out
+++ b/examples/v2/import_aliasing.rv.out
@@ -1,0 +1,3 @@
+parsed:hi
+loud!
+7

--- a/examples/v2/import_aliasing_lib.rv
+++ b/examples/v2/import_aliasing_lib.rv
@@ -1,0 +1,15 @@
+// golden:skip
+// Helper module imported by import_aliasing.rv.
+import std/string
+
+fun parse(s: String) -> String {
+    return "parsed:".concat(s)
+}
+
+fun shout(s: String) -> String {
+    return s.concat("!")
+}
+
+struct Wrapper {
+    value: Int,
+}

--- a/src/ast/decl.rs
+++ b/src/ast/decl.rs
@@ -192,15 +192,34 @@ pub struct ExternFn {
     pub span: Span,
 }
 
+/// One name in an import selector list. `import path { a, b as c }` yields
+/// selectors `a` (no rename) and `b as c` (bound locally as `c`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImportSelector {
+    /// The name as exported by the source module.
+    pub name: String,
+    /// The local name to bind it under, from `name as local`. `None` binds
+    /// under `name` itself.
+    pub alias: Option<String>,
+}
+
+impl ImportSelector {
+    /// The name this selector binds in the importing module: the rename when
+    /// present, otherwise the exported name.
+    pub fn local(&self) -> &str {
+        self.alias.as_deref().unwrap_or(&self.name)
+    }
+}
+
 /// An import declaration.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Import {
     pub source: ImportSource,
     /// `import path as alias` renames the binding to `alias`.
     pub alias: Option<String>,
-    /// `import path { a, b }` selects specific names. Empty when no
+    /// `import path { a, b as c }` selects specific names. Empty when no
     /// selector list is present.
-    pub selectors: Vec<String>,
+    pub selectors: Vec<ImportSelector>,
     pub span: Span,
 }
 

--- a/src/ast/pretty.rs
+++ b/src/ast/pretty.rs
@@ -216,7 +216,15 @@ fn pretty_decl(buf: &mut String, decl: &Decl, depth: usize) {
                 write!(buf, " alias={}", quote(a)).unwrap();
             }
             if !im.selectors.is_empty() {
-                write!(buf, " selectors=({})", im.selectors.join(" ")).unwrap();
+                let sels: Vec<String> = im
+                    .selectors
+                    .iter()
+                    .map(|s| match &s.alias {
+                        Some(a) => format!("{} as {}", s.name, a),
+                        None => s.name.clone(),
+                    })
+                    .collect();
+                write!(buf, " selectors=({})", sels.join(" ")).unwrap();
             }
             buf.push_str(")\n");
         }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -599,8 +599,16 @@ impl Printer<'_> {
             text.push_str(alias);
         }
         if !im.selectors.is_empty() {
+            let sels: Vec<String> = im
+                .selectors
+                .iter()
+                .map(|s| match &s.alias {
+                    Some(a) => format!("{} as {}", s.name, a),
+                    None => s.name.clone(),
+                })
+                .collect();
             text.push_str(" { ");
-            text.push_str(&im.selectors.join(", "));
+            text.push_str(&sels.join(", "));
             text.push_str(" }");
         }
         self.line(&text);

--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -1806,7 +1806,6 @@ fn fold_binary(op: BinaryOp, l: HirExprKind, r: HirExprKind) -> Option<HirExprKi
 /// function symbol (`std.<module>.<func>`) the call should target. The type
 /// checker has already verified the call against this function's signature.
 fn module_qualified_fn(receiver: &Expr, name: &str, cx: &LowerCtx<'_>) -> Option<String> {
-    use crate::resolve::bindings::ImportTarget;
     use crate::resolve::Binding;
     let ExprKind::Ident { generics, .. } = &receiver.kind else {
         return None;
@@ -1818,11 +1817,16 @@ fn module_qualified_fn(receiver: &Expr, name: &str, cx: &LowerCtx<'_>) -> Option
         return None;
     };
     let import = cx.resolved.map.imports.get(import_id.0)?;
-    let ImportTarget::StdlibModule { segments } = &import.target else {
-        return None;
-    };
-    let module = segments.first()?;
-    Some(crate::resolve::stdlib::mangle_stdlib_fn(module, name))
+    // The expander merged this module's functions under `mangled_prefix`, so an
+    // alias call `alias.fn()` targets `<prefix>.fn`, for std, local, and
+    // external sources alike.
+    let prefix = import.mangled_prefix.as_ref()?;
+    Some(format!(
+        "{}{}{}",
+        prefix,
+        crate::resolve::stdlib::NAMESPACE_SEP,
+        name
+    ))
 }
 
 /// Wrap an interpolation part in a `to_string()` method call when its

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -571,7 +571,13 @@ impl Parser {
             self.skip_separators();
             while !matches!(self.peek_kind(), TokenKind::RBrace) {
                 let (n, _) = self.expect_ident("identifier")?;
-                selectors.push(n);
+                let alias = if self.eat(&TokenKind::As) {
+                    let (a, _) = self.expect_ident("alias name")?;
+                    Some(a)
+                } else {
+                    None
+                };
+                selectors.push(crate::ast::ImportSelector { name: n, alias });
                 if !self.eat(&TokenKind::Comma) {
                     break;
                 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -795,7 +795,25 @@ fn parses_std_import_with_selectors() {
     let DeclKind::Import(im) = &f.items[0].kind else {
         panic!()
     };
-    assert_eq!(im.selectors, vec!["Map".to_string(), "Set".to_string()]);
+    let names: Vec<&str> = im.selectors.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["Map", "Set"]);
+    assert!(im.selectors.iter().all(|s| s.alias.is_none()));
+}
+
+#[test]
+fn parses_import_selector_renames() {
+    let f = parse_ok("import \"./a\" { parse as aparse, Table as MyTable, plain }\n");
+    let DeclKind::Import(im) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(im.selectors[0].name, "parse");
+    assert_eq!(im.selectors[0].alias.as_deref(), Some("aparse"));
+    assert_eq!(im.selectors[0].local(), "aparse");
+    assert_eq!(im.selectors[1].name, "Table");
+    assert_eq!(im.selectors[1].alias.as_deref(), Some("MyTable"));
+    assert_eq!(im.selectors[2].name, "plain");
+    assert_eq!(im.selectors[2].alias, None);
+    assert_eq!(im.selectors[2].local(), "plain");
 }
 
 #[test]

--- a/src/resolve/bindings.rs
+++ b/src/resolve/bindings.rs
@@ -116,6 +116,11 @@ pub struct ResolvedImport {
     /// Source spelling of the import path, for diagnostics.
     pub path: String,
     pub target: ImportTarget,
+    /// The namespacing prefix the expander merged this module's functions
+    /// under (`std.<mod>`, `loc.<hash>`, or `ext.<key>`), when known. A
+    /// module-alias call `alias.fn()` resolves to `<prefix>.fn`. `None` for
+    /// an external import resolved without a package context.
+    pub mangled_prefix: Option<String>,
     pub span: Span,
 }
 

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -133,11 +133,42 @@ pub fn resolve_imports_ctx(
             continue;
         };
         let id = ImportId(out_imports.len());
-        let resolved = resolve_one_import(import, &decl.span, loader, in_progress, id)?;
+        let mut resolved = resolve_one_import(import, &decl.span, loader, in_progress, id)?;
+        resolved.mangled_prefix = import_mangle_prefix(&resolved.target, ctx);
         bind_import(import, &resolved, id, scope, ctx)?;
         out_imports.push(resolved);
     }
     Ok(())
+}
+
+/// The namespacing prefix the expander merges this import's source functions
+/// under, so a module-alias call `alias.fn()` can resolve to `<prefix>.fn`.
+/// Mirrors the keys [`bind_import`] uses for selectors.
+fn import_mangle_prefix(
+    target: &ImportTarget,
+    ctx: Option<&super::stdlib::PackageContext>,
+) -> Option<String> {
+    use super::stdlib;
+    match target {
+        ImportTarget::StdlibModule { segments } => segments.first().map(|m| {
+            stdlib::mangle_stdlib_fn(m, "")
+                .trim_end_matches(stdlib::NAMESPACE_SEP)
+                .to_string()
+        }),
+        ImportTarget::LocalModule { canonical_path, .. } => {
+            Some(stdlib::local_module_key(canonical_path))
+        }
+        ImportTarget::ExternalPackage {
+            host,
+            user,
+            repo,
+            subpath,
+        } => {
+            let source = format!("github.com/{}/{}", user, repo);
+            ctx.and_then(|c| c.external_source_path(&source, subpath))
+                .map(|src| stdlib::external_module_key(host, user, repo, &src))
+        }
+    }
 }
 
 fn resolve_one_import(
@@ -168,6 +199,7 @@ fn resolve_one_import(
                 target: ImportTarget::StdlibModule {
                     segments: segments.clone(),
                 },
+                mangled_prefix: None,
                 span: import.span.clone(),
             })
         }
@@ -177,6 +209,7 @@ fn resolve_one_import(
                     id,
                     path: path.clone(),
                     target: pkg,
+                    mangled_prefix: None,
                     span: import.span.clone(),
                 })
             } else if path.starts_with("./") || path.starts_with("../") {
@@ -336,6 +369,7 @@ fn resolve_local_import(
             canonical_path: loaded.canonical_path,
             module_names,
         },
+        mangled_prefix: None,
         span: import.span.clone(),
     })
 }
@@ -396,7 +430,11 @@ fn bind_import(
     };
 
     if !import.selectors.is_empty() {
-        for name in &import.selectors {
+        for sel in &import.selectors {
+            // `name` is the exported name; `local` is what it binds as (the
+            // rename from `name as local`, otherwise `name` itself).
+            let name = &sel.name;
+            let local = sel.local();
             // Bind the selector to the namespaced function the expander
             // merged into the module scope. Fall back to the deferred
             // `ImportedItem` binding when the function is not present (an
@@ -408,28 +446,33 @@ fn bind_import(
                 let mangled = mangle(name);
                 if let Some(entry) = scope.lookup(&mangled) {
                     let binding = entry.binding.clone();
-                    scope.insert(name, binding, import.span.clone())?;
+                    scope.insert(local, binding, import.span.clone())?;
                     continue;
                 }
                 // A type (struct, enum, trait) merged from the module keeps
                 // its own name, and a bundled module may export an
-                // `extern "C"` function under its bare C name. In both cases
-                // the merged declaration is already in module scope under
-                // the selector's name, so the selector needs no new binding.
-                if matches!(
-                    scope.lookup(name).map(|e| &e.binding),
-                    Some(
+                // `extern "C"` function under its bare C name. The merged
+                // declaration is already in scope under its exported name, so
+                // without a rename the selector needs no new binding; with a
+                // rename, bind the local name to that same declaration.
+                if let Some(entry) = scope.lookup(name) {
+                    if matches!(
+                        entry.binding,
                         Binding::Extern { .. }
                             | Binding::Struct(_)
                             | Binding::Enum(_)
                             | Binding::Trait(_)
-                    )
-                ) {
-                    continue;
+                    ) {
+                        if local != name.as_str() {
+                            let binding = entry.binding.clone();
+                            scope.insert(local, binding, import.span.clone())?;
+                        }
+                        continue;
+                    }
                 }
             }
             scope.insert(
-                name,
+                local,
                 Binding::ImportedItem {
                     import_id: id,
                     name: name.clone(),

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -505,12 +505,16 @@ fn import_rename_map(
                 if let Some(module) = segments.first() {
                     if let Ok(target) = parse_bundled_module(module) {
                         let fns = top_level_fn_names(&target);
-                        for name in &import.selectors {
+                        for sel in &import.selectors {
                             // Only functions are namespaced; a type keeps its
                             // own name (see `merge_module_items`), so a type
-                            // selector needs no rename.
-                            if fns.contains(name) {
-                                map.insert(name.clone(), mangle_stdlib_fn(module, name));
+                            // selector needs no rename. The call site uses the
+                            // local name, mapped to the exported name's symbol.
+                            if fns.contains(&sel.name) {
+                                map.insert(
+                                    sel.local().to_string(),
+                                    mangle_stdlib_fn(module, &sel.name),
+                                );
                             }
                         }
                     }
@@ -524,9 +528,12 @@ fn import_rename_map(
                     if let Some(target) = parse_loaded(&loaded.source, &loaded.canonical_path) {
                         let key = local_module_key(&loaded.canonical_path);
                         let fns = top_level_fn_names(&target);
-                        for name in &import.selectors {
-                            if fns.contains(name) {
-                                map.insert(name.clone(), mangle_local_fn(&key, name));
+                        for sel in &import.selectors {
+                            if fns.contains(&sel.name) {
+                                map.insert(
+                                    sel.local().to_string(),
+                                    mangle_local_fn(&key, &sel.name),
+                                );
                             }
                         }
                     }
@@ -663,9 +670,12 @@ fn external_import_rename_map(file: &File, ctx: &PackageContext) -> HashMap<Stri
                 if let Some(module) = segments.first() {
                     if let Ok(target) = parse_bundled_module(module) {
                         let fns = top_level_fn_names(&target);
-                        for name in &import.selectors {
-                            if fns.contains(name) {
-                                map.insert(name.clone(), mangle_stdlib_fn(module, name));
+                        for sel in &import.selectors {
+                            if fns.contains(&sel.name) {
+                                map.insert(
+                                    sel.local().to_string(),
+                                    mangle_stdlib_fn(module, &sel.name),
+                                );
                             }
                         }
                     }
@@ -687,9 +697,9 @@ fn external_import_rename_map(file: &File, ctx: &PackageContext) -> HashMap<Stri
                 };
                 let key = external_module_key(&gh.host, &gh.user, &gh.repo, &src_path);
                 let fns = top_level_fn_names(&target);
-                for name in &import.selectors {
-                    if fns.contains(name) {
-                        map.insert(name.clone(), mangle_external_fn(&key, name));
+                for sel in &import.selectors {
+                    if fns.contains(&sel.name) {
+                        map.insert(sel.local().to_string(), mangle_external_fn(&key, &sel.name));
                     }
                 }
             }

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -2338,7 +2338,6 @@ impl<'a, 'b> Checker<'a, 'b> {
         args: &[Expr],
         span: &Span,
     ) -> Result<Option<Ty>, RavenError> {
-        use crate::resolve::bindings::ImportTarget;
         let ExprKind::Ident {
             name: alias,
             generics,
@@ -2357,13 +2356,19 @@ impl<'a, 'b> Checker<'a, 'b> {
         let Some(import) = self.resolved.map.imports.get(import_id.0) else {
             return Ok(None);
         };
-        let ImportTarget::StdlibModule { segments } = &import.target else {
+        // The expander merged this module's functions under `mangled_prefix`.
+        // An alias call `alias.fn()` resolves to `<prefix>.fn`, the same symbol
+        // a selective import of `fn` would bind. Works for std, local, and
+        // external sources alike.
+        let Some(prefix) = import.mangled_prefix.clone() else {
             return Ok(None);
         };
-        let Some(module) = segments.first() else {
-            return Ok(None);
-        };
-        let mangled = crate::resolve::stdlib::mangle_stdlib_fn(module, name);
+        let mangled = format!(
+            "{}{}{}",
+            prefix,
+            crate::resolve::stdlib::NAMESPACE_SEP,
+            name
+        );
         let decl = self
             .env
             .functions


### PR DESCRIPTION
Two import features so a program can use packages with clashing names without wrapper modules.

## Selector rename
```raven
import "github.com/martian56/raven-dotenv" { parse as parse_env }
import "github.com/martian56/raven-toml"   { parse as parse_toml }
import "github.com/martian56/raven-csv"    { Sheet as Table }
```
Binds the imported name under the local name. Works for functions and types across std, local, and external sources. This removes the wrapper-module pattern the sample project needed for three config parsers that all export `parse`.

## Module-alias qualified calls
```raven
import "github.com/martian56/raven-color" as color
color.red("hi")
```
`m.func(...)` now resolves for local and external packages, not just std. Each `ResolvedImport` carries the prefix the expander merged its functions under (`std.<mod>` / `loc.<hash>` / `ext.<key>`); the type checker and HIR lowering target `<prefix>.func`. Type access via an alias (`m.Type`) is out of scope; use a selector (optionally renamed) for types.

## Notes
Cross-package *type-name* collisions at merge (two packages both exporting `Table`) still need type namespacing at merge, tracked separately. Rename covers the type-import need in the meantime.

Verified: parser tests, a golden example (renamed fn + renamed type + alias call), and a manual external check (alias call + rename against raven-color). lib 558, clippy + golden green. Version 2.18.61.