### PR TITLE
Preserve non-UTF-8 bytes in read_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.152] - 2026-06-24
+
+### Fixed
+
+- `std/io.read_line` preserves a line that contains non-UTF-8 bytes. It read the line as UTF-8 text and silently returned an empty string on a bad byte; it now reads the raw bytes up to the newline, so the line round-trips through the byte-buffer `String` (#657).
+
 ## [2.18.150] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.150"
+version = "2.18.152"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.150"
+version = "2.18.152"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.150"
+version = "2.18.152"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/read_line_binary.rv
+++ b/examples/v2/read_line_binary.rv
@@ -1,0 +1,23 @@
+// golden:skip - reads from stdin; the non-UTF-8 round-trip is checked in
+// codegen_smoke.rs (read_line_preserves_non_utf8).
+//
+// read_line returns the line's raw bytes, so a byte that is not valid UTF-8
+// is preserved rather than dropped. For the input bytes 0x41 0xFF 0x42 it
+// prints:
+//   3
+//   65
+//   255
+//   66
+import std/io { read_line }
+import std/string
+import std/io { println }
+
+fun main() {
+    let line = read_line()
+    println("${line.length()}")
+    let i = 0
+    while i < line.length() {
+        println("${__str_byte_at(line, i)}")
+        i = i + 1
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -384,20 +384,24 @@ pub extern "C" fn raven_println_str(ptr: *const u8, len: usize) {
 /// Returns null only when the underlying `String` allocation fails.
 #[no_mangle]
 pub extern "C" fn raven_read_line() -> *mut object::String {
-    let mut line = std::string::String::new();
+    // Read raw bytes, not UTF-8 text: a Raven String is a byte buffer, so a line
+    // with a non-UTF-8 byte must be preserved rather than discarded. `read_line`
+    // requires valid UTF-8 and drops the line on a bad byte; `read_until` reads
+    // the bytes up to the newline regardless.
+    let mut line: Vec<u8> = Vec::new();
     let stdin = io::stdin();
     // A read error or clean EOF both leave `line` as the bytes gathered
     // so far (empty at a clean EOF); either way we hand back a String.
     // Reading a line blocks on input, so run it outside the collector's
     // running set (a goroutine waiting on stdin must not freeze a collection).
     crate::gc::blocking(|| {
-        let _ = stdin.lock().read_line(&mut line);
+        let _ = stdin.lock().read_until(b'\n', &mut line);
     });
     // Strip the trailing newline and an optional preceding carriage
     // return so callers see the line content without the terminator.
-    if line.ends_with('\n') {
+    if line.last() == Some(&b'\n') {
         line.pop();
-        if line.ends_with('\r') {
+        if line.last() == Some(&b'\r') {
             line.pop();
         }
     }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1463,6 +1463,47 @@ fn list_get_rejects_out_of_range_index() {
     );
 }
 
+#[test]
+fn read_line_preserves_non_utf8() {
+    use std::io::Write;
+    use std::process::Stdio;
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // read_line returns the line's raw bytes, so a non-UTF-8 byte is preserved
+    // rather than dropped. The program reads one line and prints its length and
+    // each byte value; the input is `A` `0xFF` `B` then a newline.
+    let example = build_example_binary("read_line_binary.rv", &runtime);
+    let mut child = Command::new(&example.binary)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn read_line_binary");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(&[0x41, 0xff, 0x42, b'\n'])
+        .expect("write stdin");
+    let output = child
+        .wait_with_output()
+        .expect("wait read_line_binary binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&example.tmp);
+    assert!(
+        output.status.success(),
+        "read_line_binary exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "3\n65\n255\n66\n",
+        "unexpected stdout for read_line_binary: {:?}",
+        stdout
+    );
+}
+
 /// A compiled example binary plus the temp dir holding it, so the caller
 /// can run the binary and then clean up.
 struct ExampleBinary {


### PR DESCRIPTION
`std/io.read_line` silently returned an empty string when the input line held a byte that was not valid UTF-8. It read the line with `BufRead::read_line`, which requires valid UTF-8 and discards the line on a bad byte, even though a Raven `String` is a byte buffer and the input API documents no UTF-8 restriction.

The runtime now reads the raw bytes up to the newline with `read_until`, so the line round-trips byte for byte. The trailing `\n` (and an optional preceding `\r`) is still stripped, and normal text input is unchanged.

Tested with a `golden:skip` example (`examples/v2/read_line_binary.rv`) driven by a new `codegen_smoke.rs` case that pipes `0x41 0xFF 0x42` to the program and checks the bytes come back as `65 255 66`. Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `read_line` now preserves raw non-UTF-8 bytes instead of dropping them, enabling proper handling of binary data in lines.

* **New Features**
  * Added example demonstrating binary-safe line reading with non-UTF-8 byte preservation.

* **Chores**
  * Version bumped to 2.18.152.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->