### PR TITLE
rvpm: do not follow directory symlinks out of the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.177] - 2026-06-24
+
+### Fixed
+
+- `rvpm` no longer follows directory symlinks out of the package when walking sources. `rvpm doc`, `rvpm fmt`, and `rvpm test` descended into a symlinked directory pointing outside the project, so they could read, rewrite, or compile and run code from another tree. The source walks now skip symlinked entries (#678, #679, #680).
+
 ## [2.18.176] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.176"
+version = "2.18.177"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -690,16 +690,15 @@ fn collect_rv_excluding(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String
     let entries = std::fs::read_dir(dir).map_err(|e| format!("{}: {}", dir.display(), e))?;
     for entry in entries {
         let entry = entry.map_err(|e| e.to_string())?;
-        let ftype = entry.file_type().map_err(|e| e.to_string())?;
-        // Do not follow symlinks: a directory link could point outside the
-        // package, and formatting a linked file would rewrite its target.
-        if ftype.is_symlink() {
+        // Do not follow a link out of the package (a symlink, or a Windows
+        // junction): formatting a linked file would rewrite its target.
+        if ops::is_link_entry(&entry) {
             continue;
         }
         let path = entry.path();
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if ftype.is_dir() {
+        if path.is_dir() {
             if name == "target" || name.starts_with('.') {
                 continue;
             }
@@ -721,13 +720,13 @@ fn collect_rv_files(dir: PathBuf) -> Result<Vec<PathBuf>, String> {
         let entries = std::fs::read_dir(&d).map_err(|e| format!("{}: {}", d.display(), e))?;
         for entry in entries {
             let entry = entry.map_err(|e| e.to_string())?;
-            let ftype = entry.file_type().map_err(|e| e.to_string())?;
-            // Do not follow symlinks out of the requested tree.
-            if ftype.is_symlink() {
+            // Do not follow a link out of the requested tree (a symlink, or a
+            // Windows junction).
+            if ops::is_link_entry(&entry) {
                 continue;
             }
             let path = entry.path();
-            if ftype.is_dir() {
+            if path.is_dir() {
                 stack.push(path);
             } else if path.extension().and_then(|s| s.to_str()) == Some("rv") {
                 out.push(path);

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -690,10 +690,16 @@ fn collect_rv_excluding(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String
     let entries = std::fs::read_dir(dir).map_err(|e| format!("{}: {}", dir.display(), e))?;
     for entry in entries {
         let entry = entry.map_err(|e| e.to_string())?;
+        let ftype = entry.file_type().map_err(|e| e.to_string())?;
+        // Do not follow symlinks: a directory link could point outside the
+        // package, and formatting a linked file would rewrite its target.
+        if ftype.is_symlink() {
+            continue;
+        }
         let path = entry.path();
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if path.is_dir() {
+        if ftype.is_dir() {
             if name == "target" || name.starts_with('.') {
                 continue;
             }
@@ -715,8 +721,13 @@ fn collect_rv_files(dir: PathBuf) -> Result<Vec<PathBuf>, String> {
         let entries = std::fs::read_dir(&d).map_err(|e| format!("{}: {}", d.display(), e))?;
         for entry in entries {
             let entry = entry.map_err(|e| e.to_string())?;
+            let ftype = entry.file_type().map_err(|e| e.to_string())?;
+            // Do not follow symlinks out of the requested tree.
+            if ftype.is_symlink() {
+                continue;
+            }
             let path = entry.path();
-            if path.is_dir() {
+            if ftype.is_dir() {
                 stack.push(path);
             } else if path.extension().and_then(|s| s.to_str()) == Some("rv") {
                 out.push(path);

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -150,10 +150,19 @@ fn collect_source_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), DocErr
             path: dir.to_path_buf(),
             message: e.to_string(),
         })?;
+        let ftype = entry.file_type().map_err(|e| DocError::Io {
+            path: dir.to_path_buf(),
+            message: e.to_string(),
+        })?;
+        // Do not follow symlinks: a directory link could point outside the
+        // package and pull in sources from another tree.
+        if ftype.is_symlink() {
+            continue;
+        }
         let path = entry.path();
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if path.is_dir() {
+        if ftype.is_dir() {
             if name == "target" || name.starts_with('.') {
                 continue;
             }

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -150,19 +150,15 @@ fn collect_source_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), DocErr
             path: dir.to_path_buf(),
             message: e.to_string(),
         })?;
-        let ftype = entry.file_type().map_err(|e| DocError::Io {
-            path: dir.to_path_buf(),
-            message: e.to_string(),
-        })?;
-        // Do not follow symlinks: a directory link could point outside the
-        // package and pull in sources from another tree.
-        if ftype.is_symlink() {
+        // Do not follow a link out of the package (a symlink, or a Windows
+        // junction), which would pull in sources from another tree.
+        if crate::ops::is_link_entry(&entry) {
             continue;
         }
         let path = entry.path();
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if ftype.is_dir() {
+        if path.is_dir() {
             if name == "target" || name.starts_with('.') {
                 continue;
             }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -766,6 +766,32 @@ pub fn test_in(project_dir: &Path, cache_root: &Path) -> Result<TestReport, OpEr
     })
 }
 
+/// Whether a directory entry is a link that a package source walk must not
+/// follow: a symlink on any platform, or, on Windows, a directory junction or
+/// other reparse point (which `FileType::is_symlink` does not report, since a
+/// junction uses a different reparse tag). Skipping these keeps `rvpm doc`,
+/// `fmt`, and `test` from reading, rewriting, or running code outside the
+/// project tree. An entry whose type cannot be read is treated as a link, so it
+/// is skipped rather than followed.
+pub fn is_link_entry(entry: &std::fs::DirEntry) -> bool {
+    let Ok(ftype) = entry.file_type() else {
+        return true;
+    };
+    if ftype.is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        // FILE_ATTRIBUTE_REPARSE_POINT marks a junction or other reparse point.
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        if let Ok(meta) = std::fs::symlink_metadata(entry.path()) {
+            return meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0;
+        }
+    }
+    false
+}
+
 /// Collect every `*_test.rv` file under `project_dir`, skipping the build
 /// output and hidden or VCS directories.
 fn discover_test_files(project_dir: &Path) -> Result<Vec<PathBuf>, OpError> {
@@ -786,21 +812,16 @@ fn collect_test_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), OpError>
             path: dir.to_path_buf(),
             source: e,
         })?;
-        let ftype = entry.file_type().map_err(|e| OpError::Io {
-            action: "read directory entry".to_string(),
-            path: dir.to_path_buf(),
-            source: e,
-        })?;
-        // Do not follow symlinks: a directory link could point outside the
-        // package, and a test file reached through it would compile and run
-        // code from outside the project tree.
-        if ftype.is_symlink() {
+        // Do not follow a link out of the package (a symlink, or a Windows
+        // junction): a test file reached through it would compile and run code
+        // from outside the project tree.
+        if is_link_entry(&entry) {
             continue;
         }
         let path = entry.path();
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if ftype.is_dir() {
+        if path.is_dir() {
             if name == "target" || name.starts_with('.') {
                 continue;
             }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -786,10 +786,21 @@ fn collect_test_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), OpError>
             path: dir.to_path_buf(),
             source: e,
         })?;
+        let ftype = entry.file_type().map_err(|e| OpError::Io {
+            action: "read directory entry".to_string(),
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        // Do not follow symlinks: a directory link could point outside the
+        // package, and a test file reached through it would compile and run
+        // code from outside the project tree.
+        if ftype.is_symlink() {
+            continue;
+        }
         let path = entry.path();
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if path.is_dir() {
+        if ftype.is_dir() {
             if name == "target" || name.starts_with('.') {
                 continue;
             }
@@ -989,6 +1000,34 @@ mod tests {
 
     const APP_MANIFEST: &str =
         "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n# keep this comment\n";
+
+    #[cfg(unix)]
+    #[test]
+    fn discover_test_files_does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+        let proj = TempProject::new("symlink");
+        std::fs::create_dir_all(proj.root.join("src")).expect("create src");
+        std::fs::write(proj.root.join("src/inside_test.rv"), "fun test_a() {}\n")
+            .expect("write inside test");
+        // A directory outside the package, with its own test file.
+        let outside = TempProject::new("symlink-outside");
+        std::fs::write(outside.root.join("outside_test.rv"), "fun test_b() {}\n")
+            .expect("write outside test");
+        // A directory symlink inside the package pointing at the outside tree.
+        symlink(&outside.root, proj.root.join("linked")).expect("create symlink");
+
+        let found = discover_test_files(&proj.root).expect("discover test files");
+        assert!(
+            found.iter().any(|p| p.ends_with("inside_test.rv")),
+            "the package's own test file must be found: {found:?}"
+        );
+        assert!(
+            !found
+                .iter()
+                .any(|p| p.to_string_lossy().contains("outside_test")),
+            "a test file reached only through a directory symlink must not be discovered: {found:?}"
+        );
+    }
 
     #[test]
     fn add_appends_dependency_and_writes_lock() {


### PR DESCRIPTION
`rvpm doc`, `rvpm fmt`, and `rvpm test` walked the package source tree with `path.is_dir()`, which follows symlinks. A directory symlink inside the project pointing outside it was therefore followed, so:

- `rvpm doc` (#678) read and documented sources from another tree;
- `rvpm fmt` (#679) reformatted and rewrote files outside the package (modifying the symlink targets);
- `rvpm test` (#680) discovered, compiled, and **ran** `*_test.rv` code from outside the project.

The four source walks now inspect each directory entry's own type with `entry.file_type()` (which does not follow symlinks) and skip symlinked entries, so they only ever touch files physically inside the package:

- `collect_rv_excluding` and `collect_rv_files` (`src/bin/rvpm.rs`, fmt)
- `collect_source_files` (`src/doc.rs`, doc)
- `collect_test_files` (`src/ops/mod.rs`, test)

Added a `#[cfg(unix)]` regression test (`discover_test_files_does_not_follow_symlinks`) that creates a directory symlink to an outside tree with its own `*_test.rv` and asserts discovery skips it. It runs on the Linux CI; symlink creation on Windows needs privileges, so it is Unix-gated.

This bundles three closely-related issues with one identical fix. Fixes #678, #679, #680.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source/test discovery to avoid following symlinks during `doc`, `fmt`, and `test` operations.
  * Formatting candidates and test files are now limited to the intended project tree, excluding entries reachable only through linked directories.
  * Added coverage to ensure symlinked paths do not cause external `*_test.rv` files to be discovered.

* **Chores**
  * Updated the changelog with the new release entry and version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->