### PR TITLE
Fix gen_range_float returning infinity for wide ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.127"
+version = "2.18.128"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.127"
+version = "2.18.128"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.127"
+version = "2.18.128"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/random_range_float_wide.rv
+++ b/examples/v2/random_range_float_wide.rv
@@ -1,0 +1,30 @@
+// gen_range_float stays within [lo, hi) even when hi - lo would overflow to
+// infinity. The result is a convex combination of the endpoints, so it is
+// always finite and in range regardless of the draw. Prints:
+//   all in range
+//   narrow ok
+import std/random
+import std/io { println }
+
+fun main() {
+    let rng = Rng.new(42)
+    let in_range = true
+    let i = 0
+    while i < 1000 {
+        let x = rng.gen_range_float(-1.0e308, 1.0e308)
+        if x < -1.0e308 || x >= 1.0e308 {
+            in_range = false
+        }
+        i = i + 1
+    }
+    println(match in_range {
+        true -> "all in range",
+        false -> "out of range",
+    })
+
+    let y = rng.gen_range_float(2.0, 4.0)
+    println(match y >= 2.0 && y < 4.0 {
+        true -> "narrow ok",
+        false -> "narrow bad",
+    })
+}

--- a/examples/v2/random_range_float_wide.rv
+++ b/examples/v2/random_range_float_wide.rv
@@ -12,7 +12,9 @@ fun main() {
     let i = 0
     while i < 1000 {
         let x = rng.gen_range_float(-1.0e308, 1.0e308)
-        if x < -1.0e308 || x >= 1.0e308 {
+        // Negated in-range test so a NaN draw counts as out of range; a bare
+        // x < lo || x >= hi would let NaN through, since it compares false.
+        if !(x >= -1.0e308 && x < 1.0e308) {
             in_range = false
         }
         i = i + 1

--- a/examples/v2/random_range_float_wide.rv.out
+++ b/examples/v2/random_range_float_wide.rv.out
@@ -1,0 +1,2 @@
+all in range
+narrow ok

--- a/stdlib/std/random.rv
+++ b/stdlib/std/random.rv
@@ -101,9 +101,12 @@ impl Rng {
         }
     }
 
-    // A float in [lo, hi).
+    // A float in [lo, hi). Interpolating as lo*(1-t) + hi*t keeps the result
+    // a convex combination of the endpoints, so it stays finite even when
+    // hi - lo would overflow to infinity for a very wide range.
     fun gen_range_float(self, lo: Float, hi: Float) -> Float {
-        return lo + self.next_float() * (hi - lo)
+        let t = self.next_float()
+        return lo * (1.0 - t) + hi * t
     }
 
     // `n` elements drawn from `xs` without replacement, in random order. If


### PR DESCRIPTION
`gen_range_float(lo, hi)` was written as `lo + next_float() * (hi - lo)`. The `hi - lo` is evaluated first, and for a wide finite range like `(-1e308, 1e308)` that subtraction overflows a float to positive infinity before the random fraction ever multiplies it. The call then returned infinity (or NaN when the fraction was exactly zero), well outside the documented half-open interval, even though both endpoints were finite and `lo < hi`.

Switching to the interpolation form `lo * (1 - t) + hi * t` avoids ever computing the full span. Since `t` is in `[0, 1)`, the result is a convex combination of the two endpoints, so it always lands between them and stays finite for any finite `lo` and `hi`. For typical small ranges it produces the same values as before.

`examples/v2/random_range_float_wide.rv` draws a thousand times from `(-1e308, 1e308)` and confirms every result is in range, plus a narrow range to show normal behavior is unchanged. The in-range property holds for any draw, so the baseline is stable.

Fixes #672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floating-point random number range generation to correctly handle extremely wide value ranges.

* **Examples**
  * Added example code demonstrating random float generation with range boundary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->