### PR TITLE
fix: make multi-module @derive(ToJson/FromJson) compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.69] - 2026-06-14
+
+### Fixed
+
+- A multi-file project that uses `@derive(ToJson)` or `@derive(FromJson)` in more than one module no longer fails to compile with "the name `raven_derive_json_decode` is declared multiple times". The shared JSON helper functions the derived `from_json` bodies call are now emitted once for the whole program instead of once per module.
+- A type used only as a method-call type argument is now namespaced when its module is merged, so `req.json<NewTask>()` resolves a selectively imported local or external type. Previously only types in signatures and struct literals were rewritten, so the type argument stayed unresolved.
+- Generated `@derive` code from different modules no longer collides on identifier resolution. Each generated source is lexed under a distinct pseudo-file, so use-sites keyed by `(file, byte range)` stay unique across modules.
+
 ## [2.18.68] - 2026-06-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.68"
+version = "2.18.69"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.68"
+version = "2.18.69"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.68"
+version = "2.18.69"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/mir/lower/pattern.rs
+++ b/src/mir/lower/pattern.rs
@@ -401,12 +401,6 @@ fn lower_sequential_match(
                     },
                 );
             }
-            _ => {
-                if !cx.builder.is_closed(next_test) {
-                    cx.builder
-                        .close_block(next_test, MirTerminator::Goto(arm_block));
-                }
-            }
         }
 
         cx.current = arm_block;

--- a/src/resolve/derive.rs
+++ b/src/resolve/derive.rs
@@ -57,9 +57,24 @@ pub fn needs_json_module(file: &File) -> bool {
 }
 
 /// Append a synthesized impl for every `@derive(...)` request in `items` to
