### PR TITLE
docs: add four core tutorials (concurrency, errors, generics, testing)

### DIFF
--- a/docs/v2/guide/tutorials/concurrency.md
+++ b/docs/v2/guide/tutorials/concurrency.md
@@ -1,0 +1,297 @@
+# Tutorial: concurrency with goroutines and channels
+
+Raven runs concurrent work as goroutines: lightweight green threads scheduled
+across a pool of OS threads. You start one with the `spawn` keyword and pass
+values between them over channels from [`std/sync`](../stdlib/sync.md). This
+tutorial builds up from a single goroutine to a parallel reduction, with a
+detour through `select` and the synchronization primitives. Every step
+compiles and runs.
+
+A couple of facts to keep in mind as you go:
+
+- `spawn` takes a `fun() -> Unit` closure and is a statement, not an
+  expression: you write `spawn(...)` on its own line, you do not assign its
+  result.
+- Channels carry `Int` values. To move richer data, send an index or a count
+  and keep the payload in shared state, or send the parts and reassemble them.
+
+## Step 1: start a goroutine
+
+`spawn` runs a closure concurrently. The closure can capture variables from
+the surrounding scope:
+
+```rust
+import std/sync { channel }
+
+fun main() {
+    let ch = channel()
+    spawn(fun() -> Unit {
+        ch.send(42)
+    })
+    print(ch.recv())        // 42
+}
+```
+
+`channel()` creates an unbuffered channel. `send` blocks until another
+goroutine is ready to `recv`, and `recv` blocks until a value arrives, so the
+two goroutines hand the value across and `main` prints `42`. Blocking here
+means "yield to the scheduler," not "burn a thread": while one goroutine waits,
+others run.
+
+## Step 2: a producer and a consumer
+
+A common shape is one goroutine producing a stream of values and another
+consuming them. The producer sends `1` through `5`; `main` receives five values
+and sums them:
+
+```rust
+import std/sync { channel }
+
+fun main() {
+    let ch = channel()
+    spawn(fun() -> Unit {
+        let i = 1
+        while i <= 5 {
+            ch.send(i)
+            i = i + 1
+        }
+    })
+
+    let sum = 0
+    let n = 0
+    while n < 5 {
+        sum = sum + ch.recv()
+        n = n + 1
+    }
+    print(sum)              // 15
+}
+```
+
+The consumer counts how many values it expects (`5`) and stops there. There is
+no "channel closed" signal in this model, so the receiver decides when it has
+read enough, usually because it knows how many producers there are or how many
+items each will send.
+
+## Step 3: fan-in from several goroutines
+
+Channels are many-to-one safe: several goroutines can send on the same channel
+and one receiver collects the results. Order is not guaranteed, so design the
+result to be order-independent (a sum, a count, a set):
+
+```rust
+import std/sync { channel }
+
+fun main() {
+    let fan = channel()
+    spawn(fun() -> Unit {
+        fan.send(3)
+    })
+    spawn(fun() -> Unit {
+        fan.send(5)
+    })
+    spawn(fun() -> Unit {
+        fan.send(7)
+    })
+
+    let total = 0
+    let k = 0
+    while k < 3 {
+        total = total + fan.recv()
+        k = k + 1
+    }
+    print(total)            // 15
+}
+```
+
+Three goroutines each send one value; `main` receives exactly three and adds
+them. The total is `15` no matter which goroutine runs first.
+
+## Step 4: buffered channels and cooperative yielding
+
+An unbuffered channel makes every `send` wait for a matching `recv`. A buffered
+channel holds up to a fixed number of values, so a sender can get ahead of the
+receiver:
+
+```rust
+import std/sync { channel_buffered, yield_now }
+
+fun main() {
+    let ch = channel_buffered(8)
+    spawn(fun() -> Unit {
+        ch.send(0)
+        yield_now()
+        ch.send(2)
+        yield_now()
+        ch.send(4)
+    })
+    ch.send(1)
+    yield_now()
+    ch.send(3)
+    yield_now()
+    ch.send(5)
+
+    let acc = 0
+    let m = 0
+    while m < 6 {
+        acc = acc + ch.recv()
+        m = m + 1
+    }
+    print(acc)              // 15
+}
+```
+
+`channel_buffered(8)` has room for eight pending values, so neither side blocks
+on a full buffer here. `yield_now()` voluntarily hands the scheduler a chance
+to run the other goroutine, interleaving the even and odd sends. The final sum
+of `0..=5` is `15` regardless of the exact interleaving.
+
+## Step 5: waiting on whichever channel is ready first
+
+When a goroutine listens to more than one source, `select_recv` receives from
+whichever channel has a value next. It returns a small result with the `value`
+and the `index` of the channel it came from (its position in the list you
+passed):
+
+```rust
+import std/sync { channel, select_recv }
+
+fun main() {
+    let a = channel()
+    let b = channel()
+
+    spawn(fun() -> Unit {
+        a.send(10)
+        a.send(20)
+    })
+    spawn(fun() -> Unit {
+        b.send(30)
+        b.send(40)
+    })
+
+    let total = 0
+    let from_a = 0
+    let from_b = 0
+    let received = 0
+    while received < 4 {
+        let r = select_recv([a, b])
+        total = total + r.value
+        if r.index == 0 {
+            from_a = from_a + 1
+        }
+        if r.index == 1 {
+            from_b = from_b + 1
+        }
+        received = received + 1
+    }
+
+    print(total)            // 100
+    print(from_a)           // 2
+    print(from_b)           // 2
+}
+```
+
+`select_recv` lets one consumer drain several producers fairly without deciding
+up front which to read from. The value sum (`100`) and the per-channel counts
+(two each) are deterministic even though the ready order is not.
+
+## Step 6: synchronizing with a wait group and a mutex
+
+Channels move values; sometimes you instead want many goroutines to update
+shared state and a way to wait for them all to finish. `std/sync` provides a
+`wait_group` to join a set of goroutines and a `mutex` to guard a shared value:
+
+```rust
+import std/sync { wait_group, mutex }
+
+struct Counter {
+    value: Int,
+}
+
+fun main() {
+    let wg = wait_group()
+    let m = mutex()
+    let counter = Counter { value: 0 }
+
+    wg.add(8)
+    let spawned = 0
+    while spawned < 8 {
+        spawn(fun() -> Unit {
+            let i = 0
+            while i < 1000 {
+                m.lock()
+                counter.value = counter.value + 1
+                m.unlock()
+                i = i + 1
+            }
+            wg.done()
+        })
+        spawned = spawned + 1
+    }
+
+    wg.wait()
+    print(counter.value)    // 8000
+}
+```
+
+Eight goroutines each increment the shared counter a thousand times. The mutex
+serializes the read-modify-write, so the total is exactly `8000`: without it,
+parallel increments would race and lose updates. `wg.add(8)` declares how many
+goroutines to wait for, each calls `wg.done()` as it finishes, and `wg.wait()`
+blocks `main` until all eight are done.
+
+## Step 7: a parallel reduction
+
+Putting it together, here is a parallel sum. Eight workers each compute a
+partial result and send it back; `main` adds the partials. Because each worker
+allocates as it runs, this also exercises the garbage collector concurrently,
+yet the answer stays exact:
+
+```rust
+import std/sync { Channel, channel }
+
+fun worker(out: Channel, n: Int) -> Unit {
+    let acc = 0
+    let i = 0
+    while i < n {
+        let items = [i, i + 1, i + 2]
+        acc = acc + items.len()
+        i = i + 1
+    }
+    out.send(acc)
+}
+
+fun main() {
+    let out = channel()
+    let spawned = 0
+    while spawned < 8 {
+        spawn(fun() -> Unit {
+            worker(out, 2000)
+        })
+        spawned = spawned + 1
+    }
+
+    let total = 0
+    let received = 0
+    while received < 8 {
+        total = total + out.recv()
+        received = received + 1
+    }
+    print(total)            // 48000
+}
+```
+
+Each worker adds `3` to its accumulator `2000` times, so it sends `6000`; eight
+workers sum to `48000`. Note the named `worker` function takes the channel by
+its type `Channel` (imported from `std/sync`), and the `spawn` closure simply
+calls it. A wrong total here would point at a real concurrency bug (a lost
+value or a scheduler race), which is what makes a deterministic reduction a good
+smoke test.
+
+## Where to go next
+
+- The [`std/sync` reference](../stdlib/sync.md) documents every channel, select,
+  and synchronization function in detail.
+- The [language reference](../language-reference.md#concurrency) covers the
+  `spawn` keyword and the scheduling model.
+- For CPU-bound pipelines, combine a buffered channel (Step 4) with a fixed pool
+  of workers (Step 7) so producers and consumers run at their own pace.

--- a/docs/v2/guide/tutorials/error-handling.md
+++ b/docs/v2/guide/tutorials/error-handling.md
@@ -1,0 +1,244 @@
+# Tutorial: error handling with Option, Result, and `?`
+
+Raven has no exceptions and no `null`. A value that might be absent has type
+`Option<T>`, and an operation that might fail returns `Result<T, E>`. Both are
+ordinary enums built into the language, so failure shows up in the type
+signature and the compiler makes you handle it. This tutorial works through
+absence, failure, the `?` operator that propagates failures, and the
+[`std/error`](../stdlib/error.md) helpers that keep the common cases short.
+Every step compiles and runs.
+
+## Step 1: absence with `Option`
+
+`Option<T>` is either `Some(value)` or `None`. Use it for a lookup that might
+find nothing. You read it back with `match`, which forces you to handle both
+the present and the absent case:
+
+```rust
+fun unwrap_or(x: Option<Int>, fallback: Int) -> Int {
+    return match x {
+        None -> fallback,
+        Some(n) -> n,
+    }
+}
+
+fun main() {
+    let present = unwrap_or(Some(5), 0)
+    let missing = unwrap_or(None, 99)
+    print(present + missing)        // 104
+}
+```
+
+There is no way to read the inner value without first checking which variant
+you have, so the "I forgot it might be empty" class of bug simply cannot
+compile.
+
+## Step 2: failure with `Result`
+
+`Result<T, E>` is either `Ok(value)` or `Err(error)`. The `E` slot is whatever
+error type you choose. A clean default is the `Error` value from `std/error`,
+built with `error("message")`:
+
+```rust
+import std/error { error, Error }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    match divide(10, 2) {
+        Ok(v) -> print(v),                  // 5
+        Err(e) -> print(e.message()),
+    }
+    match divide(1, 0) {
+        Ok(v) -> print(v),
+        Err(e) -> print(e.message()),       // divide by zero
+    }
+}
+```
+
+`Error` carries a message (and an optional kind, see Step 5). The `match`
+covers both arms, so a failure can never be silently ignored.
+
+## Step 3: propagating with `?`
+
+Matching every intermediate result gets verbose when one operation feeds the
+next. The postfix `?` operator unwraps an `Ok` to its value, or returns the
+`Err` from the enclosing function immediately. It keeps the happy path flat:
+
+```rust
+import std/error { error, Error }
+
+fun positive(n: Int) -> Result<Int, Error> {
+    if n <= 0 {
+        return Err(error("must be positive"))
+    }
+    return Ok(n)
+}
+
+fun add_positive(a: Int, b: Int) -> Result<Int, Error> {
+    let x = positive(a)?        // returns the Err early if a <= 0
+    let y = positive(b)?
+    return Ok(x + y)
+}
+
+fun main() {
+    match add_positive(3, 4) {
+        Ok(n) -> print(n),                  // 7
+        Err(e) -> print(e.message()),
+    }
+    match add_positive(3, 0) {
+        Ok(n) -> print(n),
+        Err(e) -> print(e.message()),       // must be positive
+    }
+}
+```
+
+Because `?` returns early, it can only appear in a function whose return type
+matches: `?` on a `Result` needs the function to return a `Result`, and `?` on
+an `Option` needs it to return an `Option`. Using `?` in a function that
+returns a plain value is a compile error, not a silently dropped failure.
+
+## Step 4: recovering without a full `match`
+
+When you do not need to inspect the error, the `std/error` helpers cover the
+common shortcuts so you can skip writing a `match`:
+
+```rust
+import std/error { error, unwrap_or, is_ok, is_err, ok }
+
+fun divide(a: Int, b: Int) -> Result<Int, Error> {
+    if b == 0 {
+        return Err(error("divide by zero"))
+    }
+    return Ok(a / b)
+}
+
+fun main() {
+    print(unwrap_or(divide(10, 2), -1))     // 5  (the Ok value)
+    print(unwrap_or(divide(1, 0), -1))      // -1 (the fallback)
+    print(is_ok(divide(10, 2)))             // true
+    print(is_err(divide(1, 0)))             // true
+
+    match ok(divide(8, 4)) {                // Result -> Option, dropping the error
+        Some(v) -> print(v),                // 2
+        None -> print(0),
+    }
+}
+```
+
+`unwrap_or` gives you the value or a default, `is_ok`/`is_err` test the
+variant, and `ok` converts a `Result` to an `Option` when you care whether a
+value is present but not why it failed. These are generic over any error type,
+not just `Error`.
+
+## Step 5: adding context as errors rise
+
+A low-level failure like `no such file` is more useful with a higher-level
+explanation attached. `with_context` returns a new `Error` whose message is
+prefixed, keeping the original kind:
+
+```rust
+import std/error { error_kind, unwrap_or }
+
+fun check_port(port: Int) -> Result<Int, Error> {
+    if port < 1 {
+        return Err(error_kind("config", "port must be positive"))
+    }
+    return Ok(port)
+}
+
+fun read_port(port: Int) -> Result<Int, Error> {
+    let checked = check_port(port)?
+    return Ok(checked)
+}
+
+fun labeled(port: Int) -> Result<Int, Error> {
+    return match read_port(port) {
+        Ok(p) -> Ok(p),
+        Err(e) -> Err(e.with_context("read port")),
+    }
+}
+
+fun main() {
+    print(unwrap_or(labeled(8080), 80))     // 8080
+    match labeled(-1) {
+        Ok(p) -> print("port ${p}"),
+        Err(e) -> print(e.to_string()),     // read port: port must be positive
+    }
+}
+```
+
+`error_kind("config", ...)` tags the error with a free-form kind you can branch
+on later with `e.kind()`. `to_string()` renders an error as `kind: message` (or
+just the message when the kind is empty), and `print(e)` uses the same form.
+
+## Step 6: a different error type per layer
+
+The `E` in `Result<T, E>` does not have to be `Error`. A library often defines
+a struct that carries structured failure data, and `?` threads it through
+unchanged even when the `Ok` and `Err` types differ:
+
+```rust
+import std/string
+
+struct Fail {
+    code: Int,
+    message: String,
+}
+
+fun check(n: Int) -> Result<Bool, Fail> {
+    if n < 0 {
+        return Err(Fail { code: 1, message: "negative" })
+    }
+    return Ok(true)
+}
+
+fun run(n: Int) -> Result<Int, Fail> {
+    let _ok = check(n)?         // propagates the Fail struct unchanged
+    return Ok(n * 2)
+}
+
+fun main() {
+    match run(5) {
+        Ok(v) -> print(v),                                          // 10
+        Err(e) -> print(e.message),
+    }
+    match run(0 - 3) {
+        Ok(v) -> print(v),
+        Err(e) -> print(e.message.concat(" code=").concat(e.code.to_string())),
+    }
+}
+```
+
+Here `check` returns `Result<Bool, Fail>` and `run` returns `Result<Int,
+Fail>`: the `Ok` types differ, but the `Err` type is the same, so `?` carries a
+`Fail` from `check` straight out of `run`. The `Err(e)` arm binds `e` as a
+`Fail`, so you can read `e.code` and `e.message`.
+
+## When to use what
+
+- **`Option<T>`** for a value that may be absent, with no reason needed.
+- **`Result<T, Error>`** for an operation that may fail, where a message is
+  enough.
+- **`Result<T, MyStruct>`** when callers need to branch on structured failure
+  data.
+- **`?`** to propagate, **`match`** to handle, and the `std/error` helpers to
+  recover in one line.
+
+Errors in Raven are plain values, never control flow. Reach for `panic(msg)`
+only when a bug has made the program unable to continue, not for an expected,
+recoverable failure.
+
+## Where to go next
+
+- The [`std/error` reference](../stdlib/error.md) documents every helper,
+  including `map_ok`, `map_err`, and `unwrap_or_else`.
+- The [language reference](../language-reference.md) covers `Result`, `Option`,
+  pattern matching, and the `?` operator.
+- The [testing tutorial](testing.md) shows `assert_ok`, `assert_err`,
+  `assert_some`, and `assert_none` for checking these types in tests.

--- a/docs/v2/guide/tutorials/generics-and-traits.md
+++ b/docs/v2/guide/tutorials/generics-and-traits.md
@@ -1,0 +1,280 @@
+# Tutorial: generics and traits
+
+Generics let one piece of code work over many types; traits describe what a
+type can do and let you write code against that capability. Together they are
+Raven's tools for reuse without giving up static types: a generic is
+monomorphized (specialized) per concrete type at compile time, so there is no
+runtime type check and no boxing unless you ask for it. This tutorial builds
+from a generic container to bounded functions, trait objects, and derived
+implementations. Every step compiles and runs.
+
+## Step 1: a generic struct
+
+A type parameter in angle brackets makes a struct hold any type. `Box<T>` wraps
+one value of type `T`:
+
+```rust
+struct Box<T> {
+    value: T,
+}
+
+fun main() {
+    let n = Box { value: 7 }
+    let s = Box { value: "raven" }
+    print(n.value)          // 7
+    print(s.value)          // raven
+}
+```
+
+You never write the type argument when constructing: the compiler infers `T`
+from the value you pass, so `Box { value: 7 }` is a `Box<Int>` and `Box { value:
+"raven" }` is a `Box<String>`. Each instantiation gets its own layout and its
+own garbage-collector descriptor, so wrapping an `Int` and wrapping a `String`
+are both fully typed.
+
+## Step 2: generic methods on a generic type
+
+An `impl<T>` block adds methods that work for every instantiation. A method's
+body can use `T` as the element type:
+
+```rust
+struct Box<T> {
+    value: T,
+}
+
+impl<T> Box<T> {
+    fun unwrap(self) -> T = self.value
+}
+
+fun main() {
+    let a = Box { value: 42 }
+    let b = Box { value: "raven" }
+    print(a.unwrap())       // 42     (unwrap specialized at T = Int)
+    print(b.unwrap())       // raven  (unwrap specialized at T = String)
+}
+```
+
+`unwrap` is compiled once per concrete `T` it is called with. You can also add
+methods for a *specific* instantiation with a concrete `impl`:
+
+```rust
+impl Box<Int> {
+    fun doubled(self) -> Int = self.value * 2
+}
+```
+
+`doubled` exists only on `Box<Int>`; calling it on a `Box<String>` is a compile
+error.
+
+## Step 3: a trait
+
+A trait names a set of methods a type can provide. Implement it for a type with
+`impl Trait for Type`:
+
+```rust
+trait Speak {
+    fun sound(self) -> Int
+}
+
+struct Dog {}
+struct Cat {}
+
+impl Speak for Dog {
+    fun sound(self) -> Int = 1
+}
+
+impl Speak for Cat {
+    fun sound(self) -> Int = 2
+}
+
+fun main() {
+    let d = Dog {}
+    let c = Cat {}
+    print(d.sound())        // 1
+    print(c.sound())        // 2
+}
+```
+
+`Dog` and `Cat` share no data, but both satisfy `Speak`, so any code that needs
+"something that can `sound`" accepts either.
+
+## Step 4: bounded generic functions
+
+A trait becomes useful as a *bound*: `<T: Speak>` means "any `T` that
+implements `Speak`." The function can then call the trait's methods on its
+argument, and the call is dispatched statically (resolved at compile time, no
+vtable):
+
+```rust
+trait Speak {
+    fun sound(self) -> Int
+}
+
+struct Dog {}
+impl Speak for Dog {
+    fun sound(self) -> Int = 1
+}
+
+fun loudness<T: Speak>(x: T) -> Int = x.sound() * 10
+
+fun main() {
+    print(loudness(Dog {}))     // 10
+}
+```
+
+The standard library leans on this. `ToString` is part of the always-imported
+prelude, with built-in implementations for the primitives, so a bound of
+`<T: ToString>` accepts ints, bools, and any type you implement it for:
+
+```rust
+struct Point {
+    x: Int,
+    y: Int,
+}
+
+impl ToString for Point {
+    fun to_string(self) -> String = "(${self.x}, ${self.y})"
+}
+
+fun describe<T: ToString>(x: T) -> String = x.to_string()
+
+fun main() {
+    print(describe(42))             // 42
+    print(describe(true))           // true
+    let p = Point { x: 3, y: 4 }
+    print(describe(p))              // (3, 4)
+}
+```
+
+No `import std/core` line is needed: the prelude with `ToString` is always in
+scope.
+
+## Step 5: dynamic dispatch with `dyn Trait`
+
+A bounded generic produces a separate specialization per type, which is fast but
+means the type is fixed at each call site. When you instead want one function to
+accept values of *different* concrete types at runtime (a heterogeneous
+collection, a plugin slot), use `dyn Trait`. It is a fat pointer (data plus a
+vtable), and the call dispatches through the vtable:
+
+```rust
+trait Speak {
+    fun sound(self) -> Int
+}
+
+struct Dog {}
+struct Cat {}
+
+impl Speak for Dog {
+    fun sound(self) -> Int = 1
+}
+
+impl Speak for Cat {
+    fun sound(self) -> Int = 2
+}
+
+fun describe(s: dyn Speak) -> Int = s.sound()
+
+fun main() {
+    print(describe(Dog {}))     // 1
+    print(describe(Cat {}))     // 2
+}
+```
+
+The rule of thumb: reach for `<T: Trait>` by default (static dispatch, no
+overhead), and for `dyn Trait` only when you genuinely need to mix concrete
+types behind one type at runtime.
+
+## Step 6: method-level type parameters
+
+A method can introduce its own type parameter, separate from the type's. Here
+`mapped<U>` transforms a `Box<T>` into a `U` using a function you pass:
+
+```rust
+struct Box<T> {
+    value: T,
+}
+
+impl<T> Box<T> {
+    fun mapped<U>(self, f: fun(T) -> U) -> U = f(self.value)
+}
+
+fun main() {
+    let b = Box { value: 21 }
+    let doubled = b.mapped(fun(x: Int) -> Int = x * 2)
+    let is_big = b.mapped(fun(x: Int) -> Bool = x > 10)
+    print(doubled)          // 42
+    print(is_big)           // true
+}
+```
+
+Calling `mapped` at two different `U` on the same `Box<Int>` compiles to two
+distinct specializations. The closures use the single-expression form
+`fun(x: Int) -> Int = x * 2`, which is how a closure that returns a value is
+written.
+
+## Step 7: deriving common implementations
+
+Writing equality and hashing by hand is tedious, so `@derive` generates them. A
+type used as a `Map` key must satisfy the key bounds `Eq` and `Hash`; deriving
+both makes a generic struct a valid key:
+
+```rust
+import std/collections
+
+@derive(Eq, Hash)
+struct Box<T> {
+    value: T,
+}
+
+fun main() {
+    let m: Map<Box<Int>, Int> = Map.new()
+    m.set(Box { value: 7 }, 42)
+    match m.get(Box { value: 7 }) {
+        Some(v) -> print(v),        // 42
+        None -> print(0),
+    }
+}
+```
+
+`@derive(Eq, Hash)` writes the `equals` and `hash` methods for you; `@derive`
+also understands `Ord` (ordering) among others. Without the derive, using
+`Box<Int>` as a key is a clear type error rather than a failure deep in code
+generation.
+
+## Putting it together
+
+These features compose: a generic container, a trait its element is bounded by,
+and a function that works over both. The snippet below stores any
+`ToString` value and renders it:
+
+```rust
+struct Labeled<T> {
+    name: String,
+    value: T,
+}
+
+impl<T: ToString> Labeled<T> {
+    fun show(self) -> String = "${self.name}=${self.value.to_string()}"
+}
+
+fun main() {
+    let a = Labeled { name: "count", value: 42 }
+    let b = Labeled { name: "ready", value: true }
+    print(a.show())         // count=42
+    print(b.show())         // ready=true
+}
+```
+
+The bound on the `impl<T: ToString>` block means `show` is available only when
+`T` can be turned into a string, which is exactly when its body
+(`self.value.to_string()`) makes sense.
+
+## Where to go next
+
+- The [language reference](../language-reference.md) covers generics, traits,
+  `dyn Trait`, and `@derive` in full.
+- [`std/cmp`](../stdlib/cmp.md) and [`std/hash`](../stdlib/hash.md) define the
+  `Ord`, `Eq`, and `Hash` traits the derives target.
+- The [modeling-data tutorial](task-tracker.md) uses structs, enums, and
+  `match` together, the data side that complements the abstraction tools here.

--- a/docs/v2/guide/tutorials/testing.md
+++ b/docs/v2/guide/tutorials/testing.md
@@ -1,0 +1,210 @@
+# Tutorial: testing your code
+
+Raven's test model is deliberately small: a test is a zero-argument function
+named `test_*` in a file ending in `_test.rv`. There are no attributes, no
+registration macros, and no reflection. `rvpm test` finds those functions,
+runs each in its own process, and reports pass or fail by whether its
+assertions held. The assertions come from [`std/test`](../stdlib/test.md). This
+tutorial writes a function, tests it, makes a test fail on purpose to see the
+output, then tests a library and wires the whole thing into CI.
+
+## Step 1: a project with something to test
+
+Start a package and put a function worth testing in it:
+
+```bash
+rvpm init calc
+cd calc
+```
+
+Edit `src/main.rv` so it exports an `add` function:
+
+```rust
+// src/main.rv
+fun add(a: Int, b: Int) -> Int {
+    return a + b
+}
+
+fun main() {
+    print(add(2, 3))        // 5
+}
+```
+
+## Step 2: write a test file
+
+A test lives in a `*_test.rv` file and imports the function under test from its
+module. Each check is a `test_*` function that calls assertions from
+`std/test`:
+
+```rust
+// src/add_test.rv
+import std/test { assert_eq_int }
+import "./main" { add }
+
+fun test_add_basic() {
+    assert_eq_int(add(2, 3), 5)
+}
+
+fun test_add_negative() {
+    assert_eq_int(add(-1, 1), 0)
+}
+```
+
+A test file has no `main`: `rvpm test` calls each `test_*` function for you.
+`import "./main" { add }` pulls in the function from `src/main.rv` (a local
+import is a relative path in quotes). Test function names must be unique within
+a file.
+
+## Step 3: run the tests
+
+From the package root:
+
+```bash
+rvpm test
+```
+
+`rvpm test` discovers every `test_*` function in every `*_test.rv` file, runs
+each in its own process, and prints a line per test plus a summary:
+
+```
+running 2 tests
+  ok test_add_basic
+  ok test_add_negative
+test result: ok. 2 passed; 0 failed
+```
+
+Because each test runs in a separate process, one test's failure (a panic from
+a failed assertion) cannot take down the others.
+
+## Step 4: see a failure
+
+Assertions that compare values interpolate both operands into the panic
+message, so a failure tells you what it expected. Add a deliberately wrong test:
+
+```rust
+// src/add_test.rv
+import std/test { assert_eq_int }
+import "./main" { add }
+
+fun test_add_basic() {
+    assert_eq_int(add(2, 3), 5)
+}
+
+fun test_add_wrong() {
+    assert_eq_int(add(2, 2), 5)     // add(2, 2) is 4, not 5
+}
+```
+
+Now `rvpm test` reports the failure and exits non-zero:
+
+```
+running 2 tests
+  ok test_add_basic
+  FAIL test_add_wrong (raven panic: assertion failed: 4 != 5)
+test result: FAILED. 1 passed; 1 failed
+```
+
+The `4 != 5` comes straight from `assert_eq_int` interpolating the mismatched
+values. Fix the expected value (or the code) and the test goes back to `ok`.
+
+## Step 5: pick the right assertion
+
+`std/test` has an assertion per common shape. Import the ones you use:
+
+```rust
+import std/test { assert, assert_msg, assert_true, assert_false, assert_eq_int, assert_eq_str, assert_eq, assert_ne, assert_some, assert_none }
+import std/string
+
+fun test_assertions_tour() {
+    assert(1 + 1 == 2)                          // any Bool condition
+    assert_msg(7 % 2 == 1, "7 should be odd")   // with a custom message
+    assert_true(10 > 3)
+    assert_false(3 > 10)
+
+    assert_eq_int(6 * 7, 42)                     // Int equality
+    assert_eq_str("ab".concat("c"), "abc")       // String equality, by content
+    assert_eq(2 + 2, 4)                          // generic Eq + ToString
+    assert_ne("yes", "no")
+
+    assert_some(Some(5))                         // Option is Some
+    let empty: Option<Int> = None
+    assert_none(empty)
+}
+```
+
+Use `assert_eq_int` / `assert_eq_str` when you know the type, `assert_eq` /
+`assert_ne` for any `Eq + ToString` type, and `assert_msg` when a bare
+condition would not explain itself on failure. For floats, use
+`assert_eq_float(a, b, eps)` rather than exact `==`, since computed floats
+rarely match to the bit.
+
+## Step 6: test the failure paths too
+
+Code that returns `Result` or `Option` should be tested on both outcomes.
+`assert_ok` / `assert_err` and `assert_some` / `assert_none` check the variant
+without a `match`:
+
+```rust
+// src/parse_test.rv
+import std/test { assert_ok, assert_err }
+import "./main" { parse_count }
+
+fun test_parse_accepts_valid() {
+    assert_ok(parse_count("3"))
+}
+
+fun test_parse_rejects_invalid() {
+    assert_err(parse_count("oops"))
+}
+```
+
+This assumes a `parse_count(s: String) -> Result<Int, Error>` in `src/main.rv`.
+Testing the `Err` path is how you lock in that a failure stays a failure, not a
+silent `Ok`.
+
+## Step 7: testing a library
+
+A library has no `src/main.rv`, just modules other packages import. Tests work
+the same way: a `*_test.rv` at the package root (or beside the code) imports the
+library module and asserts against it. For a library whose entry is `src/lib.rv`:
+
+```rust
+// src/lib_test.rv
+import std/test { assert_eq_int }
+import "./lib" { factorial }
+
+fun test_factorial_base() {
+    assert_eq_int(factorial(0), 1)
+}
+
+fun test_factorial_small() {
+    assert_eq_int(factorial(5), 120)
+}
+```
+
+`rvpm test` works without a `main.rv`, so a library is fully testable on its
+own.
+
+## Step 8: tests in CI
+
+`rvpm test` exits non-zero the moment any test fails, which is exactly the
+signal a CI step needs. A minimal job is just:
+
+```bash
+rvpm test
+```
+
+If every `test_*` passes, the command exits zero and the job is green; the
+first failing assertion flips the exit code and the per-test `FAIL` line tells
+you which one. If you would rather run a single test program by hand, a
+`*_test.rv` you write with its own `main` full of assertions can also be run
+directly with `raven run path/to/test.rv`, where a zero exit means it passed.
+
+## Where to go next
+
+- The [`std/test` reference](../stdlib/test.md) lists every assertion, including
+  `assert_eq_float`, `assert_some`, and `assert_ok`, with examples.
+- The [rvpm guide](../rvpm.md) covers project layout and how `rvpm test`
+  discovers and runs tests.
+- The [error-handling tutorial](error-handling.md) explains the `Result` and
+  `Option` values that `assert_ok` and `assert_some` check.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,8 +86,12 @@ nav:
   - Tutorials:
     - Word-frequency counter: v2/guide/tutorials/word-frequency.md
     - Modeling data with structs and enums: v2/guide/tutorials/task-tracker.md
