### PR TITLE
build: trigger CI on stdlib changes (#588)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
     paths:
       - "src/**"
-      - "lib/**"
+      - "stdlib/**"
       - "examples/**"
       - "tests/**"
       - "raven-runtime/**"


### PR DESCRIPTION
Fixes #588. The v2 stdlib lives in stdlib/, not the v1 lib/ path, so CI's path filter never fired for a bundled stdlib change. Replaces the stale lib/** entry with stdlib/**.

This PR touches ci.yml, so its own CI run validates main on Ubuntu (fmt, clippy, build, test).

Fixes #588