### PR TITLE
Stop format_timestamp aborting on an invalid strftime pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.149] - 2026-06-24
+
+### Fixed
+
+- `format_timestamp` returns the empty string for an invalid strftime pattern instead of aborting the process. chrono reports a bad directive through its formatter's `Display` error, and the runtime's `to_string()` panicked on it, which cannot unwind across the C ABI; the runtime now formats fallibly (#673).
+
 ## [2.18.148] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.148"
+version = "2.18.149"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.148"
+version = "2.18.149"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.148"
+version = "2.18.149"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/time_format_invalid_pattern.rv
+++ b/examples/v2/time_format_invalid_pattern.rv
@@ -1,0 +1,14 @@
+// format_timestamp returns the empty string for an invalid strftime pattern
+// instead of aborting the process, and a valid pattern formats normally.
+// Prints:
+//   [valid] 1970-01-01
+//   [invalid] []
+//   done
+import std/time { format_timestamp }
+import std/io { println }
+
+fun main() {
+    println("[valid] ${format_timestamp(0, "%Y-%m-%d")}")
+    println("[invalid] [${format_timestamp(0, "%Q")}]")
+    println("done")
+}

--- a/examples/v2/time_format_invalid_pattern.rv.out
+++ b/examples/v2/time_format_invalid_pattern.rv.out
@@ -1,0 +1,3 @@
+[valid] 1970-01-01
+[invalid] []
+done

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1084,7 +1084,18 @@ pub extern "C" fn raven_time_format(
 ) -> *mut object::String {
     let dt = time_from_ts(ts);
     let value = match env_name(pattern) {
-        Some(p) => dt.format(p).to_string(),
+        // chrono's formatter reports an invalid directive through its `Display`
+        // error. `to_string()` panics on that, which cannot unwind across the C
+        // ABI and aborts the process, so format fallibly and return the empty
+        // string for a bad pattern instead.
+        Some(p) => {
+            use std::fmt::Write;
+            let mut out = std::string::String::new();
+            if write!(out, "{}", dt.format(p)).is_err() {
+                out.clear();
+            }
+            out
+        }
         None => std::string::String::new(),
     };
     object::raven_string_from_bytes(value.as_ptr(), value.len())


### PR DESCRIPTION
`format_timestamp(0, "%Q")` aborted the whole process. chrono reports an invalid format directive through its formatter's `Display` implementation returning an error, and the runtime built the result with `dt.format(p).to_string()`, which panics when `Display` errors. That panic can't unwind across the `extern "C"` boundary, so it aborts.

The runtime now formats fallibly with `write!` and returns the empty string when the pattern is invalid, matching how a `None` pattern already produced an empty string. A valid pattern formats exactly as before.

`examples/v2/time_format_invalid_pattern.rv` checks a valid pattern, an invalid one (empty result), and that execution continues afterward. Required a `raven-runtime` rebuild; the golden and codegen_smoke suites pass against it.

Fixes #673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `format_timestamp` now gracefully handles invalid time format patterns by returning an empty string instead of crashing the application.

* **Examples**
  * Added an example demonstrating `format_timestamp` behavior with both valid and invalid time format patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->