### PR TITLE
feat(rvpm): wire [ffi] into the build's link step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.64] - 2026-06-13
+
+### Added
+
+- The `[ffi]` section of `rv.toml` is now wired into `rvpm build`. A package can list bundled C `sources` (relative to the package root) that are compiled and linked into the final program, plus `libs` to link (`-l<name>`) and raw `link_args`. The `[ffi]` of every dependency is collected, so a package can ship its own C (for example a bundled SQLite) and a consumer needs nothing installed. The C compiler is detected the same way the linker is (cl.exe on windows-msvc, `cc`/`gcc` elsewhere), and its output is discarded so it never reaches a program's stdout under `rvpm run`.
+
 ## [2.18.63] - 2026-06-13
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.62"
+version = "2.18.63"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.62"
+version = "2.18.63"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.63"
+version = "2.18.64"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -39,6 +39,7 @@ edition = "v2"
 "github.com/martian56/raven-http" = "1.0"
 
 [ffi]
+sources = ["c/sqlite3.c"]
 libs = ["m", "z"]
 link_args = ["-L/opt/lib"]
 
@@ -53,7 +54,12 @@ Sections:
   defaults to empty. `edition` defaults to `v2` (accepted: `v2`, `2026`).
 - `[dependencies]` (optional): keys are `github.com/<user>/<repo>` paths
   (optionally with a subpath); values are git refs (a tag or branch).
-- `[ffi]` (optional): native linker pass-through, `libs` and `link_args`.
+- `[ffi]` (optional): native code linked into a program that uses the
+  package. `sources` are bundled C files (relative to the package root)
+  that `rvpm build` compiles and links in, `libs` are libraries to link
+  (`-l<name>`), and `link_args` are raw linker arguments. The `[ffi]` of
+  every dependency is collected, so a package can ship its own C (for
+  example a bundled SQLite) and a consumer needs nothing installed.
 - `[fmt]` (optional): `indent_width` (default 4) and `wrap_width`
   (default 100) for the formatter.
 

--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -120,22 +120,97 @@ fn host_triple_string() -> String {
     Triple::host().to_string()
 }
 
