### PR TITLE
Send an HTTP request body as raw bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.158] - 2026-06-24
+
+### Fixed
+
+- `std/http` sends a request body of arbitrary bytes. The body was run through a UTF-8-only helper and a request was rejected as soon as the body held a byte such as `0xFF`; it is now sent as raw bytes, so a binary payload is delivered intact. The method, URL, and header lines are still text (#616).
+
 ## [2.18.157] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.157"
+version = "2.18.158"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.157"
+version = "2.18.158"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.157"
+version = "2.18.158"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_binary_body.rv
+++ b/examples/v2/http_binary_body.rv
@@ -1,0 +1,33 @@
+// golden:skip - POSTs to a loopback echo server (URL in RAVEN_HTTP_URL); the
+// binary-body round-trip is checked in codegen_smoke.rs
+// (http_sends_binary_body).
+//
+// An HTTP request body is sent as raw bytes, so a body containing non-UTF-8
+// bytes is delivered intact. The server echoes the body back. Prints:
+//   200
+//   len 3
+//   65
+//   255
+//   66
+import std/http { post }
+import std/env { get_env }
+import std/io { println }
+import std/string
+
+fun main() {
+    let url = get_env("RAVEN_HTTP_URL")
+    // bytes: A(65) 0xFF(255) B(66)
+    let body = "A".concat(__str_from_byte(255)).concat("B")
+    match post(url, body) {
+        Ok(resp) -> {
+            println("${resp.status_code}")
+            println("len ${resp.body.length()}")
+            let i = 0
+            while i < resp.body.length() {
+                println("${__str_byte_at(resp.body, i)}")
+                i = i + 1
+            }
+        }
+        Err(e) -> println("request failed"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1580,15 +1580,16 @@ pub extern "C" fn raven_http_request(
     body: *const object::String,
     headers: *const object::String,
 ) -> i64 {
-    let (Some(method), Some(url), Some(body), Some(headers)) = (
-        env_name(method),
-        env_name(url),
-        env_name(body),
-        env_name(headers),
-    ) else {
-        http_set_error("method, url, body, or headers is not valid UTF-8".to_string());
+    let (Some(method), Some(url), Some(headers)) =
+        (env_name(method), env_name(url), env_name(headers))
+    else {
+        http_set_error("method, url, or headers is not valid UTF-8".to_string());
         return 0;
     };
+    // The request body is sent as raw bytes: a Raven String is a byte buffer,
+    // so a binary body (an image, a protobuf payload) passes through unchanged.
+    // The method, URL, and header lines are still text.
+    let body = string_bytes(body).to_vec();
 
     let agent = ureq::AgentBuilder::new()
         .timeout_connect(Duration::from_secs(5))
@@ -1615,7 +1616,7 @@ pub extern "C" fn raven_http_request(
         let result = if body.is_empty() {
             req.call()
         } else {
-            req.send_string(body)
+            req.send_bytes(&body)
         };
 
         match result {

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1284,6 +1284,92 @@ fn http_program_compiles_and_runs() {
 }
 
 #[test]
+fn http_sends_binary_body() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // An HTTP request body is sent as raw bytes, so a non-UTF-8 body is
+    // delivered intact. The mock server reads the request body (length from
+    // Content-Length) and echoes it back; the client POSTs the bytes
+    // A 0xFF B and prints the byte values it reads back.
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let addr = listener
+        .local_addr()
+        .expect("listener local addr")
+        .to_string();
+    let url = format!("http://{addr}/");
+
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 256];
+            // Read the headers, then enough more to cover the body length the
+            // request's Content-Length advertises.
+            let mut header_end = None;
+            while header_end.is_none() {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        buf.extend_from_slice(&chunk[..n]);
+                        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                            header_end = Some(pos + 4);
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            let head_len = header_end.unwrap_or(buf.len());
+            let headers = String::from_utf8_lossy(&buf[..head_len]).to_lowercase();
+            let content_len = headers
+                .lines()
+                .find_map(|l| l.strip_prefix("content-length:"))
+                .and_then(|v| v.trim().parse::<usize>().ok())
+                .unwrap_or(0);
+            while buf.len() - head_len < content_len {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                    Err(_) => break,
+                }
+            }
+            let body = &buf[head_len..(head_len + content_len).min(buf.len())];
+            let resp_head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(resp_head.as_bytes());
+            let _ = stream.write_all(body);
+            let _ = stream.flush();
+        }
+    });
+
+    let example = build_example_binary("http_binary_body.rv", &runtime);
+    let output = Command::new(&example.binary)
+        .env("RAVEN_HTTP_URL", &url)
+        .output()
+        .expect("run http_binary_body binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = server.join();
+    cleanup(&example.tmp);
+    assert!(
+        output.status.success(),
+        "http_binary_body exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "200\nlen 3\n65\n255\n66\n",
+        "unexpected stdout for http_binary_body: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn time_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`std/http` could not send a request body containing arbitrary bytes. The runtime ran the body through the UTF-8-only `env_name` helper and sent it with `send_string`, so a request was rejected (`method, url, body, or headers is not valid UTF-8`) the moment the body held a byte such as `0xFF`, even though the response path already handled raw bytes.

The body is now read with the `string_bytes` helper and sent with `send_bytes`, so a binary payload is delivered intact. The method, URL, and header lines are still required to be valid UTF-8.

Verified with a `golden:skip` example against a loopback echo server and a new `codegen_smoke.rs` case: the client POSTs the bytes `A 0xFF B`, the server echoes them, and the client reads back `65 255 66`. Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP client now accepts binary request bodies instead of requiring valid UTF-8 text. Bodies are transmitted as raw bytes while method, URL, and headers remain text-validated.

* **New Features**
  * Added example demonstrating HTTP POST requests with binary payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->