### PR TITLE
Keep every value of a repeated HTTP response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.159] - 2026-06-24
+
+### Fixed
+
+- The HTTP client keeps every value of a repeated response header. A response with two `Set-Cookie` lines recorded the first value twice and lost the second, because it read only the first value per header name. It now emits one line per value for each header, so all values survive (#620).
+
 ## [2.18.157] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.157"
+version = "2.18.159"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.157"
+version = "2.18.159"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.157"
+version = "2.18.159"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_repeated_headers.rv
+++ b/examples/v2/http_repeated_headers.rv
@@ -1,0 +1,15 @@
+// golden:skip - GETs a loopback server (URL in RAVEN_HTTP_URL) that returns
+// two Set-Cookie headers; the repeated-header handling is checked in
+// codegen_smoke.rs (http_keeps_repeated_headers). Prints the full response
+// header block, which must contain both cookie values.
+import std/http { get }
+import std/env { get_env }
+import std/io { println }
+
+fun main() {
+    let url = get_env("RAVEN_HTTP_URL")
+    match get(url) {
+        Ok(resp) -> println(resp.headers),
+        Err(e) -> println("request failed"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1530,8 +1530,16 @@ fn http_capture(resp: ureq::Response) -> HttpResp {
         reason.to_string()
     };
     let mut header_lines: Vec<std::string::String> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     for name in resp.headers_names() {
-        if let Some(value) = resp.header(&name) {
+        // `headers_names` can list a repeated header (two `Set-Cookie` lines)
+        // more than once, and `header` only returns its first value. Process
+        // each name once and emit one line per value with `all`, so a repeated
+        // header keeps every value instead of duplicating the first.
+        if !seen.insert(name.to_ascii_lowercase()) {
+            continue;
+        }
+        for value in resp.all(&name) {
             header_lines.push(format!("{name}: {value}"));
         }
     }

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1284,6 +1284,70 @@ fn http_program_compiles_and_runs() {
 }
 
 #[test]
+fn http_keeps_repeated_headers() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A server that sends two Set-Cookie lines must surface both values, not
+    // the first one twice. The mock server returns Set-Cookie: a=1 and
+    // Set-Cookie: b=2; the client prints the whole header block, which must
+    // contain both distinct values.
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let addr = listener
+        .local_addr()
+        .expect("listener local addr")
+        .to_string();
+    let url = format!("http://{addr}/");
+
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 256];
+            loop {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        buf.extend_from_slice(&chunk[..n]);
+                        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            let resp = "HTTP/1.1 200 OK\r\nSet-Cookie: a=1\r\nSet-Cookie: b=2\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    let example = build_example_binary("http_repeated_headers.rv", &runtime);
+    let output = Command::new(&example.binary)
+        .env("RAVEN_HTTP_URL", &url)
+        .output()
+        .expect("run http_repeated_headers binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = server.join();
+    cleanup(&example.tmp);
+    assert!(
+        output.status.success(),
+        "http_repeated_headers exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert!(
+        stdout.contains("a=1") && stdout.contains("b=2"),
+        "both Set-Cookie values must be present, got: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn time_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
The HTTP client corrupted repeated response headers. When a server sent two `Set-Cookie` lines, `HttpResponse.headers` recorded the first value twice and lost the second.

`http_capture` iterated `headers_names()` (which can list a repeated name more than once) and read a single value with `resp.header(name)` (always the first). So a duplicated name produced the first value twice and never surfaced the rest.

It now processes each header name once and emits one line per value with `resp.all(name)`, so every value of a repeated header is preserved in the documented newline-joined `headers` field.

Verified with a `golden:skip` example against a loopback server that returns `Set-Cookie: a=1` and `Set-Cookie: b=2`, plus a new `codegen_smoke.rs` case asserting both values are present. Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP client handling for repeated response headers so all values are preserved (for example, multiple `Set-Cookie` lines no longer get dropped or duplicated).
  * Added a regression smoke test and a runnable example to verify repeated-header preservation against a loopback HTTP server.

* **Documentation**
  * Updated the changelog for version `2.18.159` to reflect the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->