### PR TITLE
fix: formatter and doc comment robustness (#577, #578, #579, #580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.116] - 2026-06-16
+
+Continuing the codex-review fix batch (one patch per issue).
+
+### Fixed
+
+- The doc extractor counts only structural braces when capturing a `struct`/`enum`/`trait` block, skipping braces inside comments, strings, and char literals so a brace in a doc comment no longer truncates the declaration (#577).
+- A quoted import path is re-escaped when formatted, so a `"` or `\` in the path produces valid, round-tripping output (#578).
+- The formatter weaves interior comments into struct literals, map literals, and `match` arms instead of dropping or relocating them (#579).
+- Comment scanning skips `${ ... }` interpolations as a unit, so a string nested in an interpolation no longer ends the outer literal early and mis-scans a following comment (#580).
+
 ## [2.18.112] - 2026-06-15
 
 Continuing the codex-review fix batch (one patch per issue).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.112"
+version = "2.18.116"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.112"
+version = "2.18.116"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.112"
+version = "2.18.116"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1603,7 +1603,10 @@ pub extern "C" fn raven_http_status_text(id: i64) -> *mut object::String {
 pub extern "C" fn raven_http_body(id: i64) -> *mut object::String {
     let registry = http_registry().lock().unwrap();
     let empty: &[u8] = &[];
-    let body: &[u8] = registry.get(&id).map(|r| r.body.as_slice()).unwrap_or(empty);
+    let body: &[u8] = registry
+        .get(&id)
+        .map(|r| r.body.as_slice())
+        .unwrap_or(empty);
     object::raven_string_from_bytes(body.as_ptr(), body.len())
 }
 

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -478,7 +478,10 @@ fn cmd_run(args: &[String]) -> ExitCode {
     let sep = args.iter().position(|a| a == "--");
     let rvpm_wants_help = match sep {
         Some(i) => args[..i].iter().any(|a| a == "--help" || a == "-h"),
-        None => args.first().map(|a| a == "--help" || a == "-h").unwrap_or(false),
+        None => args
+            .first()
+            .map(|a| a == "--help" || a == "-h")
+            .unwrap_or(false),
     };
     if rvpm_wants_help {
         println!("{}", run_usage());

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -229,6 +229,13 @@ fn block_text(source: &str, start: usize) -> String {
     let mut end = source.len();
     let mut i = start;
     while i < bytes.len() {
+        // Skip comments, string, and char literals so a brace inside one (a
+        // `{` in a doc comment or a string default) does not throw off the
+        // structural depth count and truncate the declaration.
+        if let Some(next) = skip_non_code(bytes, i) {
+            i = next;
+            continue;
+        }
         match bytes[i] {
             b'{' => {
                 depth += 1;
@@ -246,6 +253,39 @@ fn block_text(source: &str, start: usize) -> String {
         i += 1;
     }
     source[start..end].trim_end().to_string()
+}
+
+/// If `bytes[i]` begins a comment, string, or char literal, return the index
+/// just past it; otherwise `None`. Lets a brace/`=` scanner skip non-code.
+fn skip_non_code(bytes: &[u8], i: usize) -> Option<usize> {
+    match bytes[i] {
+        b'/' if bytes.get(i + 1) == Some(&b'/') => {
+            let mut j = i + 2;
+            while j < bytes.len() && bytes[j] != b'\n' {
+                j += 1;
+            }
+            Some(j)
+        }
+        b'/' if bytes.get(i + 1) == Some(&b'*') => {
+            let mut j = i + 2;
+            while j + 1 < bytes.len() && !(bytes[j] == b'*' && bytes[j + 1] == b'/') {
+                j += 1;
+            }
+            Some((j + 2).min(bytes.len()))
+        }
+        b'"' | b'\'' => {
+            let quote = bytes[i];
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j] != quote {
+                if bytes[j] == b'\\' {
+                    j += 1;
+                }
+                j += 1;
+            }
+            Some((j + 1).min(bytes.len()))
+        }
+        _ => None,
+    }
 }
 
 /// The contiguous `//` comment block immediately above the item starting at

--- a/src/format/comments.rs
+++ b/src/format/comments.rs
@@ -108,6 +108,36 @@ fn skip_string(bytes: &[u8], start: usize) -> usize {
             b'\\' => j += 2,
             b'"' => return j + 1,
             b'\n' => return j,
+            // A `${ ... }` interpolation: skip the balanced braces (respecting
+            // strings and chars nested in the expression) so an inner `"` does
+            // not terminate the outer literal and throw off comment scanning.
+            b'$' if j + 1 < n && bytes[j + 1] == b'{' => {
+                j = skip_interpolation(bytes, j + 1);
+            }
+            _ => j += 1,
+        }
+    }
+    j
+}
+
+/// Skip a `${ ... }` interpolation body. `brace` is the index of the opening
+/// `{`; returns the index just past the matching `}`.
+fn skip_interpolation(bytes: &[u8], brace: usize) -> usize {
+    let n = bytes.len();
+    let mut j = brace + 1;
+    let mut depth = 1u32;
+    while j < n && depth > 0 {
+        match bytes[j] {
+            b'{' => {
+                depth += 1;
+                j += 1;
+            }
+            b'}' => {
+                depth -= 1;
+                j += 1;
+            }
+            b'"' => j = skip_string(bytes, j),
+            b'\'' => j = skip_char(bytes, j),
             _ => j += 1,
         }
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -589,9 +589,9 @@ impl Printer<'_> {
                 }
             }
             ImportSource::Quoted(s) => {
-                text.push('"');
-                text.push_str(s);
-                text.push('"');
+                // Re-escape the path body so a `"` or `\` in it stays valid (and
+                // round-trips), rather than emitting it raw between the quotes.
+                text.push_str(&render_string_lit(s));
             }
         }
         if let Some(alias) = &im.alias {
@@ -888,20 +888,28 @@ impl Printer<'_> {
                     s.push_str(" {}");
                     return s;
                 }
