### PR TITLE
Read raw bytes in fs.read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.151] - 2026-06-24
+
+### Fixed
+
+- `std/fs.read` returns the file's raw bytes instead of requiring valid UTF-8. A Raven `String` is a byte buffer and `fs.write` already writes arbitrary bytes, so a binary file written through the API now reads back byte for byte instead of failing with a UTF-8 error (#609).
+
 ## [2.18.150] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.150"
+version = "2.18.151"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.150"
+version = "2.18.151"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.150"
+version = "2.18.151"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/fs_binary_roundtrip.rv
+++ b/examples/v2/fs_binary_roundtrip.rv
@@ -1,0 +1,41 @@
+// golden:skip - writes a file; the binary round-trip is checked in
+// codegen_smoke.rs (fs_binary_roundtrip_compiles_and_runs).
+//
+// fs.read returns raw bytes, so a file written with non-UTF-8 bytes reads
+// back byte-for-byte through the same API. Prints:
+//   wrote 5
+//   read 5
+//   0 255 104 105 254
+import std/fs { read, write, remove_file }
+import std/io { println }
+
+fun main() {
+    let data = __str_from_byte(0)
+        .concat(__str_from_byte(255))
+        .concat("hi")
+        .concat(__str_from_byte(254))
+    match write("fs_binary_roundtrip.dat", data) {
+        Ok(_) -> println("wrote ${data.length()}"),
+        Err(e) -> println("write err ${e.message()}"),
+    }
+    match read("fs_binary_roundtrip.dat") {
+        Ok(s) -> {
+            println("read ${s.length()}")
+            let i = 0
+            let line = ""
+            while i < s.length() {
+                if i > 0 {
+                    line = line.concat(" ")
+                }
+                line = line.concat("${__str_byte_at(s, i)}")
+                i = i + 1
+            }
+            println(line)
+        }
+        Err(e) -> println("read err ${e.message()}"),
+    }
+    match remove_file("fs_binary_roundtrip.dat") {
+        Ok(_) -> {},
+        Err(_) -> {},
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -784,10 +784,14 @@ pub extern "C" fn raven_fs_last_error() -> *mut object::String {
 /// `path` must be a valid `raven_string_from_bytes`-built `String`.
 #[no_mangle]
 pub extern "C" fn raven_fs_read(path: *const object::String) -> *mut object::String {
+    // Read the raw bytes, not UTF-8 text: a Raven String is a byte buffer, and
+    // `raven_fs_write` already writes arbitrary bytes, so a binary file written
+    // by one program must read back through the same API. Only the path needs
+    // to be valid UTF-8.
     let contents = crate::gc::blocking(|| {
         env_name(path)
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path is not valid UTF-8"))
-            .and_then(std::fs::read_to_string)
+            .and_then(std::fs::read)
     });
     let value = fs_record(contents).unwrap_or_default();
     object::raven_string_from_bytes(value.as_ptr(), value.len())

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1029,6 +1029,35 @@ fn fs_program_compiles_and_runs() {
 }
 
 #[test]
+fn fs_binary_roundtrip_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // fs.read returns raw bytes, so a file written with non-UTF-8 bytes reads
+    // back byte-for-byte. The program writes a small binary file in its working
+    // directory, reads it back, prints the byte values, and removes it.
+    let example = build_example_binary("fs_binary_roundtrip.rv", &runtime);
+    let output = Command::new(&example.binary)
+        .current_dir(&example.tmp)
+        .output()
+        .expect("run fs_binary_roundtrip binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&example.tmp);
+    assert!(
+        output.status.success(),
+        "fs_binary_roundtrip exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "wrote 5\nread 5\n0 255 104 105 254\n",
+        "unexpected stdout for fs_binary_roundtrip: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn net_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`std/fs.read` could not read a file containing non-UTF-8 bytes, even though a Raven `String` is a byte buffer and `std/fs.write` happily writes arbitrary bytes. So a program could write a binary string and then fail to read it back through the same API, with `read: stream did not contain valid UTF-8`.

The runtime read the file with `read_to_string`; it now reads the raw bytes with `std::fs::read`, so a binary file round-trips byte for byte. Only the path still has to be valid UTF-8, and `fs_record`'s generic error handling is unchanged. Normal text reads are unaffected.

Tested with a `golden:skip` example (`examples/v2/fs_binary_roundtrip.rv`) driven by a new `codegen_smoke.rs` case that writes a file with `0x00`/`0xFF`/`0xFE` bytes, reads it back, and checks the byte values. Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `std/fs.read` now returns raw bytes from files, supporting non-UTF-8 content without validation errors

* **Documentation**
  * Added example demonstrating binary file read/write round-trip operations

* **Tests**
  * Added smoke test for binary file I/O verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->