### PR TITLE
Make Float Eq and Ord total for NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.143] - 2026-06-24
+
+### Fixed
+
+- The `Eq` and `Ord` trait impls for `Float` are total in the presence of NaN. `Eq` is now reflexive (a NaN equals itself, so a `Float` map key or a derived struct compares to itself), and `Ord.compare` gives NaN one fixed position (two NaN are equal, a NaN sorts after every number) instead of comparing equal to everything. The `==`/`<` operators keep their IEEE meaning (#610).
+
 ## [2.18.142] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.142"
+version = "2.18.143"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.142"
+version = "2.18.143"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.142"
+version = "2.18.143"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/float_nan_traits.rv
+++ b/examples/v2/float_nan_traits.rv
@@ -1,0 +1,27 @@
+// Float's Eq and Ord trait impls are total: a NaN equals itself and sorts
+// after every ordinary number, so sorting and equality stay well defined even
+// with NaN present. The < and > operators keep their IEEE meaning. Prints:
+//   nan equals nan: true
+//   1
+//   2
+//   3
+//   NaN
+import std/cmp { sort }
+import std/math { nan }
+import std/io { println }
+
+fun main() {
+    let n = nan()
+    println("nan equals nan: ${n.equals(n)}")
+
+    let sorted = sort([3.0, nan(), 1.0, 2.0])
+    let i = 0
+    while i < sorted.len() {
+        let v = sorted.get(i)
+        println(match v != v {
+            true -> "NaN",
+            false -> v.to_string(),
+        })
+        i = i + 1
+    }
+}

--- a/examples/v2/float_nan_traits.rv.out
+++ b/examples/v2/float_nan_traits.rv.out
@@ -1,0 +1,5 @@
+nan equals nan: true
+1
+2
+3
+NaN

--- a/stdlib/std/core.rv
+++ b/stdlib/std/core.rv
@@ -50,7 +50,14 @@ impl Eq for Int {
 }
 
 impl Eq for Float {
-    fun equals(self, other: Float) -> Bool = self == other
+    fun equals(self, other: Float) -> Bool {
+        if self == other {
+            return true
+        }
+        // `Eq` is reflexive, but IEEE says NaN != NaN. Count two NaN as equal so
+        // a Float used as a map key or in a derived struct compares to itself.
+        return self != self && other != other
+    }
 }
 
 impl Eq for Bool {
@@ -151,6 +158,20 @@ impl Ord for Float {
         }
         if self > other {
             return 1
+        }
+        // Equal under IEEE, or a NaN is involved (every `<` and `>` was false).
+        // Give NaN one fixed place so the order is total and reflexive: two NaN
+        // are equal, and a NaN sorts after every ordinary number.
+        let self_nan = self != self
+        let other_nan = other != other
+        if self_nan {
+            if other_nan {
+                return 0
+            }
+            return 1
+        }
+        if other_nan {
+            return -1
         }
         0
     }


### PR DESCRIPTION
The prelude implemented `Eq` and `Ord` for `Float` with plain IEEE comparisons, which break the trait contracts when a value is NaN:

- `Eq` is meant to be reflexive, but `nan().equals(nan())` was `false`, so a `Float` map key or a derived struct containing a `Float` did not compare equal to itself.
- `Ord.compare` is meant to be a total order, but it returned `0` for any comparison involving NaN, so NaN compared equal to every number and sorting was undefined.

`equals` now counts two NaN as equal, and `compare` gives NaN a single fixed position: two NaN are equal, and a NaN sorts after every ordinary number. The order is total and reflexive.

This only touches the trait methods (the ones sorting, `Set`/`Map` keys, and `@derive(Eq/Ord)` use). The language `==` and `<` operators are untouched and keep their IEEE semantics, so `nan() == nan()` is still `false` and numeric comparisons are unchanged.

`examples/v2/float_nan_traits.rv` checks reflexivity and that `sort([3.0, nan(), 1.0, 2.0])` yields `1, 2, 3, NaN`.

Fixes #610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Float comparison operations now properly handle NaN: NaN equals itself and consistently sorts after all regular numbers.

* **Documentation**
  * Added example demonstrating Float behavior with NaN values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->