### PR TITLE
Stop allocating under the registry lock in response accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.156] - 2026-06-24
+
+### Fixed
+
+- The `std/process` and `std/http` response accessors no longer hold their registry lock while allocating the returned `String`. The allocation can trigger a stop-the-world collection, so holding the lock across it could deadlock the collector against another worker blocked on the same lock. Each accessor now copies the value out and releases the lock before allocating (#670).
+
 ## [2.18.154] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.154"
+version = "2.18.156"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.154"
+version = "2.18.156"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.154"
+version = "2.18.156"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1610,11 +1610,16 @@ pub extern "C" fn raven_http_status(id: i64) -> i64 {
 /// unknown id yields an empty `String`.
 #[no_mangle]
 pub extern "C" fn raven_http_status_text(id: i64) -> *mut object::String {
-    let registry = http_registry().lock().unwrap();
-    let text = registry
-        .get(&id)
-        .map(|r| r.status_text.as_str())
-        .unwrap_or("");
+    // Copy out, then drop the registry lock before allocating the result: the
+    // allocation can trigger a stop-the-world collection, and holding the lock
+    // across it deadlocks a collector another worker is blocked behind.
+    let text: std::string::String = {
+        let registry = http_registry().lock().unwrap();
+        registry
+            .get(&id)
+            .map(|r| r.status_text.clone())
+            .unwrap_or_default()
+    };
     object::raven_string_from_bytes(text.as_ptr(), text.len())
 }
 
@@ -1622,12 +1627,15 @@ pub extern "C" fn raven_http_status_text(id: i64) -> *mut object::String {
 /// `String`.
 #[no_mangle]
 pub extern "C" fn raven_http_body(id: i64) -> *mut object::String {
-    let registry = http_registry().lock().unwrap();
-    let empty: &[u8] = &[];
-    let body: &[u8] = registry
-        .get(&id)
-        .map(|r| r.body.as_slice())
-        .unwrap_or(empty);
+    // Copy out before allocating; see `raven_http_status_text` for why the lock
+    // must not be held across the allocation.
+    let body: Vec<u8> = {
+        let registry = http_registry().lock().unwrap();
+        registry
+            .get(&id)
+            .map(|r| r.body.clone())
+            .unwrap_or_default()
+    };
     object::raven_string_from_bytes(body.as_ptr(), body.len())
 }
 
@@ -1640,20 +1648,24 @@ pub extern "C" fn raven_http_body(id: i64) -> *mut object::String {
 #[no_mangle]
 pub extern "C" fn raven_http_header(id: i64, name: *const object::String) -> *mut object::String {
     let wanted = env_name(name).unwrap_or("");
-    let registry = http_registry().lock().unwrap();
-    let value = registry
-        .get(&id)
-        .and_then(|r| {
-            r.headers.lines().find_map(|line| {
-                let (k, v) = line.split_once(':')?;
-                if k.trim().eq_ignore_ascii_case(wanted) {
-                    Some(v.trim().to_string())
-                } else {
-                    None
-                }
+    // Build the owned value, then drop the lock before allocating; see
+    // `raven_http_status_text` for why.
+    let value: std::string::String = {
+        let registry = http_registry().lock().unwrap();
+        registry
+            .get(&id)
+            .and_then(|r| {
+                r.headers.lines().find_map(|line| {
+                    let (k, v) = line.split_once(':')?;
+                    if k.trim().eq_ignore_ascii_case(wanted) {
+                        Some(v.trim().to_string())
+                    } else {
+                        None
+                    }
+                })
             })
-        })
-        .unwrap_or_default();
+            .unwrap_or_default()
+    };
     object::raven_string_from_bytes(value.as_ptr(), value.len())
 }
 
@@ -1661,8 +1673,14 @@ pub extern "C" fn raven_http_header(id: i64, name: *const object::String) -> *mu
 /// unknown id yields an empty `String`.
 #[no_mangle]
 pub extern "C" fn raven_http_headers(id: i64) -> *mut object::String {
-    let registry = http_registry().lock().unwrap();
-    let headers = registry.get(&id).map(|r| r.headers.as_str()).unwrap_or("");
+    // Copy out before allocating; see `raven_http_status_text` for why.
+    let headers: std::string::String = {
+        let registry = http_registry().lock().unwrap();
+        registry
+            .get(&id)
+            .map(|r| r.headers.clone())
+            .unwrap_or_default()
+    };
     object::raven_string_from_bytes(headers.as_ptr(), headers.len())
 }
 
@@ -2005,11 +2023,15 @@ pub extern "C" fn raven_process_exit_code(id: i64) -> i64 {
 /// empty `String`.
 #[no_mangle]
 pub extern "C" fn raven_process_stdout(id: i64) -> *mut object::String {
-    let registry = process_registry().lock().unwrap();
-    let out: &[u8] = registry
-        .get(&id)
-        .map(|r| r.stdout.as_slice())
-        .unwrap_or(&[]);
+    // Copy out before allocating; see `raven_http_status_text` for why the lock
+    // must not be held across the allocation.
+    let out: Vec<u8> = {
+        let registry = process_registry().lock().unwrap();
+        registry
+            .get(&id)
+            .map(|r| r.stdout.clone())
+            .unwrap_or_default()
+    };
     object::raven_string_from_bytes(out.as_ptr(), out.len())
 }
 
@@ -2017,11 +2039,14 @@ pub extern "C" fn raven_process_stdout(id: i64) -> *mut object::String {
 /// empty `String`.
 #[no_mangle]
 pub extern "C" fn raven_process_stderr(id: i64) -> *mut object::String {
-    let registry = process_registry().lock().unwrap();
-    let err: &[u8] = registry
-        .get(&id)
-        .map(|r| r.stderr.as_slice())
-        .unwrap_or(&[]);
+    // Copy out before allocating; see `raven_http_status_text` for why.
+    let err: Vec<u8> = {
+        let registry = process_registry().lock().unwrap();
+        registry
+            .get(&id)
+            .map(|r| r.stderr.clone())
+            .unwrap_or_default()
+    };
     object::raven_string_from_bytes(err.as_ptr(), err.len())
 }
 


### PR DESCRIPTION
The `std/process` stdout/stderr accessors and the `std/http` status-text, body, header, and headers accessors held their registry mutex while allocating the Raven `String` they return.

That allocation can trigger a stop-the-world collection. If the worker holding the lock starts one while another worker is blocked acquiring the same lock, the blocked worker is still counted as running Raven code, never reaches a safepoint, and the collector waits forever.

Each accessor now copies the value out of the registry into an owned `String`/`Vec<u8>`, releases the lock, and only then allocates the result. This is a structural lock-discipline change with no observable behavior difference; the existing `http_program`, `process_program`, and `proc_binary_io` smoke tests confirm the accessors still return the right data. The deadlock itself is a timing race that does not reproduce deterministically.

Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential deadlock in HTTP response and process output accessors that could occur during garbage collection. Accessors now properly manage lock timing to prevent holding locks during memory allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->