### PR TITLE
Reject undefined metavariables in macro templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.145] - 2026-06-24
+
+### Fixed
+
+- A macro template that splices an undefined metavariable is rejected at the definition instead of silently dropping it. `macro keep { ($x:expr) => { $missing $x } }` now reports `template uses undefined metavariable $missing` rather than expanding to just `$x` (#663).
+
 ## [2.18.142] - 2026-06-24
 
 ### Fixed

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -425,10 +425,38 @@ fn parse_rules(inner: &[Token], name: &str, span: &Span) -> Result<Vec<Rule>, Ra
             )
         })?;
         let template = parse_template(&inner[j + 1..tclose], name)?;
+        // Every metavariable the template splices must be bound by the matcher.
+        // An undefined one (a typo, say) was silently dropped at expansion;
+        // reject it at the definition instead.
+        let bound = matcher_meta_names(&matcher);
+        for var in template_meta_names(&template) {
+            if !bound.contains(&var) {
+                return Err(err(
+                    inner[j].span.clone(),
+                    format!(
+                        "macro `{}`: template uses undefined metavariable `${}`",
+                        name, var
+                    ),
+                ));
+            }
+        }
         rules.push(Rule { matcher, template });
         i = tclose + 1;
     }
     Ok(rules)
+}
+
+/// Names of metavariables a matcher binds, including those inside repetitions.
+fn matcher_meta_names(items: &[MatchItem]) -> Vec<String> {
+    let mut out = Vec::new();
+    for it in items {
+        match it {
+            MatchItem::Meta { name, .. } => out.push(name.clone()),
+            MatchItem::Rep { sub, .. } => out.extend(matcher_meta_names(sub)),
+            MatchItem::Literal(_) => {}
+        }
+    }
+    out
 }
 
 /// Parse a matcher token slice into match items.

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -107,6 +107,18 @@ fn literal_fragment_rejects_a_non_literal() {
 }
 
 #[test]
+fn template_undefined_metavar_is_an_error() {
+    let src = "macro keep { ($x:expr) => { $missing $x } }\nkeep!(7)\n";
+    let e = expand_tokens(&lex(src)).expect_err("undefined template metavariable");
+    let msg = format!("{}", e);
+    assert!(
+        msg.contains("undefined metavariable `$missing`"),
+        "got: {}",
+        msg
+    );
+}
+
+#[test]
 fn block_fragment_captures_a_brace_group() {
     let src = "macro run { ($b:block) => { $b } }\nrun!({ let a = 1 })\n";
     assert_eq!(expand_render(src), "{ let a = 1 }");


### PR DESCRIPTION
A macro template that splices a metavariable the matcher never bound dropped it silently at expansion:

```raven
macro keep { ($x:expr) => { $missing $x } }
keep!(7)   // expanded to just `7`, the `$missing` vanished
```

So a typo in a metavariable name produced wrong output with no diagnostic. The macro definition now collects the matcher's metavariable names (including those inside repetitions) and rejects any template metavariable outside that set:

```
error: macro `keep`: template uses undefined metavariable `$missing`
```

Valid macros, including repetition macros where a metavariable is bound under `$( ... )`, are unaffected. Added a unit test for the error in `src/macros/tests.rs`; the existing macro and parser-golden suites still pass.

Fixes #663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Macro templates that reference undefined metavariables are now rejected at definition time with a clear error message, instead of silently dropping the missing references during expansion.
* **Tests**
  * Added a unit test to verify expansion fails and reports `undefined metavariable $missing` when a macro template references an unbound metavariable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->