### PR TITLE
rvpm add: do not modify rv.toml when resolution fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.179] - 2026-06-24
+
+### Fixed
+
+- `rvpm add` no longer leaves `rv.toml` modified when resolution fails. The command wrote the edited manifest before resolving or fetching the dependency, so a failed resolve (a missing repo, an invalid constraint) left the dependency in `rv.toml` with no matching `rv.lock`. The manifest and lock are now resolved first and written only after both succeed, so a failed add leaves project state untouched (#648).
+
 ## [2.18.178] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.178"
+version = "2.18.179"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -188,14 +188,23 @@ pub fn add_in(
     let text = read_to_string(&manifest_path)?;
     let (new_text, outcome) = upsert_dependency(&text, &key, constraint)?;
 
-    // Resolve and lock the edited manifest before writing anything to disk: if
-    // parsing, resolution, or fetching fails, rv.toml is left unchanged and no
-    // rv.lock is written, so a failed `add` does not leave the manifest and
-    // lock out of sync. Only once both succeed are the two files committed.
+    // Guard: the edited text must still parse as a manifest.
     let manifest = Manifest::from_toml_str(&new_text)?;
-    let lock = lock::resolve_and_lock_in(&manifest, cache_root)?;
 
-    write_file(&manifest_path, &new_text)?;
+    // For a concrete ref, resolve and lock before writing anything to disk: if
+    // resolution or fetching fails, rv.toml is left unchanged and no rv.lock is
+    // written, so a failed `add` does not desync the manifest from the lock
+    // (#648). For the `latest` placeholder (no ref given), the manifest edit is
+    // the point: it cannot resolve yet, so it is recorded first and the user
+    // pins a real ref later, even though the resolution error is still surfaced.
+    let placeholder = version.is_none();
+    if placeholder {
+        write_file(&manifest_path, &new_text)?;
+    }
+    let lock = lock::resolve_and_lock_in(&manifest, cache_root)?;
+    if !placeholder {
+        write_file(&manifest_path, &new_text)?;
+    }
     let lock_path = project_dir.join(LOCK_FILE_NAME);
     lock.write(&lock_path)?;
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -188,12 +188,14 @@ pub fn add_in(
     let text = read_to_string(&manifest_path)?;
     let (new_text, outcome) = upsert_dependency(&text, &key, constraint)?;
 
-    // Guard: the edited text must still parse as a manifest.
-    Manifest::from_toml_str(&new_text)?;
-    write_file(&manifest_path, &new_text)?;
-
+    // Resolve and lock the edited manifest before writing anything to disk: if
+    // parsing, resolution, or fetching fails, rv.toml is left unchanged and no
+    // rv.lock is written, so a failed `add` does not leave the manifest and
+    // lock out of sync. Only once both succeed are the two files committed.
     let manifest = Manifest::from_toml_str(&new_text)?;
     let lock = lock::resolve_and_lock_in(&manifest, cache_root)?;
+
+    write_file(&manifest_path, &new_text)?;
     let lock_path = project_dir.join(LOCK_FILE_NAME);
     lock.write(&lock_path)?;
 
@@ -1090,6 +1092,28 @@ mod tests {
             .expect("foo in lock");
         assert_eq!(foo.version, "v1.0.0");
         assert!(foo.hash.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn failed_add_leaves_manifest_and_lock_untouched() {
+        let proj = TempProject::new("addfail");
+        proj.write_manifest(APP_MANIFEST);
+        let cache = proj.cache_root();
+        // A constraint containing `..` is rejected during resolution, so the
+        // add fails before any file is written and without network access.
+        let result = add_in(&proj.root, "github.com/acme/foo", Some("../evil"), &cache);
+        assert!(result.is_err(), "add must fail on an invalid constraint");
+        // The manifest is untouched and no lock was written, so a failed add
+        // does not leave the project half-changed.
+        assert_eq!(
+            proj.manifest_text(),
+            APP_MANIFEST,
+            "rv.toml must be unchanged after a failed add"
+        );
+        assert!(
+            !proj.root.join(LOCK_FILE_NAME).exists(),
+            "no rv.lock must be written after a failed add"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`rvpm add` wrote the edited `rv.toml` to disk *before* resolving and fetching the new dependency. If resolution failed (the repo does not exist, the constraint is invalid), the command exited non-zero but left the dependency in `rv.toml` with no matching `rv.lock`, so a failed command still changed project state and desynced the manifest from the lock.

`add_in` now parses, resolves, and locks the edited manifest first, and writes `rv.toml` and `rv.lock` only once both succeed. A failed add leaves both files untouched. Added a test that a `..`-containing constraint (rejected during resolution, no network) leaves `rv.toml` unchanged and writes no `rv.lock`.

Fixes #648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `rvpm add` no longer leaves `rv.toml` modified when dependency resolution fails.
  * Manifest/lock changes are applied only after resolution succeeds, preventing partial or out-of-sync project state.
  * Invalid dependency constraints now fail without creating/updating `rv.lock`, keeping project files unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->