### PR TITLE
Reject a macro matcher that binds a metavariable twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.147] - 2026-06-24
+
+### Fixed
+
+- A macro matcher that binds the same metavariable name twice is rejected. `macro choose { ($x:expr, $x:expr) => { $x } }` reported no error and the second capture silently overwrote the first; it now reports `metavariable $x is bound more than once` (#665).
+
 ## [2.18.146] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.146"
+version = "2.18.147"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.146"
+version = "2.18.147"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.146"
+version = "2.18.147"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -429,6 +429,21 @@ fn parse_rules(inner: &[Token], name: &str, span: &Span) -> Result<Vec<Rule>, Ra
         // An undefined one (a typo, say) was silently dropped at expansion;
         // reject it at the definition instead.
         let bound = matcher_meta_names(&matcher);
+        // A matcher must not bind the same metavariable name twice: the second
+        // capture silently overwrote the first, so `$x` referred to only one of
+        // the arguments.
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for var in &bound {
+            if !seen.insert(var.as_str()) {
+                return Err(err(
+                    inner[i].span.clone(),
+                    format!(
+                        "macro `{}`: metavariable `${}` is bound more than once",
+                        name, var
+                    ),
+                ));
+            }
+        }
         for var in template_meta_names(&template) {
             if !bound.contains(&var) {
                 return Err(err(

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -119,6 +119,18 @@ fn template_undefined_metavar_is_an_error() {
 }
 
 #[test]
+fn duplicate_matcher_metavariable_is_an_error() {
+    let src = "macro choose { ($x:expr, $x:expr) => { $x } }\nchoose!(1, 2)\n";
+    let e = expand_tokens(&lex(src)).expect_err("duplicate metavariable");
+    let msg = format!("{}", e);
+    assert!(
+        msg.contains("metavariable `$x` is bound more than once"),
+        "got: {}",
+        msg
+    );
+}
+
+#[test]
 fn block_fragment_captures_a_brace_group() {
     let src = "macro run { ($b:block) => { $b } }\nrun!({ let a = 1 })\n";
     assert_eq!(expand_render(src), "{ let a = 1 }");


### PR DESCRIPTION
A macro matcher that named the same metavariable more than once was accepted, and the second capture silently overwrote the first:

```raven
macro choose { ($x:expr, $x:expr) => { $x } }
choose!(1, 2)   // expanded to `2`; the first `$x` was lost
```

The definition now rejects a duplicate metavariable name:

```
error: macro `choose`: metavariable `$x` is bound more than once
```

A metavariable used inside a repetition (`$($x:expr),+`) is still bound once and works as before, since it is one binding repeated across the matched sequence. Added a unit test; the existing macro suite passes.

Fixes #665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Macro matchers now reject duplicate metavariable bindings with a clear error message instead of silently overwriting previous bindings.

* **Tests**
  * Added test coverage for duplicate metavariable validation in macros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->