### PR TITLE
Balance angle brackets in a ty macro fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Raven are documented in this file.
 
-## [2.18.147] - 2026-06-24
+## [2.18.148] - 2026-06-24
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.147] - 2026-06-24
+
+### Fixed
+
+- A `ty` macro fragment balances angle brackets, so a comma inside generic arguments stays part of the type. `$t:ty` matching `Pair<Int, String>` now captures the whole type instead of stopping at the first comma. `<`/`>` in an `expr` or `pat` fragment are still treated as comparison operators (#662).
+
 ## [2.18.146] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.146"
+version = "2.18.147"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.146"
+version = "2.18.147"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.147"
+version = "2.18.148"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.147"
+version = "2.18.148"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.146"
+version = "2.18.147"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.147"
+version = "2.18.148"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -766,7 +766,12 @@ fn match_seq(
                 // and the parentheses of a constructor pattern stay balanced.
                 Fragment::Expr | Fragment::Ty | Fragment::Pat => {
                     let delim = next_delim(matcher, idx + 1, outer_delim);
-                    let end = capture_balanced(args, pos, delim.as_ref())?;
+                    // A `ty` fragment also balances angle brackets, so a comma
+                    // inside generic arguments (`Pair<Int, String>`) does not end
+                    // the type. `<`/`>` are comparison operators in an `expr` or
+                    // `pat`, so those fragments leave angles untracked.
+                    let angles = matches!(frag, Fragment::Ty);
+                    let end = capture_balanced(args, pos, delim.as_ref(), angles)?;
                     if end == pos {
                         return None;
                     }
@@ -889,7 +894,12 @@ fn next_delim(
 /// Capture a balanced token run from `start` until a top-level `delim` (or
 /// the end of `args` when `delim` is `None`). Bracket depth must be balanced
 /// at the stop point. Returns the index of the stop position.
-fn capture_balanced(args: &[Token], start: usize, delim: Option<&TokenKind>) -> Option<usize> {
+fn capture_balanced(
+    args: &[Token],
+    start: usize,
+    delim: Option<&TokenKind>,
+    angles: bool,
+) -> Option<usize> {
     let mut depth: i32 = 0;
     let mut i = start;
     while i < args.len() {
@@ -902,6 +912,13 @@ fn capture_balanced(args: &[Token], start: usize, delim: Option<&TokenKind>) -> 
                 }
                 depth -= 1;
             }
+            // For a `ty` fragment, angle brackets are generic delimiters: `<`
+            // opens one and `>` closes it, and a `<<`/`>>` token spans two (a
+            // nested generic like `Vec<Vec<Int>>`).
+            TokenKind::Lt if angles => depth += 1,
+            TokenKind::Shl if angles => depth += 2,
+            TokenKind::Gt if angles && depth > 0 => depth -= 1,
+            TokenKind::Shr if angles && depth > 0 => depth = (depth - 2).max(0),
             _ => {}
         }
         if depth == 0 {

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -93,6 +93,18 @@ fn ty_fragment_captures_a_balanced_type() {
 }
 
 #[test]
+fn ty_fragment_keeps_a_comma_inside_generics() {
+    // The comma inside `Pair<Int, String>` belongs to the type, not the
+    // matcher's `,` delimiter, so the whole type is one `$t`.
+    let src = "macro first { ($t:ty, $e:expr) => { take($t, $e) } }\n\
+               let r = first!(Pair<Int, String>, 0)\n";
+    assert_eq!(
+        expand_render(src),
+        "let r = take ( Pair `<` Int , String > , 0 )"
+    );
+}
+
+#[test]
 fn literal_fragment_captures_one_literal() {
     let src = "macro dbl { ($x:literal) => { ($x) + ($x) } }\nlet y = dbl!(21)\n";
     assert_eq!(expand_render(src), "let y = ( 21 ) + ( 21 )");


### PR DESCRIPTION
A `ty` macro fragment captured a balanced token run over `()`, `[]`, and `{}`, but not angle brackets. So a comma inside generic arguments ended the type early:

```raven
macro show_type { ($t:ty, $ignored:expr) => { type_name<$t>() } }
show_type!(Pair<Int, String>, 0)   // $t captured only `Pair<Int`
```

The `ty` capture now tracks `<` / `>` (and the `<<` / `>>` tokens that nested generics like `Vec<Vec<Int>>` produce), so `Pair<Int, String>` is captured whole and the matcher's `,` delimiter is the one after the closing `>`. `expr` and `pat` fragments deliberately leave angles untracked, since there `<` and `>` are comparison operators, so `cmp!(3, 5)` with `($a) < ($b)` still works.

Added a unit test that a comma inside `Pair<Int, String>` stays in the `$t` capture.

Fixes #662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macro parsing for `$t:ty` so generic types with internal commas (e.g., `Pair<Int, String>`) are captured correctly as a single type fragment.
  * Improved balanced handling for nested generic angle brackets to prevent premature termination at delimiters that would otherwise end parsing.
* **Tests**
  * Added a macro-expansion test covering comma-containing generic type fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->