### PR TITLE
Validate enum payload arity in derived FromJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.164] - 2026-06-24
+
+### Fixed
+
+- A derived enum `FromJson` validates that the `values` payload is an array with exactly the variant's arity. A unit variant now rejects a non-array or non-empty payload, and a tuple variant rejects too few or too many elements, instead of decoding malformed data as `Ok` (#681).
+
 ## [2.18.163] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.163"
+version = "2.18.164"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.163"
+version = "2.18.164"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.163"
+version = "2.18.164"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/derive_enum_json_arity.rv
+++ b/examples/v2/derive_enum_json_arity.rv
@@ -1,0 +1,49 @@
+// A derived enum FromJson validates that `values` is an array with exactly the
+// variant's payload arity, so malformed payloads are rejected instead of
+// decoding. Prints:
+//   rejected: enum payload values is not an array
+//   rejected: wrong number of payload values for variant
+//   rejected: wrong number of payload values for variant
+//   accepted: Dot
+//   accepted: Circle(5)
+import std/json { JsonValue }
+import std/collections { Map }
+
+@derive(FromJson, ToString)
+enum Shape {
+    Dot,
+    Circle(Int),
+}
+
+fun check(j: JsonValue) {
+    match Shape.from_json(j) {
+        Ok(value) -> print("accepted: ".concat(value.to_string())),
+        Err(e) -> print("rejected: ".concat(e.message)),
+    }
+}
+
+fun tagged(tag: String, values: List<JsonValue>) -> JsonValue {
+    let m: Map<String, JsonValue> = Map.new()
+    m.set("tag", JsonValue.Str(tag))
+    m.set("values", JsonValue.Array(values))
+    return JsonValue.Object(m)
+}
+
+fun main() {
+    // A unit variant with a non-array payload.
+    let wrong_type: Map<String, JsonValue> = Map.new()
+    wrong_type.set("tag", JsonValue.Str("Dot"))
+    wrong_type.set("values", JsonValue.Bool(false))
+    check(JsonValue.Object(wrong_type))
+
+    // A unit variant carrying an unexpected payload element.
+    check(tagged("Dot", [JsonValue.Number(1.0)]))
+
+    // A tuple variant with an extra element.
+    check(tagged("Circle", [JsonValue.Number(7.0), JsonValue.Number(8.0)]))
+
+    // Well-formed payloads decode.
+    let empty: List<JsonValue> = []
+    check(tagged("Dot", empty))
+    check(tagged("Circle", [JsonValue.Number(5.0)]))
+}

--- a/examples/v2/derive_enum_json_arity.rv.out
+++ b/examples/v2/derive_enum_json_arity.rv.out
@@ -1,0 +1,5 @@
+rejected: enum payload values is not an array
+rejected: wrong number of payload values for variant
+rejected: wrong number of payload values for variant
+accepted: Dot
+accepted: Circle(5)

--- a/src/resolve/derive.rs
+++ b/src/resolve/derive.rs
@@ -491,6 +491,12 @@ fun raven_derive_json_index(j: JsonValue, i: Int) -> Result<JsonValue, Error> {
         None -> Err(Error { kind: "json", message: "missing payload element" }),
     }
 }
+fun raven_derive_json_arity(vals: JsonValue, n: Int) -> Result<Bool, Error> {
+    return match vals {
+        Array(items) -> if items.len() == n { Ok(true) } else { Err(Error { kind: "json", message: "wrong number of payload values for variant" }) },
+        _ -> Err(Error { kind: "json", message: "enum payload values is not an array" }),
+    }
+}
 fun raven_derive_json_tag(j: JsonValue) -> Result<String, Error> {
     let t = raven_derive_json_field(j, "tag")?
     return match t {
@@ -634,6 +640,13 @@ fn enum_from_json_body(e: &Enum, self_ty: &str) -> String {
     for v in &e.variants {
         body.push_str(&format!("        if tag.equals(\"{}\") {{\n", v.name));
         let tys = variant_tuple_types(v);
+        // `values` must be an array holding exactly this variant's payload
+        // arity, so a unit variant rejects any non-empty payload and a tuple
+        // variant rejects too few or too many elements.
+        body.push_str(&format!(
+            "            let _arity = raven_derive_json_arity(vals, {})?\n",
+            tys.len()
+        ));
         if tys.is_empty() {
             body.push_str(&format!("            return Ok({}.{})\n", e.name, v.name));
         } else {


### PR DESCRIPTION
A derived enum `FromJson` did not validate that the `values` payload is an array with exactly the variant's arity. So malformed data decoded successfully:

- a unit variant accepted any JSON in `values` (a Boolean, or an array with elements);
- unit and tuple variants accepted extra payload elements.

The generated `from_json` now calls a new `raven_derive_json_arity` helper that checks `values` is an array of exactly the variant's payload length (0 for a unit variant) before decoding, so a wrong type, a non-empty unit payload, or too few/too many tuple elements all return `Err`.

Verified with `examples/v2/derive_enum_json_arity.rv` (a golden example): a non-array payload, an over-long unit payload, and an over-long tuple payload are rejected, while well-formed payloads still decode. Existing JSON/derive examples and the lib, golden, and codegen_smoke suites pass.

Fixes #681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `@derive(FromJson)` for enums to validate JSON payload arity more strictly. Unit variants now reject non-array or non-empty payloads, and tuple variants now reject arrays with too few **or** too many elements instead of accepting malformed data.

* **Documentation**
  * Added an example showing how derived enum JSON decoding accepts valid payloads and rejects payloads with incorrect structure or element counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->