### PR TITLE
Report a truncated HTTP response body as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.160] - 2026-06-24
+
+### Fixed
+
+- The HTTP client reports a truncated response body as an error instead of `Ok`. If the server advertised a larger `Content-Length` and closed the connection early, the partial bytes were returned with the original success status; the client now treats a body shorter than `Content-Length` (or a read error) as a failed request (#615).
+
 ## [2.18.159] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.159"
+version = "2.18.160"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.159"
+version = "2.18.160"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.159"
+version = "2.18.160"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_truncated_body.rv
+++ b/examples/v2/http_truncated_body.rv
@@ -1,0 +1,17 @@
+// golden:skip - GETs a loopback server (URL in RAVEN_HTTP_URL) that
+// advertises a larger Content-Length than it sends and then closes; the
+// truncation handling is checked in codegen_smoke.rs
+// (http_detects_truncated_body). A truncated response is an error, so this
+// prints:
+//   truncated
+import std/http { get }
+import std/env { get_env }
+import std/io { println }
+
+fun main() {
+    let url = get_env("RAVEN_HTTP_URL")
+    match get(url) {
+        Ok(resp) -> println("ok ${resp.status_code}"),
+        Err(e) -> println("truncated"),
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1521,7 +1521,7 @@ fn http_reason(code: u16) -> &'static str {
 /// Capture a ureq response into an owned `HttpResp`, reading the status,
 /// reason, headers, and body eagerly (reading the body consumes the
 /// response).
-fn http_capture(resp: ureq::Response) -> HttpResp {
+fn http_capture(resp: ureq::Response) -> Option<HttpResp> {
     let status = resp.status();
     let reason = resp.status_text();
     let status_text = if reason.is_empty() {
@@ -1544,16 +1544,38 @@ fn http_capture(resp: ureq::Response) -> HttpResp {
         }
     }
     let headers = header_lines.join("\n");
+    // The body length the server promised, if any. A body shorter than this was
+    // cut short in transit.
+    let expected_len: Option<u64> = resp
+        .header("Content-Length")
+        .and_then(|v| v.trim().parse::<u64>().ok());
     // Read the body as raw bytes (not `into_string`, which lossily replaces a
     // non-UTF-8 byte with U+FFFD and corrupts a binary response).
     let mut body = Vec::new();
-    resp.into_reader().read_to_end(&mut body).ok();
-    HttpResp {
+    let read = resp.into_reader().read_to_end(&mut body);
+    // A read error, or fewer bytes than Content-Length promised, means a
+    // truncated transfer. Report it instead of returning the partial body with
+    // a success status, so a caller can tell a complete response from a broken
+    // one.
+    if read.is_err() {
+        http_set_error("incomplete response body".to_string());
+        return None;
+    }
+    if let Some(expected) = expected_len {
+        if (body.len() as u64) < expected {
+            http_set_error(format!(
+                "incomplete response body: expected {expected} bytes, received {}",
+                body.len()
+            ));
+            return None;
+        }
+    }
+    Some(HttpResp {
         status: status as i64,
         status_text,
         headers,
         body,
-    }
+    })
 }
 
 /// Store a captured response and return its id, clearing the last error.
@@ -1628,9 +1650,11 @@ pub extern "C" fn raven_http_request(
         };
 
         match result {
-            Ok(resp) => http_store(http_capture(resp)),
+            // A captured `None` means a truncated body; `http_capture` has set
+            // the last error, so surface the failure as id 0.
+            Ok(resp) => http_capture(resp).map(http_store).unwrap_or(0),
             // A non-2xx status is a response, not a transport failure.
-            Err(ureq::Error::Status(_, resp)) => http_store(http_capture(resp)),
+            Err(ureq::Error::Status(_, resp)) => http_capture(resp).map(http_store).unwrap_or(0),
             Err(ureq::Error::Transport(t)) => {
                 http_set_error(t.to_string());
                 0

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1434,6 +1434,71 @@ fn http_sends_binary_body() {
 }
 
 #[test]
+fn http_detects_truncated_body() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A response whose body is shorter than its Content-Length was cut short in
+    // transit; the client must report an error rather than returning the
+    // partial body with a success status. The mock server advertises
+    // Content-Length: 100 but sends only 5 bytes and closes.
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let addr = listener
+        .local_addr()
+        .expect("listener local addr")
+        .to_string();
+    let url = format!("http://{addr}/");
+
+    let server = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 256];
+            loop {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        buf.extend_from_slice(&chunk[..n]);
+                        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            // Promise 100 bytes, send 5, then close.
+            let resp = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\nConnection: close\r\n\r\nhello";
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    let example = build_example_binary("http_truncated_body.rv", &runtime);
+    let output = Command::new(&example.binary)
+        .env("RAVEN_HTTP_URL", &url)
+        .output()
+        .expect("run http_truncated_body binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let _ = server.join();
+    cleanup(&example.tmp);
+    assert!(
+        output.status.success(),
+        "http_truncated_body exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "truncated\n",
+        "a truncated response must be an error, got: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn time_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
The HTTP client reported a truncated response body as `Ok`. If the server advertised a larger `Content-Length` and then closed the connection early, `http_capture` read whatever bytes arrived (`read_to_end(...).ok()` discarded the result) and returned the partial body with the original success status, so a caller could not tell a complete response from a broken transfer.

`http_capture` now captures the promised body length first and returns `Option<HttpResp>`: a read error, or a body shorter than `Content-Length`, becomes `None`, which the request path surfaces as id 0 with a last-error set (`incomplete response body: expected N bytes, received M`). A complete response is unchanged.

Verified with a `golden:skip` example against a loopback server that advertises `Content-Length: 100` but sends 5 bytes and closes, plus a new `codegen_smoke.rs` case asserting the client reports an error. The existing http smoke tests still pass. Required a `raven-runtime` rebuild; golden and codegen_smoke pass.

Fixes #615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP client now correctly detects and reports truncated responses when a server closes the connection early despite advertising a larger Content-Length, preventing silent acceptance of incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->