### PR TITLE
feat: opt-in access log for std/http Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.70] - 2026-06-14
+
+### Added
+
+- `std/http` `Server` gains an opt-in access log: `Server.new().with_access_log()` writes one line per request to stdout (method, path, and status code, for example `GET /tasks 200`). Logging happens at the single point every request passes through, so it covers every route with no per-handler code.
+
 ## [2.18.69] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.69"
+version = "2.18.70"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.69"
+version = "2.18.70"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.69"
+version = "2.18.70"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -226,6 +226,28 @@ fun main() {
 
 `listen` binds the address and blocks, serving connections one at a time.
 
+### Access log
+
+`with_access_log()` turns on a one-line-per-request log to stdout, returning the
+server so it chains onto `Server.new()`. Each served request prints its method,
+path, and status code:
+
+```rust
+fun main() {
+    let app = Server.new().with_access_log()
+    app.get("/", fun(req: Request) -> Response = Response.text("ok"))
+    app.listen("127.0.0.1:8080")
+}
+```
+
+```text
+GET / 200
+GET /missing 404
+```
+
+The log is written at the single point every request passes through, so it
+covers every route without a line in each handler. It is off by default.
+
 ### Routing
 
 Register a handler per method with `get`, `post`, `put`, `delete`, or `patch`

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -310,16 +310,27 @@ struct Route {
 }
 
 // An HTTP server: a routing table built with `get`/`post`/... and served with
-// `listen`.
+// `listen`. `access_log` is off by default; enable it with `with_access_log`.
 struct Server {
     routes: List<Route>,
+    access_log: Bool,
 }
 
 impl Server {
-    // A new server with an empty routing table.
+    // A new server with an empty routing table and the access log off.
     fun new() -> Server {
         let r: List<Route> = []
-        return Server { routes: r }
+        return Server { routes: r, access_log: false }
+    }
+
+    // Enable a one-line-per-request access log to stdout (method, path, and
+    // status code, for example `GET /tasks 200`), returning self so it chains:
+    // `let app = Server.new().with_access_log()`. Logging happens at the single
+    // point every request passes through, so it covers every route without a
+    // line in each handler.
+    fun with_access_log(self) -> Server {
+        self.access_log = true
+        return self
     }
 
     // Register `handler` for `method` requests whose path matches `pattern`.
@@ -369,11 +380,12 @@ impl Server {
         match listen(addr) {
             Ok(socket) -> {
                 let routes = self.routes
+                let access_log = self.access_log
                 while true {
                     match socket.accept() {
                         Ok(stream) -> {
                             spawn(fun() -> Unit {
-                                serve_connection(routes, stream)
+                                serve_connection(routes, access_log, stream)
                             })
                         }
                         Err(_) -> {}
@@ -385,14 +397,25 @@ impl Server {
     }
 }
 
-// Read, parse, route, and answer a single connection, then close it.
-fun serve_connection(routes: List<Route>, stream: TcpStream) {
+// Read, parse, route, and answer a single connection, then close it. When
+// `access_log` is on, write one line per request to stdout after the response
+// is sent: the method, the path, and the status code.
+fun serve_connection(routes: List<Route>, access_log: Bool, stream: TcpStream) {
     match read_request(stream) {
         Ok(req) -> {
             let resp = dispatch(routes, req)
             write_response(stream, resp)
+            if access_log {
+                let method = req.method.to_string().to_upper()
+                print("${method} ${req.path} ${resp.status}")
+            }
         }
-        Err(_) -> write_response(stream, Response.bad_request("Bad Request")),
+        Err(_) -> {
+            write_response(stream, Response.bad_request("Bad Request"))
+            if access_log {
+                print("- - 400")
+            }
+        }
     }
     stream.close()
 }


### PR DESCRIPTION
Adds per-request access logging to the `std/http` server, at the framework layer so apps get it without a log line in every handler.

## API

```raven
let app = Server.new().with_access_log()
```

`with_access_log()` is a chainable opt-in (off by default). It logs one line per request to stdout, the method, path, and status code, written at `serve_connection`, the single point every request flows through:

```text
GET / 200
GET /api/tasks 200
GET /missing 404
```

## Why framework-level

Every request already funnels through `serve_connection` -> `dispatch`. Logging there covers every route automatically and can't be forgotten on a new handler. Raven's block-form closures can't return a value, so an app-side middleware wrapper would be awkward; the framework is the right home. App-level domain logging (startup, business events) is still a job for a package like `raven-log`.

## Verification

Built the compiler with the new stdlib and ran the multi-module `raven-board` sample with `.with_access_log()`: hitting `/`, `/api/tasks`, and a missing path produced exactly `GET / 200`, `GET /api/tasks 200`, `GET /nope 404`. `fmt_golden` (stdlib idempotency + AST preservation) passes.

Patch release 2.18.70.