+    - Error handling with Option, Result, and ?: v2/guide/tutorials/error-handling.md
+    - Generics and traits: v2/guide/tutorials/generics-and-traits.md
+    - Concurrency with goroutines and channels: v2/guide/tutorials/concurrency.md
     - A guestbook HTTP server: v2/guide/tutorials/http-server.md
     - Calling C from Raven: v2/guide/tutorials/c-interop.md
+    - Testing your code: v2/guide/tutorials/testing.md
     - Building and publishing a library: v2/guide/tutorials/publishing-a-library.md
   - Standard Library:
     - Overview: v2/guide/standard-library.md


### PR DESCRIPTION
Adds four tutorials that fill the gaps between the existing ones (word-frequency, data modeling, HTTP server, C interop, publishing a library):

- **Concurrency with goroutines and channels** (`concurrency.md`): `spawn`, unbuffered and buffered channels, fan-in, `select_recv`, `wait_group`/`mutex`, and a parallel reduction.
- **Error handling with Option, Result, and `?`** (`error-handling.md`): absence vs failure, the `?` operator, `std/error` helpers, `with_context`, and per-layer error types.
- **Generics and traits** (`generics-and-traits.md`): generic structs and methods, traits, bounded generics, `dyn Trait`, method-level type parameters, and `@derive`.
- **Testing your code** (`testing.md`): the `rvpm test` model (`test_*` functions in `*_test.rv`), the assertion set, failure output, testing libraries, and CI wiring.

Every code snippet is grounded in an already golden-tested `examples/v2/*` program or a `std/*` reference page, so the syntax matches working code (channels carry `Int`, `spawn` takes a `fun() -> Unit`, value-returning closures use the `= expr` form, selective imports are single-line). The four are wired into the mkdocs nav.

Docs only; no code or CI-relevant paths changed.