### PR TITLE
fix: actionable error when no C compiler is found for [ffi] sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.68] - 2026-06-14
+
+### Changed
+
+- When a package with bundled C (`[ffi]`) `sources` is built and no C compiler is found, the error now says what to install instead of a raw "program not found". On a windows-msvc host it points to the Visual Studio C++ Build Tools (with the `winget` command) and notes that a MinGW `gcc` cannot be used for the MSVC-targeted release; elsewhere it points at installing `gcc`/`clang` or setting `CC`. The compiler is located through the Windows registry the same way the linker's `link.exe` is, so an installed toolchain is found with no Developer Command Prompt.
+- `rvpm` no longer leaks the C compiler's `cargo:warning=...` detection chatter to the console.
+
+### Docs
+
+- The rvpm guide documents the C-compiler prerequisite for building `[ffi]` sources, including the Windows Build Tools install command.
+
 ## [2.18.67] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.67"
+version = "2.18.68"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.67"
+version = "2.18.68"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.67"
+version = "2.18.68"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -59,11 +59,32 @@ Sections:
   that `rvpm build` compiles and links in, `libs` are libraries to link
   (`-l<name>`), and `link_args` are raw linker arguments. The `[ffi]` of
   every dependency is collected, so a package can ship its own C (for
-  example a bundled SQLite) and a consumer needs nothing installed.
+  example a bundled SQLite) and a consumer needs no system library
+  preinstalled. Building bundled `sources` does need a **C compiler** on
+  the machine doing the build (see below); pure-Raven packages with no
+  `[ffi]` sources do not.
 - `[fmt]` (optional): `indent_width` (default 4) and `wrap_width`
   (default 100) for the formatter.
 
 Unknown fields are rejected so typos surface early.
