### PR TITLE
feat: keep-alive and graceful shutdown for the std/http server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.72] - 2026-06-14
+
+### Added
+
+- `std/http` `Server` now keeps connections alive: an HTTP/1.1 connection is reused for subsequent requests instead of being closed after one, unless the client sends `Connection: close` (HTTP/1.0 stays close-by-default unless it sends `Connection: keep-alive`). Each response carries the matching `Connection` header. The read timeout bounds an idle kept-alive connection. (HTTP pipelining is not supported; clients send requests sequentially.)
+- `std/http` `Server.shutdown()` performs a graceful shutdown: it stops accepting new connections, lets in-flight requests finish, and then `listen` returns. Call it from another goroutine or a handler, since `listen` blocks. Useful for clean teardown in tests and controlled stops.
+
 ## [2.18.71] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.71"
+version = "2.18.72"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.71"
+version = "2.18.72"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.71"
+version = "2.18.72"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -268,6 +268,47 @@ client). The read timeout bounds reading the request line, headers, and body;
 the write timeout bounds writing the response. When a read times out the server
 closes the connection instead of waiting.
 
+### Keep-alive
+
+Connections are kept alive by default: an HTTP/1.1 client can send several
+requests over one connection instead of reconnecting each time, which is faster
+and is what browsers and HTTP libraries expect. The server reuses the
+connection unless the client sends `Connection: close` (an HTTP/1.0 client must
+opt in with `Connection: keep-alive`). Each response carries the matching
+`Connection` header, and an idle kept-alive connection is closed once the read
+timeout elapses. HTTP pipelining is not supported, send one request and read
+its response before sending the next.
+
+### Graceful shutdown
+
+`shutdown()` stops the server cleanly: it stops accepting new connections, lets
+the requests already in flight finish, and then `listen` returns. Because
+`listen` blocks, call `shutdown` from another goroutine:
+
+```rust
+import std/http { Server, Request, Response }
+import std/sync { sleep_millis }
+
+fun main() {
+    let app = Server.new()
+    app.get("/", fun(req: Request) -> Response = Response.text("ok"))
+    // Stop cleanly from another goroutine (here after a delay; in a real
+    // program on some condition):
+    spawn(fun() -> Unit {
+        sleep_millis(5000)
+        app.shutdown()
+    })
+    app.listen("127.0.0.1:8080")       // returns once in-flight requests drain
+    print("stopped")
+}
+```
+
+`shutdown` is safe to call more than once. It is the clean way to stop a server
+in a test (start it in a goroutine, exercise it, then shut it down) or to wire
+up a controlled stop. To trigger it from inside a request handler, have the
+handler call a named function that calls `app.shutdown()`, since a handler
+closure is a single expression.
+
 ### Routing
 
 Register a handler per method with `get`, `post`, `put`, `delete`, or `patch`

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -9,11 +9,12 @@
 // kind "http". See docs/v2/specs/std-http.md.
 
 import std/error { error_kind }
-import std/net { listen, TcpStream }
+import std/net { listen, connect, TcpStream }
 import std/string
 import std/collections
 import std/json { JsonValue, ToJson, FromJson, stringify, parse, decode }
 import std/fs { read }
