### PR TITLE
Update math docs: pow_int detects overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.133] - 2026-06-23
+
+### Fixed
+
+- The `std/math` guide and spec no longer claim `pow_int` ignores overflow. They describe the current behavior: `pow_int` aborts with `pow_int overflow`, `abs_int` aborts on `i64::MIN`, and `lcm` aborts on an overflowing product (#633).
+
 ## [2.18.121] - 2026-06-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.131"
+version = "2.18.133"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.131"
+version = "2.18.133"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.131"
+version = "2.18.133"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/stdlib/math.md
+++ b/docs/v2/guide/stdlib/math.md
@@ -53,7 +53,8 @@ Clamp `x` into the closed range `[lo, hi]`: return `lo` if `x < lo`, `hi` if
 
 `base` raised to `exp`, computed by squaring. A negative `exp` has no integer
 result and returns `0`. The result is exact when it fits in a 64-bit signed
-integer; overflow is not detected.
+integer; a result that would overflow aborts with `pow_int overflow` rather
+than wrapping.
 
 ```rust
 import std/math { abs_int, min_int, max_int, clamp_int, pow_int }

--- a/docs/v2/specs/std-math.md
+++ b/docs/v2/specs/std-math.md
@@ -93,7 +93,9 @@ renamed to the conventional Raven spellings. The integer functions,
 The transcendentals are the platform C library's, so accuracy matches the
 host libm (correctly rounded or near-correctly-rounded doubles on a normal
 desktop target). `pow_int` is exact for results that fit in a 64-bit signed
-integer; it does not detect overflow.
+integer and aborts with `pow_int overflow` when a result would exceed it.
+`abs_int` aborts on `i64::MIN` (it has no positive counterpart), and `lcm`
+aborts on an overflowing product.
 
 ## Out of scope
 


### PR DESCRIPTION
`docs/v2/guide/stdlib/math.md` and `docs/v2/specs/std-math.md` both still said `pow_int` does not detect overflow. That described the behavior from before it was fixed. `pow_int` now checks each multiply and abort with `pow_int overflow` rather than wrapping, `abs_int` aborts on `i64::MIN` (which has no positive counterpart), and `lcm` aborts on an overflowing product.

This updates both documents to describe the current behavior. Docs only.

Fixes #633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `std/math` overflow behavior: `pow_int` now aborts on overflow, `abs_int` aborts on `i64::MIN`, and `lcm` aborts on product overflow.

* **Chores**
  * Bumped version to 2.18.133.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->