-/// Link `object_path` with `runtime` into `output`.
+/// Native code to link into the program, gathered from the `[ffi]` sections of
+/// a project and its dependencies: object files compiled from bundled C
+/// sources, system library names (`-l`), and raw linker arguments.
+#[derive(Debug, Clone, Default)]
+pub struct NativeLink {
+    /// Object files (compiled from bundled C sources) to link in.
+    pub objects: Vec<PathBuf>,
+    /// System library names to link, passed as `-l<name>` (or `<name>.lib`).
+    pub libs: Vec<String>,
+    /// Raw linker arguments passed through verbatim.
+    pub link_args: Vec<String>,
+}
+
+/// Compile each bundled C source into an object file under `out_dir`,
+/// returning their paths to link directly. Uses the `cc` crate's compiler
+/// detection (cl.exe on windows-msvc, `cc`/`gcc` elsewhere), configured
+/// explicitly so it needs no build-script environment. The compiler's stdout
+/// is discarded so chatter (cl.exe echoes the source name) never reaches a
+/// program's output under `rvpm run`.
+pub fn compile_c_sources(
+    sources: &[PathBuf],
+    out_dir: &Path,
+) -> Result<Vec<PathBuf>, CodegenError> {
+    std::fs::create_dir_all(out_dir)
+        .map_err(|e| CodegenError::Target(format!("create ffi build dir: {}", e)))?;
+    let triple = host_triple_string();
+    let mut build = cc::Build::new();
+    build
+        .cargo_metadata(false)
+        .opt_level(2)
+        .debug(false)
+        .warnings(false)
+        .host(&triple)
+        .target(&triple)
+        .out_dir(out_dir);
+    let compiler = build
+        .try_get_compiler()
+        .map_err(|e| CodegenError::Target(format!("no C compiler for the [ffi] sources: {}", e)))?;
+    let msvc = compiler.is_like_msvc();
+
+    let mut objects = Vec::with_capacity(sources.len());
+    for (index, source) in sources.iter().enumerate() {
+        let stem = source.file_stem().and_then(|s| s.to_str()).unwrap_or("src");
+        let object = out_dir.join(format!(
+            "{}_{}.{}",
+            stem,
+            index,
+            if msvc { "obj" } else { "o" }
+        ));
+        let mut cmd = compiler.to_command();
+        if msvc {
+            cmd.arg("/nologo")
+                .arg("/c")
+                .arg(source)
+                .arg(format!("/Fo{}", object.display()));
+        } else {
+            cmd.arg("-c").arg(source).arg("-o").arg(&object);
+        }
+        let out = cmd
+            .stdout(std::process::Stdio::null())
+            .output()
+            .map_err(|e| CodegenError::Target(format!("C compiler failed to launch: {}", e)))?;
+        if !out.status.success() {
+            return Err(CodegenError::Target(format!(
+                "compiling {} failed:\n{}",
+                source.display(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        objects.push(object);
+    }
+    Ok(objects)
+}
+
+/// Link `object_path` with `runtime` and any `native` FFI inputs into `output`.
 ///
 /// Selects the linker by host target triple. See the module docs for
 /// the per-platform behavior.
 pub fn link(
     object_path: &Path,
     runtime: &RuntimeStaticLib,
+    native: &NativeLink,
     output: &Path,
 ) -> Result<LinkOutput, CodegenError> {
     let triple = Triple::host();
     if is_windows_msvc(&triple) {
-        link_msvc(object_path, runtime, output)
+        link_msvc(object_path, runtime, native, output)
     } else if is_windows_gnu(&triple) {
-        link_gnu(object_path, runtime, output)
+        link_gnu(object_path, runtime, native, output)
     } else {
-        link_unix(object_path, runtime, output)
+        link_unix(object_path, runtime, native, output)
     }
 }
 
@@ -148,11 +223,12 @@ pub fn link(
 fn link_msvc(
     object_path: &Path,
     runtime: &RuntimeStaticLib,
+    native: &NativeLink,
     output: &Path,
 ) -> Result<LinkOutput, CodegenError> {
     let triple = host_triple_string();
     if let Some(mut cmd) = msvc_link_tool(&triple) {
-        push_msvc_args(&mut cmd, object_path, runtime, output);
+        push_msvc_args(&mut cmd, object_path, runtime, native, output);
         run_linker(cmd, "link.exe", output)
     } else if let Some(lld) = locate_rust_lld() {
         // Best-effort fallback. `rust-lld` in lld-link flavor speaks the
@@ -161,7 +237,7 @@ fn link_msvc(
         // shell (or a prior `link.exe` discovery) must already be set.
         let mut cmd = Command::new(&lld);
         cmd.arg("-flavor").arg("link");
-        push_msvc_args(&mut cmd, object_path, runtime, output);
+        push_msvc_args(&mut cmd, object_path, runtime, native, output);
         run_linker(cmd, "rust-lld", output)
     } else {
         Err(CodegenError::Target(
@@ -184,12 +260,24 @@ fn push_msvc_args(
     cmd: &mut Command,
     object_path: &Path,
     runtime: &RuntimeStaticLib,
+    native: &NativeLink,
     output: &Path,
 ) {
     cmd.arg("/NOLOGO");
     cmd.arg(format!("/OUT:{}", output.display()));
     cmd.arg(object_path);
     cmd.arg(&runtime.path);
+    // FFI inputs from `[ffi]`: compiled C objects, then named libraries
+    // (`name` links `name.lib`), then any raw linker arguments.
+    for object in &native.objects {
+        cmd.arg(object);
+    }
+    for lib in &native.libs {
+        cmd.arg(format!("{}.lib", lib));
+    }
+    for arg in &native.link_args {
+        cmd.arg(arg);
+    }
     for lib in MSVC_NATIVE_STATIC_LIBS {
         cmd.arg(lib);
     }
@@ -241,6 +329,7 @@ fn rustc_sysroot() -> Option<PathBuf> {
 fn link_gnu(
     object_path: &Path,
     runtime: &RuntimeStaticLib,
+    native: &NativeLink,
     output: &Path,
 ) -> Result<LinkOutput, CodegenError> {
     let cc = which_cc().ok_or_else(|| {
@@ -252,6 +341,7 @@ fn link_gnu(
     })?;
     let mut cmd = Command::new(&cc);
     cmd.arg(object_path).arg(&runtime.path);
+    push_native_unix(&mut cmd, native);
     cmd.arg("-o").arg(output);
     // Rust's std on MinGW pulls in these system libs.
     cmd.args([
@@ -285,12 +375,14 @@ fn link_gnu(
 fn link_unix(
     object_path: &Path,
     runtime: &RuntimeStaticLib,
+    native: &NativeLink,
     output: &Path,
 ) -> Result<LinkOutput, CodegenError> {
     let cc =
         which_cc().ok_or_else(|| CodegenError::Target("no `cc` driver on PATH".to_string()))?;
     let mut cmd = Command::new(&cc);
     cmd.arg(object_path).arg(&runtime.path);
+    push_native_unix(&mut cmd, native);
     cmd.arg("-o").arg(output);
     if cfg!(target_os = "linux") {
         cmd.args(["-lpthread", "-ldl", "-lm", "-lrt", "-lgcc_s", "-lutil"]);
@@ -327,6 +419,21 @@ fn link_unix(
     Ok(LinkOutput {
         binary: output.to_path_buf(),
     })
+}
+
+/// Append the FFI inputs to a `cc`/`gcc` command line, after the program and
+/// runtime objects: compiled C archives (linked in full), then `-l` libraries,
+/// then raw linker arguments.
+fn push_native_unix(cmd: &mut Command, native: &NativeLink) {
+    for object in &native.objects {
+        cmd.arg(object);
+    }
+    for lib in &native.libs {
+        cmd.arg(format!("-l{}", lib));
+    }
+    for arg in &native.link_args {
+        cmd.arg(arg);
+    }
 }
 
 /// Run a configured linker command and map its result.

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -104,6 +104,18 @@ pub fn build_binary(
     output: &Path,
     ctx: Option<&PackageContext>,
 ) -> Result<(), DriverError> {
+    build_binary_native(input, output, ctx, &linker::NativeLink::default())
+}
+
+/// Compile `input` to a native executable like [`build_binary`], additionally
+/// linking the `native` FFI inputs (compiled C archives, `-l` libraries, and
+/// raw linker arguments) gathered from `[ffi]` sections.
+pub fn build_binary_native(
+    input: &Path,
+    output: &Path,
+    ctx: Option<&PackageContext>,
+    native: &linker::NativeLink,
+) -> Result<(), DriverError> {
     let source = std::fs::read_to_string(input)
         .map_err(|e| DriverError::Io(format!("read {}: {}", input.display(), e)))?;
 
@@ -115,7 +127,7 @@ pub fn build_binary(
     std::fs::write(&object_path, &object_bytes)
         .map_err(|e| DriverError::Io(format!("write object: {}", e)))?;
 
-    linker::link(&object_path, &runtime, output).map_err(DriverError::from)?;
+    linker::link(&object_path, &runtime, native, output).map_err(DriverError::from)?;
     Ok(())
 }
 

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -66,10 +66,16 @@ pub struct Dependency {
     pub constraint: String,
 }
 
-/// The optional `[ffi]` section. Linker pass-through; wiring into the
-/// actual link step is deferred.
+/// The optional `[ffi]` section: how a package's native code is linked into a
+/// program that uses it. `rvpm build` compiles each `sources` C file and links
+/// it in, links each `libs` library, and passes `link_args` to the linker. The
+/// `[ffi]` of every dependency is collected, so a package can bundle its own C
+/// (for example SQLite) and a consumer needs no system setup.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Ffi {
+    /// Bundled C source files, relative to the package root, compiled and
+    /// linked into the final binary. For example `["c/sqlite3.c"]`.
+    pub sources: Vec<String>,
     /// Library names to link, for example `["m", "z"]`.
     pub libs: Vec<String>,
     /// Extra raw linker arguments.
@@ -181,6 +187,8 @@ struct RawPackage {
 #[serde(deny_unknown_fields)]
 struct RawFfi {
     #[serde(default)]
+    sources: Vec<String>,
+    #[serde(default)]
     libs: Vec<String>,
     #[serde(default)]
     link_args: Vec<String>,
@@ -251,6 +259,7 @@ impl Manifest {
         let ffi = raw
             .ffi
             .map(|f| Ffi {
+                sources: f.sources,
                 libs: f.libs,
                 link_args: f.link_args,
             })

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -16,9 +16,10 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use crate::codegen::linker;
 use crate::driver::{self, DriverError};
 use crate::lock::{self, LockError, LockFile, LOCK_FILE_NAME};
-use crate::manifest::{Manifest, ManifestError};
+use crate::manifest::{Ffi, Manifest, ManifestError};
 use crate::pkg;
 use crate::resolve::{GithubPath, PackageContext};
 
@@ -215,6 +216,69 @@ pub fn add_in(
         outcome_lines: lines,
         package_count: lock.packages.len(),
     })
+}
+
+/// Collect the native link inputs from a project and its dependencies' `[ffi]`
+/// sections, compiling any bundled C sources into a single static archive.
+fn gather_native_link(
+    project_dir: &Path,
+    manifest: &Manifest,
+    lock: &LockFile,
+    cache_root: &Path,
+    out_dir: &Path,
+) -> Result<linker::NativeLink, OpError> {
+    let mut sources: Vec<PathBuf> = Vec::new();
+    let mut libs: Vec<String> = Vec::new();
+    let mut link_args: Vec<String> = Vec::new();
+
+    // The project's own [ffi], resolved against the project root.
+    collect_ffi(
+        &manifest.ffi,
+        project_dir,
+        &mut sources,
+        &mut libs,
+        &mut link_args,
+    );
+
+    // Each dependency's [ffi], resolved against its cache directory, so a
+    // package can bundle its own C and a consumer needs nothing installed.
+    for entry in &lock.packages {
+        let Some(gh) = GithubPath::parse(&entry.source) else {
+            continue;
+        };
+        let dir = pkg::cache_dir_in(cache_root, &gh.host, &gh.user, &gh.repo, &entry.version);
+        let dep_manifest = dir.join(MANIFEST_FILE_NAME);
+        if dep_manifest.exists() {
+            if let Ok(dep) = Manifest::load(&dep_manifest) {
+                collect_ffi(&dep.ffi, &dir, &mut sources, &mut libs, &mut link_args);
+            }
+        }
+    }
+
+    let objects = if sources.is_empty() {
+        Vec::new()
+    } else {
+        linker::compile_c_sources(&sources, out_dir).map_err(DriverError::from)?
+    };
+    Ok(linker::NativeLink {
+        objects,
+        libs,
+        link_args,
+    })
+}
+
+fn collect_ffi(
+    ffi: &Ffi,
+    base: &Path,
+    sources: &mut Vec<PathBuf>,
+    libs: &mut Vec<String>,
+    link_args: &mut Vec<String>,
+) {
+    for source in &ffi.sources {
+        sources.push(base.join(source));
+    }
+    libs.extend(ffi.libs.iter().cloned());
+    link_args.extend(ffi.link_args.iter().cloned());
 }
 
 /// What an install did, for reporting.
@@ -439,7 +503,14 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
                     source: e,
                 })?;
             }
-            driver::build_binary(&entry, &binary, Some(&ctx))?;
+            // Gather native code to link from the `[ffi]` of the project and
+            // its dependencies (bundled C sources, libraries, linker args).
+            let ffi_dir = binary
+                .parent()
+                .map(|p| p.join("ffi"))
+                .unwrap_or_else(|| PathBuf::from("ffi"));
+            let native = gather_native_link(project_dir, &manifest, &lock, cache_root, &ffi_dir)?;
+            driver::build_binary_native(&entry, &binary, Some(&ctx), &native)?;
             Ok(BuildReport {
                 outcome_lines: vec![format!(
                     "Compiled {} to {}",

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -935,7 +935,12 @@ fn env_program_compiles_and_runs() {
     } else {
         "use_env"
     });
-    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        &runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }
@@ -993,7 +998,12 @@ fn fs_program_compiles_and_runs() {
     } else {
         "use_fs"
     });
-    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        &runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }
@@ -1073,7 +1083,12 @@ fn net_program_compiles_and_runs() {
     } else {
         "use_net"
     });
-    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        &runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }
@@ -1163,7 +1178,12 @@ fn http_program_compiles_and_runs() {
     } else {
         "use_http"
     });
-    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        &runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }
@@ -1218,7 +1238,12 @@ fn time_program_compiles_and_runs() {
     } else {
         "use_time"
     });
-    if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        &runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }
@@ -1434,7 +1459,12 @@ fn build_example_binary(name: &str, runtime: &RuntimeStaticLib) -> ExampleBinary
     } else {
         stem.to_string()
     });
-    if let Err(e) = linker::link(&object_path, runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }
@@ -1491,7 +1521,12 @@ fn compile_link_run_and_check(name: &str, expected: &str, runtime: &RuntimeStati
         stem.to_string()
     });
 
-    if let Err(e) = linker::link(&object_path, runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }

--- a/tests/concurrency_soak.rs
+++ b/tests/concurrency_soak.rs
@@ -168,7 +168,12 @@ fn build_program(source: &str, runtime: &RuntimeStaticLib) -> Result<CompiledPro
     let object_path = tmp.join("gen.o");
     std::fs::write(&object_path, &object_bytes).expect("write object");
     let binary = tmp.join(if cfg!(windows) { "gen.exe" } else { "gen" });
-    if let Err(e) = linker::link(&object_path, runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         let _ = std::fs::remove_dir_all(&tmp);
         return Err(format!("link: {e}"));
     }

--- a/tests/gc_rooting_stress.rs
+++ b/tests/gc_rooting_stress.rs
@@ -455,7 +455,12 @@ fn build_program(source: &str, runtime: &RuntimeStaticLib) -> Result<CompiledPro
     let object_path = tmp.join("gen.o");
     std::fs::write(&object_path, &object_bytes).expect("write object");
     let binary = tmp.join(if cfg!(windows) { "gen.exe" } else { "gen" });
-    if let Err(e) = linker::link(&object_path, runtime, &binary) {
+    if let Err(e) = linker::link(
+        &object_path,
+        runtime,
+        &linker::NativeLink::default(),
+        &binary,
+    ) {
         cleanup(&tmp);
         return Err(format!("link: {e}"));
     }

--- a/tests/golden.rs
+++ b/tests/golden.rs
@@ -57,7 +57,12 @@ fn v2_examples_match_golden_baselines() {
         } else {
             example.stem.clone()
         });
-        if let Err(e) = linker::link(&object_path, &runtime, &binary) {
+        if let Err(e) = linker::link(
+            &object_path,
+            &runtime,
+            &linker::NativeLink::default(),
+            &binary,
+        ) {
             cleanup(&tmp);
             failures.push(format!("{}: link failed: {}", example.label, e));
             continue;

--- a/tests/rvpm_build.rs
+++ b/tests/rvpm_build.rs
@@ -94,6 +94,71 @@ fn project_with_github_dependency_builds_and_runs() {
     assert_eq!(stdout, "hi!\n", "unexpected program stdout: {:?}", stdout);
 }
 
+/// A dependency that bundles a C source through `[ffi]` is compiled and linked
+/// into the consuming program: `cmath` ships `c/quad.c`, exposes it via an
+/// `extern "C"` wrapper, and the project calls it. This is the shape a SQLite
+/// binding (bundled `sqlite3.c`) takes.
+#[test]
+fn project_with_dependency_bundling_c_builds_and_runs() {
+    if !supported_runtime() {
+        return;
+    }
+
+    let work = workdir();
+    let cache = work.join("cache");
+    let project = work.join("project");
+    std::fs::create_dir_all(&project).expect("mkdir project");
+
+    let pkg_dir = cache.join("github.com").join("acme").join("cmath@v1.0.0");
+    std::fs::create_dir_all(pkg_dir.join("c")).expect("mkdir pkg/c");
+    std::fs::write(
+        pkg_dir.join("rv.toml"),
+        "[package]\nname = \"cmath\"\nversion = \"0.1.0\"\n\n[ffi]\nsources = [\"c/quad.c\"]\n",
+    )
+    .expect("write pkg toml");
+    std::fs::write(
+        pkg_dir.join("c").join("quad.c"),
+        "int quad(int x) { return x * 4; }\n",
+    )
+    .expect("write pkg c");
+    std::fs::write(
+        pkg_dir.join("lib.rv"),
+        "extern \"C\" {\n    fun quad(x: CInt) -> CInt\n}\nfun times4(x: CInt) -> CInt { return quad(x) }\n",
+    )
+    .expect("write pkg lib");
+
+    std::fs::write(
+        project.join("rv.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/cmath\" = \"v1.0.0\"\n",
+    )
+    .expect("write project toml");
+    let src = project.join("src");
+    std::fs::create_dir_all(&src).expect("mkdir src");
+    std::fs::write(
+        src.join("main.rv"),
+        "import \"github.com/acme/cmath/lib\" { times4 }\nfun main() { print(times4(5)) }\n",
+    )
+    .expect("write main");
+
+    let run = rvpm(&project, &cache, &["run".to_string()]);
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&run.stderr).into_owned();
+    cleanup(&work);
+    assert!(
+        run.status.success(),
+        "rvpm run failed: stdout={} stderr={}",
+        stdout,
+        stderr
+    );
+    // times4(5) calls the bundled C quad(5) = 20.
+    assert_eq!(
+        stdout.trim(),
+        "20",
+        "unexpected program stdout: {:?}",
+        stdout
+    );
+}
+
 /// Invoke the real `rvpm` binary in `project_dir` with an isolated cache.
 fn rvpm(project_dir: &Path, cache: &Path, args: &[String]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_rvpm"))


### PR DESCRIPTION
Makes the `[ffi]` section of `rv.toml` actually do something, so packages can bundle and link native C. This is the prerequisite for raven-sqlite (Option B: ship `sqlite3.c`).

## What
```toml
[ffi]
sources = ["c/sqlite3.c"]   # compiled and linked in
libs = ["m"]                # linked as -lm
link_args = ["-L/opt/lib"]
```
`rvpm build` now compiles each bundled C source and links it into the program, along with `libs` and `link_args`, and **collects the `[ffi]` of every dependency** too. So a package ships its own C and a consumer needs nothing installed.

## How
- **manifest**: `sources` added to `[ffi]`.
- **linker**: a `NativeLink` (objects + libs + raw args) threaded through the msvc/gnu/unix paths. `compile_c_sources` compiles each `.c` to an object with the cc-crate-detected compiler (cl.exe / cc / gcc), **discarding the compiler's stdout** so cl.exe's source-name echo never pollutes a program's stdout under `rvpm run`.
- **driver**: `build_binary_native`.
- **ops**: gather the project's and each locked dependency's `[ffi]`, compile the C, build the `NativeLink`.

## Verified
New end-to-end test `project_with_dependency_bundling_c_builds_and_runs`: a cached dependency bundles `c/quad.c`, exposes it via `extern "C"`, and the consuming project calls it (prints 20). Also verified a self-contained app bundling C: build and run stdout both clean. 560 lib tests, golden, clippy --all-targets all pass.

No new Rust dependencies (cc was already a dep). Next: build raven-sqlite on this.