### PR TITLE
Carry arbitrary bytes through std/process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.153] - 2026-06-24
+
+### Fixed
+
+- `std/process` carries arbitrary bytes through a child. A child's stdout and stderr are captured as raw bytes instead of being lossily decoded as UTF-8 (a non-UTF-8 byte was replaced with U+FFFD), and `run_with_input` feeds non-UTF-8 stdin instead of rejecting it before spawning. Only the program path and its args still need to be valid UTF-8 (#608).
+
 ## [2.18.152] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.152"
+version = "2.18.153"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.152"
+version = "2.18.153"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.152"
+version = "2.18.153"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/proc_binary_child.rv
+++ b/examples/v2/proc_binary_child.rv
@@ -1,0 +1,8 @@
+// golden:skip - the child half of the std/process binary I/O smoke test
+// (proc_binary_parent.rv, checked in codegen_smoke.rs). Writes the bytes
+// 0x00 0xFF 0x41 to stdout (the builtin print adds a trailing newline).
+import std/string
+
+fun main() {
+    print(__str_from_byte(0).concat(__str_from_byte(255)).concat(__str_from_byte(65)))
+}

--- a/examples/v2/proc_binary_parent.rv
+++ b/examples/v2/proc_binary_parent.rv
@@ -1,0 +1,40 @@
+// golden:skip - std/process binary I/O parent, checked in codegen_smoke.rs
+// (proc_binary_io_compiles_and_runs). Runs the child (path in
+// RAVEN_PROC_CHILD) with non-UTF-8 stdin, which must be accepted, then runs
+// it again and prints the byte values of its captured (binary) stdout.
+// Prints:
+//   stdin ok
+//   4
+//   0
+//   255
+//   65
+//   10
+import std/process { run, run_with_input }
+import std/env { get_env }
+import std/io { println }
+import std/string
+
+fun main() {
+    let child = get_env("RAVEN_PROC_CHILD")
+    let no_args: List<String> = []
+
+    // A Raven String is a byte buffer, so non-UTF-8 stdin must not be rejected.
+    let bin_stdin = __str_from_byte(255).concat(__str_from_byte(0))
+    match run_with_input(child, no_args, bin_stdin) {
+        Ok(_) -> println("stdin ok"),
+        Err(e) -> println("stdin rejected: ${e.message()}"),
+    }
+
+    // The child's binary stdout is captured byte for byte.
+    match run(child, no_args) {
+        Ok(out) -> {
+            println("${out.stdout.length()}")
+            let i = 0
+            while i < out.stdout.length() {
+                println("${__str_byte_at(out.stdout, i)}")
+                i = i + 1
+            }
+        }
+        Err(e) -> println("run failed: ${e.message()}"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -172,8 +172,10 @@ fn process_clear_error() {
 /// id so only an opaque integer crosses the FFI.
 struct ProcResult {
     code: i64,
-    stdout: std::string::String,
-    stderr: std::string::String,
+    // Raw bytes, not text: a child can write arbitrary binary to stdout/stderr
+    // and a Raven String is a byte buffer, so the output is captured verbatim.
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
 }
 
 /// The process-wide child-result registry keyed by an incrementing id. Ids
@@ -1906,13 +1908,22 @@ pub extern "C" fn raven_process_run(
     args_nul_joined: *const object::String,
     stdin_data: *const object::String,
 ) -> i64 {
-    let (Some(program), Some(args_joined), Some(stdin_data)) = (
-        env_name(program),
-        env_name(args_nul_joined),
-        env_name(stdin_data),
-    ) else {
-        process_set_error("program, args, or stdin is not valid UTF-8".to_string());
+    let (Some(program), Some(args_joined)) = (env_name(program), env_name(args_nul_joined)) else {
+        process_set_error("program or args is not valid UTF-8".to_string());
         return 0;
+    };
+    // stdin is fed as raw bytes: a Raven String is a byte buffer, so binary
+    // input passes through unchanged. Only the program and its args, which are
+    // OS strings, need to be valid UTF-8.
+    let stdin_bytes = {
+        let ptr = object::raven_string_bytes(stdin_data);
+        let len = object::raven_string_len(stdin_data) as usize;
+        if ptr.is_null() || len == 0 {
+            Vec::new()
+        } else {
+            // SAFETY: a Raven String holds `len` initialized bytes.
+            unsafe { slice::from_raw_parts(ptr, len).to_vec() }
+        }
     };
 
     // The args are joined by NUL. An empty String is zero args; otherwise
@@ -1943,7 +1954,6 @@ pub extern "C" fn raven_process_run(
     // child fills its output pipe buffer faster than we consume it: the child
     // blocks writing stdout and we block writing stdin.
     let stdin_pipe = child.stdin.take();
-    let stdin_bytes = stdin_data.as_bytes().to_vec();
     let writer = std::thread::spawn(move || {
         if let Some(mut pipe) = stdin_pipe {
             // A broken pipe is fine: a child that exits without reading still
@@ -1968,8 +1978,8 @@ pub extern "C" fn raven_process_run(
     let code = output.status.code().map(|c| c as i64).unwrap_or(-1);
     let result = ProcResult {
         code,
-        stdout: std::string::String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: std::string::String::from_utf8_lossy(&output.stderr).into_owned(),
+        stdout: output.stdout,
+        stderr: output.stderr,
     };
     let id = process_next_id();
     process_registry().lock().unwrap().insert(id, result);
@@ -1994,7 +2004,10 @@ pub extern "C" fn raven_process_exit_code(id: i64) -> i64 {
 #[no_mangle]
 pub extern "C" fn raven_process_stdout(id: i64) -> *mut object::String {
     let registry = process_registry().lock().unwrap();
-    let out = registry.get(&id).map(|r| r.stdout.as_str()).unwrap_or("");
+    let out: &[u8] = registry
+        .get(&id)
+        .map(|r| r.stdout.as_slice())
+        .unwrap_or(&[]);
     object::raven_string_from_bytes(out.as_ptr(), out.len())
 }
 
@@ -2003,7 +2016,10 @@ pub extern "C" fn raven_process_stdout(id: i64) -> *mut object::String {
 #[no_mangle]
 pub extern "C" fn raven_process_stderr(id: i64) -> *mut object::String {
     let registry = process_registry().lock().unwrap();
-    let err = registry.get(&id).map(|r| r.stderr.as_str()).unwrap_or("");
+    let err: &[u8] = registry
+        .get(&id)
+        .map(|r| r.stderr.as_slice())
+        .unwrap_or(&[]);
     object::raven_string_from_bytes(err.as_ptr(), err.len())
 }
 

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1390,6 +1390,40 @@ fn process_program_compiles_and_runs() {
 }
 
 #[test]
+fn proc_binary_io_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // std/process carries arbitrary bytes both ways. The child writes the
+    // bytes 0x00 0xFF 0x41 (plus print's newline) to stdout; the parent feeds
+    // it non-UTF-8 stdin (which must be accepted, not rejected) and then prints
+    // the byte values of the child's captured stdout, which must come back
+    // verbatim rather than mangled into U+FFFD.
+    let child = build_example_binary("proc_binary_child.rv", &runtime);
+    let parent = build_example_binary("proc_binary_parent.rv", &runtime);
+
+    let output = Command::new(&parent.binary)
+        .env("RAVEN_PROC_CHILD", &child.binary)
+        .output()
+        .expect("run proc_binary_parent binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&child.tmp);
+    cleanup(&parent.tmp);
+    assert!(
+        output.status.success(),
+        "proc_binary_parent exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "stdin ok\n4\n0\n255\n65\n10\n",
+        "unexpected stdout for proc_binary_parent: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn gc_stress_survives_repeated_collections() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`std/process` could not move arbitrary bytes through a child:

- A child's stdout and stderr were captured with `String::from_utf8_lossy`, so any non-UTF-8 byte the child wrote came back as `U+FFFD` instead of the original byte.
- `run_with_input` required the stdin `String` to be valid UTF-8 and returned a spawn error otherwise, so binary input could not be fed at all.

A Raven `String` is a byte buffer, so the captured output is now stored and returned as raw bytes (`Vec<u8>`), and stdin is written as raw bytes. Only the program path and its arguments, which are OS strings, still have to be valid UTF-8.

Tested with `golden:skip` child/parent examples driven by a new `codegen_smoke.rs` case: the parent feeds non-UTF-8 stdin (accepted, not rejected) and reads back the child's `0x00 0xFF 0x41` stdout byte for byte. Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved child process stdout/stderr capture to preserve raw binary data, preventing data loss and corruption from lossy UTF-8 conversion
* Enhanced stdin input handling to accept and feed raw binary data without enforcing UTF-8 validation, enabling non-text process communication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->