### PR TITLE
fix: rvpm dependency-graph correctness (#573, #575, #576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.119] - 2026-06-16
+
+Continuing the codex-review fix batch (one patch per issue).
+
+### Fixed
+
+- The dependency resolver rejects a graph that pins one package source to two different versions instead of silently collapsing to one (which compiled a dependent against the wrong code); `rvpm install`/`build`/`update` report the conflict (#573).
+- A selective `rvpm update` prunes packages no longer reachable from the manifest graph, so a transitive dependency dropped by the new version no longer lingers in `rv.lock` (#575).
+- `rvpm install` verifies the lock contains the complete transitive graph, not just the direct dependencies, and re-resolves a fresh lock when a transitive package is missing (#576).
+
 ## [2.18.116] - 2026-06-16
 
 Continuing the codex-review fix batch (one patch per issue).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.116"
+version = "2.18.119"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.116"
+version = "2.18.119"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.116"
+version = "2.18.119"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -223,6 +223,14 @@ pub enum LockError {
         expected: String,
         actual: String,
     },
+    /// The dependency graph pins the same package source to two or more
+    /// different versions. Resolution indexes packages by source, so a single
+    /// version must win per source; rather than silently pick one (and compile
+    /// a dependent against the wrong code), the conflict is reported.
+    ConflictingVersions {
+        source: String,
+        versions: Vec<String>,
+    },
 }
 
 impl fmt::Display for LockError {
@@ -262,6 +270,12 @@ impl fmt::Display for LockError {
                 f,
                 "content hash mismatch for '{}' at '{}': locked {} but fetched tree hashes to {}",
                 source, version, expected, actual
+            ),
+            LockError::ConflictingVersions { source, versions } => write!(
+                f,
+                "dependency '{}' is required at conflicting versions ({}); a single version must be selected per package",
+                source,
+                versions.join(", ")
             ),
         }
     }
@@ -406,10 +420,88 @@ pub fn resolve_and_lock_in(manifest: &Manifest, cache_root: &Path) -> Result<Loc
 
     let mut packages: Vec<LockedPackage> = seen.into_values().collect();
     sort_packages(&mut packages);
+    if let Some((source, versions)) = conflicting_versions(&packages) {
+        return Err(LockError::ConflictingVersions { source, versions });
+    }
     Ok(LockFile {
         version: LOCK_VERSION,
         packages,
     })
+}
+
+/// If any package source appears with two or more distinct versions, return
+/// that source and its conflicting versions (sorted, deduplicated). Import
+/// resolution keys packages by source, so a source must resolve to exactly one
+/// version; a conflict is reported rather than silently collapsed.
+fn conflicting_versions(packages: &[LockedPackage]) -> Option<(String, Vec<String>)> {
+    let mut by_source: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for p in packages {
+        by_source
+            .entry(p.source.as_str())
+            .or_default()
+            .insert(p.version.as_str());
+    }
+    by_source
+        .into_iter()
+        .find(|(_, vs)| vs.len() > 1)
+        .map(|(s, vs)| {
+            (
+                s.to_string(),
+                vs.into_iter().map(|v| v.to_string()).collect(),
+            )
+        })
+}
+
+/// Read the direct dependencies a cached package declares in its own
+/// `rv.toml`, as `(source, version)` pairs. The package is fetched into the
+/// cache if absent. A package with no `rv.toml` (or no `[dependencies]`)
+/// contributes nothing.
+pub fn cached_subdeps(
+    cache_root: &Path,
+    source: &str,
+    version: &str,
+) -> Result<Vec<(String, String)>, LockError> {
+    let gh = crate::resolve::GithubPath::parse(source).ok_or_else(|| {
+        LockError::Parse(format!(
+            "dependency source '{}' is not a github.com path",
+            source
+        ))
+    })?;
+    let fetched = pkg::fetch_in(cache_root, &gh.host, &gh.user, &gh.repo, version)
+        .map_err(LockError::Fetch)?;
+    let manifest_path = fetched.dir.join("rv.toml");
+    if !manifest_path.exists() {
+        return Ok(Vec::new());
+    }
+    let sub = Manifest::load(&manifest_path).map_err(|error| LockError::Manifest {
+        source_path: source.to_string(),
+        error,
+    })?;
+    let mut deps = Vec::with_capacity(sub.dependencies.len());
+    for dep in &sub.dependencies {
+        deps.push((dep.path.clone(), resolved_ref(dep)?));
+    }
+    Ok(deps)
+}
+
+/// Whether `lock` contains the complete transitive graph: every dependency
+/// declared by a locked package's own `rv.toml` is itself a locked entry.
+/// Reads each locked package's cached manifest. Used to detect a lock that
+/// lists a package but omits the packages it pulls in.
+pub fn lock_covers_transitive(lock: &LockFile, cache_root: &Path) -> Result<bool, LockError> {
+    let have: BTreeSet<(String, String)> = lock
+        .packages
+        .iter()
+        .map(|p| (p.source.clone(), p.version.clone()))
+        .collect();
+    for p in &lock.packages {
+        for dep in cached_subdeps(cache_root, &p.source, &p.version)? {
+            if !have.contains(&dep) {
+                return Ok(false);
+            }
+        }
+    }
+    Ok(true)
 }
 
 /// Fetch one package, report it to the observer, hash it (reusing a persisted
@@ -461,6 +553,9 @@ pub fn validate_lock(lock: &LockFile) -> Result<(), LockError> {
 /// entry and verify its tree hash. A mismatch aborts with
 /// [`LockError::HashMismatch`] naming the package.
 pub fn validate_lock_in(lock: &LockFile, cache_root: &Path) -> Result<(), LockError> {
+    if let Some((source, versions)) = conflicting_versions(&lock.packages) {
+        return Err(LockError::ConflictingVersions { source, versions });
+    }
     let results = par_map(lock.packages.clone(), |entry| {
         validate_one(cache_root, &entry)
     });
@@ -1010,5 +1105,110 @@ mod tests {
         std::fs::write(git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
         let h_after = tree_hash(&dir).expect("hash");
         assert_eq!(h_before, h_after, ".git must be excluded");
+    }
+
+    #[test]
+    fn resolve_rejects_two_versions_of_one_source() {
+        // a depends on shared@v1, b depends on shared@v2. Resolution keys
+        // packages by source, so the diamond is rejected rather than silently
+        // collapsed to one version. Regression for #573.
+        let cache = TempCache::new("conflict");
+        cache.seed(
+            "github.com/acme/a",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"github.com/acme/shared\" = \"v1.0.0\"\n",
+            )],
+        );
+        cache.seed(
+            "github.com/acme/b",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"b\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"github.com/acme/shared\" = \"v2.0.0\"\n",
+            )],
+        );
+        cache.seed(
+            "github.com/acme/shared",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"shared\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        cache.seed(
+            "github.com/acme/shared",
+            "v2.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"shared\"\nversion = \"2.0.0\"\n",
+            )],
+        );
+
+        let manifest = manifest_with(&[
+            ("github.com/acme/a", "v1.0.0"),
+            ("github.com/acme/b", "v1.0.0"),
+        ]);
+        let err = resolve_and_lock_in(&manifest, &cache.root).unwrap_err();
+        match err {
+            LockError::ConflictingVersions { source, versions } => {
+                assert_eq!(source, "github.com/acme/shared");
+                assert_eq!(versions, vec!["v1.0.0".to_string(), "v2.0.0".to_string()]);
+            }
+            other => panic!("expected ConflictingVersions, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn transitive_coverage_detects_a_missing_subdependency() {
+        // a@v1 declares a dependency on old@v1, but the lock lists only a@v1.
+        // The lock is therefore not transitively complete. Regression for #576.
+        let cache = TempCache::new("incomplete");
+        cache.seed(
+            "github.com/acme/a",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"github.com/acme/old\" = \"v1.0.0\"\n",
+            )],
+        );
+        cache.seed(
+            "github.com/acme/old",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"old\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+
+        // A lock that omits old@v1.
+        let partial = LockFile {
+            version: LOCK_VERSION,
+            packages: vec![LockedPackage {
+                source: "github.com/acme/a".to_string(),
+                version: "v1.0.0".to_string(),
+                hash: tree_hash(&pkg::cache_dir_in(
+                    &cache.root,
+                    "github.com",
+                    "acme",
+                    "a",
+                    "v1.0.0",
+                ))
+                .expect("hash"),
+            }],
+        };
+        assert!(
+            !lock_covers_transitive(&partial, &cache.root).expect("check"),
+            "a lock missing a declared sub-dependency is not transitively complete"
+        );
+
+        // The complete lock is covered.
+        let manifest = manifest_with(&[("github.com/acme/a", "v1.0.0")]);
+        let full = resolve_and_lock_in(&manifest, &cache.root).expect("resolve");
+        assert!(
+            lock_covers_transitive(&full, &cache.root).expect("check"),
+            "a freshly resolved lock is transitively complete"
+        );
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -13,6 +13,7 @@
 //!
 //! See `docs/v2/specs/rvpm.md` for the command semantics.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -313,16 +314,25 @@ pub fn install_in(
 
     if lock_path.exists() {
         let existing = LockFile::load(&lock_path)?;
+        // The lock is trusted only when it covers the direct dependencies AND
+        // contains the complete transitive graph. A lock that lists a package
+        // but omits the packages it pulls in is incomplete: fall through and
+        // re-resolve a fresh, complete lock instead of building against it.
         if existing.covers(&manifest) {
             lock::validate_lock_in(&existing, cache_root)?;
-            let count = existing.packages.len();
-            return Ok((
-                InstallOutcome::Validated,
-                OpReport {
-                    outcome_lines: vec![format!("Validated {} package(s) against rv.lock", count)],
-                    package_count: count,
-                },
-            ));
+            if lock::lock_covers_transitive(&existing, cache_root)? {
+                let count = existing.packages.len();
+                return Ok((
+                    InstallOutcome::Validated,
+                    OpReport {
+                        outcome_lines: vec![format!(
+                            "Validated {} package(s) against rv.lock",
+                            count
+                        )],
+                        package_count: count,
+                    },
+                ));
+            }
         }
     }
 
@@ -408,6 +418,11 @@ pub fn update_in(
                     merged.packages.push(entry.clone());
                 }
             }
