### PR TITLE
fix: stdlib numeric/format/JSON robustness (#427, #554, #555, #557-#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.94] - 2026-06-15
+
+A batch of fixes from a full-codebase review (codex). The version is bumped one
+patch per issue fixed across this and the two preceding batches.
+
+### Fixed
+
+- Frontend diagnostics instead of compiler panics / Cranelift crashes / silent miscompiles: `break`/`continue` outside a loop (#547), `break` with a value outside a `loop` (#551), a named-field variant matched with `{ ... }` (#545), a constructor pattern on a non-enum value (#546), duplicate enum variants (#548), duplicate impl/trait methods (#550), and duplicate parameter names (#549).
+- `std/fmt`: `format_float` no longer hangs on infinity or formats NaN as zero (#555); `pad_int` renders `Int::MIN` without a doubled minus sign (#554).
+- `String.parse_float` caps its exponent so `"1e999999999"` no longer spins billions of iterations (#427).
+- `std/random` `gen_range` covers a full-width range instead of returning only `lo` when the span overflows (#557).
+- `std/json` rejects invalid input it used to accept: a leading zero in a number, a raw control byte in a string, and an unpaired/invalid `\u` surrogate (#558); and `stringify` no longer emits raw non-UTF-8 bytes, replacing an invalid byte with the U+FFFD escape (#559).
+- `std/test` `assert_eq_float` no longer treats a NaN operand as equal (#560).
+- Docs, website, and the VS Code extension: build the saved buffer (#582), broader macro/interpolation grammar (#583), v2-accurate extension docs (#584), `rvpm new` for the create-a-directory flow (#585), copy button excludes its own icon (#586), no macOS package claims (#587), no nonexistent `raven run` subcommand (#589), and `mkdocs build --strict` passes (#590).
+
+
 ## [2.18.72] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.72"
+version = "2.18.94"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.72"
+version = "2.18.94"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.72"
+version = "2.18.94"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/stdlib_robustness.rv
+++ b/examples/v2/stdlib_robustness.rv
@@ -1,0 +1,30 @@
+// Regressions for codex-review stdlib robustness fixes: non-finite float
+// formatting (#555), a capped parse_float exponent (#427), and JSON validation
+// of leading zeros and raw control bytes (#558). Prints:
+//   inf
+//   NaN
+//   ok-bigexp
+//   reject-leadingzero
+//   reject-control
+import std/fmt { format_float }
+import std/json { parse }
+import std/string
+import std/io { println }
+
+fun main() {
+    let zero = 0.0
+    println(format_float(1.0 / zero, 2))
+    println(format_float(zero / zero, 2))
+    match "1e999999999".parse_float() {
+        Some(v) -> println("ok-bigexp"),
+        None -> println("rejected-bigexp"),
+    }
+    match parse("01") {
+        Ok(v) -> println("BAD-leadingzero"),
+        Err(e) -> println("reject-leadingzero"),
+    }
+    match parse("\"a\tb\"") {
+        Ok(v) -> println("BAD-control"),
+        Err(e) -> println("reject-control"),
+    }
+}

--- a/examples/v2/stdlib_robustness.rv.out
+++ b/examples/v2/stdlib_robustness.rv.out
@@ -1,0 +1,5 @@
+inf
+NaN
+ok-bigexp
+reject-leadingzero
+reject-control

--- a/stdlib/std/fmt.rv
+++ b/stdlib/std/fmt.rv
@@ -225,6 +225,19 @@ fun float_digit_char(d: Float) -> String {
 // half up. `format_float(3.14159, 2)` is "3.14"; `format_float(-2.5, 0)` is
 // "-3".
 fun format_float(x: Float, decimals: Int) -> String {
+    // Non-finite values have no decimal form: NaN compares false everywhere
+    // (so the scaling loop would never run and pad to "0.00") and infinity
+    // never falls below 1.0 (so the digit loop would spin forever). `x != x`
+    // is true only for NaN; `x * 0.0` is NaN for an infinity and 0 otherwise.
+    if x != x {
+        return "NaN"
+    }
+    if x * 0.0 != 0.0 {
+        if x < 0.0 {
+            return "-inf"
+        }
+        return "inf"
+    }
     let neg = x < 0.0
     let v = fabs(x)
     let scale = 1.0
@@ -272,7 +285,11 @@ fun format_float(x: Float, decimals: Int) -> String {
 // digits, so pad_int(-7, 4) is "-007".
 fun pad_int(n: Int, width: Int) -> String {
     if n < 0 {
-        let digits = (0 - n).to_string()
+        // Render through `to_string` and strip the leading '-' rather than
+        // negating, which overflows (and stays negative) at Int::MIN, producing
+        // a doubled minus sign.
+        let s = n.to_string()
+        let digits = s.substring(1, s.length())
         return __str_concat("-", pad_left(digits, width - 1, "0"))
     }
     return pad_left(n.to_string(), width, "0")

--- a/stdlib/std/json.rv
+++ b/stdlib/std/json.rv
@@ -192,16 +192,16 @@ fun parse_string(c: Cursor) -> Result<String, Error> {
                                 let astral = 65536 + ((cp - 55296) << 10) + (low - 56320)
                                 out = encode_utf8(out, astral)
                             } else {
-                                out = encode_utf8(out, 65533)
+                                return Err(json_error("invalid low surrogate in \\u escape"))
                             }
                         } else {
-                            out = encode_utf8(out, 65533)
+                            return Err(json_error("unpaired high surrogate in \\u escape"))
                         }
                     } else {
-                        out = encode_utf8(out, 65533)
+                        return Err(json_error("unpaired high surrogate in \\u escape"))
                     }
                 } else if cp >= 56320 && cp <= 57343 {
-                    out = encode_utf8(out, 65533)
+                    return Err(json_error("lone low surrogate in \\u escape"))
                 } else {
                     out = encode_utf8(out, cp)
                 }
@@ -209,6 +209,11 @@ fun parse_string(c: Cursor) -> Result<String, Error> {
                 return Err(json_error("bad escape"))
             }
         } else {
+            // JSON forbids a raw control character (U+0000..U+001F) in a
+            // string; it must be escaped. Reject it rather than copy it through.
+            if b < 32 {
+                return Err(json_error("unescaped control character in string"))
+            }
             out = __str_concat(out, __str_from_byte(b))
         }
     }
@@ -228,11 +233,19 @@ fun parse_number(c: Cursor) -> Result<Float, Error> {
     if !is_digit(c.peek()) {
         return Err(json_error("invalid number"))
     }
+    let lead = c.peek()
     let int_value = 0.0
+    let int_digits = 0
     while is_digit(c.peek()) {
         let d = c.peek() - 48
         int_value = int_value * 10.0 + raven_int_to_float(d)
         c.advance()
+        int_digits = int_digits + 1
+    }
+    // JSON forbids a leading zero in the integer part (`01`, `00`); a lone `0`
+    // is fine.
+    if lead == 48 && int_digits > 1 {
+        return Err(json_error("number has a leading zero"))
     }
     let value = int_value
     if c.peek() == 46 {
@@ -479,12 +492,61 @@ fun escape_string(out: String, s: String) -> String {
             r = __str_concat(r, "\\u00")
             r = __str_concat(r, __str_from_byte(hex_digit(b >> 4)))
             r = __str_concat(r, __str_from_byte(hex_digit(b & 15)))
-        } else {
+        } else if b < 128 {
             r = __str_concat(r, __str_from_byte(b))
+        } else {
+            // Non-ASCII: JSON allows raw UTF-8, so pass a valid sequence through
+            // unchanged, but a Raven String can hold arbitrary bytes. Replace an
+            // invalid byte with the U+FFFD escape so the output is always valid
+            // JSON (and valid UTF-8) rather than leaking a raw bad byte.
+            let len = utf8_seq_len(s, i, n)
+            if len == 0 {
+                r = __str_concat(r, "\\uFFFD")
+            } else {
+                let j = 0
+                while j < len {
+                    r = __str_concat(r, __str_from_byte(__str_byte_at(s, i + j)))
+                    j = j + 1
+                }
+                i = i + (len - 1)
+            }
         }
         i = i + 1
     }
     return r
+}
+
+// The length (1..4) of the valid UTF-8 sequence starting at byte `i` of `s`, or
+// 0 when the byte cannot begin a valid sequence (an invalid lead byte or a
+// truncated/ill-formed continuation).
+fun utf8_seq_len(s: String, i: Int, n: Int) -> Int {
+    let b = __str_byte_at(s, i)
+    if b < 128 {
+        return 1
+    }
+    if b >= 194 && b <= 223 {
+        if i + 1 < n && is_utf8_cont(__str_byte_at(s, i + 1)) {
+            return 2
+        }
+        return 0
+    }
+    if b >= 224 && b <= 239 {
+        if i + 2 < n && is_utf8_cont(__str_byte_at(s, i + 1)) && is_utf8_cont(__str_byte_at(s, i + 2)) {
+            return 3
+        }
+        return 0
+    }
+    if b >= 240 && b <= 244 {
+        if i + 3 < n && is_utf8_cont(__str_byte_at(s, i + 1)) && is_utf8_cont(__str_byte_at(s, i + 2)) && is_utf8_cont(__str_byte_at(s, i + 3)) {
+            return 4
+        }
+        return 0
+    }
+    return 0
+}
+
+fun is_utf8_cont(b: Int) -> Bool {
+    return b >= 128 && b <= 191
 }
 
 fun hex_digit(v: Int) -> Int {

--- a/stdlib/std/random.rv
+++ b/stdlib/std/random.rv
@@ -53,9 +53,20 @@ impl Rng {
             return lo
         }
         let span = hi - lo
-        // Force a non-negative magnitude before the modulo.
-        let r = ushr(self.next_int(), 1)
-        return lo + (r % span)
+        if span > 0 {
+            // Force a non-negative magnitude before the modulo.
+            let r = ushr(self.next_int(), 1)
+            return lo + (r % span)
+        }
+        // `hi - lo` overflowed Int, so the range is wider than Int::MAX and the
+        // modulo above would divide by a wrapped, non-positive span (returning
+        // only `lo`). Draw a full-width value and reject those outside [lo, hi);
+        // for a range this large most draws land in range, so this is quick.
+        let v = self.next_int()
+        while v < lo || v >= hi {
+            v = self.next_int()
+        }
+        return v
     }
 
     // In [0.0, 1.0): the top 53 bits of a draw scaled by 2^-53, which is

--- a/stdlib/std/string.rv
+++ b/stdlib/std/string.rv
@@ -523,6 +523,13 @@ impl String {
                         break
                     }
                     exp = exp * 10 + (b - 48)
+                    // Clamp the exponent: a Float overflows to infinity (or
+                    // underflows to zero) well before 1e400, so a larger value
+                    // changes nothing but would make the apply loop below run
+                    // billions of times (a DoS) and could overflow `exp` itself.
+                    if exp > 400 {
+                        exp = 400
+                    }
                     exp_digit = true
                     i = i + 1
                 }

--- a/stdlib/std/test.rv
+++ b/stdlib/std/test.rv
@@ -58,6 +58,12 @@ fun assert_ne<T: Eq + ToString>(a: T, b: T) {
 // Assert two floats are within `eps` of each other (the right way to compare
 // floats).
 fun assert_eq_float(a: Float, b: Float, eps: Float) {
+    // A NaN operand makes every comparison false, so `d > eps` would not catch
+    // it and the assertion would silently pass. NaN is never equal to anything
+    // (including itself), so reject it explicitly. `v != v` is true only for NaN.
+    if a != a || b != b {
+        __panic("assertion failed: ${a} != ${b} within ${eps}")
+    }
     let d = a - b
     if d < 0.0 {
         d = 0.0 - d


### PR DESCRIPTION
Fixes codex-review issues #427, #554, #555, #557, #558, #559, #560.

- **#555** `std/fmt` `format_float` no longer hangs on infinity (the digit loop spun forever) or formats NaN as `0.00`; returns `inf`/`-inf`/`NaN`.
- **#554** `pad_int` renders `Int::MIN` without a doubled minus (it negated, which overflows and stays negative).
- **#427** `String.parse_float` caps its exponent (a Float saturates well before 1e400), so `"1e999999999"` no longer runs ~10⁹ iterations.
- **#557** `std/random` `gen_range` covers a full-width range (rejection sampling) instead of returning only `lo` when `hi - lo` overflows.
- **#558** `std/json` rejects a leading zero in a number, a raw control byte in a string, and an unpaired/invalid `\u` surrogate.
- **#559** `std/json` `stringify` replaces an invalid non-UTF-8 byte with the `\uFFFD` escape instead of emitting it raw (output is always valid JSON/UTF-8).
- **#560** `std/test` `assert_eq_float` rejects a NaN operand instead of silently passing.

Adds `examples/v2/stdlib_robustness.rv` as a golden regression. Verified locally: the full golden suite passes, and a direct run confirms the non-finite/huge-exponent paths terminate (no hang) and the JSON validation rejects.

Version bumped to **2.18.94** (one patch per issue across this and the two prior review batches; PR1 #545-#551 and the docs PR #582-#590). CI temporarily disabled for the review batch; verified locally with MSVC.

Fixes #427
Fixes #554
Fixes #555
Fixes #557
Fixes #558
Fixes #559
Fixes #560