### PR TITLE
docs: show a range-pattern example in the match section

### DIFF
--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -382,6 +382,20 @@ fun classify(n: Int) -> String {
 }
 ```
 
+A range pattern matches any value the range covers. As with `for`, `a..b`
+excludes `b` and `a..=b` includes it:
+
+```rust
+fun grade(score: Int) -> String {
+    return match score {
+        90..=100 -> "A",
+        80..=89 -> "B",
+        70..=79 -> "C",
+        _ -> "F",
+    }
+}
+```
+
 ## List, set, and map literals
 
 A list literal is comma-separated values in brackets, `[1, 2, 3]`, and an


### PR DESCRIPTION
The match section already lists ranges as a supported pattern kind, but its example only showed a guard. Now that range-pattern matching works (#526), add a short `grade` example so the documented feature has a runnable demonstration. `examples/v2/match_range.rv` is the executable counterpart.

Docs only; no code or CI-relevant paths changed.