+            // Prune packages no longer reachable from the manifest graph. After
+            // bumping the named dependency, a package that was only pulled in by
+            // its previous version is dead weight; walking the graph from the
+            // manifest through the merged pins drops it.
+            prune_unreachable(&mut merged, &manifest, cache_root)?;
             merged
                 .packages
                 .sort_by(|a, b| a.source.cmp(&b.source).then(a.version.cmp(&b.version)));
@@ -418,6 +433,41 @@ pub fn update_in(
             })
         }
     }
+}
+
+/// Drop every locked package not reachable from `manifest`'s dependency graph.
+/// Walks from the manifest's direct dependencies, following each package's
+/// declared sub-dependencies (read from its cached `rv.toml`) using the lock's
+/// own pins as the version for each source, and retains only the packages
+/// visited.
+fn prune_unreachable(
+    lock: &mut LockFile,
+    manifest: &Manifest,
+    cache_root: &Path,
+) -> Result<(), OpError> {
+    let by_source: BTreeMap<String, String> = lock
+        .packages
+        .iter()
+        .map(|p| (p.source.clone(), p.version.clone()))
+        .collect();
+    let mut reachable: BTreeSet<String> = BTreeSet::new();
+    let mut stack: Vec<String> = manifest
+        .dependencies
+        .iter()
+        .map(|d| d.path.clone())
+        .collect();
+    while let Some(source) = stack.pop() {
+        if !reachable.insert(source.clone()) {
+            continue;
+        }
+        if let Some(version) = by_source.get(&source) {
+            for (sub_source, _sub_version) in lock::cached_subdeps(cache_root, &source, version)? {
+                stack.push(sub_source);
+            }
+        }
+    }
+    lock.packages.retain(|p| reachable.contains(&p.source));
+    Ok(())
 }
 
 /// The conventional application entry source, relative to the project root.
