### PR TITLE
feat(rvpm): concurrent tarball fetch, persisted hashes, fetch progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.63] - 2026-06-13
+
+### Changed
+
+- rvpm fetches package dependencies faster and shows live progress. A new version is downloaded as a gzip tarball through codeload (one HTTP GET, no git history) instead of a clone, falling back to `git clone` when `curl`/`tar` are unavailable. The dependencies of one install are fetched concurrently, and each fetched tree hash is recorded in a sidecar file so a warm install reuses it instead of re-reading every file (a cheap metadata signature still catches an edited cache entry). Commands that fetch (`install`, `build`, `run`, `add`, `update`) now print a line per package (downloaded or cached) and a one-line summary. `rvpm cache dir`, `list`, and `clean` account for the new sidecar files.
+
 ## [2.18.62] - 2026-06-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.62"
+version = "2.18.63"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -266,10 +266,14 @@ version:
 
 The cache root is `$RVPM_CACHE_DIR` if set, otherwise
 `${HOME}/.rvpm/cache` (`%USERPROFILE%` on Windows). A populated entry is
-reused and never re-cloned. Cloning is shallow, and the `.git` directory
-is dropped after a clone, so the cache stores only working-tree content.
-Use `rvpm cache list` to see what is cached and `rvpm cache clean` to
-clear it.
+reused and never re-fetched. A new version is downloaded as a gzip tarball
+(a single HTTP GET, no history), falling back to a shallow `git clone` when
+that is unavailable; either way the cache stores only working-tree content.
+The dependencies of one install are fetched concurrently, and each version's
+tree hash is recorded in a sidecar so a warm install does not re-hash an
+unchanged tree. Commands that fetch print a line per package (downloaded or
+cached) and a short summary. Use `rvpm cache list` to see what is cached and
+`rvpm cache clean` to clear it.
 
 `rv.lock` pins every transitive dependency by `(source, version)` plus a
 SHA-256 tree content hash, sorted deterministically so the file is stable

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -360,7 +360,9 @@ fn with_fetch_progress<T>(f: impl FnOnce() -> T) -> T {
                 d.fetch_add(1, Ordering::Relaxed);
                 "downloaded"
             };
-            println!("  {:<10} {}@{}", status, source, version);
+            // Progress goes to stderr so it never mixes with a program's
+            // stdout under `rvpm run`.
+            eprintln!("  {:<10} {}@{}", status, source, version);
         },
     )));
 
@@ -375,7 +377,7 @@ fn with_fetch_progress<T>(f: impl FnOnce() -> T) -> T {
             .unwrap()
             .map(|t| t.duration_since(started).as_secs_f64())
             .unwrap_or(0.0);
-        println!(
+        eprintln!(
             "  fetched in {:.2}s ({} downloaded, {} cached)",
             secs, dn, cn
         );

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -234,6 +234,16 @@ fn cache_clean(args: &[String]) -> Result<(), String> {
                     removed += 1;
                 }
             }
+            // Remove the tree-hash sidecar files (`<repo>@<version>.rvpm-hash`)
+            // that sit beside the version directories.
+            for entry in std::fs::read_dir(&user_dir).map_err(|e| e.to_string())? {
+                let entry = entry.map_err(|e| e.to_string())?;
+                if let Some(name) = entry.file_name().to_str() {
+                    if name.ends_with(".rvpm-hash") && name.starts_with(&prefix) {
+                        let _ = std::fs::remove_file(entry.path());
+                    }
+                }
+            }
             println!("removed {} cached version(s) of {}", removed, spec);
             Ok(())
         }
@@ -272,8 +282,8 @@ fn cmd_fetch(args: &[String]) -> Result<(), String> {
         .ok_or_else(|| format!("'{}' is missing an '@<version>' suffix", spec))?;
     let gh = GithubPath::parse(path)
         .ok_or_else(|| format!("'{}' is not a 'github.com/<user>/<repo>' path", path))?;
-    let dir = pkg::fetch(&gh.host, &gh.user, &gh.repo, version).map_err(|e| e.to_string())?;
-    println!("{}", dir.display());
+    let fetched = pkg::fetch(&gh.host, &gh.user, &gh.repo, version).map_err(|e| e.to_string())?;
+    println!("{}", fetched.dir.display());
     Ok(())
 }
 
