### PR TITLE
Describe the current parallel scheduler in the concurrency docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.166] - 2026-06-24
+
+### Fixed
+
+- The concurrency documentation describes the current parallel scheduler. The language reference and the `std/sync` guide no longer claim that exactly one goroutine runs at a time on a single OS thread or that multicore parallelism and `select` are future work; the M:N scheduler runs goroutines in parallel across a worker pool, and the `std/sync` guide now documents `sleep_millis`, the mutex, the wait group, `select_recv`, and channel `free` (#638).
+
 ## [2.18.165] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.165"
+version = "2.18.166"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -530,10 +530,12 @@ holds different implementers.
 ## Concurrency
 
 `spawn` starts a goroutine: a lightweight green thread that runs a
-`fun() -> Unit` closure. Goroutines run on a cooperative scheduler. The
-program multiplexes many of them onto one OS thread, and exactly one runs
-at a time. A goroutine runs until it reaches a yield point, then the
-scheduler resumes another ready goroutine.
+`fun() -> Unit` closure. Goroutines run on an M:N scheduler that
+multiplexes them onto a pool of worker OS threads, one per available core,
+so goroutines run in parallel. Scheduling within a worker is cooperative: a
+goroutine runs until it reaches a yield point (a channel operation, an
+explicit `yield_now()`, or its body finishing), then the worker resumes
+another ready goroutine.
 
 ```rust
 spawn(fun() -> Unit {
@@ -575,11 +577,13 @@ When `main` returns the program exits, and any goroutines still alive are
 abandoned. If every goroutine is blocked with none ready, the scheduler
 reports a deadlock and exits.
 
-The model is cooperative on a single OS thread in this release: there is
-no preemption and no multicore parallelism. A goroutine that blocks in a
-runtime IO call (a net read, a file read, an http request) stalls the
-whole scheduler, since those calls are synchronous. True multicore
-parallelism, `select`, and non-blocking IO are future work.
+Goroutines run in parallel across the worker pool, so the runtime uses
+every core. A goroutine that blocks in a runtime IO call (a net read, a
+file read, an http request) does so without stalling the other workers: the
+blocking call runs outside the scheduler's running set, so other goroutines
+keep running on the remaining workers. Beyond channels, `std/sync` provides
+`select_recv` to wait on the first ready of several channels, a mutex, a
+wait group, and `sleep_millis`.
 
 ## Modules and imports
 

--- a/docs/v2/guide/stdlib/sync.md
+++ b/docs/v2/guide/stdlib/sync.md
@@ -1,11 +1,13 @@
 # std/sync
 
 Goroutine-style concurrency primitives: channels for passing values between
-green threads. `std/sync` pairs with the `spawn` keyword, which starts a
-goroutine running a `fun() -> Unit` closure. Goroutines are cooperative green
-threads: exactly one runs at a time, and a goroutine keeps running until it
-hits a yield point (a blocking channel operation or an explicit `yield_now()`),
-at which the scheduler resumes another ready goroutine.
+green threads, plus a mutex, a wait group, timed sleeping, and a multi-channel
+receive. `std/sync` pairs with the `spawn` keyword, which starts a goroutine
+running a `fun() -> Unit` closure. Goroutines run on an M:N scheduler that
+spreads them across a pool of worker threads (one per available core), so they
+run in parallel. Within a worker, scheduling is cooperative: a goroutine keeps
+running until it hits a yield point (a blocking channel operation or an explicit
+`yield_now()`), at which the worker resumes another ready goroutine.
 
 ```rust
 import std/sync { channel, channel_buffered, yield_now }
@@ -193,7 +195,109 @@ fun main() {
 }
 ```
 
+## Releasing a channel
+
+### `free(self)`
+
+Release a channel's runtime resources when you are done with it. A channel is
+otherwise reclaimed when the program exits; `free` is for a long-running program
+that creates many channels over time.
+
+## Sleeping
+
+### `sleep_millis(ms: Int)`
+
+Block the current goroutine for `ms` milliseconds, yielding so other goroutines
+run in the meantime.
+
+```rust
+import std/sync { sleep_millis }
+
+fun main() {
+    spawn(fun() -> Unit {
+        sleep_millis(50)
+        print(2)
+    })
+    print(1)
+    sleep_millis(100)           // give the goroutine time to finish
+}
+```
+
+## Mutex
+
+A mutex guards a critical section so only one goroutine holds it at a time,
+which matters now that goroutines run in parallel across worker threads.
+
+### `mutex() -> Mutex`, `lock(self)`, `unlock(self)`
+
+```rust
+import std/sync { mutex }
+
+fun main() {
+    let m = mutex()
+    m.lock()
+    // ... exclusive section ...
+    m.unlock()
+}
+```
+
+## Wait group
+
+A wait group counts outstanding work and lets one goroutine block until it
+reaches zero, the usual way to wait for spawned goroutines to finish.
+
+### `wait_group() -> WaitGroup`
+
+Create a wait group with a zero counter.
+
+### `add(self, n: Int)`, `done(self)`, `wait(self)`, `free(self)`
+
+`add(n)` raises the counter by `n` (call it before spawning the work),
+`done()` lowers it by one (call it as each unit finishes), `wait()` blocks
+until the counter reaches zero, and `free()` releases the wait group.
+
+```rust
+import std/sync { wait_group, sleep_millis }
+
+fun main() {
+    let wg = wait_group()
+    wg.add(2)
+    spawn(fun() -> Unit {
+        sleep_millis(20)
+        wg.done()
+    })
+    spawn(fun() -> Unit {
+        sleep_millis(20)
+        wg.done()
+    })
+    wg.wait()                   // both goroutines have finished
+    wg.free()
+}
+```
+
+## Selecting over several channels
+
+### `select_recv(channels: List<Channel>) -> SelectResult`
+
+Block until one of `channels` has a value to receive, then return a
+`SelectResult` with `index` (the position in the list of the channel that
+produced the value, or `-1` when the list is empty) and `value` (that value).
+When several channels are ready, the lowest index wins.
+
+```rust
+import std/sync { channel_buffered, select_recv }
+
+fun main() {
+    let a = channel_buffered(1)
+    let b = channel_buffered(1)
+    b.send(22)
+    let chosen = select_recv([a, b])
+    print(chosen.index)         // 1
+    print(chosen.value)         // 22
+}
+```
+
 ## See also
 
 - The [language reference](../language-reference.md#concurrency) for `spawn`,
-  goroutines, the cooperative scheduler, and deadlock behavior.
+  goroutines, the parallel scheduler, and deadlock behavior.


### PR DESCRIPTION
The language reference and the `std/sync` guide still described the original single-thread cooperative scheduler: that exactly one goroutine runs at a time on one OS thread, that a blocking runtime IO call stalls the whole scheduler, and that multicore parallelism and `select` are future work. None of that is true now.

Updated both pages to match the shipped runtime:

- Goroutines run on an M:N scheduler across a pool of worker threads (one per core), so they run in parallel.
- A goroutine that blocks in a runtime IO call does so outside the scheduler's running set, so the other workers keep running.
- The `std/sync` guide now documents the primitives that shipped alongside channels: `sleep_millis`, the mutex (`mutex`/`lock`/`unlock`), the wait group (`wait_group`/`add`/`done`/`wait`/`free`), `select_recv`/`SelectResult`, and channel `free`.

Docs-only change; signatures were taken from `stdlib/std/sync.rv`.

Fixes #638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated concurrency model documentation to accurately describe parallel scheduler behavior.
  * Expanded synchronization documentation with additional primitives and practical examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->