### PR TITLE
Document fs.is_symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.134] - 2026-06-23
+
+### Fixed
+
+- The `std/fs` guide and spec document `is_symlink(path: String) -> Bool`, the shipped query that reports whether a path is a symbolic link without following it. The boolean-check sections previously stopped at `is_dir` (#637).
+
 ## [2.18.121] - 2026-06-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.131"
+version = "2.18.134"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.131"
+version = "2.18.134"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.131"
+version = "2.18.134"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/stdlib/fs.md
+++ b/docs/v2/guide/stdlib/fs.md
@@ -268,12 +268,15 @@ fun total(a: String, b: String) -> Result<Int, Error> {
 fun exists(path: String) -> Bool
 fun is_file(path: String) -> Bool
 fun is_dir(path: String) -> Bool
+fun is_symlink(path: String) -> Bool
 ```
 
 These return a plain `Bool`, never a `Result`. A missing path is a normal
 `false`, not an `Err`. `is_file` is `false` for a path that exists but is not
 a regular file (a directory, say), and `is_dir` is `false` for anything that
-is not a directory.
+is not a directory. `is_symlink` reports whether the path itself is a symbolic
+link, without following it, so it stays `true` for a link whose target is
+missing.
 
 ```rust
 import std/fs { exists, is_dir, read }

--- a/docs/v2/specs/std-fs.md
+++ b/docs/v2/specs/std-fs.md
@@ -63,11 +63,14 @@ yields an empty list, not a one-element list containing `""`.
 fun exists(path: String) -> Bool
 fun is_file(path: String) -> Bool
 fun is_dir(path: String) -> Bool
+fun is_symlink(path: String) -> Bool
 ```
 
 These return a plain `Bool` and never an error: a missing path is a normal
 `false`, not an `Err`. A path that exists but is not a regular file is
-`false` from `is_file`, and likewise for `is_dir`.
+`false` from `is_file`, and likewise for `is_dir`. `is_symlink` tests the path
+itself without following it, so it is `true` for a symbolic link even when its
+target does not exist.
 
 ## Path manipulation
 


### PR DESCRIPTION
`stdlib/std/fs.rv` exposes `is_symlink(path: String) -> Bool` (backed by the runtime's `raven_fs_is_symlink`), and `walk` already uses it internally, but it was missing from the docs. The boolean-check section of both the guide and the spec stopped at `is_dir`.

This adds `is_symlink` to both, noting that it tests the path itself without following the link, so it stays `true` for a link whose target is gone. Docs only.

Fixes #637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new filesystem function to check if a path is a symbolic link without following it.

* **Documentation**
  * Updated filesystem module guide and specification documentation with new function details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->