### PR TITLE
fix: runtime and HTTP server robustness (#561-#567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.101] - 2026-06-15
+
+Continuing the codex-review fix batch (one patch per issue).
+
+### Fixed
+
+- `std/fs` write/append now write the raw bytes of a Raven String, so binary or non-UTF-8 content is no longer rejected (#561).
+- The HTTP client keeps the raw response body bytes instead of a lossily UTF-8-decoded string, so a binary or non-UTF-8 response is not corrupted (#562).
+- `WaitGroup` saturates its counter at zero, so a `done` past zero cannot drive it negative and let a later `wait` return early (#563).
+- `std/http` `Server` releases the listening socket after a graceful shutdown so the port is freed (#564); `parse_query` percent-decodes keys/values and turns `+` into a space (#565); keep-alive carries bytes read past one request's body so a pipelined request is not lost (#566); a non-numeric `Content-Length` is answered with 400 rather than treated as an empty body (#567).
+
 ## [2.18.94] - 2026-06-15
 
 A batch of fixes from a full-codebase review (codex). The version is bumped one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.94"
+version = "2.18.101"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.94"
+version = "2.18.101"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.94"
+version = "2.18.101"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -212,7 +212,10 @@ struct HttpResp {
     status_text: std::string::String,
     // Response headers as `Key: Value` lines joined by `\n`.
     headers: std::string::String,
-    body: std::string::String,
+    // The raw response body bytes. A Raven String is a byte buffer, so the body
+    // is kept as raw bytes rather than a lossily UTF-8-decoded `String`, which
+    // would corrupt a binary or non-UTF-8 response.
+    body: Vec<u8>,
 }
 
 /// The process-wide HTTP response registry keyed by an incrementing id.
@@ -800,11 +803,22 @@ pub extern "C" fn raven_fs_write(
     path: *const object::String,
     contents: *const object::String,
 ) -> bool {
-    let result = crate::gc::blocking(|| match (env_name(path), env_name(contents)) {
-        (Some(p), Some(c)) => std::fs::write(p, c),
-        _ => Err(io::Error::new(
+    // The contents are written as raw bytes: a Raven String is a byte buffer
+    // that may hold arbitrary (non-UTF-8) data, for example binary read back
+    // from another file. Only the path must be valid UTF-8.
+    let ptr = object::raven_string_bytes(contents);
+    let len = object::raven_string_len(contents) as usize;
+    let bytes: &[u8] = if ptr.is_null() || len == 0 {
+        &[]
+    } else {
+        // SAFETY: a Raven String holds `len` initialized bytes.
+        unsafe { slice::from_raw_parts(ptr, len) }
+    };
+    let result = crate::gc::blocking(|| match env_name(path) {
+        Some(p) => std::fs::write(p, bytes),
+        None => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "path or contents is not valid UTF-8",
+            "path is not valid UTF-8",
         )),
     });
     fs_record(result).is_some()
@@ -820,15 +834,25 @@ pub extern "C" fn raven_fs_append(
     path: *const object::String,
     contents: *const object::String,
 ) -> bool {
-    let result = crate::gc::blocking(|| match (env_name(path), env_name(contents)) {
-        (Some(p), Some(c)) => std::fs::OpenOptions::new()
+    // Append raw bytes for the same reason as `raven_fs_write`: a Raven String
+    // may hold non-UTF-8 data. Only the path must be valid UTF-8.
+    let ptr = object::raven_string_bytes(contents);
+    let len = object::raven_string_len(contents) as usize;
+    let bytes: &[u8] = if ptr.is_null() || len == 0 {
+        &[]
+    } else {
+        // SAFETY: a Raven String holds `len` initialized bytes.
+        unsafe { slice::from_raw_parts(ptr, len) }
+    };
+    let result = crate::gc::blocking(|| match env_name(path) {
+        Some(p) => std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(p)
-            .and_then(|mut f| f.write_all(c.as_bytes())),
-        _ => Err(io::Error::new(
+            .and_then(|mut f| f.write_all(bytes)),
+        None => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "path or contents is not valid UTF-8",
+            "path is not valid UTF-8",
         )),
     });
     fs_record(result).is_some()
@@ -1455,7 +1479,10 @@ fn http_capture(resp: ureq::Response) -> HttpResp {
         }
     }
     let headers = header_lines.join("\n");
-    let body = resp.into_string().unwrap_or_default();
+    // Read the body as raw bytes (not `into_string`, which lossily replaces a
+    // non-UTF-8 byte with U+FFFD and corrupts a binary response).
+    let mut body = Vec::new();
+    resp.into_reader().read_to_end(&mut body).ok();
     HttpResp {
         status: status as i64,
         status_text,
@@ -1575,7 +1602,8 @@ pub extern "C" fn raven_http_status_text(id: i64) -> *mut object::String {
 #[no_mangle]
 pub extern "C" fn raven_http_body(id: i64) -> *mut object::String {
     let registry = http_registry().lock().unwrap();
-    let body = registry.get(&id).map(|r| r.body.as_str()).unwrap_or("");
+    let empty: &[u8] = &[];
+    let body: &[u8] = registry.get(&id).map(|r| r.body.as_slice()).unwrap_or(empty);
     object::raven_string_from_bytes(body.as_ptr(), body.len())
 }
 

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -726,7 +726,10 @@ pub extern "C" fn raven_waitgroup_new() -> i64 {
 pub extern "C" fn raven_waitgroup_add(id: i64, delta: i64) {
     let woken = with_sched(|sched| match sched.wait_groups.get_mut(&id) {
         Some(wg) => {
-            wg.count += delta;
+            // Saturate at zero: a `done` past zero must not drive the count
+            // negative, or a later `add` would bring it back to zero and let a
+            // waiter that should still block return early.
+            wg.count = (wg.count + delta).max(0);
             if wg.count <= 0 {
                 std::mem::take(&mut wg.waiters)
             } else {

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -15,6 +15,7 @@ import std/collections
 import std/json { JsonValue, ToJson, FromJson, stringify, parse, decode }
 import std/fs { read }
 import std/sync { mutex, wait_group, Mutex }
+import std/encoding { url_decode }
 
 struct HttpResponse {
     status_code: Int,
@@ -472,6 +473,9 @@ impl Server {
                     }
                 }
                 inflight.wait()
+                // Release the listening socket so the port is free after a
+                // graceful shutdown returns, rather than staying bound.
+                socket.close()
             }
             Err(e) -> print("http: cannot bind ".concat(addr).concat(": ").concat(e.message()))
         }
@@ -494,9 +498,12 @@ fun serve_connection(server: Server, stream: TcpStream) {
     }
     let open = true
     let served = 0
+    let carry = ""
     while open {
-        match read_request(stream) {
-            Ok(req) -> {
+        match read_request(stream, carry) {
+            Ok(parsed) -> {
+                carry = parsed.rest
+                let req = parsed.request
                 let resp = dispatch(server.routes, req)
                 let keep = should_keep_alive(req)
                 if server.is_stopping() {
@@ -617,8 +624,17 @@ fun path_segments(path: String) -> List<String> {
 
 // Read one HTTP request off `stream`: the header block up to the first blank
 // line, then the body up to the request's Content-Length.
-fun read_request(stream: TcpStream) -> Result<Request, Error> {
-    let buf = ""
+// One parsed request plus any bytes read past its body, which belong to the
+// next (pipelined) request on a kept-alive connection.
+struct ReadResult {
+    request: Request,
+    rest: String,
+}
+
+// Parse one request, beginning from `initial` (bytes carried over from a prior
+// request on the same connection) and reading more from `stream` as needed.
+fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error> {
+    let buf = initial
     let split = buf.index_of("\r\n\r\n")
     while split < 0 {
         let chunk = stream.read(4096)?
@@ -666,7 +682,11 @@ fun read_request(stream: TcpStream) -> Result<Request, Error> {
             Some(n) -> {
                 want = n
             }
-            None -> {}
+            // A non-numeric Content-Length is a malformed request; answer 400
+            // rather than silently treating the body as empty.
+            None -> {
+                return Err(error_kind("http", "invalid Content-Length"))
+            }
         }
     }
     // Reject a negative or oversized declared body before reading it, so a
@@ -686,6 +706,11 @@ fun read_request(stream: TcpStream) -> Result<Request, Error> {
         }
         body = body.concat(chunk)
     }
+    // Keep exactly `want` bytes as this request's body; anything already read
+    // past it is the start of the next pipelined request, carried over so it is
+    // not lost when the keep-alive loop reads again.
+    let actual_body = body.substring(0, want)
+    let rest = body.substring(want, body.length())
 
     let path = target
     let query: Map<String, String> = Map.new()
@@ -696,18 +721,22 @@ fun read_request(stream: TcpStream) -> Result<Request, Error> {
     }
 
     let params: Map<String, String> = Map.new()
-    return Ok(Request {
-        method: method,
-        path: path,
-        version: version,
-        headers: headers,
-        params: params,
-        query: query,
-        body: body,
+    return Ok(ReadResult {
+        request: Request {
+            method: method,
+            path: path,
+            version: version,
+            headers: headers,
+            params: params,
+            query: query,
+            body: actual_body,
+        },
+        rest: rest,
     })
 }
 
-// Decode `a=1&b=2` query-string pairs into `out`.
+// Decode `a=1&b=2` query-string pairs into `out`, percent-decoding each key and
+// value and turning `+` into a space (the form-urlencoded convention).
 fun parse_query(qs: String, out: Map<String, String>) {
     let pairs = qs.split("&")
     let i = 0
@@ -716,13 +745,19 @@ fun parse_query(qs: String, out: Map<String, String>) {
         if pair.length() > 0 {
             let eq = pair.index_of("=")
             if eq >= 0 {
-                out.set(pair.substring(0, eq), pair.substring(eq + 1, pair.length()))
+                let k = decode_query_part(pair.substring(0, eq))
+                let v = decode_query_part(pair.substring(eq + 1, pair.length()))
+                out.set(k, v)
             } else {
-                out.set(pair, "")
+                out.set(decode_query_part(pair), "")
             }
         }
         i += 1
     }
+}
+
+fun decode_query_part(s: String) -> String {
+    return url_decode(s.replace("+", " "))
 }
 
 // Write `resp` to `stream` as an HTTP/1.1 response, framing it with

--- a/stdlib/std/net.rv
+++ b/stdlib/std/net.rv
@@ -73,6 +73,11 @@ impl TcpListener {
         }
         return Ok(TcpStream { id: id })
     }
+
+    // Close the listener, releasing the bound port so it can be reused.
+    fun close(self) {
+        raven_net_close(self.id)
+    }
 }
 
 impl TcpStream {


### PR DESCRIPTION
Fixes codex-review issues #561-#567. Verified locally (runtime build/clippy/tests, golden suite, and a live server test confirming query decode, pipelining, 400 on bad Content-Length, and port release).

- **#561** std/fs write/append write raw String bytes (binary content no longer rejected).
- **#562** HTTP client keeps the raw body bytes, not a lossy UTF-8 decode.
- **#563** WaitGroup saturates at zero (a stray done cannot make wait return early).
- **#564** Server frees the listening socket after graceful shutdown.
- **#565** parse_query percent-decodes and turns + into space.
- **#566** keep-alive carries leftover bytes so pipelined requests are not lost.
- **#567** non-numeric Content-Length answered with 400.

Version bumped to 2.18.101. CI temporarily disabled for the batch.

Fixes #561
Fixes #562
Fixes #563
Fixes #564
Fixes #565
Fixes #566
Fixes #567