+import std/sync { mutex, wait_group, Mutex }
 
 struct HttpResponse {
     status_code: Int,
@@ -313,12 +314,16 @@ struct Route {
 // `listen`. `access_log` is off by default; enable it with `with_access_log`.
 // `read_timeout_ms` and `write_timeout_ms` bound how long a single slow client
 // can hold a connection (0 disables); they default to 30 seconds so an idle or
-// slow client cannot pin a goroutine forever.
+// slow client cannot pin a goroutine forever. `lock`/`stopping`/`addr` back
+// graceful shutdown.
 struct Server {
     routes: List<Route>,
     access_log: Bool,
     read_timeout_ms: Int,
     write_timeout_ms: Int,
+    lock: Mutex,
+    stopping: Bool,
+    addr: String,
 }
 
 impl Server {
@@ -326,7 +331,41 @@ impl Server {
     // second read and write timeouts.
     fun new() -> Server {
         let r: List<Route> = []
-        return Server { routes: r, access_log: false, read_timeout_ms: 30000, write_timeout_ms: 30000 }
+        return Server {
+            routes: r,
+            access_log: false,
+            read_timeout_ms: 30000,
+            write_timeout_ms: 30000,
+            lock: mutex(),
+            stopping: false,
+            addr: "",
+        }
+    }
+
+    // Request a graceful shutdown: stop accepting new connections, let the
+    // requests already in flight finish, then `listen` returns. Call it from
+    // another goroutine or from a handler, since `listen` blocks. Safe to call
+    // more than once.
+    fun shutdown(self) {
+        self.lock.lock()
+        self.stopping = true
+        self.lock.unlock()
+        // The runtime's `accept` blocks on a cloned listener handle and cannot
+        // be cancelled, so nudge it with a throwaway local connection: the
+        // accept loop then sees the stopping flag and drops it without serving.
+        match connect(wakeup_addr(self.addr)) {
+            Ok(s) -> s.close(),
+            Err(_) -> {},
+        }
+    }
+
+    // Whether a graceful shutdown has been requested. Read under the lock so the
+    // accept loop and the goroutine calling `shutdown` agree.
+    fun is_stopping(self) -> Bool {
+        self.lock.lock()
+        let s = self.stopping
+        self.lock.unlock()
+        return s
     }
 
     // Enable a one-line-per-request access log to stdout (method, path, and
@@ -402,62 +441,119 @@ impl Server {
         self.route(Method.Get, prefix.concat("/:file"), fun(req: Request) -> Response = serve_from(dir, req))
     }
 
-    // Bind `addr` ("host:port") and serve forever, handling each connection on
-    // its own goroutine so a slow client never blocks the others. Blocks until
-    // the process ends; a failed bind is reported and returns.
+    // Bind `addr` ("host:port") and serve, handling each connection on its own
+    // goroutine so a slow client never blocks the others. Blocks until
+    // `shutdown` is called, after which it stops accepting, waits for in-flight
+    // requests to finish, and returns. A failed bind is reported and returns.
     fun listen(self, addr: String) {
+        self.addr = addr
         match listen(addr) {
             Ok(socket) -> {
-                let routes = self.routes
-                let access_log = self.access_log
-                let read_timeout = self.read_timeout_ms
-                let write_timeout = self.write_timeout_ms
-                while true {
+                // Track in-flight connection goroutines so a graceful shutdown
+                // can wait for them to drain before returning.
+                let inflight = wait_group()
+                while !self.is_stopping() {
                     match socket.accept() {
                         Ok(stream) -> {
-                            spawn(fun() -> Unit {
-                                serve_connection(routes, access_log, read_timeout, write_timeout, stream)
-                            })
+                            // A connection accepted after shutdown began (a real
+                            // late arrival or the wakeup nudge) is dropped, not
+                            // served: only already-accepted requests drain.
+                            if self.is_stopping() {
+                                stream.close()
+                            } else {
+                                inflight.add(1)
+                                spawn(fun() -> Unit {
+                                    serve_connection(self, stream)
+                                    inflight.done()
+                                })
+                            }
                         }
                         Err(_) -> {}
                     }
                 }
+                inflight.wait()
             }
             Err(e) -> print("http: cannot bind ".concat(addr).concat(": ").concat(e.message()))
         }
     }
 }
 
-// Read, parse, route, and answer a single connection, then close it. The read
-// and write timeouts (milliseconds, 0 to disable) are applied to the stream
-// first, so a slow client cannot hold the goroutine open indefinitely while
-// the request is read or the response is written. When `access_log` is on,
-// write one line per request to stdout after the response is sent: the method,
-// the path, and the status code.
-fun serve_connection(routes: List<Route>, access_log: Bool, read_timeout_ms: Int, write_timeout_ms: Int, stream: TcpStream) {
-    if read_timeout_ms > 0 {
-        stream.set_read_timeout_ms(read_timeout_ms)
+// Serve one connection: read a request, route it, write the response, and
+// repeat on the same connection while keep-alive is in effect, then close it.
+// The read and write timeouts are applied to the stream first, so a slow client
+// cannot hold the goroutine open indefinitely. The connection is kept alive
+// for the next request unless the client asked to close it, the server is
+// shutting down, or the request could not be read. When the access log is on,
+// each served request prints its method, path, and status.
+fun serve_connection(server: Server, stream: TcpStream) {
+    if server.read_timeout_ms > 0 {
+        stream.set_read_timeout_ms(server.read_timeout_ms)
     }
-    if write_timeout_ms > 0 {
-        stream.set_write_timeout_ms(write_timeout_ms)
+    if server.write_timeout_ms > 0 {
+        stream.set_write_timeout_ms(server.write_timeout_ms)
     }
-    match read_request(stream) {
-        Ok(req) -> {
-            let resp = dispatch(routes, req)
-            write_response(stream, resp)
-            if access_log {
-                let method = req.method.to_string().to_upper()
-                print("${method} ${req.path} ${resp.status}")
+    let open = true
+    let served = 0
+    while open {
+        match read_request(stream) {
+            Ok(req) -> {
+                let resp = dispatch(server.routes, req)
+                let keep = should_keep_alive(req)
+                if server.is_stopping() {
+                    keep = false
+                }
+                write_response(stream, resp, keep)
+                if server.access_log {
+                    let method = req.method.to_string().to_upper()
+                    print("${method} ${req.path} ${resp.status}")
+                }
+                served += 1
+                if !keep {
+                    open = false
+                }
             }
-        }
-        Err(_) -> {
-            write_response(stream, Response.bad_request("Bad Request"))
-            if access_log {
-                print("- - 400")
+            Err(_) -> {
+                // A failed first read is a malformed request, answered with 400.
+                // A failed read after one or more served requests is just an
+                // idle or closed keep-alive connection, closed silently.
+                if served == 0 {
+                    write_response(stream, Response.bad_request("Bad Request"), false)
+                    if server.access_log {
+                        print("- - 400")
+                    }
+                }
+                open = false
             }
         }
     }
     stream.close()
+}
+
+// Whether to keep the connection open for another request. HTTP/1.1 keeps it
+// open unless the client sent `Connection: close`; HTTP/1.0 closes it unless
+// the client sent `Connection: keep-alive`.
+fun should_keep_alive(req: Request) -> Bool {
+    let conn = req.header("connection").to_lower()
+    if req.version == "HTTP/1.0" {
+        return conn == "keep-alive"
+    }
+    return conn != "close"
+}
+
+// A connectable address for the shutdown wakeup. A server bound to the
+// wildcard `0.0.0.0` (or an empty host) is not reachable by that address, but
+// its port is reachable on loopback; a concrete bound host is reachable as is.
+fun wakeup_addr(addr: String) -> String {
+    let colon = addr.index_of(":")
+    if colon < 0 {
+        return addr
+    }
+    let host = addr.substring(0, colon)
+    let port = addr.substring(colon, addr.length())
+    if host == "0.0.0.0" || host == "" {
+        return "127.0.0.1".concat(port)
+    }
+    return addr
 }
 
 // Find the first route matching `req` and run its handler; 404 if none match.
@@ -631,9 +727,13 @@ fun parse_query(qs: String, out: Map<String, String>) {
 
 // Write `resp` to `stream` as an HTTP/1.1 response, framing it with
 // Content-Length and closing the connection after.
-fun write_response(stream: TcpStream, resp: Response) {
+fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool) {
     resp.headers.set("Content-Length", resp.body.length().to_string())
-    resp.headers.set("Connection", "close")
+    if keep_alive {
+        resp.headers.set("Connection", "keep-alive")
+    } else {
+        resp.headers.set("Connection", "close")
+    }
     let status_line = "HTTP/1.1 ".concat(resp.status.to_string()).concat(" ")
     let line = status_line.concat(reason_phrase(resp.status)).concat("\r\n")
     let block = ""


### PR DESCRIPTION
The next two robustness/throughput steps for the server, both pure stdlib (no runtime changes).

## Keep-alive

`serve_connection` now loops on a single connection, reading the next request instead of closing after one. An HTTP/1.1 connection is reused unless the client sends `Connection: close`; HTTP/1.0 stays close-by-default unless it sends `Connection: keep-alive`. Each response carries the matching `Connection` header, and the existing read timeout bounds an idle kept-alive connection. (Sequential requests only; HTTP pipelining is not supported, which matches what browsers and HTTP libraries do.)

## Graceful shutdown

`Server.shutdown()` requests a clean stop: it sets a mutex-guarded `stopping` flag and returns. `listen` stops accepting, waits for in-flight connection goroutines to drain via a `WaitGroup`, then returns. Call it from another goroutine since `listen` blocks.

The tricky part: the runtime's `raven_net_accept` blocks on a **cloned** listener handle outside the registry lock, so closing the listener does not unblock a parked `accept`. The portable fix is a self-connect wakeup, `shutdown` makes a throwaway loopback connection to nudge `accept` once, and the loop drops it on seeing the flag. An early shutdown (before `accept` parks) is caught by the `while !is_stopping()` loop condition, so it returns without relying on the nudge.

## Verification

Built the compiler and ran scratch servers:
- **Keep-alive:** two sequential requests over one TCP connection both returned `200 OK` / `ok`, with `Connection: keep-alive` on the first.
- **Graceful shutdown:** a server that self-shuts-down after 500ms unblocked, drained, printed `drained and stopped`, and exited cleanly (instead of hanging).

`fmt_golden` (stdlib idempotency) and `cargo fmt` clean.

Patch release 2.18.72.

Robustness roadmap status: timeouts (2.18.71), keep-alive + graceful shutdown (this), done. Remaining: handler panic recovery (needs a language-level recover mechanism) and optional in-app TLS (lower priority behind a reverse proxy).