### PR TITLE
Remove stray wrapper tags from v2 docs pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.165] - 2026-06-24
+
+### Fixed
+
+- Removed stray `</content>` and `</invoke>` wrapper tags accidentally left at the end of `docs/v2/guide/stdlib/io.md`, `docs/v2/guide/stdlib/net.md`, and `docs/v2/migration.md`, which MkDocs copied verbatim into the published HTML (#658).
+
 ## [2.18.164] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.164"
+version = "2.18.165"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/stdlib/io.md
+++ b/docs/v2/guide/stdlib/io.md
@@ -132,5 +132,3 @@ fun main() {
   output.
 - [std/fs](fs.md) when you want to read from and write to files instead of the
   console.
-</content>
-</invoke>

--- a/docs/v2/guide/stdlib/net.md
+++ b/docs/v2/guide/stdlib/net.md
@@ -273,5 +273,3 @@ fun main() {
   operator used above.
 - [std/string](string.md) for slicing and scanning the byte buffers that
   `read` returns.
-</content>
-</invoke>

--- a/docs/v2/migration.md
+++ b/docs/v2/migration.md
@@ -875,4 +875,3 @@ When converting a v1 file, work through this list:
    forms, dropping `export` and `from`.
 10. Move the project under `rvpm`: an `rv.toml` manifest with the entry at
     `src/main.rv`, built with `rvpm build` or run with `rvpm run`.
-</content>


### PR DESCRIPTION
Three Markdown pages ended with leftover `</content>` / `</invoke>` tags that are not documentation markup. MkDocs copies them verbatim into the generated HTML, so the published pages carried invalid leftover tags even though `mkdocs build --strict` succeeded.

Removed the stray trailing lines from:
- `docs/v2/guide/stdlib/io.md`
- `docs/v2/guide/stdlib/net.md`
- `docs/v2/migration.md`

Each file now ends on its real last content line. A repo-wide search for `</content>`/`</invoke>`/`<invoke`/`<content>` under `docs/` is now clean.

Fixes #658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected documentation formatting issues where stray HTML wrapper tags were appearing in the published documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->