@@ -324,6 +334,55 @@ fn run(result: Result<Vec<String>, String>) -> ExitCode {
 /// Append (or update) a dependency in rv.toml, then resolve and write
 /// rv.lock. Accepts `github.com/<user>/<repo>` with an optional
 /// `@<version>`; without a version a placeholder constraint is recorded.
+/// Run `f` with a fetch observer installed, printing a live line per package
+/// as it is fetched (downloaded or served from cache) and a one-line summary
+/// afterward. Used by the commands that resolve or validate dependencies.
+fn with_fetch_progress<T>(f: impl FnOnce() -> T) -> T {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+
+    let started = Instant::now();
+    let downloaded = Arc::new(AtomicUsize::new(0));
+    let cached = Arc::new(AtomicUsize::new(0));
+    let last = Arc::new(Mutex::new(None::<Instant>));
+
+    let d = Arc::clone(&downloaded);
+    let c = Arc::clone(&cached);
+    let l = Arc::clone(&last);
+    lock::set_fetch_observer(Some(Box::new(
+        move |source: &str, version: &str, was_cached: bool| {
+            *l.lock().unwrap() = Some(Instant::now());
+            let status = if was_cached {
+                c.fetch_add(1, Ordering::Relaxed);
+                "cached"
+            } else {
+                d.fetch_add(1, Ordering::Relaxed);
+                "downloaded"
+            };
+            println!("  {:<10} {}@{}", status, source, version);
+        },
+    )));
+
+    let result = f();
+    lock::set_fetch_observer(None);
+
+    let dn = downloaded.load(Ordering::Relaxed);
+    let cn = cached.load(Ordering::Relaxed);
+    if dn + cn > 0 {
+        let secs = last
+            .lock()
+            .unwrap()
+            .map(|t| t.duration_since(started).as_secs_f64())
+            .unwrap_or(0.0);
+        println!(
+            "  fetched in {:.2}s ({} downloaded, {} cached)",
+            secs, dn, cn
+        );
+    }
+    result
+}
+
 fn cmd_add(args: &[String]) -> Result<Vec<String>, String> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return Ok(vec![add_usage()]);
@@ -336,7 +395,8 @@ fn cmd_add(args: &[String]) -> Result<Vec<String>, String> {
         None => (spec.as_str(), None),
     };
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
-    let report = ops::add(&cwd, path, version).map_err(|e| e.to_string())?;
+    let report =
+        with_fetch_progress(|| ops::add(&cwd, path, version)).map_err(|e| e.to_string())?;
     Ok(report.outcome_lines)
 }
 
@@ -347,7 +407,8 @@ fn cmd_install(args: &[String]) -> Result<Vec<String>, String> {
         return Ok(vec![install_usage()]);
     }
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
-    let (_outcome, report) = ops::install(&cwd).map_err(|e| e.to_string())?;
+    let (_outcome, report) =
+        with_fetch_progress(|| ops::install(&cwd)).map_err(|e| e.to_string())?;
     Ok(report.outcome_lines)
 }
 
@@ -358,7 +419,7 @@ fn cmd_update(args: &[String]) -> Result<Vec<String>, String> {
     }
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
     let package = args.first().map(String::as_str);
-    let report = ops::update(&cwd, package).map_err(|e| e.to_string())?;
+    let report = with_fetch_progress(|| ops::update(&cwd, package)).map_err(|e| e.to_string())?;
     Ok(report.outcome_lines)
 }
 
@@ -369,7 +430,7 @@ fn cmd_build(args: &[String]) -> Result<Vec<String>, String> {
         return Ok(vec![build_usage()]);
     }
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
-    let report = ops::build(&cwd).map_err(|e| e.to_string())?;
+    let report = with_fetch_progress(|| ops::build(&cwd)).map_err(|e| e.to_string())?;
     Ok(report.outcome_lines)
 }
 