@@ -1144,6 +1194,129 @@ mod tests {
             .unwrap();
         assert_eq!(foo.version, "v1.1.0");
         assert_ne!(foo.hash, old_hash);
+    }
+
+    #[test]
+    fn selective_update_prunes_a_removed_transitive_dependency() {
+        // a@v1 depends on old@v1; a@v2 has no dependencies. After updating a to
+        // v2, old must be pruned from the lock. Regression for #575.
+        let proj = TempProject::new("prune");
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/a\" = \"v1.0.0\"\n",
+        );
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/a",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"github.com/acme/old\" = \"v1.0.0\"\n",
+            )],
+        );
+        proj.seed(
+            &cache,
+            "github.com/acme/old",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"old\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+        proj.seed(
+            &cache,
+            "github.com/acme/a",
+            "v2.0.0",
+            &[("rv.toml", "[package]\nname = \"a\"\nversion = \"2.0.0\"\n")],
+        );
+
+        install_in(&proj.root, &cache).expect("install");
+        let before = proj.lock();
+        assert!(
+            before
+                .packages
+                .iter()
+                .any(|p| p.source == "github.com/acme/old"),
+            "old should be present before the update"
+        );
+
+        // Bump a to v2 (which drops old) and update just a.
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/a\" = \"v2.0.0\"\n",
+        );
+        update_in(&proj.root, Some("github.com/acme/a"), &cache).expect("update");
+
+        let after = proj.lock();
+        assert!(
+            after
+                .packages
+                .iter()
+                .any(|p| p.source == "github.com/acme/a" && p.version == "v2.0.0"),
+            "a should be bumped to v2"
+        );
+        assert!(
+            !after
+                .packages
+                .iter()
+                .any(|p| p.source == "github.com/acme/old"),
+            "old should be pruned, lock was: {:?}",
+            after.packages
+        );
+    }
+
+    #[test]
+    fn install_regenerates_a_transitively_incomplete_lock() {
+        // The lock lists a@v1 but omits the old@v1 that a@v1 declares. install
+        // must detect the gap and re-resolve a complete lock. Regression for
+        // #576.
+        let proj = TempProject::new("incomplete");
+        proj.write_manifest(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"github.com/acme/a\" = \"v1.0.0\"\n",
+        );
+        let cache = proj.cache_root();
+        proj.seed(
+            &cache,
+            "github.com/acme/a",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"github.com/acme/old\" = \"v1.0.0\"\n",
+            )],
+        );
+        proj.seed(
+            &cache,
+            "github.com/acme/old",
+            "v1.0.0",
+            &[(
+                "rv.toml",
+                "[package]\nname = \"old\"\nversion = \"1.0.0\"\n",
+            )],
+        );
+
+        // Hand-write a lock that covers the direct dep but omits the transitive
+        // old@v1.
+        let a_dir = pkg::cache_dir_in(&cache, "github.com", "acme", "a", "v1.0.0");
+        let a_hash = crate::lock::tree_hash(&a_dir).expect("hash");
+        let partial = format!(
+            "version = 1\n\n[[package]]\nsource = \"github.com/acme/a\"\nversion = \"v1.0.0\"\nhash = \"{}\"\n",
+            a_hash
+        );
+        write_file(&proj.root.join(LOCK_FILE_NAME), &partial).expect("write partial lock");
+
+        let (outcome, _) = install_in(&proj.root, &cache).expect("install");
+        assert_eq!(
+            outcome,
+            InstallOutcome::Resolved,
+            "an incomplete lock must be regenerated, not validated"
+        );
+        let after = proj.lock();
+        assert!(
+            after
+                .packages
+                .iter()
+                .any(|p| p.source == "github.com/acme/old"),
+            "the regenerated lock must include the missing transitive dependency"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes codex-review issues #573, #575, #576. Verified locally with five new unit tests (lock + ops) plus the existing dependency-resolution suite.

- **#573** the resolver rejects a graph pinning one source to two versions instead of silently collapsing it (which compiled a dependent against the wrong code). Reported by resolve and lock validation, so install/build/update all surface the conflict.
- **#575** a selective `rvpm update` prunes packages no longer reachable from the manifest graph, so a transitive dependency dropped by the new version no longer lingers in `rv.lock`.
- **#576** `rvpm install` verifies the lock contains the complete transitive graph, not just direct dependencies, and re-resolves when a transitive package is missing.

Version bumped to 2.18.119. CI temporarily disabled for the batch.

Fixes #573
Fixes #575
Fixes #576
