### PR TITLE
Match macro literal tokens by value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.175] - 2026-06-24
+
+### Fixed
+
+- A literal token in a macro matcher matches by value, not just by token kind. `(foo)` matched every identifier and `(1)` every integer, so rules differing only by a literal value were unreachable; a literal matcher token now has to appear verbatim (#651).
+
 ## [2.18.174] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.174"
+version = "2.18.175"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -779,8 +779,11 @@ fn match_seq(
     for (idx, item) in matcher.iter().enumerate() {
         match item {
             MatchItem::Literal(kind) => {
+                // A literal matcher token must appear verbatim: compare the full
+                // token, not just its kind, so `(foo)` matches the identifier
+                // `foo` and not every identifier, and `(1)` matches only `1`.
                 let tok = args.get(pos)?;
-                if !same_kind(&tok.kind, kind) {
+                if &tok.kind != kind {
                     return None;
                 }
                 pos += 1;

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -257,6 +257,16 @@ fn first_matching_rule_wins() {
 }
 
 #[test]
+fn literal_matcher_matches_by_value() {
+    // A literal matcher token must appear verbatim, so a rule that differs only
+    // by the literal value is selected by that value (not by token kind alone).
+    let by_ident = "macro pick { (foo) => { 10 } (bar) => { 20 } }\nlet a = pick!(bar)\n";
+    assert_eq!(expand_render(by_ident), "let a = 20");
+    let by_int = "macro num { (1) => { 100 } (2) => { 200 } }\nlet b = num!(2)\n";
+    assert_eq!(expand_render(by_int), "let b = 200");
+}
+
+#[test]
 fn duplicate_macro_is_an_error() {
     let src = "macro dup { ($x:expr) => { ($x) } }\nmacro dup { ($x:expr) => { ($x) } }\n";
     let e = expand_tokens(&lex(src)).expect_err("duplicate def");


### PR DESCRIPTION
A literal token in a declarative macro matcher was matched only by its token-kind discriminant, not its value:

```raven
macro by_name { (foo) => { 10 } (bar) => { 20 } }
by_name!(bar)   // printed 10: (foo) matched every identifier
```

So any identifier matched an identifier literal, any integer matched an integer literal, and a rule differing only by a literal value was unreachable (the first rule always won), contradicting the spec ("a literal matcher token must appear verbatim").

The literal matcher arm now compares the full token (`tok.kind == kind`) instead of `same_kind`, so `(foo)` matches only `foo` and `(1)` only `1`. `same_kind` is still used for separator and delimiter matching, which is value-free. Added a unit test; `by_name!(bar)` is now `20` and `by_number!(2)` is `200`.

Fixes #651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Macro literal matching now uses the exact token value, so rules are selected only when the literal matches verbatim.
  * Fixed cases where rules with different literal values could not be reached correctly.
  * Added coverage to verify matching for identifier-like and numeric literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->