-                let multiline = self.spans_multiple_lines(e.span.start, e.span.end);
+                let multiline = self.spans_multiple_lines(e.span.start, e.span.end)
+                    || self.pending_comment_within(e.span.start, e.span.end);
                 if multiline {
                     s.push_str(" {\n");
                     for f in fields {
+                        self.weave_own_line_comments(&mut s, f.span.start, base + 1);
                         for _ in 0..base + 1 {
                             s.push_str(&self.indent_unit);
                         }
                         let value = self.field_value(f);
                         if is_field_shorthand(&f.name, &f.value) {
-                            let _ = writeln!(s, "{},", f.name);
+                            let _ = write!(s, "{},", f.name);
                         } else {
-                            let _ = writeln!(s, "{}: {},", f.name, value);
+                            let _ = write!(s, "{}: {},", f.name, value);
                         }
+                        if let Some(t) = self.take_trailing_comment(self.line_of(f.span.end)) {
+                            s.push(' ');
+                            s.push_str(&t);
+                        }
+                        s.push('\n');
                     }
+                    self.weave_own_line_comments(&mut s, e.span.end, base + 1);
                     for _ in 0..base {
                         s.push_str(&self.indent_unit);
                     }
@@ -952,6 +960,9 @@ impl Printer<'_> {
             ExprKind::MapLit(pairs) => {
                 if pairs.is_empty() {
                     return "[:]".to_string();
+                }
+                if self.pending_comment_within(e.span.start, e.span.end) {
+                    return self.map_multiline(pairs, e.span.end, base);
                 }
                 let parts: Vec<String> = pairs
                     .iter()
@@ -1034,7 +1045,9 @@ impl Printer<'_> {
                 then_branch,
                 else_branch,
             } => self.render_if(cond, then_branch, else_branch, base),
-            ExprKind::Match { scrutinee, arms } => self.render_match(scrutinee, arms, base),
+            ExprKind::Match { scrutinee, arms } => {
+                self.render_match(scrutinee, arms, e.span.end, base)
+            }
             ExprKind::Loop(b) => {
                 let body = self.render_block(b, base);
                 format!("loop {}", body)
@@ -1133,9 +1146,48 @@ impl Printer<'_> {
         s
     }
 
+    /// Render a map literal multi-line, weaving interior comments at their
+    /// source positions. `close_byte` is the position of the closing `]`.
+    fn map_multiline(&mut self, pairs: &[(Expr, Expr)], close_byte: usize, base: usize) -> String {
+        let mut s = String::from("[\n");
+        for (k, v) in pairs {
+            self.weave_own_line_comments(&mut s, k.span.start, base + 1);
+            self.push_indent(&mut s, base + 1);
+            let kk = self.expr_at(k, base + 1);
+            let vv = self.expr_at(v, base + 1);
+            let _ = write!(s, "{}: {},", kk, vv);
+            if let Some(t) = self.take_trailing_comment(self.line_of(v.span.end)) {
+                s.push(' ');
+                s.push_str(&t);
+            }
+            s.push('\n');
+        }
+        self.weave_own_line_comments(&mut s, close_byte, base + 1);
+        self.push_indent(&mut s, base);
+        s.push(']');
+        s
+    }
+
     fn push_indent(&self, s: &mut String, level: usize) {
         for _ in 0..level {
             s.push_str(&self.indent_unit);
+        }
+    }
+
+    /// Append every pending own-line comment that begins before `byte` into
+    /// `s`, each on its own line indented at `level`, advancing the cursor.
+    /// Used to weave interior comments into struct literals, map literals, and
+    /// match arms so they are not dropped.
+    fn weave_own_line_comments(&mut self, s: &mut String, byte: usize, level: usize) {
+        while let Some(c) = self.comments.get(self.next_comment) {
+            if c.start >= byte || !c.own_line {
+                break;
+            }
+            let text = c.text.clone();
+            self.push_indent(s, level);
+            s.push_str(&text);
+            s.push('\n');
+            self.next_comment += 1;
         }
     }
 
@@ -1218,28 +1270,38 @@ impl Printer<'_> {
         s
     }
 
