### PR TITLE
fix: reject malformed programs the frontend crashed or miscompiled on (#545-#551)

### DIFF
--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -21,6 +21,19 @@ use crate::span::Span;
 use super::bindings::{Binding, DeclId, ResolutionMap};
 use super::scope::{ScopeKind, ScopeStack};
 
+/// Insert a parameter binding, rejecting a name that already appears in the
+/// same parameter list (which would otherwise silently shadow the earlier one,
+/// so reads selected the last). A repeated `_` is allowed: it never binds a
+/// usable name.
+fn insert_param(scope: &mut ScopeStack, name: &str, span: Span) -> Result<(), RavenError> {
+    if name == "_" {
+        scope.insert_shadowing(name, Binding::Param(span.clone()), span);
+        Ok(())
+    } else {
+        scope.insert(name, Binding::Param(span.clone()), span)
+    }
+}
+
 /// Walk every body in `file`, recording bindings in `map`.
 pub fn walk_file(
     file: &File,
@@ -44,7 +57,7 @@ fn walk_decl(
             scope.push(ScopeKind::Function);
             push_generics(scope, &f.generics, &decl.span)?;
             for p in &f.params {
-                scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+                insert_param(scope, &p.name, p.span.clone())?;
                 walk_type(&p.ty, scope, map)?;
             }
             if let Some(r) = &f.ret {
@@ -124,7 +137,7 @@ fn walk_trait(
             if p.name == "self" {
                 scope.insert_shadowing("self", Binding::SelfValue, p.span.clone());
             } else {
-                scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+                insert_param(scope, &p.name, p.span.clone())?;
                 walk_type(&p.ty, scope, map)?;
             }
         }
@@ -184,7 +197,7 @@ fn walk_impl(
             if p.name == "self" {
                 scope.insert_shadowing("self", Binding::SelfValue, p.span.clone());
             } else {
-                scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+                insert_param(scope, &p.name, p.span.clone())?;
                 walk_type(&p.ty, scope, map)?;
             }
         }
@@ -510,7 +523,7 @@ fn walk_expr(
         } => {
             scope.push(ScopeKind::Function);
             for p in params {
-                scope.insert_shadowing(&p.name, Binding::Param(p.span.clone()), p.span.clone());
+                insert_param(scope, &p.name, p.span.clone())?;
                 if let Some(t) = &p.ty {
                     walk_type(t, scope, map)?;
                 }

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -480,6 +480,12 @@ fn fill_enum(
                 VariantPayloadSig::Struct(out)
             }
         };
+        if variants.iter().any(|x: &VariantSig| x.name == v.name) {
+            return Err(RavenError::ty(
+                TypeError::Custom(format!("duplicate enum variant `{}`", v.name)),
+                v.span.clone(),
+            ));
+        }
         variants.push(VariantSig {
             name: v.name.clone(),
             payload,
@@ -522,6 +528,12 @@ fn fill_trait(
         push_generics_into_scope(&mut scope, &m_generics);
         let sig = collect_fn_sig(member, resolved, env, Some(&trait_self), &scope, m_generics)?;
         scope.pop();
+        if methods.contains_key(&member.name) {
+            return Err(RavenError::ty(
+                TypeError::Custom(format!("duplicate method `{}` in this trait", member.name)),
+                member.span.clone(),
+            ));
+        }
         method_order.push(member.name.clone());
         methods.insert(member.name.clone(), sig);
     }
@@ -610,6 +622,14 @@ fn fill_impl(i: &Impl, resolved: &ResolvedFile<'_>, env: &mut TypeEnv) -> Result
         push_generics_into_scope(&mut scope, &m_generics);
         let sig = collect_fn_sig(f, resolved, env, Some(&self_ty), &scope, m_generics)?;
         scope.pop();
+        // Two methods of the same name in one impl mangle to the same symbol
+        // and collide at the linker; reject the duplicate here instead.
+        if methods.contains_key(&f.name) {
+            return Err(RavenError::ty(
+                TypeError::Custom(format!("duplicate method `{}` in this impl block", f.name)),
+                f.span.clone(),
+            ));
+        }
         methods.insert(f.name.clone(), sig);
     }
     env.impls.push(ImplSig {

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -307,6 +307,12 @@ struct Checker<'a, 'b> {
     /// the whole shared map, so a later body never tries to resolve an earlier
     /// body's variable against its own (foreign) inference context.
     recorded: Vec<UseKey>,
+    /// Stack of enclosing loops, one entry per `loop`/`while`/`for` currently
+    /// being checked; `true` for a value-producing `loop`, `false` for
+    /// `while`/`for`. Empty means `break`/`continue` here is outside any loop.
+    /// Reset to empty when checking a lambda body, since a loop does not extend
+    /// across a nested function.
+    loop_kinds: Vec<bool>,
 }
 
 /// Keys used by the locals map. Mirrors the resolver's `Binding`
@@ -371,6 +377,7 @@ impl<'a, 'b> Checker<'a, 'b> {
             errors: Vec::new(),
             const_locals: std::collections::HashSet::new(),
             recorded: Vec::new(),
+            loop_kinds: Vec::new(),
         }
     }
 
@@ -838,11 +845,35 @@ impl<'a, 'b> Checker<'a, 'b> {
                 self.unify_recover(&ret, &actual, &stmt.span);
             }
             StmtKind::Break(e) => {
+                match self.loop_kinds.last() {
+                    None => self.errors.push(RavenError::ty(
+                        TypeError::Custom("`break` is only valid inside a loop".to_string()),
+                        stmt.span.clone(),
+                    )),
+                    // A value carried by `break` is only meaningful in a `loop`,
+                    // which yields it; a `while`/`for` produces no value, so the
+                    // operand would be silently dropped by lowering.
+                    Some(false) if e.is_some() => self.errors.push(RavenError::ty(
+                        TypeError::Custom(
+                            "`break` with a value is only valid inside a `loop`, not a `while` or `for`"
+                                .to_string(),
+                        ),
+                        stmt.span.clone(),
+                    )),
+                    _ => {}
+                }
                 if let Some(expr) = e {
                     self.check_expr_recover(expr);
                 }
             }
-            StmtKind::Continue => {}
+            StmtKind::Continue => {
+                if self.loop_kinds.is_empty() {
+                    self.errors.push(RavenError::ty(
+                        TypeError::Custom("`continue` is only valid inside a loop".to_string()),
+                        stmt.span.clone(),
+                    ));
+                }
+            }
             StmtKind::Defer(e) => {
                 self.check_expr_recover(e);
             }
@@ -1031,13 +1062,19 @@ impl<'a, 'b> Checker<'a, 'b> {
             } => self.check_if(cond, then_branch, else_branch.as_deref(), &expr.span),
             ExprKind::Match { scrutinee, arms } => self.check_match(scrutinee, arms, &expr.span),
             ExprKind::Loop(b) => {
-                self.check_block(b)?;
+                self.loop_kinds.push(true);
+                let r = self.check_block(b);
+                self.loop_kinds.pop();
+                r?;
                 Ok(Ty::Unit)
             }
             ExprKind::While { cond, body } => {
                 let c = self.check_expr(cond)?;
                 self.unify(&Ty::Bool, &c, &cond.span)?;
-                self.check_block(body)?;
+                self.loop_kinds.push(false);
+                let r = self.check_block(body);
+                self.loop_kinds.pop();
+                r?;
                 Ok(Ty::Unit)
             }
             ExprKind::For {
@@ -1090,7 +1127,10 @@ impl<'a, 'b> Checker<'a, 'b> {
                 // method resolution (used by the iterator-driven path).
                 self.record(&pat.span, elem.clone());
                 pattern::bind(pat, &elem, self.env, &mut self.locals)?;
-                self.check_block(body)?;
+                self.loop_kinds.push(false);
+                let r = self.check_block(body);
+                self.loop_kinds.pop();
+                r?;
                 Ok(Ty::Unit)
             }
             ExprKind::Lambda {
@@ -3110,10 +3150,16 @@ impl<'a, 'b> Checker<'a, 'b> {
             Some(t) => Some(self.resolve_ast_ty(t)?),
             None => None,
         };
+        // A lambda is its own function: an enclosing loop does not extend into
+        // it, so `break`/`continue` in the body are outside any loop. Check the
+        // body with a fresh loop stack, then restore the caller's.
+        let saved_loops = std::mem::take(&mut self.loop_kinds);
         let body_ty = match body {
-            LambdaBody::Block(b) => self.check_block(b)?,
-            LambdaBody::Expr(e) => self.check_expr(e)?,
+            LambdaBody::Block(b) => self.check_block(b),
+            LambdaBody::Expr(e) => self.check_expr(e),
         };
+        self.loop_kinds = saved_loops;
+        let body_ty = body_ty?;
         let final_ret = match declared_ret {
             Some(d) => {
                 self.unify(

--- a/src/tycheck/pattern.rs
+++ b/src/tycheck/pattern.rs
@@ -134,9 +134,27 @@ pub fn bind(
                     )),
                 }
             }
+            // Suppress a cascade: a constructor pattern over an already-failed
+            // scrutinee binds its parts to Error without a second diagnostic.
+            (Some(_), Ty::Error) => {
+                for sub_pat in elements {
+                    bind(sub_pat, &Ty::Error, env, locals)?;
+                }
+                Ok(())
+            }
+            // A named constructor pattern (`Nope(x)`) over a non-enum value (an
+            // `Int`, a `List`, ...) is a type error, not a silent Error binding
+            // that would otherwise reach codegen and crash Cranelift.
+            (Some(ctor), other) => Err(RavenError::ty(
+                TypeError::Custom(format!(
+                    "`{}` is not a constructor of `{}`; a constructor pattern needs an enum, Option, or Result value",
+                    ctor, other
+                )),
+                pat.span.clone(),
+            )),
             _ => {
-                // Unhandled tuple pattern; bind sub patterns as Error
-                // to suppress cascading errors.
+                // A nameless tuple pattern; bind sub patterns as Error to
+                // suppress cascading errors.
                 for sub_pat in elements {
                     bind(sub_pat, &Ty::Error, env, locals)?;
                 }
@@ -177,7 +195,25 @@ pub fn bind(
                     return Ok(());
                 }
             }
-            // Struct enum variant pattern handling, or fallthrough.
+            // A struct pattern whose scrutinee is an enum is a named-field
+            // variant match (`Point { x, y }`). Struct-variants are only
+            // partially implemented (construction is rejected too), and the MIR
+            // path crashes Cranelift on this pattern, so reject it up front with
+            // a diagnostic instead of binding fields to Error and reaching
+            // codegen. (Matching by position with `Point(x, y)` works.)
+            if let Ty::Enum { id, .. } = scrut_ty.strip_self() {
+                if env.enums.contains_key(id) {
+                    return Err(RavenError::ty(
+                        TypeError::Custom(format!(
+                            "matching the named-field variant `{}` with `{{ ... }}` is not yet supported; match it positionally as `{}(...)`",
+                            name, name
+                        )),
+                        pat.span.clone(),
+                    ));
+                }
+            }
+            // Fallthrough (for example an already-failed scrutinee): bind to
+            // Error to suppress a cascade.
             for fpat in fields {
                 if let Some(p) = &fpat.pattern {
                     bind(p, &Ty::Error, env, locals)?;

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -712,6 +712,80 @@ fn try_on_option_in_non_option_fn_is_error() {
 }
 
 #[test]
+fn break_and_continue_outside_a_loop_are_rejected() {
+    assert!(check("fun f() { break }\n").is_err(), "break outside a loop");
+    assert!(
+        check("fun f() { continue }\n").is_err(),
+        "continue outside a loop"
+    );
+    // A loop does not extend into a nested lambda: a break inside the lambda is
+    // outside any loop.
+    assert!(
+        check("fun f() { loop { let g = fun() -> Unit { break } } }\n").is_err(),
+        "break inside a lambda body is outside the enclosing loop"
+    );
+}
+
+#[test]
+fn break_and_continue_inside_a_loop_are_ok() {
+    check("fun f() { loop { break } }\n").expect("break in a loop");
+    check("fun f() {\n    let i = 0\n    while i < 3 {\n        i = i + 1\n        continue\n    }\n}\n")
+        .expect("continue in a while");
+}
+
+#[test]
+fn break_with_a_value_outside_a_value_loop_is_rejected() {
+    assert!(
+        check("fun f() { while true { break 5 } }\n").is_err(),
+        "break with a value is only valid in a `loop`"
+    );
+}
+
+#[test]
+fn duplicate_enum_variant_is_rejected() {
+    assert!(check("enum E { A, A }\nfun main() {}\n").is_err());
+}
+
+#[test]
+fn duplicate_method_in_impl_is_rejected() {
+    assert!(
+        check("struct S {}\nimpl S {\n    fun m(self) -> Int = 1\n    fun m(self) -> Int = 2\n}\nfun main() {}\n")
+            .is_err()
+    );
+}
+
+#[test]
+fn duplicate_parameter_name_is_rejected() {
+    assert!(check("fun f(x: Int, x: Int) -> Int = x\nfun main() {}\n").is_err());
+}
+
+#[test]
+fn constructor_pattern_on_a_non_enum_is_rejected() {
+    let err = check("fun f(n: Int) -> Int {\n    return match n {\n        Nope(x) -> x,\n        _ -> 0,\n    }\n}\nfun main() {}\n")
+        .unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => match *b {
+            TypeError::Custom(m) => assert!(m.contains("not a constructor"), "got: {}", m),
+            other => panic!("expected Custom, got {:?}", other),
+        },
+        other => panic!("expected TypeError, got {:?}", other),
+    }
+}
+
+#[test]
+fn struct_variant_pattern_is_rejected_not_crashed() {
+    // A named-field variant matched with `{ ... }` is rejected with a
+    // diagnostic instead of reaching codegen and crashing Cranelift (#545).
+    let err = check("enum E {\n    P(x: Int, y: Int),\n    Z,\n}\nfun f(e: E) -> Int {\n    return match e {\n        P { x, y } -> x + y,\n        Z -> 0,\n    }\n}\nfun main() {}\n")
+        .unwrap_err();
+    assert!(
+        matches!(err, RavenError::Type(_, _, _)),
+        "expected a type error, got {:?}",
+        err
+    );
+}
+
+#[test]
 fn ty_display_does_not_panic() {
     // Sanity check that exotic Ty values render.
     let t = Ty::List(Box::new(Ty::Option(Box::new(Ty::Int))));


### PR DESCRIPTION
Fixes codex-review issues #545, #546, #547, #548, #549, #550, #551.

Programs the type checker accepted and then panicked the compiler / crashed Cranelift on, or silently miscompiled, now get clean frontend diagnostics:

- **#547 / #551** `break`/`continue` outside a loop (was a MIR-lowering panic); `break <value>` outside a value-producing `loop` (the value was dropped). The checker now tracks a loop stack, reset across lambda bodies.
- **#545** named-field variant match `P { x, y }` is rejected with a diagnostic (the feature is unimplemented end to end, construction is rejected too) rather than binding fields to the error type and crashing Cranelift.
- **#546** constructor pattern on a non-enum (`Nope(x)` on `Int`) is a type error, not an Error binding that reached codegen.
- **#548** duplicate enum variant names rejected.
- **#550** duplicate method names in one impl/trait rejected (collided as duplicate linker symbols).
- **#549** duplicate parameter name in a function/method/lambda rejected (silently shadowed before); repeated `_` still allowed.

Tycheck unit tests added for each. Verified locally: 574 lib tests, all tycheck tests, and the full golden example suite pass.

CI is temporarily disabled for this issue-fix batch (per request, to cut runs); verified locally with MSVC.

Fixes #545
Fixes #546
Fixes #547
Fixes #548
Fixes #549
Fixes #550
Fixes #551