+
+### A C compiler for `[ffi]` sources
+
+Compiling a package's bundled C `sources` (for example raven-sqlite's
+`sqlite3.c`) needs a C compiler that matches the Raven build's ABI. On
+**Windows** that is the MSVC toolchain: install the Visual Studio C++ Build
+Tools, which rvpm then finds automatically, with no Developer Command Prompt
+needed:
+
+```text
+winget install Microsoft.VisualStudio.2022.BuildTools --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+A MinGW `gcc` will not work for the prebuilt Windows release: it emits GNU-ABI
+objects that do not link into the MSVC-targeted build. On **Linux and macOS**,
+any `cc`, `gcc`, or `clang` on `PATH` is used. Packages with no `[ffi]` sources
+need only a linker, which the release ships with, so they build with no extra
+toolchain.
 
 ## Dependencies
 

--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -133,6 +133,44 @@ pub struct NativeLink {
     pub link_args: Vec<String>,
 }
 
+/// The actionable error shown on a windows-msvc host when no MSVC C compiler
+/// can be located. A package such as raven-sqlite bundles C that must be
+/// compiled, and the MSVC build is the supported Windows toolchain.
+const NO_MSVC_C_COMPILER: &str = "no C compiler found to build this package's bundled C \
+    ([ffi]) sources, which a package such as raven-sqlite ships. Install the Visual Studio \
+    C++ Build Tools, which provide cl.exe: run\n  \
+    winget install Microsoft.VisualStudio.2022.BuildTools --override \"--quiet --wait --add \
+    Microsoft.VisualStudio.Workload.VCTools --includeRecommended\"\nthen open a new terminal \
+    and try again. (A MinGW gcc cannot be used here: it produces GNU-ABI objects that do not \
+    link into the MSVC-targeted Raven build.)";
+
+/// The actionable error shown on a non-msvc host when no C compiler is found.
+const NO_C_COMPILER: &str = "no C compiler found to build this package's bundled C ([ffi]) \
+    sources. Install a C toolchain (gcc or clang) and put it on PATH, or set the CC environment \
+    variable to the compiler's path.";
+
+/// Locate the C compiler for the `[ffi]` sources, with an actionable error when
+/// none is installed.
+///
+/// On a windows-msvc host this mirrors the linker's `link.exe` lookup: it
+/// resolves `cl.exe` through the Windows registry (vswhere), which also presets
+/// the SDK and CRT include/lib environment, so no Developer Command Prompt is
+/// needed. cc's own detection instead hands back a bare `cl.exe` that only
+/// fails to launch later (a cryptic "program not found"), so the registry
+/// result is checked directly to report the missing toolchain up front. A `CC`
+/// override or a non-msvc host defers to cc's normal detection.
+fn locate_c_compiler(triple: &str, build: &cc::Build) -> Result<cc::Tool, CodegenError> {
+    let host = Triple::host();
+    let cc_override = std::env::var_os("CC").is_some();
+    if is_windows_msvc(&host) && !cc_override {
+        return cc::windows_registry::find_tool(triple, "cl.exe")
+            .ok_or_else(|| CodegenError::Target(NO_MSVC_C_COMPILER.to_string()));
+    }
+    build
+        .try_get_compiler()
+        .map_err(|_| CodegenError::Target(NO_C_COMPILER.to_string()))
+}
+
 /// Compile each bundled C source into an object file under `out_dir`,
 /// returning their paths to link directly. Uses the `cc` crate's compiler
 /// detection (cl.exe on windows-msvc, `cc`/`gcc` elsewhere), configured
@@ -149,15 +187,17 @@ pub fn compile_c_sources(
     let mut build = cc::Build::new();
     build
         .cargo_metadata(false)
+        // Suppress cc's `cargo:warning=...` chatter (for example "Compiler
+        // family detection failed"): it leaks to the console of a user running
+        // `rvpm`, who is not running cargo at all.
+        .cargo_warnings(false)
         .opt_level(2)
         .debug(false)
         .warnings(false)
         .host(&triple)
         .target(&triple)
         .out_dir(out_dir);
-    let compiler = build
-        .try_get_compiler()
-        .map_err(|e| CodegenError::Target(format!("no C compiler for the [ffi] sources: {}", e)))?;
+    let compiler = locate_c_compiler(&triple, &build)?;
     let msvc = compiler.is_like_msvc();
 
     let mut objects = Vec::with_capacity(sources.len());
@@ -219,6 +259,19 @@ fn object_is_fresh(source: &Path, object: &Path) -> bool {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[test]
+    fn missing_compiler_errors_are_actionable() {
+        // The Windows message must name the toolchain and the command that
+        // installs it, so a user who hits the no-compiler path knows exactly
+        // what to do rather than seeing a raw "program not found".
+        assert!(NO_MSVC_C_COMPILER.contains("Build Tools"));
+        assert!(NO_MSVC_C_COMPILER.contains("winget"));
+        assert!(NO_MSVC_C_COMPILER.contains("cl.exe"));
+        // The non-Windows message must point at the fix (PATH or CC).
+        assert!(NO_C_COMPILER.contains("PATH"));
+        assert!(NO_C_COMPILER.contains("CC"));
+    }
 
     #[test]
     fn compile_reuses_an_unchanged_object() {


### PR DESCRIPTION
## Problem

Building a package that bundles C (an `[ffi]` `sources` entry, e.g. raven-sqlite's `sqlite3.c`) on a machine with no C compiler failed with a cryptic message and console noise:

```
cargo:warning=Compiler family detection failed due to error: ToolNotFound: failed to find tool "cl.exe": program not found
rvpm: codegen: target setup failed: C compiler failed to launch: program not found
```

`cc::Build::try_get_compiler()` returns a bare `cl.exe` tool when its registry detection fails, so the failure only surfaced as "program not found" when the command was run, and cc's `cargo:warning=...` line leaked to a user who is not running cargo.

## Fix

- **Locate the compiler via the registry**, the same way `link_msvc` already locates `link.exe`: on a windows-msvc host, `cc::windows_registry::find_tool(triple, "cl.exe")`. That also presets the SDK/CRT environment, so an installed toolchain is found with no Developer Command Prompt. A `CC` override or a non-msvc host defers to cc's normal detection.
- **Actionable error** when no compiler is found: the Windows message names the Visual Studio C++ Build Tools and the `winget` install command, and notes a MinGW `gcc` cannot be used for the MSVC-targeted release (wrong ABI); elsewhere it points at installing `gcc`/`clang` or setting `CC`.
- **Suppress the `cargo:warning=` leak** with `cargo_warnings(false)`.
- **Docs**: the rvpm guide now documents the C-compiler prerequisite for `[ffi]` sources, including the Windows install command.

The happy path is unchanged: on a machine with MSVC (or any `cc` on a non-msvc host), the same compiler is resolved and used exactly as before. Pure-Raven packages with no `[ffi]` sources are unaffected (they need only the linker, which the release ships with via rust-lld).

A unit test pins the actionable content of both messages; the existing `compile_reuses_an_unchanged_object` test exercises the resolve path end to end on CI.

Patch release 2.18.68.