### PR TITLE
Pass a lone empty argument through std/process.run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.154] - 2026-06-24
+
+### Fixed
+
+- `std/process.run` passes a single empty command-line argument through to the child. The args were NUL-joined, so an empty argument list and a one-element list `[""]` both encoded to the empty String and the runtime rebuilt zero arguments for each. Each argument is now NUL-prefixed, so the two cases stay distinct (#607).
+
 ## [2.18.152] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.152"
+version = "2.18.154"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.152"
+version = "2.18.154"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.152"
+version = "2.18.154"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/proc_argv_child.rv
+++ b/examples/v2/proc_argv_child.rv
@@ -1,0 +1,10 @@
+// golden:skip - the child of the std/process argv smoke test
+// (proc_argv_parent.rv, checked in codegen_smoke.rs). Prints its argument
+// count (including argv[0], the program path), so the parent can tell how
+// many arguments it actually received.
+import std/env { arg_count }
+import std/io { println }
+
+fun main() {
+    println("${arg_count()}")
+}

--- a/examples/v2/proc_argv_parent.rv
+++ b/examples/v2/proc_argv_parent.rv
@@ -1,0 +1,30 @@
+// golden:skip - std/process argv parent, checked in codegen_smoke.rs
+// (proc_argv_preserves_empty_arg). Runs the child (path in RAVEN_PROC_CHILD)
+// with three argument lists and prints the child's reported argument count.
+// A single empty argument must not vanish, so the counts are:
+//   1   (no args)
+//   2   (one empty arg, plus argv[0])
+//   3   ("a" then "")
+import std/process { run }
+import std/env { get_env }
+import std/io { print }
+
+fun main() {
+    let child = get_env("RAVEN_PROC_CHILD")
+    let none: List<String> = []
+    let one_empty: List<String> = [""]
+    let a_then_empty: List<String> = ["a", ""]
+
+    match run(child, none) {
+        Ok(out) -> print(out.stdout),
+        Err(e) -> print("fail ${e.message()}"),
+    }
+    match run(child, one_empty) {
+        Ok(out) -> print(out.stdout),
+        Err(e) -> print("fail ${e.message()}"),
+    }
+    match run(child, a_then_empty) {
+        Ok(out) -> print(out.stdout),
+        Err(e) -> print("fail ${e.message()}"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1915,13 +1915,15 @@ pub extern "C" fn raven_process_run(
         return 0;
     };
 
-    // The args are joined by NUL. An empty String is zero args; otherwise
-    // each NUL-separated field is one arg. Program args effectively never
-    // contain NUL, so this round-trips unambiguously.
+    // Each arg is NUL-prefixed. An empty String is zero args; otherwise the
+    // split has a leading empty piece (before the first NUL) to drop, and each
+    // field after it is one arg. NUL-prefixing rather than NUL-separating keeps
+    // an empty arg list and a single empty arg distinct. Program args
+    // effectively never contain NUL, so this round-trips unambiguously.
     let args: Vec<&str> = if args_joined.is_empty() {
         Vec::new()
     } else {
-        args_joined.split('\0').collect()
+        args_joined.split('\0').skip(1).collect()
     };
 
     let mut command = process::Command::new(program);

--- a/stdlib/std/process.rv
+++ b/stdlib/std/process.rv
@@ -37,19 +37,18 @@ impl Output {
     }
 }
 
-// Join `args` into one String with a single NUL byte between elements, the
-// encoding the runtime splits back into the child's argument list. An empty
-// list yields the empty String (zero args). An arg must not contain NUL.
+// Join `args` into one String, NUL-prefixing each element, the encoding the
+// runtime splits back into the child's argument list. An empty list yields the
+// empty String (zero args); a one-element list `[""]` yields a single NUL, so a
+// lone empty argument is distinguishable from no arguments. An arg must not
+// contain NUL.
 fun join_args(args: List<String>) -> String {
     let out = ""
     let nul = __str_from_byte(0)
     let i = 0
     let n = args.len()
     while i < n {
-        if i > 0 {
-            out = out.concat(nul)
-        }
-        out = out.concat(args[i])
+        out = out.concat(nul).concat(args[i])
         i = i + 1
     }
     return out

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1390,6 +1390,39 @@ fn process_program_compiles_and_runs() {
 }
 
 #[test]
+fn proc_argv_preserves_empty_arg() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A single empty argument must reach the child, not vanish in the
+    // NUL-encoded argv. The child prints its argument count (argv[0] included);
+    // the parent runs it with no args (1), one empty arg (2), and "a" then ""
+    // (3).
+    let child = build_example_binary("proc_argv_child.rv", &runtime);
+    let parent = build_example_binary("proc_argv_parent.rv", &runtime);
+
+    let output = Command::new(&parent.binary)
+        .env("RAVEN_PROC_CHILD", &child.binary)
+        .output()
+        .expect("run proc_argv_parent binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&child.tmp);
+    cleanup(&parent.tmp);
+    assert!(
+        output.status.success(),
+        "proc_argv_parent exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "1\n2\n3\n",
+        "unexpected stdout for proc_argv_parent: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn gc_stress_survives_repeated_collections() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`std/process.run(prog, [""])` dropped the single empty argument: the child saw zero arguments, identical to `run(prog, [])`.

The arguments were joined with a NUL byte between elements, so an empty list and a one-element list holding the empty String both encoded to the empty String, and the runtime could not tell them apart (both rebuilt zero args).

Each argument is now NUL-prefixed instead of NUL-separated, so `[]` encodes to the empty String while `[""]` encodes to a single NUL. The runtime drops the leading empty piece when splitting, and every other case round-trips unchanged. This is a coordinated change to `stdlib/std/process.rv` (the encoder) and the runtime decoder.

Verified with a `golden:skip` child/parent pair and a new `codegen_smoke.rs` case: running the child with `[]`, `[""]`, and `["a", ""]` makes it report 1, 2, and 3 arguments (argv[0] included). Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed process command-line argument encoding/decoding so empty arguments are preserved correctly, keeping an empty argument list distinct from a single empty argument during execution.

* **Tests**
  * Added an end-to-end smoke test that builds and runs parent/child programs to verify argv counts for: no arguments, one empty argument, and `["a", ""]`.

* **Examples**
  * Added new parent/child argv example programs to demonstrate and validate the behavior.

* **Documentation**
  * Updated the changelog and bumped the workspace version to **2.18.154**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->