### PR TITLE
fix: rvpm and build robustness (#568, #569, #570, #571, #572, #574)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.112] - 2026-06-15
+
+Continuing the codex-review fix batch (one patch per issue).
+
+### Fixed
+
+- Bundled `[ffi]` C is compiled with the dynamic CRT (`/MD`) on windows-msvc, matching the Rust/Raven objects, so the linker no longer reports an `LNK4098` defaultlib conflict (#568).
+- The bundled C object cache keys on a content hash, so a source edited with its modification time preserved is recompiled instead of skipped (#569).
+- `rvpm run` forwards `--help` to the program (only a leading `--help`, or one before a `--` separator, is rvpm's) (#570).
+- `rvpm build`/`install`/`update`/`doc`/`fmt` reject an unknown `-` option instead of silently ignoring it (#571).
+- Package names are validated as a restricted identifier at manifest parse and in `rvpm init`/`new`, and `rvpm new` rejects a `..` in the target path, closing a path-traversal vector (#572).
+- `rvpm test` writes its generated dispatcher to a per-process unique file, so it never overwrites or deletes a user file named `.rvpm-test-main.rv` (#574).
+
 ## [2.18.106] - 2026-06-15
 
 Continuing the codex-review fix batch (one patch per issue).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.106"
+version = "2.18.112"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.106"
+version = "2.18.112"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.106"
+version = "2.18.112"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -154,6 +154,20 @@ fn cmd_new(args: &[String]) -> Result<(), String> {
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or(target.as_str());
+    if !raven::manifest::is_valid_package_name(name) {
+        return Err(format!(
+            "'{}' is not a valid package name; use only ASCII letters, digits, '-', and '_'",
+            name
+        ));
+    }
+    // Reject a `..` in the target so `rvpm new` cannot scaffold outside the
+    // current directory tree.
+    if Path::new(target)
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(format!("target path '{}' must not contain '..'", target));
+    }
     std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     init_project(&dir, name, kind).map_err(|e| e.to_string())?;
     let label = match kind {
@@ -402,12 +416,28 @@ fn cmd_add(args: &[String]) -> Result<Vec<String>, String> {
     Ok(report.outcome_lines)
 }
 
+/// Reject an unrecognized `-`-prefixed option for `cmd`, so a typo'd or unknown
+/// flag is reported rather than silently ignored. `known` lists the options the
+/// command accepts; positional arguments (which do not start with `-`) pass.
+fn reject_unknown_options(args: &[String], cmd: &str, known: &[&str]) -> Result<(), String> {
+    for a in args {
+        if a.starts_with('-') && a != "-" && !known.contains(&a.as_str()) {
+            return Err(format!(
+                "unknown option `{}` for `rvpm {}`; run `rvpm {} --help`",
+                a, cmd, cmd
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Re-resolve rv.toml against rv.lock and fill the cache, validating an
 /// existing lock or writing a fresh one.
 fn cmd_install(args: &[String]) -> Result<Vec<String>, String> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return Ok(vec![install_usage()]);
     }
+    reject_unknown_options(args, "install", &["--help", "-h"])?;
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
     let (_outcome, report) =
         with_fetch_progress(|| ops::install(&cwd)).map_err(|e| e.to_string())?;
@@ -419,6 +449,7 @@ fn cmd_update(args: &[String]) -> Result<Vec<String>, String> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return Ok(vec![update_usage()]);
     }
+    reject_unknown_options(args, "update", &["--help", "-h"])?;
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
     let package = args.first().map(String::as_str);
     let report = with_fetch_progress(|| ops::update(&cwd, package)).map_err(|e| e.to_string())?;
@@ -431,6 +462,7 @@ fn cmd_build(args: &[String]) -> Result<Vec<String>, String> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return Ok(vec![build_usage()]);
     }
+    reject_unknown_options(args, "build", &["--help", "-h"])?;
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
     let report = with_fetch_progress(|| ops::build(&cwd)).map_err(|e| e.to_string())?;
     Ok(report.outcome_lines)
@@ -439,10 +471,23 @@ fn cmd_build(args: &[String]) -> Result<Vec<String>, String> {
 /// Build the package then run the produced binary, forwarding any args
 /// after `run` to the program and exiting with its code.
 fn cmd_run(args: &[String]) -> ExitCode {
-    if args.iter().any(|a| a == "--help" || a == "-h") {
+    // Args before a `--` separator are rvpm's; everything after is forwarded to
+    // the program verbatim. With no separator only a leading `--help`/`-h` is
+    // rvpm's, so the program can still receive `--help` (`rvpm run -- --help`,
+    // or `rvpm run somearg --help`).
+    let sep = args.iter().position(|a| a == "--");
+    let rvpm_wants_help = match sep {
+        Some(i) => args[..i].iter().any(|a| a == "--help" || a == "-h"),
+        None => args.first().map(|a| a == "--help" || a == "-h").unwrap_or(false),
+    };
+    if rvpm_wants_help {
         println!("{}", run_usage());
         return ExitCode::SUCCESS;
     }
+    let prog_args: Vec<String> = match sep {
+        Some(i) => args[i + 1..].to_vec(),
+        None => args.to_vec(),
+    };
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => {
@@ -450,7 +495,7 @@ fn cmd_run(args: &[String]) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    match with_fetch_progress(|| ops::run_package(&cwd, args)) {
+    match with_fetch_progress(|| ops::run_package(&cwd, &prog_args)) {
         Ok(code) => {
             let code: u8 = code.try_into().unwrap_or(1);
             ExitCode::from(code)
@@ -499,6 +544,7 @@ fn cmd_doc(args: &[String]) -> Result<Vec<String>, String> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return Ok(vec![doc_usage()]);
     }
+    reject_unknown_options(args, "doc", &["--help", "-h"])?;
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
     let report = raven::doc::generate(&cwd).map_err(|e| e.to_string())?;
     Ok(report.outcome_lines)
@@ -513,6 +559,10 @@ fn cmd_fmt(args: &[String]) -> ExitCode {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         println!("{}", fmt_usage());
         return ExitCode::SUCCESS;
+    }
+    if let Err(e) = reject_unknown_options(args, "fmt", &["--help", "-h", "--check"]) {
+        eprintln!("rvpm: {}", e);
+        return ExitCode::from(1);
     }
     let check = args.iter().any(|a| a == "--check");
     let paths: Vec<&String> = args.iter().filter(|a| !a.starts_with('-')).collect();

--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -22,6 +22,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use sha2::{Digest, Sha256};
 use target_lexicon::{OperatingSystem, Triple};
 
 use super::CodegenError;
@@ -218,7 +219,11 @@ pub fn compile_c_sources(
         }
         let mut cmd = compiler.to_command();
         if msvc {
+            // `/MD` selects the dynamic CRT to match the Rust/Raven objects,
+            // which use it too. Without it cl.exe defaults to the static CRT
+            // (LIBCMT) and the linker reports a defaultlib conflict (LNK4098).
             cmd.arg("/nologo")
+                .arg("/MD")
                 .arg("/c")
                 .arg(source)
                 .arg(format!("/Fo{}", object.display()));
@@ -236,23 +241,49 @@ pub fn compile_c_sources(
                 String::from_utf8_lossy(&out.stderr).trim()
             )));
         }
+        // Record the source hash beside the fresh object so a later build reuses
+        // it only while the source is byte-for-byte unchanged.
+        if let Some(hash) = source_content_hash(source) {
+            let _ = std::fs::write(object_hash_sidecar(&object), hash);
+        }
         objects.push(object);
     }
     Ok(objects)
 }
 
-/// True when `object` exists and is at least as new as `source`, so the cached
-/// object can be reused instead of recompiling. A missing file or unreadable
-/// timestamp returns false, so the safe default is to recompile.
+/// True when `object` exists and was built from the current contents of
+/// `source`, so the cached object can be reused. Freshness is keyed on a content
+/// hash recorded in a `<object>.hash` sidecar, not the modification time: a
+/// source edited with its mtime preserved (a checkout, a restore) would
+/// otherwise be skipped. A missing object, missing sidecar, or hash mismatch
+/// returns false, so the safe default is to recompile.
 fn object_is_fresh(source: &Path, object: &Path) -> bool {
-    let (Ok(src_meta), Ok(obj_meta)) = (std::fs::metadata(source), std::fs::metadata(object))
-    else {
+    if !object.exists() {
+        return false;
+    }
+    let Some(hash) = source_content_hash(source) else {
         return false;
     };
-    match (src_meta.modified(), obj_meta.modified()) {
-        (Ok(src), Ok(obj)) => obj >= src,
-        _ => false,
+    match std::fs::read_to_string(object_hash_sidecar(object)) {
+        Ok(stored) => stored.trim() == hash,
+        Err(_) => false,
     }
+}
+
+/// The SHA-256 of `source`'s bytes as a hex string, or `None` when it cannot be
+/// read.
+fn source_content_hash(source: &Path) -> Option<String> {
+    let bytes = std::fs::read(source).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Some(format!("{:x}", hasher.finalize()))
+}
+
+/// The sidecar path holding the source hash a cached object was built from.
+fn object_hash_sidecar(object: &Path) -> PathBuf {
+    let mut name = object.as_os_str().to_os_string();
+    name.push(".hash");
+    PathBuf::from(name)
 }
 
 #[cfg(test)]

--- a/src/manifest/init.rs
+++ b/src/manifest/init.rs
@@ -26,6 +26,8 @@ pub enum ProjectKind {
 pub enum InitError {
     /// An `rv.toml` already exists in the target directory.
     ManifestExists,
+    /// The package name is not a valid identifier.
+    InvalidName(String),
     /// A filesystem operation failed.
     Io(io::Error),
 }
@@ -36,6 +38,11 @@ impl std::fmt::Display for InitError {
             InitError::ManifestExists => {
                 write!(f, "rv.toml already exists; refusing to overwrite")
             }
+            InitError::InvalidName(name) => write!(
+                f,
+                "'{}' is not a valid package name; use only ASCII letters, digits, '-', and '_'",
+                name
+            ),
             InitError::Io(e) => write!(f, "{}", e),
         }
     }
@@ -98,6 +105,9 @@ pub fn gitignore_template() -> &'static str {
 /// without writing anything if `<dir>/rv.toml` already exists; an existing
 /// `.gitignore` or entry file is left untouched.
 pub fn init_project(dir: &Path, name: &str, kind: ProjectKind) -> Result<(), InitError> {
+    if !super::is_valid_package_name(name) {
+        return Err(InitError::InvalidName(name.to_string()));
+    }
     let manifest_path = dir.join("rv.toml");
     if manifest_path.exists() {
         return Err(InitError::ManifestExists);

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -26,6 +26,18 @@ pub const DEFAULT_EDITION: &str = "v2";
 /// The accepted `[package].edition` values.
 pub const ACCEPTED_EDITIONS: &[&str] = &["v2", "2026"];
 
+/// Whether `name` is a valid package name: a non-empty run of ASCII letters,
+/// digits, `-`, and `_` that does not start with `-`. The name is interpolated
+/// into scaffolded source and joined onto the output directory as a binary
+/// name, so a path separator or `..` must be rejected to prevent traversal.
+pub fn is_valid_package_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.starts_with('-')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 /// The default `[fmt].indent_width` when the section or field is absent.
 pub const DEFAULT_INDENT_WIDTH: u32 = 4;
 
@@ -227,6 +239,13 @@ impl Manifest {
                 message: "must not be empty".to_string(),
             });
         }
+        if !is_valid_package_name(&name) {
+            return Err(ManifestError::InvalidValue {
+                section: "package".to_string(),
+                field: "name".to_string(),
+                message: "must contain only ASCII letters, digits, '-', and '_', and may not start with '-' (the name is used as a file and output binary name)".to_string(),
+            });
+        }
         let edition = match raw_pkg.edition {
             Some(e) => {
                 if !ACCEPTED_EDITIONS.contains(&e.as_str()) {
@@ -300,6 +319,25 @@ impl Manifest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn package_name_validation() {
+        assert!(is_valid_package_name("raven-http"));
+        assert!(is_valid_package_name("my_lib2"));
+        // Path-traversal and separator forms are rejected.
+        assert!(!is_valid_package_name("../../../escaped"));
+        assert!(!is_valid_package_name("a/b"));
+        assert!(!is_valid_package_name(".."));
+        assert!(!is_valid_package_name("-leading"));
+        assert!(!is_valid_package_name(""));
+        assert!(!is_valid_package_name("has space"));
+    }
+
+    #[test]
+    fn manifest_rejects_a_traversal_name() {
+        let src = "[package]\nname = \"../../escaped\"\nversion = \"0.1.0\"\n";
+        assert!(Manifest::from_toml_str(src).is_err());
+    }
 
     #[test]
     fn full_manifest_parses() {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -581,10 +581,6 @@ fn output_binary_path(project_dir: &Path, name: &str) -> PathBuf {
     p
 }
 
-/// The generated test-runner entry written to the project root while a test
-/// run compiles, then removed.
-const TEST_MAIN_FILE: &str = ".rvpm-test-main.rv";
-
 /// The name of the compiled test-runner binary under `target/raven-out`.
 const TEST_BINARY_NAME: &str = ".rvpm-test";
 
@@ -642,7 +638,11 @@ pub fn test_in(project_dir: &Path, cache_root: &Path) -> Result<TestReport, OpEr
         });
     }
 
-    let main_path = project_dir.join(TEST_MAIN_FILE);
+    // A per-process unique name in the project root (where relative imports
+    // resolve), so a test run never overwrites or deletes a user file that
+    // happens to be named `.rvpm-test-main.rv`; only the file we create here is
+    // removed below.
+    let main_path = project_dir.join(format!(".rvpm-test-main-{}.rv", std::process::id()));
     let binary = output_binary_path(project_dir, TEST_BINARY_NAME);
     if let Some(parent) = binary.parent() {
         std::fs::create_dir_all(parent).map_err(|e| OpError::Io {


### PR DESCRIPTION
Fixes codex-review issues #568, #569, #570, #571, #572, #574. Verified locally (manifest/linker unit tests, rvpm integration tests, and the SQLite-backed board app links with no LNK4098).

- **#568** bundled [ffi] C compiles with the dynamic CRT (/MD) on windows-msvc (clears the LNK4098 conflict).
- **#569** the C object cache keys on a source content hash (sidecar), not mtime.
- **#570** rvpm run forwards --help to the program (only a leading/pre-`--` --help is rvpm's).
- **#571** build/install/update/doc/fmt reject unknown `-` options.
- **#572** package names validated (no path separators, `..`, leading `-`) at parse and in init/new; `rvpm new` rejects `..` in the target (path-traversal fix).
- **#574** rvpm test uses a per-process unique dispatcher file, never clobbering a user's `.rvpm-test-main.rv`.

Version bumped to 2.18.112. CI temporarily disabled for the batch.

Fixes #568
Fixes #569
Fixes #570
Fixes #571
Fixes #572
Fixes #574