### PR TITLE
Update the http guide for concurrent serving and pipelining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.167] - 2026-06-24
+
+### Fixed
+
+- The `std/http` guide describes the current server: `listen` serves each connection in its own goroutine (connections are handled concurrently), and HTTP pipelining is supported (bytes past one request are carried into the next parse), correcting the previous claims that connections are served one at a time and that pipelining is unsupported (#644).
+
 ## [2.18.166] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.166"
+version = "2.18.167"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -224,7 +224,8 @@ fun main() {
 }
 ```
 
-`listen` binds the address and blocks, serving connections one at a time.
+`listen` binds the address and blocks, accepting connections and serving each
+in its own goroutine, so connections are handled concurrently.
 
 ### Access log
 
@@ -276,8 +277,9 @@ and is what browsers and HTTP libraries expect. The server reuses the
 connection unless the client sends `Connection: close` (an HTTP/1.0 client must
 opt in with `Connection: keep-alive`). Each response carries the matching
 `Connection` header, and an idle kept-alive connection is closed once the read
-timeout elapses. HTTP pipelining is not supported, send one request and read
-its response before sending the next.
+timeout elapses. HTTP pipelining is supported: bytes read past one request are
+carried into the next parse, so a client may send several requests back to back
+on one connection and read the responses in order.
 
 ### Graceful shutdown
 


### PR DESCRIPTION
The `std/http` user guide claimed:

- `listen` serves connections one at a time.
- HTTP pipelining is not supported.

Both are out of date. The server's `listen` loop spawns a goroutine per accepted connection (`serve_connection` runs under `spawn`), so connections are served concurrently, and `serve_connection` carries the bytes read past one request (`carry = parsed.rest`) into the next parse, so a client can pipeline several requests on one connection.

Updated both statements to describe the current behavior. Docs-only change.

Fixes #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP server documentation to clarify concurrent connection handling, explaining that each connection operates independently
  * Enhanced documentation to confirm HTTP pipelining support for multiple sequential requests over a single connection
  * Version bumped to 2.18.167

<!-- end of auto-generated comment: release notes by coderabbit.ai -->