### PR TITLE
Document the std/path operations that ship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.140] - 2026-06-24
+
+### Fixed
+
+- The `std/path` spec documents the operations the module ships. `normalize`, `components`, `is_relative`, and `with_extension` were either marked deferred or missing from the surface table even though they are implemented; the spec now lists them and no longer calls path normalization out of scope (#635).
+
 ## [2.18.139] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.139"
+version = "2.18.140"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.139"
+version = "2.18.140"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.139"
+version = "2.18.140"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/std-path.md
+++ b/docs/v2/specs/std-path.md
@@ -40,24 +40,18 @@ fun main() {
 | `dirname(p)` | `String` | everything up to the last `/`; `"."` when there is no `/`; `"/"` when the only `/` is at index 0. |
 | `extension(p)` | `String` | substring after the last `.` in the basename, or `""` when none. A leading dot (a dotfile such as `.gitignore`) is not an extension. |
 | `stem(p)` | `String` | basename without its extension. |
+| `with_extension(p, ext)` | `String` | replace the extension with `ext` (no leading dot); an empty `ext` removes it. A trailing dot counts as the separator, matching `stem`. |
 | `is_absolute(p)` | `Bool` | whether `p` starts with `/`. The empty string is relative. |
+| `is_relative(p)` | `Bool` | the negation of `is_absolute`. |
+| `components(p)` | `List<String>` | the non-empty `/`-separated segments, in order; leading, trailing, and repeated separators drop out. |
+| `normalize(p)` | `String` | resolve `.` and `..` segments and collapse repeated separators, keeping a leading `/` for an absolute path. An empty relative result is `"."`. A `..` that would escape a relative root is kept; one at an absolute root is dropped. |
 
 Indices are byte offsets, consistent with `std/string`. Paths are assumed
 to be valid UTF-8 with the separator and dot appearing only as their own
 single-byte ASCII forms.
 
-## normalize
-
-`normalize` (resolving `.` and `..` segments and collapsing repeated
-separators) is deferred. It is fiddly to specify (root escapes, trailing
-slashes, empty results) and not required by the current consumers. It can
-be added later without changing the existing surface.
-
 ## Out of scope
 
 - Windows `\` separators, drive letters, and UNC paths.
-- `normalize` and any `..`/`.` resolution.
 - Filesystem queries (existence, canonicalization); those belong to
   `std/fs`.
-- Splitting a path into a `List` of components (waits on a stable list
-  return convention in the stdlib).


### PR DESCRIPTION
`docs/v2/specs/std-path.md` lagged behind the implementation. It marked `normalize` as deferred, listed path normalization and component splitting as out of scope, and left `is_relative` and `with_extension` off the surface table, even though all four are implemented in `stdlib/std/path.rv` (and the user guide already documents them).

This adds `with_extension`, `is_relative`, `components`, and `normalize` to the surface table with their actual behavior, and removes the deferred `normalize` section and the now-incorrect out-of-scope bullets. Docs only.

Fixes #635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated std/path specification to define four path manipulation functions (normalize, components, is_relative, with_extension) that were previously marked as out of scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->