### PR TITLE
Validate the size limit in TcpStream.read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.155] - 2026-06-24
+
+### Fixed
+
+- `TcpStream.read` validates its size limit. A negative limit is now an error instead of a zero-length `Ok("")` that looked like a clean EOF, and a limit too large to allocate fails gracefully instead of aborting the process on the buffer allocation (#671).
+
 ## [2.18.154] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.154"
+version = "2.18.155"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.154"
+version = "2.18.155"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.154"
+version = "2.18.155"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/net_read_limits.rv
+++ b/examples/v2/net_read_limits.rv
@@ -1,0 +1,33 @@
+// golden:skip - connects to a loopback server (address in RAVEN_NET_ADDR);
+// the read-limit validation is checked in codegen_smoke.rs
+// (net_read_rejects_bad_limits).
+//
+// TcpStream.read validates its limit: a negative size is an error (not Ok("")
+// that looks like EOF), and a size too large to allocate fails gracefully
+// instead of aborting the process. Prints:
+//   neg err
+//   huge err
+//   alive
+import std/net { connect }
+import std/env { get_env }
+import std/io { println }
+
+fun main() {
+    let addr = get_env("RAVEN_NET_ADDR")
+    match connect(addr) {
+        Ok(s) -> {
+            s.set_read_timeout_ms(2000)
+            match s.read(0 - 1) {
+                Ok(data) -> println("neg unexpectedly ok"),
+                Err(e) -> println("neg err"),
+            }
+            match s.read(9000000000000000000) {
+                Ok(data) -> println("huge unexpectedly ok"),
+                Err(e) -> println("huge err"),
+            }
+            println("alive")
+            s.close()
+        },
+        Err(e) -> println("connect failed"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1248,7 +1248,13 @@ pub extern "C" fn raven_net_accept(listener_id: i64) -> i64 {
 /// On error sets the last error and returns an empty `String`.
 #[no_mangle]
 pub extern "C" fn raven_net_read(stream_id: i64, max: i64) -> *mut object::String {
-    let cap = max.max(0) as usize;
+    // A negative limit is a caller error, not a zero-length read: returning
+    // Ok("") would be indistinguishable from a clean EOF.
+    if max < 0 {
+        net_set_error("read size must be non-negative".to_string());
+        return object::raven_string_from_bytes(std::ptr::null(), 0);
+    }
+    let cap = max as usize;
     // Clone the stream handle under the registry lock, then read without holding
     // it, so a blocked read does not serialize other goroutines' net operations
     // on the shared registry. Block outside the collector's running set so a slow
@@ -1267,11 +1273,20 @@ pub extern "C" fn raven_net_read(stream_id: i64, max: i64) -> *mut object::Strin
     };
     let result = match stream {
         Ok(mut s) => crate::gc::blocking(|| {
-            let mut buf = vec![0u8; cap];
-            s.read(&mut buf).map(|n| {
-                buf.truncate(n);
-                buf
-            })
+            // A very large `max` must fail gracefully: a plain `vec![0; cap]`
+            // aborts the process when the allocation fails. Reserve fallibly so
+            // an oversized request becomes an error instead.
+            let mut buf: Vec<u8> = Vec::new();
+            buf.try_reserve_exact(cap).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::OutOfMemory,
+                    "read size too large to allocate",
+                )
+            })?;
+            buf.resize(cap, 0);
+            let n = s.read(&mut buf)?;
+            buf.truncate(n);
+            Ok(buf)
         }),
         Err(e) => Err(e),
     };

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1143,6 +1143,52 @@ fn net_program_compiles_and_runs() {
 }
 
 #[test]
+fn net_read_rejects_bad_limits() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // TcpStream.read validates its limit: a negative size is an error (not a
+    // zero-length Ok that mimics EOF), and a size too large to allocate fails
+    // gracefully instead of aborting. The server only has to accept the
+    // connection; both reads fail before any bytes move.
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let addr = listener
+        .local_addr()
+        .expect("listener local addr")
+        .to_string();
+    let server = std::thread::spawn(move || {
+        if let Ok((stream, _)) = listener.accept() {
+            // Hold the connection briefly so the client can run its reads.
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            drop(stream);
+        }
+    });
+
+    let example = build_example_binary("net_read_limits.rv", &runtime);
+    let output = Command::new(&example.binary)
+        .env("RAVEN_NET_ADDR", &addr)
+        .output()
+        .expect("run net_read_limits binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = server.join();
+    cleanup(&example.tmp);
+    assert!(
+        output.status.success(),
+        "net_read_limits exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "neg err\nhuge err\nalive\n",
+        "unexpected stdout for net_read_limits: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn http_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`TcpStream.read(max)` did not validate `max`:

- A negative value was clamped to zero and returned as `Ok("")`, which a caller cannot distinguish from a clean EOF.
- A very large positive value was passed straight to `vec![0u8; cap]`, so a request too big to allocate aborted the whole process instead of returning an error.

The runtime now rejects a negative limit with an error, and reserves the read buffer with `try_reserve_exact` so an oversized request becomes an `Err` (out of memory) rather than an abort. A normal read is unchanged.

Tested with a `golden:skip` example against a loopback server and a new `codegen_smoke.rs` case: `read(-1)` and `read(9_000_000_000_000_000_000)` both return `Err` and the program keeps running. Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network read operations now properly reject negative size limits, returning an error instead of an empty successful response.
  * Network read operations now handle excessively large read limits gracefully by returning an error, rather than aborting due to memory allocation failure.

* **Tests**
  * Added comprehensive smoke test validating error handling for network read operations when given invalid size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->