### PR TITLE
Cap the token count during macro expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.171] - 2026-06-24
+
+### Fixed
+
+- Declarative macro expansion caps the generated token count, not just the pass count. A macro that expands one call into several (`boom!() => boom!() + boom!()`) doubled the token stream every pass and exhausted memory before the 128-pass limit; it now reports the likely-recursive diagnostic once the stream grows past the size cap (#652).
+
 ## [2.18.170] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.170"
+version = "2.18.171"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -42,6 +42,13 @@ use crate::span::Span;
 /// bound also limits recursion depth of macros that expand to other calls.
 const EXPANSION_LIMIT: usize = 128;
 
+/// Upper bound on the token-stream length during expansion. A macro that
+/// expands one call into several (`boom!() => boom!() + boom!()`) doubles the
+/// stream every pass and exhausts memory long before the pass limit, so a size
+/// cap reports the same likely-recursive diagnostic instead of aborting on a
+/// failed allocation. Far above any real program's expanded token count.
+const TOKEN_LIMIT: usize = 2_000_000;
+
 /// The free (definition-site) identifiers a macro expansion introduces, keyed
 /// by file and start offset. The resolver resolves these against the module
 /// scope so a call-site local cannot capture them. The file is part of the key
@@ -180,8 +187,29 @@ pub fn expand_with_table(tokens: &[Token], table: &MacroTable) -> Result<Vec<Tok
             ));
         }
         stream = expand_once(&stream, &table.defs, &mut spans)?;
+        if stream.len() > TOKEN_LIMIT {
+            return Err(token_limit_error(&stream, tokens));
+        }
     }
     Ok(stream)
+}
+
+/// The "likely recursive" diagnostic for an expansion whose token stream grew
+/// past [`TOKEN_LIMIT`]. Anchored at the first token of the runaway stream, or
+/// the original input's first token when the stream is somehow empty.
+fn token_limit_error(stream: &[Token], original: &[Token]) -> RavenError {
+    let span = stream
+        .first()
+        .or_else(|| original.first())
+        .map(|t| t.span.clone())
+        .expect("a non-empty token stream");
+    err(
+        span,
+        format!(
+            "macro expansion produced over {} tokens; a macro is likely recursive",
+            TOKEN_LIMIT
+        ),
+    )
 }
 
 /// Expand all declarative macros in `tokens`.
@@ -226,6 +254,9 @@ pub fn expand_tokens_hygienic(tokens: &[Token]) -> Result<(Vec<Token>, DefSites)
             ));
         }
         stream = expand_once(&stream, &defs, &mut spans)?;
+        if stream.len() > TOKEN_LIMIT {
+            return Err(token_limit_error(&stream, tokens));
+        }
     }
     Ok((stream, spans.def_sites))
 }

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -236,6 +236,17 @@ fn expansion_limit_guards_recursion() {
 }
 
 #[test]
+fn token_limit_guards_exponential_expansion() {
+    // A macro that expands one call into two doubles the token stream every
+    // pass, exhausting memory before the pass limit. The size cap reports the
+    // likely-recursive diagnostic instead.
+    let src = "macro boom { () => { boom!() + boom!() } }\nlet y = boom!()\n";
+    let e = expand_tokens(&lex(src)).expect_err("should hit the token limit");
+    let msg = format!("{}", e);
+    assert!(msg.contains("a macro is likely recursive"), "got: {}", msg);
+}
+
+#[test]
 fn first_matching_rule_wins() {
     let src = "macro pick { ($a:expr, $b:expr) => { two } ($a:expr) => { one } }\n\
                let r = pick!(x)\n";


### PR DESCRIPTION
The declarative macro expander limited the number of passes (128) but not the number of generated tokens. A macro that expands one call into several doubles the token stream every pass:

```raven
macro boom { () => { boom!() + boom!() } }
```

so it exhausts memory long before reaching the pass limit, and the compiler aborted on a failed allocation instead of printing the intended `a macro is likely recursive` diagnostic.

Both expansion loops now also cap the token-stream length (`TOKEN_LIMIT`, far above any real program's expanded size) and report the likely-recursive error when it is exceeded. The pass limit still guards linear recursion. Added a unit test; the macro suite and the full lib suite pass.

Fixes #652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of overly expanding macros so expansion stops sooner and reports a clearer “likely recursive” error before consuming excessive resources.
  * Added a regression test to help prevent this issue from returning in future releases.

* **Chores**
  * Updated the release version to **2.18.171**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->