### PR TITLE
feat: read and write timeouts for the std/http server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.71] - 2026-06-14
+
+### Added
+
+- `std/http` `Server` now applies read and write timeouts so a slow or idle client cannot hold a connection's goroutine open forever. Both default to 30 seconds and are configurable: `with_timeout(seconds)` sets both, `with_read_timeout(seconds)` and `with_write_timeout(seconds)` set one, and `0` disables a timeout.
+- `std/net` `TcpStream` gains `set_write_timeout_ms`, the write-side counterpart to `set_read_timeout_ms`.
+
 ## [2.18.70] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.70"
+version = "2.18.71"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.70"
+version = "2.18.71"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.70"
+version = "2.18.71"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -248,6 +248,26 @@ GET /missing 404
 The log is written at the single point every request passes through, so it
 covers every route without a line in each handler. It is off by default.
 
+### Timeouts
+
+A `Server` bounds how long one slow client can hold a connection, so an idle or
+trickling client cannot pin a goroutine open indefinitely. Read and write
+timeouts both default to **30 seconds** and are set in seconds:
+
+```rust
+let app = Server.new()
+    .with_timeout(15)         // both read and write -> 15s
+// or set them separately:
+let app2 = Server.new()
+    .with_read_timeout(10)    // waiting for the request
+    .with_write_timeout(30)   // sending the response
+```
+
+`0` disables a timeout (the connection may then block forever on a slow
+client). The read timeout bounds reading the request line, headers, and body;
+the write timeout bounds writing the response. When a read times out the server
+closes the connection instead of waiting.
+
 ### Routing
 
 Register a handler per method with `get`, `post`, `put`, `delete`, or `patch`

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1323,6 +1323,26 @@ pub extern "C" fn raven_net_set_read_timeout_ms(stream_id: i64, ms: i64) {
     }
 }
 
