### PR TITLE
Expand declarative macros in imported modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.173] - 2026-06-24
+
+### Fixed
+
+- A declarative macro call inside an imported local module is expanded. Macro expansion ran only on the entry file, so a macro used inside an imported module reached HIR lowering unexpanded and failed with an internal error; imported modules now get the same macro pre-pass, and the free identifiers their macros introduce flow to the resolver (#650).
+
 ## [2.18.171] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.171"
+version = "2.18.173"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/macro_module_lib.rv
+++ b/examples/v2/macro_module_lib.rv
@@ -1,0 +1,9 @@
+// golden:skip - the imported module half of the macro-in-module test
+// (macro_module_main.rv, checked in codegen_smoke.rs). Defines a macro and a
+// function that uses it; the macro must expand even though this file is
+// imported, not the entry point.
+macro double { ($x:expr) => { ($x) + ($x) } }
+
+fun compute() -> Int {
+    return double!(21)
+}

--- a/examples/v2/macro_module_main.rv
+++ b/examples/v2/macro_module_main.rv
@@ -1,0 +1,8 @@
+// golden:skip - imports a module that uses a macro internally and prints the
+// result, which is 42 once the imported module's macro is expanded. Checked in
+// codegen_smoke.rs (macro_in_imported_module_compiles_and_runs).
+import "./macro_module_lib" { compute }
+
+fun main() {
+    print(compute())
+}

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -145,7 +145,13 @@ pub fn check(source: &str, input: &Path, ctx: Option<&PackageContext>) -> Result
         .map_err(|e| frontend_diag(e, input, source))?;
     let file = parse_with_macros_all(&tokens, macro_table)
         .map_err(|es| frontend_diags(es, input, source))?;
-    let file = expand_with_stdlib_ctx(&file, ctx).map_err(|e| frontend_diag(e, input, source))?;
+    let (file, module_def_sites) =
+        expand_with_stdlib_ctx(&file, ctx).map_err(|e| frontend_diag(e, input, source))?;
+    // Merge the entry file's macro def-sites with those from imported modules'
+    // macros so the resolver treats every macro-introduced free identifier the
+    // same way, regardless of which file the macro was defined in.
+    let mut macro_def_sites = macro_def_sites;
+    macro_def_sites.extend(module_def_sites);
     let mut loader = FsLoader;
     let resolved = resolve_file_ctx(&file, &mut loader, ctx, macro_def_sites)
         .map_err(|e| frontend_diag(e, input, source))?;
@@ -172,7 +178,13 @@ pub fn compile_to_object(
         .map_err(|e| frontend_diag(e, input, source))?;
     let file = parse_with_macros_all(&tokens, macro_table)
         .map_err(|es| frontend_diags(es, input, source))?;
-    let file = expand_with_stdlib_ctx(&file, ctx).map_err(|e| frontend_diag(e, input, source))?;
+    let (file, module_def_sites) =
+        expand_with_stdlib_ctx(&file, ctx).map_err(|e| frontend_diag(e, input, source))?;
+    // Merge the entry file's macro def-sites with those from imported modules'
+    // macros so the resolver treats every macro-introduced free identifier the
+    // same way, regardless of which file the macro was defined in.
+    let mut macro_def_sites = macro_def_sites;
+    macro_def_sites.extend(module_def_sites);
     let mut loader = FsLoader;
     let resolved = resolve_file_ctx(&file, &mut loader, ctx, macro_def_sites)
         .map_err(|e| frontend_diag(e, input, source))?;

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -29,7 +29,8 @@ use crate::ast::{
 };
 use crate::error::{RavenError, ResolveError};
 use crate::lexer::Lexer;
-use crate::parser::parse;
+use crate::macros::{collect_macro_table, expand_tokens_hygienic, DefSites};
+use crate::parser::{parse, parse_with_macros};
 
 use super::imports::{FsLoader, GithubPath, SourceLoader};
 
@@ -211,7 +212,7 @@ pub fn bundled_source(module_path: &str) -> Option<&'static str> {
 /// the import pass to report as `UnresolvedImport`; this function only
 /// merges the modules it can load.
 pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
-    expand_with_stdlib_ctx(user, None)
+    expand_with_stdlib_ctx(user, None).map(|(file, _def_sites)| file)
 }
 
 /// Expand `user` like [`expand_with_stdlib`], additionally resolving any
@@ -229,7 +230,11 @@ pub fn expand_with_stdlib(user: &File) -> Result<File, RavenError> {
 pub fn expand_with_stdlib_ctx(
     user: &File,
     ctx: Option<&PackageContext>,
-) -> Result<File, RavenError> {
+) -> Result<(File, DefSites), RavenError> {
+    // Definition-site identifiers introduced by macros in imported local
+    // modules, accumulated as the modules are loaded and handed back to the
+    // resolver alongside the entry file's own.
+    let mut def_sites = DefSites::new();
     // The `@derive` expansion emits global helper functions under a reserved
     // prefix; reject a user declaration that would collide with one before any
     // merging, so the error names the user's declaration rather than the
@@ -271,7 +276,7 @@ pub fn expand_with_stdlib_ctx(
     // itself `import std/...`, and those bundled modules must merge too so
     // the local module's own calls resolve.
     let mut loader = FsLoader;
-    let local_modules = load_local_modules(user, &mut loader)?;
+    let local_modules = load_local_modules(user, &mut loader, &mut def_sites)?;
     for module_file in &local_modules {
         collect_std_module_imports(module_file, &mut wanted);
     }
@@ -414,10 +419,13 @@ pub fn expand_with_stdlib_ctx(
         combined_items.extend(super::derive::json_helper_decls()?);
     }
 
-    Ok(File {
-        items: combined_items,
-        span: user.span.clone(),
-    })
+    Ok((
+        File {
+            items: combined_items,
+            span: user.span.clone(),
+        },
+        def_sites,
+    ))
 }
 
 /// Add every bundled `std/<module>` imported by `file` to `wanted`. Only
@@ -585,11 +593,22 @@ fn merge_module_items(
 /// once and the back edge is ignored, mirroring the bundled set's fixed
 /// point behavior. A missing file is left for the import resolution pass
 /// to report with a precise span; this function only loads what it can.
-fn load_local_modules(user: &File, loader: &mut dyn SourceLoader) -> Result<Vec<File>, RavenError> {
+fn load_local_modules(
+    user: &File,
+    loader: &mut dyn SourceLoader,
+    def_sites: &mut DefSites,
+) -> Result<Vec<File>, RavenError> {
     let mut loaded_paths: BTreeSet<PathBuf> = BTreeSet::new();
     let mut out: Vec<File> = Vec::new();
     for (importing, target) in local_import_targets(user) {
-        load_local_module(&importing, &target, loader, &mut loaded_paths, &mut out)?;
+        load_local_module(
+            &importing,
+            &target,
+            loader,
+            &mut loaded_paths,
+            &mut out,
+            def_sites,
+        )?;
     }
     Ok(out)
 }
@@ -604,6 +623,7 @@ fn load_local_module(
     loader: &mut dyn SourceLoader,
     loaded: &mut BTreeSet<PathBuf>,
     out: &mut Vec<File>,
+    def_sites: &mut DefSites,
 ) -> Result<(), RavenError> {
     let Some(loaded_mod) = loader.load(importing, target) else {
         return Ok(());
@@ -615,13 +635,31 @@ fn load_local_module(
     let tokens = Lexer::new(loaded_mod.source.clone(), loaded_mod.canonical_path.clone())
         .tokenize()
         .map_err(|e| local_error(&loaded_mod.canonical_path, format!("lex: {e}")))?;
-    let module_file = parse(&tokens)
+    // Expand the module's own declarative macros, the same pre-pass the entry
+    // file gets, so a macro call inside an imported module is rewritten rather
+    // than reaching later stages unexpanded. The macro table (collected before
+    // the definitions are stripped) handles a call inside a `"${...}"`
+    // interpolation fragment, and the def-sites flow to the resolver so a free
+    // identifier the module's macros introduce resolves at the module scope.
+    let table = collect_macro_table(&tokens)
+        .map_err(|e| local_error(&loaded_mod.canonical_path, format!("macro: {e}")))?;
+    let (tokens, module_def_sites) = expand_tokens_hygienic(&tokens)
+        .map_err(|e| local_error(&loaded_mod.canonical_path, format!("macro: {e}")))?;
+    def_sites.extend(module_def_sites);
+    let module_file = parse_with_macros(&tokens, table)
         .map_err(|e| local_error(&loaded_mod.canonical_path, format!("parse: {e}")))?;
 
     // Load the imported modules first, so they sit ahead of this one in `out`
     // and their globals initialize before this module's do.
     for (_, dep) in local_import_targets(&module_file) {
-        load_local_module(&loaded_mod.canonical_path, &dep, loader, loaded, out)?;
+        load_local_module(
+            &loaded_mod.canonical_path,
+            &dep,
+            loader,
+            loaded,
+            out,
+            def_sites,
+        )?;
     }
     out.push(module_file);
     Ok(())
@@ -1677,7 +1715,7 @@ mod tests {
         let user = parse_src(
             "import \"github.com/acme/greet/lib\" { shout }\nfun main() { print(shout(\"hi\")) }\n",
         );
-        let combined = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
+        let (combined, _sites) = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
 
         let key = external_module_key("github.com", "acme", "greet", &src_path);
         let mangled = mangle_external_fn(&key, "shout");
@@ -1744,7 +1782,7 @@ mod tests {
             "import \"./helper\" { loud }\nfun main() { print(loud(\"hi\")) }\n",
             &entry,
         );
-        let combined = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
+        let (combined, _sites) = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
 
         let ext_shout = mangle_external_fn(
             &external_module_key("github.com", "acme", "greet", &src_path),

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1875,6 +1875,35 @@ fn read_line_preserves_non_utf8() {
     );
 }
 
+#[test]
+fn macro_in_imported_module_compiles_and_runs() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A declarative macro call inside an imported local module must be expanded
+    // the same way the entry file's macros are. macro_module_lib.rv defines
+    // `double!` and uses it in `compute`; the main program imports `compute`
+    // and prints its result, which is 42 once the module's macro expands.
+    let example = build_example_binary("macro_module_main.rv", &runtime);
+    let output = Command::new(&example.binary)
+        .output()
+        .expect("run macro_module_main binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&example.tmp);
+    assert!(
+        output.status.success(),
+        "macro_module_main exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "42\n",
+        "unexpected stdout for macro_module_main: {:?}",
+        stdout
+    );
+}
+
 /// A compiled example binary plus the temp dir holding it, so the caller
 /// can run the binary and then clean up.
 struct ExampleBinary {


### PR DESCRIPTION
A declarative macro call inside an imported local module was never expanded, so it reached HIR lowering and failed:

```
error: internal error: macro call reached HIR lowering without expansion
```

The macro pre-pass ran only on the entry file. Each local module is now run through the same pre-pass when it is loaded: its macro table is collected (so a call inside a `"${...}"` interpolation fragment expands), its calls are expanded, and the definition-site identifiers its macros introduce are threaded to the resolver alongside the entry file's, so a free identifier a module macro names resolves at the module scope.

Verified with a `golden:skip` two-file example (`macro_module_main.rv` imports `macro_module_lib.rv`, which defines and uses a macro internally) driven by a new `codegen_smoke.rs` case printing `42`, plus a manual check that a module macro introducing a free function call resolves correctly. The lib, golden, and codegen_smoke suites pass.

Fixes #650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new example showing macros working inside imported modules.

* **Bug Fixes**
  * Fixed an issue where macros in imported local modules could fail during compilation; they now expand correctly before lowering.

* **Tests**
  * Added a smoke test to verify the imported-module macro example builds, runs, and outputs the expected result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->