### PR TITLE
Update the language reference for current FFI capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.170] - 2026-06-24
+
+### Fixed
+
+- The language reference describes the current FFI surface. A capturing closure can be used as a C callback through a userdata pointer (pass it to both the `CFnPtr` and the userdata `CPtr`; the compiler emits a trampoline), and a `@repr(C)` struct passed by value may have float fields, nested struct fields, and any size (the back end classifies it for the platform ABI), correcting the old claims that capturing closures are rejected and that by-value structs must be integer-class and at most 8 bytes (#640).
+
 ## [2.18.169] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.169"
+version = "2.18.170"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -754,10 +754,17 @@ C. `T` must be a C scalar (`CInt`, `CLong`, `CSize`, `CFloat`, `CDouble`,
 
 `CFnPtr` is an untyped C function pointer. A C function that takes a
 callback can call back into Raven through one. Pass a non-capturing
-top-level function by naming it bare. Its parameters and return must all
-be C-FFI types so the C ABI is well defined. A capturing closure (a local
-of function type) is rejected, since C cannot supply its capture
-environment.
+top-level function by naming it bare; its parameters and return must all
+be C-FFI types so the C ABI is well defined.
+
+A capturing closure can also be used as a callback when the C function
+carries a userdata pointer (the common C idiom). Pass the closure both
+where the `CFnPtr` is expected and where the userdata `CPtr` is expected:
+the compiler emits a trampoline for the function-pointer slot and hands the
+closure object as the userdata, and C threads it back to the trampoline,
+which invokes the closure with its captured values. The garbage collector
+traces the suspended Raven stack through the call, so a closure that
+allocates mid-callback is safe.
 
 ```rust
 import std/ffi { alloc, free, load, store, offset }
@@ -785,14 +792,17 @@ fun main() {
 signature against what the C side expects. Matching it is your
 responsibility, as in C.
 
-### Small structs by value
+### Structs by value
 
-A small C struct can cross the boundary by value. Mark the matching Raven
-struct `@repr(C)` to give it C memory layout. The supported shape is a
-struct whose fields are all integer-class C scalars (`CInt`, `CLong`,
-`CSize`, `CStr`, `CPtr<T>`, or `CFnPtr`) and whose total size is at most
-8 bytes (one machine register). A larger struct, or one with a float
-field, is rejected; pass a `CPtr<...>` to it instead.
+A C struct can cross the boundary by value. Mark the matching Raven struct
+`@repr(C)` to give it C memory layout. Its fields may be any C scalars,
+integer-class (`CInt`, `CLong`, `CSize`, `CStr`, `CPtr<T>`, `CFnPtr`) or
+floating-point (`CFloat`, `CDouble`), and a field may itself be a `@repr(C)`
+struct. The back end classifies the struct for the platform C ABI, so a
+struct larger than one register, or one with float fields, is passed
+correctly (in registers, on the stack, or by reference as the ABI requires)
+rather than rejected. You can still pass a `CPtr<...>` to a struct when you
+need to share or mutate it by address.
 
 ```rust
 @repr(C)


### PR DESCRIPTION
The primary language reference still documented the original restricted FFI surface:

- Capturing closures are rejected as C callbacks.
- A by-value `@repr(C)` struct must have only integer-class fields and be at most 8 bytes; larger or float-field structs are rejected.

Both are out of date, and the `docs/v2/specs/std-ffi.md` spec already documents the current behavior. Verified on this machine:

- A capturing closure works as a callback when the C function has a userdata pointer: pass the closure to both the `CFnPtr` slot and the userdata `CPtr`, and the compiler emits a trampoline that C threads the closure back to (`examples/v2/ffi_callback_closure.rv` prints `105 / 203 / 599500`).
- A `@repr(C)` struct with two `CDouble` fields and a 24-byte struct of three `CLong` both pass and return by value (sums `4` and `60`) using the platform ABI classification.

Updated the callbacks and by-value-struct sections of the language reference to match. Docs-only change.

Fixes #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified FFI callback support for capturing closures when a userdata pointer is provided.
  * Corrected guidance for passing `@repr(C)` structs by value, including float fields, nested structs, and larger sizes when supported by the platform ABI.
  * Added a new changelog entry for version 2.18.170.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->