### PR TITLE
fix(rvpm): link [ffi] native code in the test build too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.65] - 2026-06-13
+
+### Fixed
+
+- `rvpm test` now links the package's (and its dependencies') `[ffi]` native code, so a package can test its own FFI bindings. Previously only `rvpm build`/`run` applied `[ffi]`, so a test that called into bundled C failed to link.
+
 ## [2.18.64] - 2026-06-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.63"
+version = "2.18.64"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.63"
+version = "2.18.64"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.64"
+version = "2.18.65"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -605,7 +605,7 @@ pub fn test(project_dir: &Path) -> Result<TestReport, OpError> {
 /// runs in its own process (a small generated dispatcher selects the test by
 /// name) so a panic from a failed assertion fails only that test, not the run.
 pub fn test_in(project_dir: &Path, cache_root: &Path) -> Result<TestReport, OpError> {
-    Manifest::load(project_dir.join(MANIFEST_FILE_NAME))?;
+    let manifest = Manifest::load(project_dir.join(MANIFEST_FILE_NAME))?;
     let (_outcome, _report) = install_in(project_dir, cache_root)?;
     let lock_path = project_dir.join(LOCK_FILE_NAME);
     let lock = if lock_path.exists() {
@@ -652,6 +652,14 @@ pub fn test_in(project_dir: &Path, cache_root: &Path) -> Result<TestReport, OpEr
         })?;
     }
 
+    // Native code from the package's (and its dependencies') `[ffi]`, so a
+    // package can test its own FFI bindings. Compiled once and reused per suite.
+    let ffi_dir = binary
+        .parent()
+        .map(|p| p.join("ffi"))
+        .unwrap_or_else(|| PathBuf::from("ffi"));
+    let native = gather_native_link(project_dir, &manifest, &lock, cache_root, &ffi_dir)?;
+
     let mut passed = 0usize;
     let mut failed = 0usize;
     // Compile one dispatcher per file, then run each of its tests in isolation.
@@ -666,7 +674,7 @@ pub fn test_in(project_dir: &Path, cache_root: &Path) -> Result<TestReport, OpEr
                     source: e,
                 }
             })?;
-            driver::build_binary(&main_path, &binary, Some(&ctx))?;
+            driver::build_binary_native(&main_path, &binary, Some(&ctx), &native)?;
             for name in names {
                 let output = std::process::Command::new(&binary)
                     .arg(name)

--- a/tests/rvpm_build.rs
+++ b/tests/rvpm_build.rs
@@ -159,6 +159,58 @@ fn project_with_dependency_bundling_c_builds_and_runs() {
     );
 }
 
+/// `rvpm test` links the package's own `[ffi]` so a package can test its native
+/// bindings. A library bundles `c/inc.c`, wraps it, and a `*_test.rv` calls the
+/// wrapper.
+#[test]
+fn rvpm_test_links_package_ffi() {
+    if !supported_runtime() {
+        return;
+    }
+
+    let work = workdir();
+    let cache = work.join("cache");
+    let project = work.join("lib");
+    std::fs::create_dir_all(project.join("c")).expect("mkdir lib/c");
+
+    std::fs::write(
+        project.join("rv.toml"),
+        "[package]\nname = \"inc\"\nversion = \"0.1.0\"\n\n[ffi]\nsources = [\"c/inc.c\"]\n",
+    )
+    .expect("write toml");
+    std::fs::write(
+        project.join("c").join("inc.c"),
+        "#include <stdint.h>\nint64_t c_inc(int64_t x) { return x + 1; }\n",
+    )
+    .expect("write c");
+    std::fs::write(
+        project.join("lib.rv"),
+        "extern \"C\" {\n    fun c_inc(x: Int) -> Int\n}\nfun inc(x: Int) -> Int { return c_inc(x) }\n",
+    )
+    .expect("write lib");
+    std::fs::write(
+        project.join("lib_test.rv"),
+        "import std/test { assert_eq_int }\nimport \"./lib\" { inc }\nfun test_inc() { assert_eq_int(inc(4), 5) }\n",
+    )
+    .expect("write test");
+
+    let out = rvpm(&project, &cache, &["test".to_string()]);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    cleanup(&work);
+    assert!(
+        out.status.success(),
+        "rvpm test failed: stdout={} stderr={}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("ok   test_inc"),
+        "expected the test to pass: {}",
+        stdout
+    );
+}
+
 /// Invoke the real `rvpm` binary in `project_dir` with an isolated cache.
 fn rvpm(project_dir: &Path, cache: &Path, args: &[String]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_rvpm"))


### PR DESCRIPTION
`rvpm test` built its test binary with `build_binary` (no `[ffi]`), so a package whose tests call into bundled C failed to link with unresolved symbols. Now `test_in` gathers the package's native link inputs (the same path `build` uses) and compiles the test binary with them, once per run.

This is what lets raven-sqlite (bundled SQLite) run its own `rvpm test`. Adds an integration test: a library bundling `c/inc.c` passes its `*_test.rv`. lib + rvpm_build tests green, clippy clean. Version 2.18.65.