### PR TITLE
Tighten the macro token-limit test assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.172] - 2026-06-24
+
+### Changed
+
+- The macro token-limit test asserts the token-limit-specific error wording (`produced over`) rather than the phrase the pass-limit error also uses, so it cannot pass without exercising the size cap.
+
 ## [2.18.171] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.171"
+version = "2.18.172"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -243,7 +243,10 @@ fn token_limit_guards_exponential_expansion() {
     let src = "macro boom { () => { boom!() + boom!() } }\nlet y = boom!()\n";
     let e = expand_tokens(&lex(src)).expect_err("should hit the token limit");
     let msg = format!("{}", e);
-    assert!(msg.contains("a macro is likely recursive"), "got: {}", msg);
+    // Assert the token-limit-specific wording ("produced over"), not the
+    // "likely recursive" phrase the pass-limit error shares, so this test fails
+    // if the pass limit fires first instead of the size cap.
+    assert!(msg.contains("produced over"), "got: {}", msg);
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to PR #757. CodeRabbit pointed out that the new `token_limit_guards_exponential_expansion` test asserted `"a macro is likely recursive"`, a phrase the pass-limit diagnostic also contains, so the test could pass even if the pass limit fired before the size cap.

The test now asserts the token-limit-specific `"produced over"` wording, so it fails unless the token-count cap is actually exercised. No production change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a macro expansion test to check for the size-limit error message, making the failure condition more precise.
* **Chores**
  * Added a new release entry to the changelog for version 2.18.172.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->