-/// `combined`. Returns an error if a derive names an unsupported trait or a
-/// type the slice cannot derive (a struct enum variant payload).
-pub fn expand_derives(items: &[Decl], combined: &mut Vec<Decl>) -> Result<(), RavenError> {
+/// `combined`. Returns whether any derive needs the shared JSON helper free
+/// functions, so the caller can emit them exactly once for the whole program
+/// (see [`json_helper_decls`]); a derive over a single set of items is one of
+/// several such calls (the user's items plus every merged module), so emitting
+/// the helpers here would declare them several times. Returns an error if a
+/// derive names an unsupported trait or a type the slice cannot derive (a
+/// struct enum variant payload).
+///
+/// `source_label` is the pseudo-file the generated source is lexed under. Each
+/// call must pass a distinct label (the per-module key, the user file, the
+/// helpers), because identifier use-sites are keyed by `(file, byte range)`:
+/// two generated sources both labeled `<derive>` start at byte zero and their
+/// line-one identifiers would collide on that key.
+pub fn expand_derives(
+    items: &[Decl],
+    combined: &mut Vec<Decl>,
+    source_label: &str,
+) -> Result<bool, RavenError> {
     let mut generated = String::new();
     let mut needs_json_helpers = false;
     for decl in items {
@@ -88,22 +103,35 @@ pub fn expand_derives(items: &[Decl], combined: &mut Vec<Decl>) -> Result<(), Ra
         }
     }
     if generated.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
-    // The derived `from_json` bodies call these helpers by bare name. A
-    // bundled stdlib free function is namespaced (`std.json.f`) and so not
-    // callable by its bare name from generated source, so the helpers are
-    // emitted into the generated file itself, exactly once per program.
-    if needs_json_helpers {
-        generated.insert_str(0, JSON_HELPERS);
-    }
-    let path = std::path::PathBuf::from("<derive>");
+    let path = std::path::PathBuf::from(source_label);
     let tokens = Lexer::new(generated.clone(), path.clone())
         .tokenize()
         .map_err(|e| derive_error(format!("lex: {e}")))?;
     let parsed = parse(&tokens).map_err(|e| derive_error(format!("parse: {e}")))?;
     combined.extend(parsed.items);
-    Ok(())
+    Ok(needs_json_helpers)
+}
+
+/// The shared JSON derive helper free functions, parsed into declarations.
+///
+/// The derived `from_json` bodies call these by bare name, and a bundled
+/// stdlib free function is namespaced (`std.json.f`) and so unreachable by its
+/// bare name from generated source. They are global free functions with fixed
+/// names, so the caller emits them exactly once per program (when any
+/// `@derive(ToJson|FromJson)` is present); a second copy would be a duplicate
+/// declaration. See [`expand_derives`], which reports when they are needed.
+pub fn json_helper_decls() -> Result<Vec<Decl>, RavenError> {
+    // A distinct label from every `expand_derives` source so the helper
+    // identifiers' `(file, byte range)` use-site keys cannot collide with an
+    // impl's.
+    let path = std::path::PathBuf::from("<derive-helpers>");
+    let tokens = Lexer::new(JSON_HELPERS.to_string(), path)
+        .tokenize()
+        .map_err(|e| derive_error(format!("lex: {e}")))?;
+    let parsed = parse(&tokens).map_err(|e| derive_error(format!("parse: {e}")))?;
+    Ok(parsed.items)
 }
 
 fn check_supported(trait_name: &str, span: &crate::span::Span) -> Result<(), RavenError> {
@@ -409,9 +437,10 @@ fn enum_to_string_body(e: &Enum, method: &str) -> String {
 // checker reports a missing impl with its normal bound diagnostic).
 
 /// Helper free functions the derived `from_json` bodies call by bare name.
-/// They are emitted into the generated file (not the bundled `std/json`)
-/// because a bundled free function is namespaced and so unreachable by its
-/// bare name from generated source. The names are prefixed to avoid
+/// They are emitted into the generated program once via [`json_helper_decls`]
+/// (not the bundled `std/json`) because a bundled free function is namespaced
+/// and so unreachable by its bare name from generated source. The names are
+/// prefixed to avoid
 /// colliding with a user declaration.
 const JSON_HELPERS: &str = r#"fun raven_derive_json_decode<T: FromJson>(j: JsonValue) -> Result<T, Error> {
     return T.from_json(j)
@@ -628,7 +657,7 @@ mod tests {
     fn derived_impls(src: &str) -> Vec<Impl> {
         let file = parse_src(src);
         let mut out = Vec::new();
-        expand_derives(&file.items, &mut out).expect("expand");
+        expand_derives(&file.items, &mut out, "<derive>").expect("expand");
         out.into_iter()
             .filter_map(|d| match d.kind {
                 DeclKind::Impl(i) => Some(i),
@@ -697,7 +726,8 @@ mod tests {
     fn unsupported_trait_is_rejected() {
         let file = parse_src("@derive(Clone)\nstruct Point { x: Int }\n");
         let mut out = Vec::new();
-        let err = expand_derives(&file.items, &mut out).expect_err("Clone is not derivable");
+        let err =
+            expand_derives(&file.items, &mut out, "<derive>").expect_err("Clone is not derivable");
         assert!(format!("{err}").contains("Clone"), "got: {err}");
     }
 
@@ -718,20 +748,12 @@ mod tests {
     fn struct_variant_enum_is_rejected() {
         let file = parse_src("@derive(Eq)\nenum E { V(a: Int) }\n");
         let mut out = Vec::new();
-        let err = expand_derives(&file.items, &mut out).expect_err("struct variant not supported");
+        let err = expand_derives(&file.items, &mut out, "<derive>")
+            .expect_err("struct variant not supported");
         assert!(
             format!("{err}").contains("struct-style variant"),
             "got: {err}"
         );
-    }
-
-    /// All declarations `expand_derives` synthesizes for `src`, including the
-    /// emitted JSON helper free functions.
-    fn derived_decls(src: &str) -> Vec<Decl> {
-        let file = parse_src(src);
-        let mut out = Vec::new();
-        expand_derives(&file.items, &mut out).expect("expand");
-        out
     }
 
     #[test]
@@ -754,30 +776,49 @@ mod tests {
     }
 
     #[test]
-    fn json_derive_emits_helper_functions_once() {
-        // Two types both derive the JSON traits; the shared helper free
-        // functions must be emitted exactly once.
-        let decls = derived_decls(
+    fn json_derive_reports_helpers_needed_and_keeps_them_out_of_the_impls() {
+        // A JSON derive reports that the shared helpers are needed, but does not
+        // emit them inline: they are global, fixed-named free functions, so the
+        // caller emits them once for the whole program. Emitting them per
+        // derive call declared them several times in a multi-module project.
+        let file = parse_src(
             "@derive(ToJson)\nstruct A { x: Int }\n@derive(FromJson)\nstruct B { y: Int }\n",
         );
-        let decode_count = decls
+        let mut out = Vec::new();
+        let needs = expand_derives(&file.items, &mut out, "<derive>").expect("expand");
+        assert!(needs, "a JSON derive reports the helpers are needed");
+        assert!(
+            !out.iter().any(|d| matches!(&d.kind, DeclKind::Function(f) if f.name.starts_with("raven_derive_json"))),
+            "the helpers must not be emitted inline with the impls"
+        );
+    }
+
+    #[test]
+    fn json_helper_decls_declares_each_helper_once() {
+        // The global helper set declares each helper exactly once, so a program
+        // that emits it a single time has no duplicate declaration.
+        let helpers = json_helper_decls().expect("helpers");
+        let decode_count = helpers
             .iter()
             .filter(|d| matches!(&d.kind, DeclKind::Function(f) if f.name == "raven_derive_json_decode"))
             .count();
-        assert_eq!(decode_count, 1, "decode helper must be emitted once");
-        let field_count = decls
+        assert_eq!(decode_count, 1, "exactly one decode helper");
+        let field_count = helpers
             .iter()
             .filter(
                 |d| matches!(&d.kind, DeclKind::Function(f) if f.name == "raven_derive_json_field"),
             )
             .count();
-        assert_eq!(field_count, 1);
+        assert_eq!(field_count, 1, "exactly one field helper");
     }
 
     #[test]
-    fn non_json_derive_emits_no_json_helpers() {
-        let decls = derived_decls("@derive(Eq)\nstruct Point { x: Int }\n");
-        let has_helper = decls.iter().any(
+    fn non_json_derive_reports_no_helpers_needed() {
+        let file = parse_src("@derive(Eq)\nstruct Point { x: Int }\n");
+        let mut out = Vec::new();
+        let needs = expand_derives(&file.items, &mut out, "<derive>").expect("expand");
+        assert!(!needs, "no JSON helpers without a JSON derive");
+        let has_helper = out.iter().any(
             |d| matches!(&d.kind, DeclKind::Function(f) if f.name.starts_with("raven_derive_json")),
         );
         assert!(!has_helper, "no JSON helper without a JSON derive");
@@ -805,7 +846,8 @@ mod tests {
     fn json_derive_rejects_struct_variant_enum() {
         let file = parse_src("@derive(ToJson)\nenum E { V(a: Int) }\n");
         let mut out = Vec::new();
-        let err = expand_derives(&file.items, &mut out).expect_err("struct variant not supported");
+        let err = expand_derives(&file.items, &mut out, "<derive>")
+            .expect_err("struct variant not supported");
         assert!(
             format!("{err}").contains("struct-style variant"),
             "got: {err}"

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -316,6 +316,12 @@ pub fn expand_with_stdlib_ctx(
         merge_module_items(module_file.items, &rename, &mut combined_items);
     }
 
+    // The shared JSON derive helper free functions are global and fixed-named,
+    // so they are emitted exactly once for the whole program below, after every
+    // module and the user's own items have had their derives expanded. Track
+    // whether any of those expansions needs them.
+    let mut needs_json_helpers = false;
+
     // Merge the local modules loaded above through the same merge core,
     // with a path derived namespace instead of the `std.<module>.` one.
     for module_file in local_modules {
@@ -341,7 +347,10 @@ pub fn expand_with_stdlib_ctx(
         for name in top_level_type_names(&module_file) {
             rename.insert(name.clone(), mangle_local_fn(&key, &name));
         }
-        let items = expand_module_derives(module_file.items)?;
+        // A per-module label keeps the generated source's use-site spans from
+        // colliding with another module's `<derive>` source.
+        let (items, needs) = expand_module_derives(module_file.items, &format!("<derive:{key}>"))?;
+        needs_json_helpers |= needs;
         merge_module_items(items, &rename, &mut combined_items);
     }
 
@@ -361,7 +370,8 @@ pub fn expand_with_stdlib_ctx(
             for name in top_level_type_names(&ext.file) {
                 rename.insert(name.clone(), mangle_external_fn(&key, &name));
             }
-            let items = expand_module_derives(ext.file.items)?;
+            let (items, needs) = expand_module_derives(ext.file.items, &format!("<derive:{key}>"))?;
+            needs_json_helpers |= needs;
             merge_module_items(items, &rename, &mut combined_items);
         }
     }
@@ -378,8 +388,17 @@ pub fn expand_with_stdlib_ctx(
     // is harmless). The generated impls append after the user items and flow
     // through resolve, type checking, and codegen like hand written ones.
     let mut derived_impls = Vec::new();
-    super::derive::expand_derives(&combined_items, &mut derived_impls)?;
+    needs_json_helpers |=
+        super::derive::expand_derives(&combined_items, &mut derived_impls, "<derive>")?;
     combined_items.append(&mut derived_impls);
+
+    // Emit the shared JSON derive helpers exactly once for the whole program,
+    // as bare global free functions the derived `from_json` bodies (in the user
+    // and in every merged module) all call by name. Emitting them per module
+    // declared them several times in a multi-file project.
+    if needs_json_helpers {
+        combined_items.extend(super::derive::json_helper_decls()?);
+    }
 
     Ok(File {
         items: combined_items,
@@ -439,12 +458,15 @@ fn strip_derives(items: &mut [Decl]) {
 /// on the bare-named user and stdlib items only). Doing this after namespacing
 /// would fail, since the generated source is re-lexed and a namespaced name
 /// carries dots and a hash that do not lex as one identifier.
-fn expand_module_derives(mut items: Vec<Decl>) -> Result<Vec<Decl>, RavenError> {
+fn expand_module_derives(
+    mut items: Vec<Decl>,
+    source_label: &str,
+) -> Result<(Vec<Decl>, bool), RavenError> {
     let mut derived = Vec::new();
-    super::derive::expand_derives(&items, &mut derived)?;
+    let needs_json = super::derive::expand_derives(&items, &mut derived, source_label)?;
     strip_derives(&mut items);
     items.extend(derived);
-    Ok(items)
+    Ok((items, needs_json))
 }
 
 fn merge_module_items(
@@ -1083,8 +1105,20 @@ fn rewrite_expr(expr: &mut Expr, rename: &HashMap<String, String>) {
                 rewrite_expr(a, rename);
             }
         }
-        ExprKind::MethodCall { receiver, args, .. } => {
+        ExprKind::MethodCall {
+            receiver,
+            generics,
+            args,
+            ..
+        } => {
             rewrite_expr(receiver, rename);
+            // A method-call type argument (`req.json<NewTask>()`) names a type
+            // the same way an `Ident` or `StructLit` generic does, so it must be
+            // namespaced too. Without this a local or external type used only as
+            // a method type argument stayed bare and failed to resolve.
+            for g in generics {
+                rewrite_type(g, rename);
+            }
             for a in args {
                 rewrite_expr(a, rename);
             }
@@ -1793,6 +1827,36 @@ mod tests {
             .any(|d| matches!(&d.kind, DeclKind::Struct(s) if s.name == "Point"));
         assert!(present, "a local struct should merge under {mangled}");
         assert!(!bare, "the bare `Point` name should not remain");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn json_derive_helpers_emitted_once_across_modules() {
+        // Two local modules each derive a JSON trait. The shared helper free
+        // functions are global and fixed-named, so they must be declared
+        // exactly once in the combined program. Emitting them per module
+        // declared `raven_derive_json_decode` several times, which resolve
+        // rejected as "declared multiple times" in a multi-file project.
+        let main_src = "import \"./a\" { A }\nimport \"./b\" { B }\nfun main() {}\n";
+        let (dir, entry) = write_temp_project(
+            &[
+                ("a.rv", "@derive(FromJson)\nstruct A { x: Int }\n"),
+                ("b.rv", "@derive(ToJson)\nstruct B { y: Int }\n"),
+                ("main.rv", main_src),
+            ],
+            "main.rv",
+        );
+        let user = parse_at(main_src, &entry);
+        let combined = expand_with_stdlib(&user).expect("expand");
+        let decode_count = combined
+            .items
+            .iter()
+            .filter(|d| matches!(&d.kind, DeclKind::Function(f) if f.name == "raven_derive_json_decode"))
+            .count();
+        assert_eq!(
+            decode_count, 1,
+            "the JSON decode helper must be declared exactly once across modules"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## Problem

A multi-file project that derives a JSON trait in more than one module failed to compile:

```
rvpm: error: the name `raven_derive_json_decode` is declared multiple times
  ┌─ <derive>:1:1
```

Reported on the `raven-board` sample (derives `ToJson`/`FromJson` across `dto.rv`, `views.rv`, `handlers.rv`). Fixing the reported error uncovered two more bugs in the same module-merge machinery that were masked behind it. This fixes all three so the project builds end to end.

## Root causes and fixes

1. **Duplicate JSON helpers.** The shared helper free functions the derived `from_json` bodies call (`raven_derive_json_decode`, `raven_derive_json_field`, ...) were emitted once *per `expand_derives` call*, which runs once per merged module plus once for the user. Each module that derived a JSON trait emitted another bare copy, so a second module collided. `expand_derives` now reports whether the helpers are needed and the stdlib expander emits them exactly once for the whole program.

2. **Method-call type argument not namespaced.** `req.json<NewTask>()` left `NewTask` unresolved even though it imported fine as a parameter type. The module-merge rewrite descended into `Ident` and `StructLit` generics but the `MethodCall` arm dropped its `generics` field (`{ receiver, args, .. }`). It now rewrites method-call type arguments too.

3. **Generated-source span collision.** Every generated `@derive` source was lexed under the same `<derive>` pseudo-file starting at byte zero, so two modules' line-one identifiers collided on the `(file, byte range)` use-site key (a debug-build `double binding` panic in the resolver; a silent overwrite in release). Each generated source is now lexed under a distinct label (the per-module key, the user file, `<derive-helpers>`).

Also drops a now-unreachable `_ =>` arm in the MIR sequential-match lowering (the range arm added in 2.18.67 made it dead), clearing a build warning.

## Verification

- New unit tests: helpers reported-but-not-inlined and declared once (`resolve::derive`), and an end-to-end multi-module regression (`resolve::stdlib::json_derive_helpers_emitted_once_across_modules`) that fails on the old code.
- Full lib suite: 574 passed. `cargo clippy` clean (bar one pre-existing unrelated `linker.rs` lint). `cargo fmt` clean.
- Built `rvpm` from source and compiled the real `raven-board` project: resolve, type-check, codegen, the bundled `sqlite3.c` compile, and the link all succeed, producing `raven-board.exe`.

Patch release 2.18.69.