### PR TITLE
Ignore SIGPIPE so a closed-pipe write does not kill the program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.174] - 2026-06-24
+
+### Fixed
+
+- A compiled Raven program no longer dies from SIGPIPE when it writes to a closed pipe or socket. Writing the rest of a child's stdin after the child exits, or to a network peer that has closed the connection, raised SIGPIPE on Unix, whose default disposition terminated the program; the runtime now ignores SIGPIPE so the write surfaces as an ordinary handled error instead.
+
 ## [2.18.173] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.169"
+version = "2.18.174"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,10 +575,11 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.169"
+version = "2.18.174"
 dependencies = [
  "chrono",
  "corosensei",
+ "libc",
  "regex",
  "ureq",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.173"
+version = "2.18.174"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/sigpipe_child.rv
+++ b/examples/v2/sigpipe_child.rv
@@ -1,0 +1,8 @@
+// golden:skip - the child half of the SIGPIPE regression test
+// (sigpipe_parent.rv, checked in codegen_smoke.rs). It prints "done" and exits
+// without reading stdin, so the parent's stdin write hits a closed pipe.
+import std/io { println }
+
+fun main() {
+    println("done")
+}

--- a/examples/v2/sigpipe_parent.rv
+++ b/examples/v2/sigpipe_parent.rv
@@ -1,0 +1,28 @@
+// golden:skip - runs a child (path in RAVEN_PROC_CHILD) that ignores its stdin
+// and exits, while feeding it more stdin than a pipe buffer holds. Writing the
+// rest hits a closed pipe; the runtime must not die from SIGPIPE. Checked in
+// codegen_smoke.rs (process_stdin_broken_pipe_does_not_kill). Prints:
+//   ok
+//   survived
+import std/process { run_with_input }
+import std/env { get_env }
+import std/io { println }
+import std/string
+
+fun main() {
+    let child = get_env("RAVEN_PROC_CHILD")
+    // ~160 KB, well over a typical 64 KB pipe buffer, so the write blocks and
+    // then breaks when the child exits.
+    let big = "0123456789"
+    let i = 0
+    while i < 14 {
+        big = big.concat(big)
+        i = i + 1
+    }
+    let no_args: List<String> = []
+    match run_with_input(child, no_args, big) {
+        Ok(out) -> println("ok"),
+        Err(e) -> println("err"),
+    }
+    println("survived")
+}

--- a/raven-runtime/Cargo.toml
+++ b/raven-runtime/Cargo.toml
@@ -16,3 +16,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 corosensei = "0.3.4"
 regex = "1"
 ureq = "2.12"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -59,6 +59,23 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
+/// Ignore `SIGPIPE` once, process-wide, on Unix. Writing to a pipe or socket
+/// whose read end has closed raises `SIGPIPE`, whose default disposition
+/// terminates the process. A compiled Raven program does not go through Rust's
+/// std startup (its `main` is a Cranelift-emitted C shim), so the signal is at
+/// its default. Ignoring it makes such a write return an ordinary `EPIPE` error
+/// the caller already handles, instead of killing the program. Called lazily at
+/// the start of the operations that can hit a broken pipe.
+fn ignore_sigpipe() {
+    #[cfg(unix)]
+    {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+        });
+    }
+}
+
 thread_local! {
     // Message of the most recent fallible fs op: empty on success, the OS
     // error text on failure. The Raven wrapper reads it through
@@ -1331,6 +1348,9 @@ pub extern "C" fn raven_net_read(stream_id: i64, max: i64) -> *mut object::Strin
 /// `data` must be a valid `raven_string_from_bytes`-built `String`.
 #[no_mangle]
 pub extern "C" fn raven_net_write(stream_id: i64, data: *const object::String) -> i64 {
+    // Writing to a peer that has closed the connection would raise SIGPIPE and
+    // kill the program; ignore it so the write surfaces as an error instead.
+    ignore_sigpipe();
     let ptr = object::raven_string_bytes(data);
     let len = object::raven_string_len(data) as usize;
     let bytes: &[u8] = if ptr.is_null() || len == 0 {
@@ -1995,6 +2015,10 @@ pub extern "C" fn raven_process_run(
     args_nul_joined: *const object::String,
     stdin_data: *const object::String,
 ) -> i64 {
+    // A child that exits before reading all of its stdin closes the pipe, so
+    // writing the rest would raise SIGPIPE and kill this program. Ignore it so
+    // the write returns a (handled) error instead.
+    ignore_sigpipe();
     let (Some(program), Some(args_joined)) = (env_name(program), env_name(args_nul_joined)) else {
         process_set_error("program or args is not valid UTF-8".to_string());
         return 0;

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1665,6 +1665,41 @@ fn process_program_compiles_and_runs() {
 }
 
 #[test]
+fn process_stdin_broken_pipe_does_not_kill() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A child that exits without reading its stdin closes the pipe, so the
+    // parent's remaining stdin write hits a broken pipe. On Unix that raises
+    // SIGPIPE, whose default disposition would kill the parent (exit signal 13);
+    // the runtime ignores SIGPIPE so the write fails harmlessly. The parent
+    // feeds ~160 KB (over a pipe buffer) and must still print `ok` then
+    // `survived` and exit zero.
+    let child = build_example_binary("sigpipe_child.rv", &runtime);
+    let parent = build_example_binary("sigpipe_parent.rv", &runtime);
+
+    let output = Command::new(&parent.binary)
+        .env("RAVEN_PROC_CHILD", &child.binary)
+        .output()
+        .expect("run sigpipe_parent binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&child.tmp);
+    cleanup(&parent.tmp);
+    assert!(
+        output.status.success(),
+        "sigpipe_parent exited non zero (SIGPIPE?): status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "ok\nsurvived\n",
+        "unexpected stdout for sigpipe_parent: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn proc_argv_preserves_empty_arg() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
A compiled Raven program could be killed by `SIGPIPE` (exit signal 13) when it wrote to a pipe or socket whose read end had closed: for example, writing the rest of a child's stdin after the child exited without reading it, or writing to a TCP peer that had closed the connection.

A compiled Raven program's entry point is a Cranelift-emitted `int main(void)` shim, so it never runs Rust's std startup, which normally ignores `SIGPIPE`. The signal therefore kept its default disposition (terminate). The runtime already ignored the write *error*, but not the *signal*.

The runtime now ignores `SIGPIPE` once, process-wide, on Unix (via `libc::signal(SIGPIPE, SIG_IGN)`) before the `std/process` and `std/net` write paths run, so a broken-pipe write returns an ordinary `EPIPE` error the existing code tolerates instead of killing the program. No effect on Windows (no `SIGPIPE`).

Found while CI was flaking: `proc_binary_io_compiles_and_runs` intermittently died with `unix_wait_status(13)` (SIGPIPE) when the child exited before the parent finished writing its stdin. Added a deterministic regression test (`process_stdin_broken_pipe_does_not_kill`): a child that ignores its stdin and exits while the parent feeds ~160 KB (over a pipe buffer); the parent must survive and print `ok`/`survived`. golden and codegen_smoke pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of broken pipes so apps continue running instead of being terminated unexpectedly.
  * Writing to a closed pipe or socket now returns a normal error.
  * Added a new end-to-end check to confirm parent processes survive when a child exits early.
* **New Features**
  * Added example programs demonstrating the broken-pipe behavior and its safe handling.
* **Chores**
  * Updated the project version to **2.18.174** and added a changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->