### PR TITLE
Update std/net docs for raw bytes and concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.168] - 2026-06-24
+
+### Fixed
+
+- The `std/net` guide, spec, and module header describe current behavior: `TcpStream.read` returns raw bytes with no lossy UTF-8 conversion, goroutines let one program be both a client and a server, and the documented surface now includes `read_all`, `set_write_timeout_ms`, and `TcpListener.close` (#634).
+
 ## [2.18.167] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.167"
+version = "2.18.168"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/stdlib/net.md
+++ b/docs/v2/guide/stdlib/net.md
@@ -89,10 +89,11 @@ The stream methods come in with the `TcpStream` type.
 
 ### `read(self, max: Int) -> Result<String, Error>`
 
-Read up to `max` bytes and return them as a `String`. The payload is a byte
-buffer carried in a `String` (lossy UTF-8 at the FFI boundary), not
-guaranteed text. A clean end of stream returns `Ok("")`, so an empty result
-means EOF rather than an error.
+Read up to `max` bytes and return them as a `String`. The payload is a raw
+byte buffer carried in a `String`, not guaranteed to be text; the bytes are
+preserved exactly, with no UTF-8 conversion, so binary data round-trips. A
+clean end of stream returns `Ok("")`, so an empty result means EOF rather than
+an error.
 
 ### `read_all(self) -> Result<String, Error>`
 
@@ -127,6 +128,12 @@ Write all bytes of `data` and return the count written.
 Set the read timeout in milliseconds. A value of `0` means no timeout
 (blocking reads); a positive value makes a stalled read fail rather than hang.
 This method does not return a `Result`.
+
+### `set_write_timeout_ms(self, ms: Int)`
+
+Set the write timeout in milliseconds, the same way as the read timeout: `0`
+means no timeout, and a positive value makes a stalled write fail rather than
+hang. This method does not return a `Result`.
 
 ### `close(self)`
 
@@ -164,11 +171,12 @@ Bind a TCP listener to `addr` in `"host:port"` form.
 ### `accept(self) -> Result<TcpStream, Error>`
 
 A method on `TcpListener`. Block until a connection arrives and return the
-accepted `TcpStream`. The block is intentional: Raven v2 has no concurrency,
-so accept waits rather than polling.
+accepted `TcpStream`. `accept` blocks the calling goroutine, but the other
+goroutines keep running on the worker pool.
 
-A server loops: bind once with `listen`, then call `accept` repeatedly,
-serving each accepted stream before accepting the next.
+A server loops: bind once with `listen`, then call `accept` repeatedly. It can
+serve each accepted stream before accepting the next, or `spawn` a goroutine
+per stream to serve connections concurrently.
 
 ```rust
 import std/net { listen }
@@ -196,8 +204,15 @@ fun serve() {
 }
 ```
 
-Because v2 has no threads, a single program is a client or a server, not both
-at once.
+A single program can act as both a client and a server at once: run the accept
+loop in one goroutine and open client connections from another. Goroutines run
+in parallel across the worker pool, so the server keeps accepting while the
+client work proceeds.
+
+### `close(self)`
+
+A method on `TcpListener`. Stop listening and release the runtime-side socket,
+freeing the bound port. It does not return a `Result`.
 
 ## Resolving and probing
 

--- a/docs/v2/specs/std-net.md
+++ b/docs/v2/specs/std-net.md
@@ -67,16 +67,19 @@ fun reachable(addr: String) -> Bool
 listener to `addr`. `accept` blocks until a connection arrives and returns
 the accepted stream (blocking accept is intentional).
 
-`read` reads up to `max` bytes and returns them as a `String`. The payload
-is treated as a byte buffer carried in a String (lossy UTF-8 at the FFI
-boundary), not as guaranteed text. A clean EOF returns `Ok("")`: the runtime
-clears the last error on a successful read of zero bytes so the caller can
-tell EOF from an error. `write` writes all bytes of `data` and returns the
-count written.
+`read` reads up to `max` bytes and returns them as a `String`. The payload is
+a raw byte buffer carried in a String, preserved exactly with no UTF-8
+conversion, not guaranteed text; a negative `max` is an error. `read_all`
+reads to the end of the stream, accumulating every byte into one String. A
+clean EOF returns `Ok("")`: the runtime clears the last error on a successful
+read of zero bytes so the caller can tell EOF from an error. `write` writes all
+bytes of `data` and returns the count written.
 
-`set_read_timeout_ms` sets the stream read timeout. A value of 0 means no
-timeout (blocking reads); a positive value makes a stalled read fail rather
-than hang. `close` releases the runtime-side socket.
+`set_read_timeout_ms` and `set_write_timeout_ms` set the stream read and write
+timeouts. A value of 0 means no timeout (blocking); a positive value makes a
+stalled read or write fail rather than hang. `close` on a `TcpStream` releases
+the runtime-side socket, and `close` on a `TcpListener` stops listening and
+frees the bound port.
 
 `dns_lookup` resolves `host` to its IP addresses. The runtime joins them
 with `\n` into one String and the wrapper splits that into a
@@ -87,13 +90,13 @@ with `\n` into one String and the wrapper splits that into a
 connect_timeout to `addr` and returns whether it succeeded. It never sets an
 error and never returns a Result.
 
-## Client or server, not both
+## Client and server in one program
 
-Raven v2 has no concurrency, so a single Raven program cannot be both a
-server (blocking on `accept`) and a client at the same time. A program is
-one or the other. The end-to-end test reflects this: a loopback echo server
-runs on a background thread on the test side and the compiled Raven program
-is the client.
+Goroutines run in parallel across a worker pool, so a single Raven program can
+be both a server (a goroutine blocked on `accept`, spawning a goroutine per
+connection) and a client at the same time. The end-to-end test still runs a
+loopback echo server on a background thread on the test side with the compiled
+Raven program as the client, because the harness drives a single process.
 
 ## FFI path
 

--- a/stdlib/std/net.rv
+++ b/stdlib/std/net.rv
@@ -2,9 +2,9 @@
 // cannot cross the FFI, so the runtime keeps them in a registry keyed by an
 // opaque integer id and hands Raven that id; TcpStream and TcpListener wrap
 // the id. Fallible ops return Result<T, Error> tagged with kind "net" via
-// the runtime's thread-local last-error slot. A program is a client or a
-// server, not both at once, because Raven v2 has no threads. See
-// docs/v2/specs/std-net.md.
+// the runtime's thread-local last-error slot. Goroutines run in parallel, so a
+// program can be both a client and a server at once (spawn a goroutine per
+// accepted connection). See docs/v2/specs/std-net.md.
 
 import std/error { error_kind }
 import std/string


### PR DESCRIPTION
The `std/net` guide, spec, and module header still described behavior from before raw byte strings and concurrency shipped:

- `TcpStream.read` was described as doing lossy UTF-8 conversion at the FFI boundary. It returns raw bytes now (`FF 00 41` round-trips to `ff0041`), so the docs say the bytes are preserved exactly.
- The docs said Raven v2 has no concurrency/threads and that a program cannot be both a client and a server. Goroutines run in parallel, so a program can run an accept loop (spawning a goroutine per connection) and open client connections at the same time.
- The spec and guide omitted `TcpStream.read_all`, `TcpStream.set_write_timeout_ms`, and `TcpListener.close`; those are now documented.

The `stdlib/std/net.rv` header comment is updated to match. Docs/comment only; the net smoke test still passes.

Fixes #634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that `TcpStream.read` preserves raw bytes exactly without UTF-8 conversion.
  * Updated documentation to reflect programs can operate as both TCP client and server concurrently using goroutines.
  * Documented write timeout functionality and socket closure behavior for listeners and streams.

* **Chores**
  * Version bumped to 2.18.168.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->