+/// Set the write timeout of the stream `stream_id` to `ms` milliseconds. A
+/// value of 0 clears the timeout (blocking writes). Errors are stored in the
+/// last-error slot.
+#[no_mangle]
+pub extern "C" fn raven_net_set_write_timeout_ms(stream_id: i64, ms: i64) {
+    let timeout = if ms <= 0 {
+        None
+    } else {
+        Some(Duration::from_millis(ms as u64))
+    };
+    let registry = net_registry().lock().unwrap();
+    match registry.get(&stream_id) {
+        Some(Socket::Stream(s)) => match s.set_write_timeout(timeout) {
+            Ok(()) => net_clear_error(),
+            Err(e) => net_set_error(e.to_string()),
+        },
+        _ => net_set_error("unknown socket id".to_string()),
+    }
+}
+
 /// Resolve `host` to its IP addresses, newline-joined. On failure stores
 /// the error and returns an empty `String`.
 ///

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -311,16 +311,22 @@ struct Route {
 
 // An HTTP server: a routing table built with `get`/`post`/... and served with
 // `listen`. `access_log` is off by default; enable it with `with_access_log`.
+// `read_timeout_ms` and `write_timeout_ms` bound how long a single slow client
+// can hold a connection (0 disables); they default to 30 seconds so an idle or
+// slow client cannot pin a goroutine forever.
 struct Server {
     routes: List<Route>,
     access_log: Bool,
+    read_timeout_ms: Int,
+    write_timeout_ms: Int,
 }
 
 impl Server {
-    // A new server with an empty routing table and the access log off.
+    // A new server with an empty routing table, the access log off, and 30
+    // second read and write timeouts.
     fun new() -> Server {
         let r: List<Route> = []
-        return Server { routes: r, access_log: false }
+        return Server { routes: r, access_log: false, read_timeout_ms: 30000, write_timeout_ms: 30000 }
     }
 
     // Enable a one-line-per-request access log to stdout (method, path, and
@@ -330,6 +336,29 @@ impl Server {
     // line in each handler.
     fun with_access_log(self) -> Server {
         self.access_log = true
+        return self
+    }
+
+    // Set the read and write timeouts to `seconds` each, returning self so it
+    // chains. `0` disables both (a request or response may then block forever
+    // on a slow client). A read timeout bounds how long the server waits for
+    // the client to send its request; a write timeout bounds sending the
+    // response. The default is 30 seconds.
+    fun with_timeout(self, seconds: Int) -> Server {
+        self.read_timeout_ms = seconds * 1000
+        self.write_timeout_ms = seconds * 1000
+        return self
+    }
+
+    // Set only the read timeout, in seconds (`0` disables it). See `with_timeout`.
+    fun with_read_timeout(self, seconds: Int) -> Server {
+        self.read_timeout_ms = seconds * 1000
+        return self
+    }
+
+    // Set only the write timeout, in seconds (`0` disables it). See `with_timeout`.
+    fun with_write_timeout(self, seconds: Int) -> Server {
+        self.write_timeout_ms = seconds * 1000
         return self
     }
 
@@ -381,11 +410,13 @@ impl Server {
             Ok(socket) -> {
                 let routes = self.routes
                 let access_log = self.access_log
+                let read_timeout = self.read_timeout_ms
+                let write_timeout = self.write_timeout_ms
                 while true {
                     match socket.accept() {
                         Ok(stream) -> {
                             spawn(fun() -> Unit {
-                                serve_connection(routes, access_log, stream)
+                                serve_connection(routes, access_log, read_timeout, write_timeout, stream)
                             })
                         }
                         Err(_) -> {}
@@ -397,10 +428,19 @@ impl Server {
     }
 }
 
-// Read, parse, route, and answer a single connection, then close it. When
-// `access_log` is on, write one line per request to stdout after the response
-// is sent: the method, the path, and the status code.
-fun serve_connection(routes: List<Route>, access_log: Bool, stream: TcpStream) {
+// Read, parse, route, and answer a single connection, then close it. The read
+// and write timeouts (milliseconds, 0 to disable) are applied to the stream
+// first, so a slow client cannot hold the goroutine open indefinitely while
+// the request is read or the response is written. When `access_log` is on,
+// write one line per request to stdout after the response is sent: the method,
+// the path, and the status code.
+fun serve_connection(routes: List<Route>, access_log: Bool, read_timeout_ms: Int, write_timeout_ms: Int, stream: TcpStream) {
+    if read_timeout_ms > 0 {
+        stream.set_read_timeout_ms(read_timeout_ms)
+    }
+    if write_timeout_ms > 0 {
+        stream.set_write_timeout_ms(write_timeout_ms)
+    }
     match read_request(stream) {
         Ok(req) -> {
             let resp = dispatch(routes, req)

--- a/stdlib/std/net.rv
+++ b/stdlib/std/net.rv
@@ -26,6 +26,7 @@ extern "C" {
     fun raven_net_write(stream_id: Int, data: String) -> Int
     fun raven_net_close(stream_id: Int)
     fun raven_net_set_read_timeout_ms(stream_id: Int, ms: Int)
+    fun raven_net_set_write_timeout_ms(stream_id: Int, ms: Int)
     fun raven_dns_lookup(host: String) -> String
     fun raven_net_reachable(addr: String) -> Bool
 }
@@ -112,6 +113,11 @@ impl TcpStream {
     // Set the read timeout in milliseconds. A value of 0 means no timeout.
     fun set_read_timeout_ms(self, ms: Int) {
         raven_net_set_read_timeout_ms(self.id, ms)
+    }
+
+    // Set the write timeout in milliseconds. A value of 0 means no timeout.
+    fun set_write_timeout_ms(self, ms: Int) {
+        raven_net_set_write_timeout_ms(self.id, ms)
     }
 
     // Close the stream, releasing the runtime-side socket.


### PR DESCRIPTION
First step in making the plain-HTTP server robust. The server read the request line, headers, and body with no time bound, so a client that connected and then stalled (or trickled bytes a la slowloris) pinned a goroutine forever. This adds connection timeouts.

## API

`Server` now has read and write timeouts, applied to each accepted connection before any I/O. Both default to **30 seconds**:

```raven
let app = Server.new().with_timeout(15)          // both -> 15s
let app2 = Server.new()
    .with_read_timeout(10)                        // waiting for the request
    .with_write_timeout(30)                       // sending the response
```

`0` disables a timeout. The read timeout bounds reading the request; the write timeout bounds writing the response. On a read timeout the server drops the connection instead of waiting.

## Plumbing

- New runtime primitive `raven_net_set_write_timeout_ms` (mirrors the existing read one, `s.set_write_timeout`).
- `std/net` `TcpStream` gains `set_write_timeout_ms`.
- `Server` stores `read_timeout_ms`/`write_timeout_ms`, threads them through `listen` into `serve_connection`, which sets them on the stream before reading.

The header (64 KiB) and body (10 MiB) size caps already existed; timeouts were the remaining hole.

## Verification

Built compiler + runtime and ran a scratch server with `with_timeout(2)`:
- A complete request returns `HTTP/1.1 200 OK` / `ok` (control).
- A client that sends a partial request and stalls is released after **1.99s** (a 400 then close) instead of hanging forever.

`cargo fmt`, `cargo clippy -p raven-runtime`, and `fmt_golden` (stdlib idempotency) all clean.

Patch release 2.18.71. Next robustness steps on the roadmap: graceful shutdown, then keep-alive.