### PR TITLE
Reserve the raven_derive_ prefix for derive helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.163] - 2026-06-24
+
+### Fixed
+
+- A user declaration that uses the `raven_derive_` prefix reserved for the generated JSON derive helpers is rejected with a clear message at the declaration, instead of failing later with a confusing `declared multiple times` error pointing at the synthetic helper source (#682).
+
 ## [2.18.162] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.162"
+version = "2.18.163"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.162"
+version = "2.18.163"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.162"
+version = "2.18.163"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/resolve/derive.rs
+++ b/src/resolve/derive.rs
@@ -122,6 +122,40 @@ pub fn expand_derives(
 /// names, so the caller emits them exactly once per program (when any
 /// `@derive(ToJson|FromJson)` is present); a second copy would be a duplicate
 /// declaration. See [`expand_derives`], which reports when they are needed.
+/// The reserved name prefix for the free helper functions a `@derive`
+/// expansion emits (see [`json_helper_decls`]). A user declaration may not use
+/// it, or it would collide with a generated helper.
+pub const HELPER_PREFIX: &str = "raven_derive_";
+
+/// Reject a user-written top-level declaration whose name uses the reserved
+/// derive-helper prefix. The generated helpers are global free functions with
+/// fixed names, so a user declaration of the same name collided with them; this
+/// reports a clear reserved-name error at the user's declaration instead of a
+/// confusing "declared multiple times" pointing at the synthetic
+/// `<derive-helpers>` source.
+pub fn reject_reserved_helper_names(file: &File) -> Result<(), RavenError> {
+    for decl in &file.items {
+        let name = match &decl.kind {
+            DeclKind::Function(f) => &f.name,
+            DeclKind::Let(l) => &l.name,
+            DeclKind::Const(c) => &c.name,
+            DeclKind::Struct(s) => &s.name,
+            DeclKind::Enum(e) => &e.name,
+            DeclKind::Trait(t) => &t.name,
+            _ => continue,
+        };
+        if name.starts_with(HELPER_PREFIX) {
+            return Err(RavenError::resolve(
+                ResolveError::Other(format!(
+                    "the name `{name}` is reserved: names beginning with `{HELPER_PREFIX}` are used by derived trait implementations"
+                )),
+                decl.span.clone(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub fn json_helper_decls() -> Result<Vec<Decl>, RavenError> {
     // A distinct label from every `expand_derives` source so the helper
     // identifiers' `(file, byte range)` use-site keys cannot collide with an

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -230,6 +230,11 @@ pub fn expand_with_stdlib_ctx(
     user: &File,
     ctx: Option<&PackageContext>,
 ) -> Result<File, RavenError> {
+    // The `@derive` expansion emits global helper functions under a reserved
+    // prefix; reject a user declaration that would collide with one before any
+    // merging, so the error names the user's declaration rather than the
+    // synthetic helper source.
+    super::derive::reject_reserved_helper_names(user)?;
     // Modules to merge, collected to a fixed point. A module enters the
     // set from the user file's `std/...` imports or from a bundled
     // module's own `import std/...` line. The set deduplicates, so each
@@ -1933,6 +1938,21 @@ mod tests {
             "both module globals must be present under distinct names"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn reserved_derive_helper_name_is_rejected() {
+        // A user declaration that uses the reserved `raven_derive_` prefix is
+        // rejected with a clear message, since it would otherwise collide with a
+        // generated JSON derive helper.
+        let src = "fun raven_derive_json_decode() -> Int = 1\nfun main() {}\n";
+        let user = parse_at(src, Path::new("main.rv"));
+        let err = expand_with_stdlib(&user).expect_err("reserved name must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("raven_derive_json_decode") && msg.contains("reserved"),
+            "expected a reserved-name error, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
A `@derive(ToJson|FromJson)` expansion emits global free helper functions (`raven_derive_json_decode`, `raven_derive_json_field`, and friends). A user declaration of the same name collided with one and failed with a confusing error:

```
error: the name `raven_derive_json_decode` is declared multiple times
  ┌─ <derive-helpers>:1:1
```

The resolver now rejects a user-written top-level declaration that uses the reserved `raven_derive_` prefix up front, with a clear message pointing at the user's own declaration:

```
error: the name `raven_derive_json_decode` is reserved: names beginning with `raven_derive_` are used by derived trait implementations
```

The prefix is reserved unconditionally (whether or not a derive is present) so the rule is predictable. Generated helpers are unaffected (they are added after this check, not part of the user file). Added a unit test; the full lib and golden suites pass.

Fixes #682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User declarations using reserved naming prefixes are now rejected immediately at declaration time with clear error messages, preventing confusing validation errors that would previously occur downstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->