### PR TITLE
Initialize an imported module's globals before its importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.162] - 2026-06-24
+
+### Fixed
+
+- A local module's globals initialize before an importer that reads them at load time. Modules are now merged in dependency order (a module after every module it imports), so a top-level `let` that calls an imported function during initialization sees the imported module's initialized globals instead of zero (#669).
+
 ## [2.18.161] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.161"
+version = "2.18.162"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.161"
+version = "2.18.162"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.161"
+version = "2.18.162"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -568,6 +568,12 @@ fn merge_module_items(
 /// file's `span.file` is its canonical path, so a later caller can derive
 /// the namespacing key from the same path the import binder uses.
 ///
+/// Modules come back in dependency order: a module appears after every module
+/// it imports (a post-order walk). The combined program's global-initializer
+/// runs the modules' top-level `let` initializers in this order, so an imported
+/// module's globals are initialized before an importer that reads them at load
+/// time.
+///
 /// Modules are deduplicated by canonical path, so a module imported from
 /// several places loads once. A cycle (a module that imports itself
 /// directly or transitively) is broken gracefully: each module is loaded
@@ -575,31 +581,45 @@ fn merge_module_items(
 /// point behavior. A missing file is left for the import resolution pass
 /// to report with a precise span; this function only loads what it can.
 fn load_local_modules(user: &File, loader: &mut dyn SourceLoader) -> Result<Vec<File>, RavenError> {
-    let mut to_load: Vec<(PathBuf, String)> = local_import_targets(user);
     let mut loaded_paths: BTreeSet<PathBuf> = BTreeSet::new();
     let mut out: Vec<File> = Vec::new();
+    for (importing, target) in local_import_targets(user) {
+        load_local_module(&importing, &target, loader, &mut loaded_paths, &mut out)?;
+    }
+    Ok(out)
+}
 
-    while let Some((importing, target)) = to_load.pop() {
-        let Some(loaded) = loader.load(&importing, &target) else {
-            continue;
-        };
-        if !loaded_paths.insert(loaded.canonical_path.clone()) {
-            continue;
-        }
-
-        let tokens = Lexer::new(loaded.source.clone(), loaded.canonical_path.clone())
-            .tokenize()
-            .map_err(|e| local_error(&loaded.canonical_path, format!("lex: {e}")))?;
-        let module_file = parse(&tokens)
-            .map_err(|e| local_error(&loaded.canonical_path, format!("parse: {e}")))?;
-
-        for (_, dep) in local_import_targets(&module_file) {
-            to_load.push((loaded.canonical_path.clone(), dep));
-        }
-        out.push(module_file);
+/// Load the module `target` (resolved relative to `importing`) and, before it,
+/// every module it imports, depth first. A module is pushed to `out` only after
+/// its dependencies, so the result is in dependency order; a module already in
+/// `loaded` (a diamond or a cycle back edge) is skipped.
+fn load_local_module(
+    importing: &Path,
+    target: &str,
+    loader: &mut dyn SourceLoader,
+    loaded: &mut BTreeSet<PathBuf>,
+    out: &mut Vec<File>,
+) -> Result<(), RavenError> {
+    let Some(loaded_mod) = loader.load(importing, target) else {
+        return Ok(());
+    };
+    if !loaded.insert(loaded_mod.canonical_path.clone()) {
+        return Ok(());
     }
 
-    Ok(out)
+    let tokens = Lexer::new(loaded_mod.source.clone(), loaded_mod.canonical_path.clone())
+        .tokenize()
+        .map_err(|e| local_error(&loaded_mod.canonical_path, format!("lex: {e}")))?;
+    let module_file = parse(&tokens)
+        .map_err(|e| local_error(&loaded_mod.canonical_path, format!("parse: {e}")))?;
+
+    // Load the imported modules first, so they sit ahead of this one in `out`
+    // and their globals initialize before this module's do.
+    for (_, dep) in local_import_targets(&module_file) {
+        load_local_module(&loaded_mod.canonical_path, &dep, loader, loaded, out)?;
+    }
+    out.push(module_file);
+    Ok(())
 }
 
 /// Build the rename entries a merged module needs for the names it
@@ -1911,6 +1931,40 @@ mod tests {
         assert_eq!(
             global_count, 2,
             "both module globals must be present under distinct names"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn imported_module_globals_initialize_first() {
+        // `a` imports `b` and initializes a global from `b`'s function at load
+        // time. `b` must be merged ahead of `a`, so its global initializer runs
+        // first and `a` reads the initialized value rather than zero.
+        let main_src = "import \"./a\" { get_result }\nfun main() {}\n";
+        let (dir, entry) = write_temp_project(
+            &[
+                ("b.rv", "let b_value: Int = 42\nfun get_b() -> Int = b_value\n"),
+                (
+                    "a.rv",
+                    "import \"./b\" { get_b }\nlet a_result: Int = get_b()\nfun get_result() -> Int = a_result\n",
+                ),
+                ("main.rv", main_src),
+            ],
+            "main.rv",
+        );
+        let user = parse_at(main_src, &entry);
+        let combined = expand_with_stdlib(&user).expect("expand");
+        let pos = |needle: &str| {
+            combined
+                .items
+                .iter()
+                .position(|d| matches!(&d.kind, DeclKind::Let(l) if l.name.ends_with(needle)))
+        };
+        let b_pos = pos("b_value").expect("b_value global present");
+        let a_pos = pos("a_result").expect("a_result global present");
+        assert!(
+            b_pos < a_pos,
+            "the imported module's global must initialize first (b={b_pos}, a={a_pos})"
         );
         std::fs::remove_dir_all(&dir).ok();
     }


### PR DESCRIPTION
A local module's top-level `let` initializers ran in load order, which placed an importing module ahead of the module it imports. A global initialized from an imported function at load time therefore saw zero:

```raven
// a.rv
import "./b" { get_b }
let a_result: Int = get_b()   // was 0, b's globals had not initialized yet
```

`load_local_modules` now walks imports depth first and appends each module only after the modules it imports (a post-order walk), so the combined program merges modules in dependency order. The global initializer runs the modules' `let` initializers in that order, so an imported module's globals are set before an importer reads them. A diamond or a cycle back edge is still loaded once.

Verified end to end (the example above now prints `42 42`), with a new resolve unit test that the imported module's global is merged ahead of the importer's, and the full lib, golden, and codegen_smoke suites passing.

Fixes #669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Module-level globals now initialize in dependency order, ensuring that globals depending on imported functions receive properly initialized values instead of default/zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->