### PR TITLE
Saturate the WaitGroup counter on add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.150] - 2026-06-24
+
+### Fixed
+
+- `WaitGroup.add` saturates its counter instead of doing an unchecked signed add. A delta that would overflow i64 no longer aborts the debug runtime, nor wraps negative and falsely completes the group so `wait()` returns without the work being done (#674).
+
 ## [2.18.148] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.148"
+version = "2.18.150"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.148"
+version = "2.18.150"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.148"
+version = "2.18.150"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/waitgroup_add_overflow.rv
+++ b/examples/v2/waitgroup_add_overflow.rv
@@ -1,0 +1,20 @@
+// WaitGroup.add saturates its counter, so a delta that would overflow i64
+// neither aborts the runtime nor wraps negative and falsely completes the
+// group. A normal add/done/wait still completes. Prints:
+//   no abort on overflow
+//   normal wait completed
+import std/sync { wait_group }
+import std/io { println }
+
+fun main() {
+    let wg = wait_group()
+    wg.add(9223372036854775807)
+    wg.add(1)
+    println("no abort on overflow")
+
+    let wg2 = wait_group()
+    wg2.add(1)
+    wg2.done()
+    wg2.wait()
+    println("normal wait completed")
+}

--- a/examples/v2/waitgroup_add_overflow.rv.out
+++ b/examples/v2/waitgroup_add_overflow.rv.out
@@ -1,0 +1,2 @@
+no abort on overflow
+normal wait completed

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -728,8 +728,10 @@ pub extern "C" fn raven_waitgroup_add(id: i64, delta: i64) {
         Some(wg) => {
             // Saturate at zero: a `done` past zero must not drive the count
             // negative, or a later `add` would bring it back to zero and let a
-            // waiter that should still block return early.
-            wg.count = (wg.count + delta).max(0);
+            // waiter that should still block return early. The add itself also
+            // saturates so a huge delta cannot overflow i64 (which aborts the
+            // debug runtime, or wraps negative and falsely completes the group).
+            wg.count = wg.count.saturating_add(delta).max(0);
             if wg.count <= 0 {
                 std::mem::take(&mut wg.waiters)
             } else {


### PR DESCRIPTION
`WaitGroup.add` did an unchecked signed addition on its runtime counter. A delta large enough to overflow `i64` panicked inside the `extern "C"` function and aborted the debug runtime; in an optimized build the addition wrapped negative and the following `.max(0)` clamped it to zero, marking the group complete so `wait()` returned even though no `done()` had run.

The add now uses `saturating_add` before the existing zero clamp, so an overflowing delta caps at `i64::MAX` (the group stays incomplete) instead of aborting or wrapping. Normal `add`/`done`/`wait` is unchanged.

`examples/v2/waitgroup_add_overflow.rv` adds `i64::MAX` then `1` (no abort) and runs a normal `add`/`done`/`wait` to completion. Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #674