### PR TITLE
Allow a matcher item after a macro repetition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.176] - 2026-06-24
+
+### Fixed
+
+- A declarative macro repetition can be followed by another matcher item. `($($x:expr),* ; $tail:expr)` failed to match because the repetition's last element ran past the `;`; the last element of a repetition now stops at the token that follows the repetition, so a trailing matcher item after a `*`/`+` group matches (#661).
+
 ## [2.18.175] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.175"
+version = "2.18.176"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -758,7 +758,7 @@ fn expand_call(
 fn try_match(matcher: &[MatchItem], args: &[Token]) -> Option<HashMap<String, Capture>> {
     let args = strip_newlines(args);
     let mut binds: HashMap<String, Capture> = HashMap::new();
-    let pos = match_seq(matcher, &args, 0, None, &mut binds)?;
+    let pos = match_seq(matcher, &args, 0, None, None, &mut binds)?;
     if pos != args.len() {
         return None;
     }
@@ -774,6 +774,10 @@ fn match_seq(
     args: &[Token],
     mut pos: usize,
     outer_delim: Option<&TokenKind>,
+    // The token that follows the repetition this sequence is the body of, if
+    // any. The last element captured here stops before it, so a repetition can
+    // be followed by another matcher item (`$($x:expr),* ; $tail`).
+    follow: Option<&TokenKind>,
     binds: &mut HashMap<String, Capture>,
 ) -> Option<usize> {
     for (idx, item) in matcher.iter().enumerate() {
@@ -820,7 +824,10 @@ fn match_seq(
                     // the type. `<`/`>` are comparison operators in an `expr` or
                     // `pat`, so those fragments leave angles untracked.
                     let angles = matches!(frag, Fragment::Ty);
-                    let end = capture_balanced(args, pos, delim.as_ref(), angles)?;
+                    // The last item of a repetition body also stops at the token
+                    // following the repetition (`follow`), only relevant when
+                    // `delim` (the next matcher delimiter) is not hit first.
+                    let end = capture_balanced(args, pos, delim.as_ref(), follow, angles)?;
                     if end == pos {
                         return None;
                     }
@@ -829,7 +836,18 @@ fn match_seq(
                 }
             },
             MatchItem::Rep { sub, sep, plus } => {
-                pos = match_rep(sub, sep.as_ref(), *plus, args, pos, binds)?;
+                // The token after the repetition delimits the repetition's last
+                // element, so it can be followed by another matcher item.
+                let rep_follow = next_delim(matcher, idx + 1, outer_delim);
+                pos = match_rep(
+                    sub,
+                    sep.as_ref(),
+                    *plus,
+                    args,
+                    pos,
+                    rep_follow.as_ref(),
+                    binds,
+                )?;
             }
         }
     }
@@ -846,6 +864,10 @@ fn match_rep(
     plus: bool,
     args: &[Token],
     mut pos: usize,
+    // The token following the repetition in the enclosing matcher, used to
+    // bound the last captured element so the repetition can be followed by
+    // another matcher item.
+    follow: Option<&TokenKind>,
     binds: &mut HashMap<String, Capture>,
 ) -> Option<usize> {
     let names = meta_names(sub);
@@ -873,7 +895,7 @@ fn match_rep(
             }
         }
         let mut iter_binds: HashMap<String, Capture> = HashMap::new();
-        match match_seq(sub, args, pos, sep, &mut iter_binds) {
+        match match_seq(sub, args, pos, sep, follow, &mut iter_binds) {
             Some(next) if next > pos => {
                 // Each iteration contributes one capture per metavariable. A
                 // metavariable inside a nested repetition contributes a
@@ -940,13 +962,17 @@ fn next_delim(
         .or_else(|| outer_delim.cloned())
 }
 
-/// Capture a balanced token run from `start` until a top-level `delim` (or
-/// the end of `args` when `delim` is `None`). Bracket depth must be balanced
-/// at the stop point. Returns the index of the stop position.
+/// Capture a balanced token run from `start` until a top-level `delim` or
+/// `delim2` (or the end of `args` when both are `None`). `delim2` is the token
+/// that follows the enclosing repetition, if any, so the last element of a
+/// repetition stops before it (`$($x:expr),* ; $tail` captures the final `$x`
+/// up to the `;`). Bracket depth must be balanced at the stop point. Returns
+/// the index of the stop position.
 fn capture_balanced(
     args: &[Token],
     start: usize,
     delim: Option<&TokenKind>,
+    delim2: Option<&TokenKind>,
     angles: bool,
 ) -> Option<usize> {
     let mut depth: i32 = 0;
@@ -970,12 +996,10 @@ fn capture_balanced(
             TokenKind::Shr if angles && depth > 0 => depth = (depth - 2).max(0),
             _ => {}
         }
-        if depth == 0 {
-            if let Some(d) = delim {
-                if same_kind(k, d) {
-                    break;
-                }
-            }
+        if depth == 0
+            && (delim.is_some_and(|d| same_kind(k, d)) || delim2.is_some_and(|d| same_kind(k, d)))
+        {
+            break;
         }
         i += 1;
     }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -884,11 +884,9 @@ fn match_rep(
         // and not present, the repetition stops.
         if count > 0 {
             if let Some(s) = sep {
-                if !args
-                    .get(pos)
-                    .map(|t| same_kind(&t.kind, s))
-                    .unwrap_or(false)
-                {
+                // Compare the full token: a separator that carries a payload
+                // must match that exact token, not every token of its kind.
+                if !args.get(pos).map(|t| &t.kind == s).unwrap_or(false) {
                     break;
                 }
                 pos += 1;
@@ -996,9 +994,11 @@ fn capture_balanced(
             TokenKind::Shr if angles && depth > 0 => depth = (depth - 2).max(0),
             _ => {}
         }
-        if depth == 0
-            && (delim.is_some_and(|d| same_kind(k, d)) || delim2.is_some_and(|d| same_kind(k, d)))
-        {
+        // Compare the full token, not just its kind: a delimiter that carries a
+        // payload (a literal identifier or number, for instance a follow token
+        // like `foo`) must stop the capture only on that exact token, not on
+        // every identifier or number.
+        if depth == 0 && (delim.is_some_and(|d| k == d) || delim2.is_some_and(|d| k == d)) {
             break;
         }
         i += 1;

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -310,6 +310,17 @@ fn plus_repetition_matches_multiple() {
 }
 
 #[test]
+fn repetition_can_be_followed_by_a_matcher_item() {
+    // The repetition's last element stops before the `;` that follows the
+    // repetition, so the trailing `; $t` matches and the rule applies.
+    let src = "macro tail { ($($x:expr),* ; $t:expr) => { $t } }\nlet r = tail!(1, 2; 99)\n";
+    assert_eq!(expand_render(src), "let r = 99");
+    // Zero reps before the trailing item also works.
+    let zero = "macro tail { ($($x:expr),* ; $t:expr) => { $t } }\nlet z = tail!(; 7)\n";
+    assert_eq!(expand_render(zero), "let z = 7");
+}
+
+#[test]
 fn repetition_with_multiple_metavariables_per_rep() {
     let src = "macro pairs { ($($k:ident : $v:expr),*) => { [$(($k, $v)),*] } }\n\
                let p = pairs!(a : 1, b : 2)\n";

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -318,6 +318,12 @@ fn repetition_can_be_followed_by_a_matcher_item() {
     // Zero reps before the trailing item also works.
     let zero = "macro tail { ($($x:expr),* ; $t:expr) => { $t } }\nlet z = tail!(; 7)\n";
     assert_eq!(expand_render(zero), "let z = 7");
+    // A payload-carrying follow token (the identifier `foo`) stops the last
+    // element only on that exact token, not on every identifier, so the `bar`
+    // inside the expression does not break the capture early.
+    let payload =
+        "macro pick { ($($x:expr),* foo $t:expr) => { $t } }\nlet p = pick!(1 + bar foo 99)\n";
+    assert_eq!(expand_render(payload), "let p = 99");
 }
 
 #[test]


### PR DESCRIPTION
A declarative macro repetition could not be followed by another matcher item:

```raven
macro tail { ($($x:expr),* ; $tail:expr) => { $tail } }
tail!(1, 2; 99)   // error: no rule of macro `tail!` matches
```

The repetition's element capture stopped only at the repetition separator (`,`), so the last `$x` ran past the `;` and consumed the rest of the input, leaving nothing for the trailing `; $tail`.

The matcher now threads the token that follows a repetition (its "follow" delimiter) down to the element capture, so the last element of a `*`/`+` group stops before that token. A repetition with no trailing item is unchanged, and zero-rep cases still work (`tail!(; 7)` is `7`).

`capture_balanced` takes a second optional delimiter, `match_seq`/`match_rep` thread the follow token, and the top-level call passes `None`. Added a unit test; the existing repetition tests and the full lib suite pass.

Fixes #661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macro matcher behavior so repetitions (`*`/`+`) stop correctly and no longer interfere with subsequent matcher items after `;`.
  * Tightened repetition separator and balanced capture termination to require exact token matches, improving reliability for payload-carrying tokens.

* **Tests**
  * Added macro-expansion coverage for repetitions followed by another matcher item, including non-zero, zero (empty capture), and payload-specific follow-token scenarios.

* **Chores**
  * Updated the changelog and bumped the workspace version to **2.18.176**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->