@@ -387,7 +448,7 @@ fn cmd_run(args: &[String]) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    match ops::run_package(&cwd, args) {
+    match with_fetch_progress(|| ops::run_package(&cwd, args)) {
         Ok(code) => {
             let code: u8 = code.try_into().unwrap_or(1);
             ExitCode::from(code)

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -16,14 +16,157 @@
 //! See `docs/v2/specs/rvpm.md` for the lock format and the tree-hash
 //! scheme.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 use sha2::{Digest, Sha256};
 
 use crate::manifest::{Manifest, ManifestError};
 use crate::pkg::{self, PkgError};
+
+/// A callback invoked once per package as it is fetched during resolution or
+/// validation, with the package source, version, and whether it was served
+/// from the cache (no network). Set by [`set_fetch_observer`]; rvpm uses it
+/// to print live progress.
+type FetchObserver = Box<dyn Fn(&str, &str, bool) + Send + Sync>;
+
+static FETCH_OBSERVER: Mutex<Option<FetchObserver>> = Mutex::new(None);
+
+/// Install a process-wide fetch observer, or clear it with `None`. The
+/// observer is called from worker threads, so it must be `Send + Sync`; calls
+/// are serialized through a lock, so it does not need its own.
+pub fn set_fetch_observer(observer: Option<FetchObserver>) {
+    if let Ok(mut guard) = FETCH_OBSERVER.lock() {
+        *guard = observer;
+    }
+}
+
+fn notify_fetch(source: &str, version: &str, cached: bool) {
+    if let Ok(guard) = FETCH_OBSERVER.lock() {
+        if let Some(observer) = guard.as_ref() {
+            observer(source, version, cached);
+        }
+    }
+}
+
+/// The most concurrent fetches to run at once. Fetching is network-bound, so
+/// this exceeds the core count, but stays modest to avoid hammering the host.
+fn max_fetch_workers() -> usize {
+    12
+}
+
+/// Map `f` over `items` with bounded concurrency, preserving input order. A
+/// single item runs inline; the rest fan out across scoped worker threads that
+/// pull from a shared index.
+fn par_map<T, R>(items: Vec<T>, f: impl Fn(T) -> R + Sync) -> Vec<R>
+where
+    T: Send,
+    R: Send,
+{
+    let n = items.len();
+    if n <= 1 {
+        return items.into_iter().map(f).collect();
+    }
+    let workers = n.min(max_fetch_workers());
+    let slots: Vec<Mutex<Option<T>>> = items.into_iter().map(|t| Mutex::new(Some(t))).collect();
+    let results: Vec<Mutex<Option<R>>> = (0..n).map(|_| Mutex::new(None)).collect();
+    let next = AtomicUsize::new(0);
+    let f = &f;
+    let slots = &slots;
+    let results = &results;
+    let next = &next;
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(move || loop {
+                let i = next.fetch_add(1, Ordering::Relaxed);
+                if i >= n {
+                    break;
+                }
+                let item = slots[i].lock().unwrap().take().unwrap();
+                let r = f(item);
+                *results[i].lock().unwrap() = Some(r);
+            });
+        }
+    });
+    results
+        .iter()
+        .map(|m| m.lock().unwrap().take().unwrap())
+        .collect()
+}
+
+/// Hash a fetched tree, reusing a persisted hash when the tree is unchanged so
+/// a warm install does not re-read and re-hash every file.
+///
+/// The sidecar stores the content hash plus a cheap metadata signature (file
+/// count, total bytes, newest mtime). When the recomputed signature matches,
+/// the stored hash is trusted; when it differs, or no sidecar exists, the full
+/// content hash is recomputed and the sidecar refreshed. The signature is a
+/// metadata-only walk (no file reads), so it stays fast while still catching an
+/// edited cache file, which changes its size or mtime.
+fn hash_with_cache(dir: &Path) -> Result<String, LockError> {
+    let to_io = |e: std::io::Error| LockError::Io {
+        action: "hash dependency tree".to_string(),
+        path: dir.to_path_buf(),
+        source: e,
+    };
+    let signature = tree_signature(dir).map_err(to_io)?;
+    let sidecar = pkg::hash_sidecar(dir);
+    if let Ok(content) = std::fs::read_to_string(&sidecar) {
+        let mut lines = content.lines();
+        let stored_hash = lines.next().unwrap_or("").trim();
+        let stored_sig = lines.next().unwrap_or("").trim();
+        if stored_hash.starts_with("sha256:") && stored_sig == signature {
+            return Ok(stored_hash.to_string());
+        }
+    }
+    let hash = tree_hash(dir).map_err(to_io)?;
+    let _ = std::fs::write(&sidecar, format!("{}\n{}\n", hash, signature));
+    Ok(hash)
+}
+
+/// A cheap fingerprint of a tree from file metadata alone (no content reads):
+/// file count, total bytes, and the newest mtime, formatted as one line. Any
+/// edit to a cached file changes its size or mtime, so it changes the
+/// signature. The `.git` directory is skipped, matching [`tree_hash`].
+fn tree_signature(dir: &Path) -> std::io::Result<String> {
+    let mut count: u64 = 0;
+    let mut bytes: u64 = 0;
+    let mut newest: u128 = 0;
+    signature_walk(dir, &mut count, &mut bytes, &mut newest)?;
+    Ok(format!("{} {} {}", count, bytes, newest))
+}
+
+fn signature_walk(
+    dir: &Path,
+    count: &mut u64,
+    bytes: &mut u64,
+    newest: &mut u128,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            signature_walk(&entry.path(), count, bytes, newest)?;
+        } else {
+            *count += 1;
+            if let Ok(meta) = entry.metadata() {
+                *bytes += meta.len();
+                if let Ok(modified) = meta.modified() {
+                    if let Ok(since) = modified.duration_since(std::time::UNIX_EPOCH) {
+                        *newest = (*newest).max(since.as_nanos());
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
 
 /// The lock format version stamped into `rv.lock`.
 pub const LOCK_VERSION: u32 = 1;
@@ -226,51 +369,29 @@ pub fn resolve_and_lock(manifest: &Manifest) -> Result<LockFile, LockError> {
 /// [`tree_hash`]. The returned lock is sorted deterministically.
 pub fn resolve_and_lock_in(manifest: &Manifest, cache_root: &Path) -> Result<LockFile, LockError> {
     let mut seen: BTreeMap<(String, String), LockedPackage> = BTreeMap::new();
-    // Work queue of (source, version) pairs to resolve.
-    let mut queue: Vec<(String, String)> = Vec::new();
+    let mut queued: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut wave: Vec<(String, String)> = Vec::new();
     for dep in &manifest.dependencies {
-        queue.push((dep.path.clone(), resolved_ref(dep)?));
+        let key = (dep.path.clone(), resolved_ref(dep)?);
+        if queued.insert(key.clone()) {
+            wave.push(key);
+        }
     }
 
-    while let Some((source, version)) = queue.pop() {
-        let key = (source.clone(), version.clone());
-        if seen.contains_key(&key) {
-            continue;
-        }
-
-        let gh = crate::resolve::GithubPath::parse(&source).ok_or_else(|| {
-            LockError::Parse(format!(
-                "dependency source '{}' is not a github.com path",
-                source
-            ))
-        })?;
-        let dir = pkg::fetch_in(cache_root, &gh.host, &gh.user, &gh.repo, &version)
-            .map_err(LockError::Fetch)?;
-
-        let hash = tree_hash(&dir).map_err(|e| LockError::Io {
-            action: "hash dependency tree".to_string(),
-            path: dir.clone(),
-            source: e,
-        })?;
-
-        seen.insert(
-            key,
-            LockedPackage {
-                source: source.clone(),
-                version: version.clone(),
-                hash,
-            },
-        );
-
-        // Read the fetched package's manifest for its own dependencies.
-        let sub_manifest_path = dir.join("rv.toml");
-        if sub_manifest_path.exists() {
-            let sub = Manifest::load(&sub_manifest_path).map_err(|error| LockError::Manifest {
-                source_path: source.clone(),
-                error,
-            })?;
-            for dep in &sub.dependencies {
-                queue.push((dep.path.clone(), resolved_ref(dep)?));
+    // Fetch each level of the graph concurrently, then queue the dependencies
+    // discovered from the fetched manifests as the next level.
+    while !wave.is_empty() {
+        let results = par_map(std::mem::take(&mut wave), |(source, version)| {
+            fetch_and_read(cache_root, &source, &version)
+        });
+        for result in results {
+            let (package, sub_deps) = result?;
+            let key = (package.source.clone(), package.version.clone());
+            seen.insert(key, package);
+            for dep in sub_deps {
+                if !seen.contains_key(&dep) && queued.insert(dep.clone()) {
+                    wave.push(dep);
+                }
             }
         }
     }
@@ -283,6 +404,46 @@ pub fn resolve_and_lock_in(manifest: &Manifest, cache_root: &Path) -> Result<Loc
     })
 }
 
+/// Fetch one package, report it to the observer, hash it (reusing a persisted
+/// hash when present), and read its direct dependencies from the fetched
+/// manifest.
+fn fetch_and_read(
+    cache_root: &Path,
+    source: &str,
+    version: &str,
+) -> Result<(LockedPackage, Vec<(String, String)>), LockError> {
+    let gh = crate::resolve::GithubPath::parse(source).ok_or_else(|| {
+        LockError::Parse(format!(
+            "dependency source '{}' is not a github.com path",
+            source
+        ))
+    })?;
+    let fetched = pkg::fetch_in(cache_root, &gh.host, &gh.user, &gh.repo, version)
+        .map_err(LockError::Fetch)?;
+    notify_fetch(source, version, fetched.cached);
+    let hash = hash_with_cache(&fetched.dir)?;
+
+    let mut sub_deps = Vec::new();
+    let sub_manifest_path = fetched.dir.join("rv.toml");
+    if sub_manifest_path.exists() {
+        let sub = Manifest::load(&sub_manifest_path).map_err(|error| LockError::Manifest {
+            source_path: source.to_string(),
+            error,
+        })?;
+        for dep in &sub.dependencies {
+            sub_deps.push((dep.path.clone(), resolved_ref(dep)?));
+        }
+    }
+    Ok((
+        LockedPackage {
+            source: source.to_string(),
+            version: version.to_string(),
+            hash,
+        },
+        sub_deps,
+    ))
+}
+
 /// Validate `lock` against the shared cache (default cache root).
 pub fn validate_lock(lock: &LockFile) -> Result<(), LockError> {
     validate_lock_in(lock, &pkg::cache_root())
@@ -292,28 +453,35 @@ pub fn validate_lock(lock: &LockFile) -> Result<(), LockError> {
 /// entry and verify its tree hash. A mismatch aborts with
 /// [`LockError::HashMismatch`] naming the package.
 pub fn validate_lock_in(lock: &LockFile, cache_root: &Path) -> Result<(), LockError> {
-    for entry in &lock.packages {
-        let gh = crate::resolve::GithubPath::parse(&entry.source).ok_or_else(|| {
-            LockError::Parse(format!(
-                "locked source '{}' is not a github.com path",
-                entry.source
-            ))
-        })?;
-        let dir = pkg::fetch_in(cache_root, &gh.host, &gh.user, &gh.repo, &entry.version)
-            .map_err(LockError::Fetch)?;
-        let actual = tree_hash(&dir).map_err(|e| LockError::Io {
-            action: "hash dependency tree".to_string(),
-            path: dir.clone(),
-            source: e,
-        })?;
-        if actual != entry.hash {
-            return Err(LockError::HashMismatch {
-                source: entry.source.clone(),
-                version: entry.version.clone(),
-                expected: entry.hash.clone(),
-                actual,
-            });
-        }
+    let results = par_map(lock.packages.clone(), |entry| {
+        validate_one(cache_root, &entry)
+    });
+    for result in results {
+        result?;
+    }
+    Ok(())
+}
+
+/// Fetch one locked package, report it, and verify its tree hash against the
+/// lock. A persisted hash is reused when present.
+fn validate_one(cache_root: &Path, entry: &LockedPackage) -> Result<(), LockError> {
+    let gh = crate::resolve::GithubPath::parse(&entry.source).ok_or_else(|| {
+        LockError::Parse(format!(
+            "locked source '{}' is not a github.com path",
+            entry.source
+        ))
+    })?;
+    let fetched = pkg::fetch_in(cache_root, &gh.host, &gh.user, &gh.repo, &entry.version)
+        .map_err(LockError::Fetch)?;
+    notify_fetch(&entry.source, &entry.version, fetched.cached);
+    let actual = hash_with_cache(&fetched.dir)?;
+    if actual != entry.hash {
+        return Err(LockError::HashMismatch {
+            source: entry.source.clone(),
+            version: entry.version.clone(),
+            expected: entry.hash.clone(),
+            actual,
+        });
     }
     Ok(())
 }
@@ -727,6 +895,30 @@ mod tests {
         let h2 = tree_hash(&dir).expect("hash again");
         assert_eq!(h1, h2, "hashing is deterministic");
         assert!(h1.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn hash_with_cache_persists_beside_dir_and_reuses() {
+        let cache = TempCache::new("hashcache");
+        let dir = cache.seed("github.com/acme/bar", "v1.0.0", &[("a.rv", "one")]);
+        let sidecar = pkg::hash_sidecar(&dir);
+        assert!(!sidecar.exists());
+
+        let first = hash_with_cache(&dir).expect("first");
+        assert!(sidecar.exists(), "a sidecar is written");
+        // The sidecar lives beside the version dir, so it does not perturb the
+        // tree hash of that dir.
+        assert_eq!(first, tree_hash(&dir).expect("direct"));
+        // A second call returns the same hash from the sidecar.
+        assert_eq!(first, hash_with_cache(&dir).expect("second"));
+    }
+
+    #[test]
+    fn par_map_preserves_order() {
+        let input: Vec<usize> = (0..50).collect();
+        let out = par_map(input, |x| x * 2);
+        let expected: Vec<usize> = (0..50).map(|x| x * 2).collect();
+        assert_eq!(out, expected);
     }
 
     #[test]

--- a/src/pkg/mod.rs
+++ b/src/pkg/mod.rs
@@ -1,15 +1,19 @@
 //! Package fetching and the shared content cache for rvpm.
 //!
-//! A GitHub dependency `github.com/<user>/<repo>@<version>` is resolved
-//! by cloning the named tag or branch into a cache shared across
-//! projects. The cache lives at `<cache_root>/<host>/<user>/<repo>@<version>`.
+//! A GitHub dependency `github.com/<user>/<repo>@<version>` is resolved by
+//! downloading the named tag or branch into a cache shared across projects.
+//! The cache lives at `<cache_root>/<host>/<user>/<repo>@<version>`. A version
+//! is fetched as a gzip tarball through codeload (one HTTP GET, no history),
+//! falling back to a shallow `git clone` when that is unavailable. The hash of
+//! each version is recorded in a `<repo>@<version>.rvpm-hash` sidecar beside
+//! its directory so a warm install need not re-hash unchanged trees.
 //!
 //! Version-constraint resolution (semver ranges) is out of scope here.
 //! This module takes an explicit `version` string that is a git tag or
 //! branch and fetches it. The lock file (`rv.lock`) is built on top in
 //! `raven::lock`.
 //!
-//! See `docs/v2/specs/rvpm.md` for the cache layout and clone strategy.
+//! See `docs/v2/specs/rvpm.md` for the cache layout and fetch strategy.
 
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -112,35 +116,150 @@ pub fn cache_dir_in(root: &Path, host: &str, user: &str, repo: &str, version: &s
         .join(format!("{}@{}", repo, version))
 }
 
-/// Fetch `host/user/repo` at `version` into the shared cache and return
-/// the cache directory.
+/// The outcome of a fetch: where the package landed, and whether it was
+/// already in the cache (no network) or freshly downloaded.
+#[derive(Debug, Clone)]
+pub struct Fetched {
+    pub dir: PathBuf,
+    /// True when the cache already held this version, so nothing was
+    /// downloaded.
+    pub cached: bool,
+}
+
+/// Fetch `host/user/repo` at `version` into the shared cache.
 ///
 /// If the cache directory already exists and is non-empty this is a
 /// cache hit: the existing directory is returned without contacting the
-/// remote. Otherwise the repository is cloned from
-/// `https://<host>/<user>/<repo>` at the given tag or branch.
-pub fn fetch(host: &str, user: &str, repo: &str, version: &str) -> Result<PathBuf, PkgError> {
+/// remote. Otherwise the version is downloaded (see [`fetch_in`]).
+pub fn fetch(host: &str, user: &str, repo: &str, version: &str) -> Result<Fetched, PkgError> {
     fetch_in(&cache_root(), host, user, repo, version)
 }
 
-/// Fetch `host/user/repo` at `version` into an explicit cache root and
-/// return the cache directory. Behaves like [`fetch`] but does not
-/// consult `RVPM_CACHE_DIR`, so callers can isolate the cache without
-/// touching global environment state.
+/// Fetch `host/user/repo` at `version` into an explicit cache root.
+///
+/// A populated cache directory is returned as-is. Otherwise the version is
+/// downloaded as a gzip tarball (a single HTTP GET, no git history), which
+/// is faster than a clone. If the tarball path is unavailable (no `curl` or
+/// `tar`, a non-github host, or a transient error) it falls back to a
+/// shallow `git clone`, which also reports a genuinely missing ref.
 pub fn fetch_in(
     root: &Path,
     host: &str,
     user: &str,
     repo: &str,
     version: &str,
-) -> Result<PathBuf, PkgError> {
+) -> Result<Fetched, PkgError> {
     let dest = cache_dir_in(root, host, user, repo, version);
     if is_populated(&dest) {
-        return Ok(dest);
+        return Ok(Fetched {
+            dir: dest,
+            cached: true,
+        });
     }
-    let url = format!("https://{}/{}/{}", host, user, repo);
-    clone_from(&url, version, &dest)?;
-    Ok(dest)
+    if download_tarball(host, user, repo, version, &dest).is_err() {
+        // Clear any partial extraction, then fall back to a git clone.
+        let _ = std::fs::remove_dir_all(&dest);
+        let url = format!("https://{}/{}/{}", host, user, repo);
+        clone_from(&url, version, &dest)?;
+    }
+    Ok(Fetched {
+        dir: dest,
+        cached: false,
+    })
+}
+
+/// The sidecar file that caches a version's tree hash, kept beside (not
+/// inside) the version directory so it never affects the tree hash itself.
+pub fn hash_sidecar(version_dir: &Path) -> PathBuf {
+    let mut name = version_dir.file_name().unwrap_or_default().to_os_string();
+    name.push(".rvpm-hash");
+    version_dir.parent().unwrap_or(version_dir).join(name)
+}
+
+/// Download `github.com/user/repo` at `version` as a gzip tarball through
+/// codeload and extract it into `dest`, stripping the version-prefixed top
+/// directory the archive carries. Only `github.com` is served this way; any
+/// failure (including a missing `curl`/`tar`) returns an error so the caller
+/// can fall back to git. A partial `dest` is removed on failure.
+fn download_tarball(
+    host: &str,
+    user: &str,
+    repo: &str,
+    version: &str,
+    dest: &Path,
+) -> Result<(), PkgError> {
+    if host != "github.com" {
+        return Err(PkgError::CloneFailed {
+            url: host.to_string(),
+            reference: version.to_string(),
+            stderr: "tarball download is only available for github.com".to_string(),
+        });
+    }
+    let url = format!(
+        "https://codeload.github.com/{}/{}/tar.gz/{}",
+        user, repo, version
+    );
+    let tmp = std::env::temp_dir().join(format!(
+        "rvpm-{}-{}-{}-{}.tar.gz",
+        user,
+        repo,
+        version.replace(['/', '\\', ':'], "_"),
+        std::process::id()
+    ));
+
+    let dl = Command::new("curl")
+        .args(["-fsSL", "--retry", "2", "-o"])
+        .arg(&tmp)
+        .arg(&url)
+        .output()
+        .map_err(PkgError::GitNotFound)?;
+    if !dl.status.success() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(PkgError::CloneFailed {
+            url,
+            reference: version.to_string(),
+            stderr: String::from_utf8_lossy(&dl.stderr).into_owned(),
+        });
+    }
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| PkgError::Io {
+            action: "create cache directory".to_string(),
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
+    std::fs::create_dir_all(dest).map_err(|e| PkgError::Io {
+        action: "create cache entry".to_string(),
+        path: dest.to_path_buf(),
+        source: e,
+    })?;
+
+    let ex = Command::new("tar")
+        .arg("-xzf")
+        .arg(&tmp)
+        .arg("-C")
+        .arg(dest)
+        .arg("--strip-components=1")
+        .output();
+    let _ = std::fs::remove_file(&tmp);
+    let ex = match ex {
+        Ok(o) => o,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(dest);
+            return Err(PkgError::GitNotFound(e));
+        }
+    };
+    if !ex.status.success() {
+        let stderr = String::from_utf8_lossy(&ex.stderr).into_owned();
+        let _ = std::fs::remove_dir_all(dest);
+        return Err(PkgError::CloneFailed {
+            url,
+            reference: version.to_string(),
+            stderr,
+        });
+    }
+    Ok(())
 }
 
 /// True when `dir` exists and contains at least one entry.

--- a/tests/rvpm_fetch.rs
+++ b/tests/rvpm_fetch.rs
@@ -125,8 +125,9 @@ fn fetch_clones_then_hits_cache() {
     std::fs::remove_dir_all(&src).unwrap();
 
     let got = pkg::fetch("github.com", "acme", "dep", "v1.0.0").expect("cache hit");
-    assert_eq!(got, expected);
-    assert!(got.join("src").join("lib.rv").is_file());
+    assert_eq!(got.dir, expected);
+    assert!(got.cached, "a populated entry is served from the cache");
+    assert!(got.dir.join("src").join("lib.rv").is_file());
 
     std::env::remove_var("RVPM_CACHE_DIR");
     cleanup(&root);


### PR DESCRIPTION
Makes `rvpm install`/`build` faster and adds live progress feedback.

## Faster
- **Tarball download** instead of git clone: a new version is fetched as a gzip tarball through codeload (one HTTP GET, no history), with **git clone as a fallback** when curl/tar are missing, the host isn't github, or the download fails.
- **Concurrent fetch**: each level of the dependency graph is fetched in parallel through a bounded scoped-thread pool (order preserved).
- **Persisted tree hashes**: each version's hash is recorded in a `<repo>@<version>.rvpm-hash` sidecar (beside the dir, so it never affects the tree hash). A warm install reuses it instead of re-reading every file. A cheap metadata signature (count, bytes, newest mtime) guards it, so an **edited cache entry is still detected** (tamper tests pass).

## Better feedback
- `install`, `build`, `run`, `add`, `update` print a line per package (`downloaded` / `cached`) and a summary: `fetched in 0.75s (12 downloaded, 0 cached)`.

## Verified
On the 12-package sample: cold install ~0.75s (12 parallel downloads), warm install ~0.1s (all cached, hashes reused), and a tampered cache file is caught with a clear hash-mismatch error. `cache dir`/`list`/`clean` all correct (sidecars removed with the package). 560 lib tests, clippy clean.

curl + tar ship on modern Windows/Linux/macOS and on the CI runners; git remains the fallback. No new Rust dependencies.