-    fn render_match(&mut self, scrutinee: &Expr, arms: &[MatchArm], base: usize) -> String {
+    fn render_match(
+        &mut self,
+        scrutinee: &Expr,
+        arms: &[MatchArm],
+        end: usize,
+        base: usize,
+    ) -> String {
         let scrut = self.expr_at(scrutinee, base);
         let mut s = format!("match {} {{\n", scrut);
         for arm in arms {
-            let pat = render_pattern(&arm.pattern);
-            let guard = arm.guard.as_ref().map(|g| self.expr_at(g, base + 1));
-            let body = self.expr_at(&arm.body, base + 1);
-            for _ in 0..base + 1 {
-                s.push_str(&self.indent_unit);
-            }
-            s.push_str(&pat);
-            if let Some(g) = guard {
+            // Own-line comments that precede this arm.
+            self.weave_own_line_comments(&mut s, arm.span.start, base + 1);
+            self.push_indent(&mut s, base + 1);
+            s.push_str(&render_pattern(&arm.pattern));
+            if let Some(g) = arm.guard.as_ref() {
+                let g = self.expr_at(g, base + 1);
                 s.push_str(" if ");
                 s.push_str(&g);
             }
             s.push_str(" -> ");
+            let body = self.expr_at(&arm.body, base + 1);
             s.push_str(&body);
-            s.push_str(",\n");
+            s.push(',');
+            if let Some(t) = self.take_trailing_comment(self.line_of(arm.span.end)) {
+                s.push(' ');
+                s.push_str(&t);
+            }
+            s.push('\n');
         }
-        for _ in 0..base {
-            s.push_str(&self.indent_unit);
-        }
+        // Own-line comments between the last arm and the closing brace.
+        self.weave_own_line_comments(&mut s, end, base + 1);
+        self.push_indent(&mut s, base);
         s.push('}');
         s
     }

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -389,3 +389,60 @@ fn empty_list_stays_a_list() {
     let out = fmt("fun f(){let e=[]}");
     assert_eq!(out, "fun f() {\n    let e = []\n}\n");
 }
+
+#[test]
+fn comment_inside_struct_literal_is_kept() {
+    // A comment interior to a struct literal must survive formatting. Before
+    // #579 the struct-literal printer ignored the comment cursor and the
+    // comment was relocated past the literal. Regression for #579.
+    let src = "fun f() {\n    let p = Point {\n        x: 1, // the x\n        // the y\n        y: 2,\n    }\n}\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("x: 1, // the x"),
+        "trailing field comment lost: {out:?}"
+    );
+    assert!(
+        out.contains("// the y"),
+        "own-line field comment lost: {out:?}"
+    );
+}
+
+#[test]
+fn comment_inside_map_literal_is_kept() {
+    // Regression for #579: a comment inside a map literal must be kept and the
+    // literal laid out multi-line.
+    let src = "fun f() {\n    let m = [\n        \"a\": 1, // first\n        \"b\": 2,\n    ]\n}\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("\"a\": 1, // first"),
+        "map entry comment lost: {out:?}"
+    );
+}
+
+#[test]
+fn comment_inside_match_is_kept() {
+    // Regression for #579: comments between and after match arms must survive.
+    let src = "fun f(x: Int) -> Int {\n    match x {\n        // the zero case\n        0 -> 1, // one\n        _ -> 2,\n    }\n}\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("// the zero case"),
+        "own-line arm comment lost: {out:?}"
+    );
+    assert!(
+        out.contains("0 -> 1, // one"),
+        "trailing arm comment lost: {out:?}"
+    );
+}
+
+#[test]
+fn interpolation_with_nested_string_does_not_break_comment_scan() {
+    // A string interpolation may itself contain a string literal. The comment
+    // scanner must skip the whole interpolation so the inner `"` does not end
+    // the outer literal and mis-scan a following `//`. Regression for #580.
+    let src = "fun f(name: String) {\n    let s = \"hi ${name.concat(\"!\")}\" // a greeting\n    print(s)\n}\n";
+    let out = fmt(src);
+    assert!(
+        out.contains("// a greeting"),
+        "trailing comment after an interpolated string was lost: {out:?}"
+    );
+}

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -713,7 +713,10 @@ fn try_on_option_in_non_option_fn_is_error() {
 
 #[test]
 fn break_and_continue_outside_a_loop_are_rejected() {
-    assert!(check("fun f() { break }\n").is_err(), "break outside a loop");
+    assert!(
+        check("fun f() { break }\n").is_err(),
+        "break outside a loop"
+    );
     assert!(
         check("fun f() { continue }\n").is_err(),
         "continue outside a loop"
@@ -790,7 +793,9 @@ fn duplicate_variant_arm_is_redundant() {
     let err = check("fun f(o: Option<Int>) -> Int {\n    return match o {\n        None -> 0,\n        None -> 1,\n        Some(n) -> n,\n    }\n}\nfun main() {}\n")
         .unwrap_err();
     match err {
-        RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::RedundantPattern), "got {:?}", b),
+        RavenError::Type(b, _, _) => {
+            assert!(matches!(*b, TypeError::RedundantPattern), "got {:?}", b)
+        }
         other => panic!("expected TypeError, got {:?}", other),
     }
 }
@@ -800,7 +805,9 @@ fn duplicate_literal_arm_is_redundant() {
     let err = check("fun f(n: Int) -> String {\n    return match n {\n        0 -> \"a\",\n        0 -> \"b\",\n        _ -> \"c\",\n    }\n}\nfun main() {}\n")
         .unwrap_err();
     match err {
-        RavenError::Type(b, _, _) => assert!(matches!(*b, TypeError::RedundantPattern), "got {:?}", b),
+        RavenError::Type(b, _, _) => {
+            assert!(matches!(*b, TypeError::RedundantPattern), "got {:?}", b)
+        }
         other => panic!("expected TypeError, got {:?}", other),
     }
 }


### PR DESCRIPTION
Fixes codex-review issues #577, #578, #579, #580. Verified locally: all 52 formatter unit tests (4 new) and the fmt-golden suite pass.

- **#577** the doc extractor counts only structural braces, skipping comments/strings/chars, so a brace in a doc comment no longer truncates a `struct`/`enum`/`trait`.
- **#578** a quoted import path is re-escaped when formatted (a quote or backslash stays valid and round-trips).
- **#579** the formatter weaves interior comments into struct literals, map literals, and `match` arms instead of dropping/relocating them.
- **#580** comment scanning skips `${ ... }` interpolations as a unit, so a nested string no longer ends the outer literal early.

Version bumped to 2.18.116. Also auto-formats two files whose formatting drifted while CI was off. CI temporarily disabled for the batch.

Fixes #577
Fixes #578
Fixes #579
Fixes #580
