### PR TITLE
rvpm: validate package cache path components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.180] - 2026-06-24
+
+### Fixed
+
+- The package manager validates a dependency's user, repo, and version before using them to build a cache path. Each becomes a directory name under the cache, so a single shared check (`is_safe_cache_component`) now rejects an empty, `.`/`..`, separator-, drive-colon-, or control-character-bearing component in `GithubPath::parse` (user/repo) and the lock's version resolution, and the fetch and clone paths refuse a cache destination that still contains a `..` component, so a malicious transitive dependency cannot steer directory creation outside the cache root (#431).
+
 ## [2.18.179] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.179"
+version = "2.18.180"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -679,10 +679,10 @@ fn resolved_ref(dep: &crate::manifest::Dependency) -> Result<String, LockError> 
             source: dep_source(&dep.path),
         });
     }
-    // The version becomes a directory name under the cache, so reject anything
-    // that could climb out of it. A real version never holds a separator or a
-    // parent reference.
-    if r.contains('/') || r.contains('\\') || r.contains("..") {
+    // The version becomes a directory name under the cache, so it must be a
+    // single, in-tree path component: reject a separator, `..`, drive colon, or
+    // control character that could climb out of the cache root.
+    if !crate::pkg::is_safe_cache_component(r) {
         return Err(LockError::InvalidConstraint {
             source: dep_source(&dep.path),
             value: r.to_string(),

--- a/src/pkg/mod.rs
+++ b/src/pkg/mod.rs
@@ -38,6 +38,10 @@ pub enum PkgError {
         reference: String,
         stderr: String,
     },
+    /// The cache destination contains a parent (`..`) component, which would
+    /// place it outside the cache root. A defense-in-depth check at directory
+    /// creation, independent of the upstream component validation.
+    UnsafeCachePath { path: PathBuf },
 }
 
 impl fmt::Display for PkgError {
@@ -67,6 +71,11 @@ impl fmt::Display for PkgError {
                 url,
                 reference,
                 stderr.trim()
+            ),
+            PkgError::UnsafeCachePath { path } => write!(
+                f,
+                "refusing to create cache directory outside the cache root: '{}'",
+                path.display()
             ),
         }
     }
@@ -116,6 +125,21 @@ pub fn cache_dir_in(root: &Path, host: &str, user: &str, repo: &str, version: &s
         .join(format!("{}@{}", repo, version))
 }
 
+/// Whether `s` is safe to use as a single path component under the package
+/// cache. A package's user, repo, and version each become a directory name, so
+/// each must be a single, in-tree segment: non-empty, not a current or parent
+/// directory reference, and free of a path separator, a Windows drive/stream
+/// colon, or a control character. This blocks a malicious dependency from
+/// steering cache directory creation outside the cache root.
+pub fn is_safe_cache_component(s: &str) -> bool {
+    !s.is_empty()
+        && s != "."
+        && s != ".."
+        && !s
+            .chars()
+            .any(|c| matches!(c, '/' | '\\' | ':') || c.is_control())
+}
+
 /// The outcome of a fetch: where the package landed, and whether it was
 /// already in the cache (no network) or freshly downloaded.
 #[derive(Debug, Clone)]
@@ -156,6 +180,15 @@ pub fn fetch_in(
     version: &str,
 ) -> Result<Fetched, PkgError> {
     let dest = cache_dir_in(root, host, user, repo, version);
+    // Defense in depth: a `..` in any component would place the cache entry
+    // outside the cache root. The path components are validated upstream, but
+    // this guards the directory creation directly.
+    if dest
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(PkgError::UnsafeCachePath { path: dest.clone() });
+    }
     if is_populated(&dest) {
         return Ok(Fetched {
             dir: dest,
@@ -343,6 +376,16 @@ fn is_populated(dir: &Path) -> bool {
 /// pinned tag or branch is never updated in place, so the history is not
 /// needed.
 pub fn clone_from(url: &str, reference: &str, dest: &Path) -> Result<(), PkgError> {
+    // Defense in depth: never create a cache directory through a parent
+    // reference, even if a component validation upstream were bypassed.
+    if dest
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(PkgError::UnsafeCachePath {
+            path: dest.to_path_buf(),
+        });
+    }
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent).map_err(|e| PkgError::Io {
             action: "create cache directory".to_string(),
@@ -398,6 +441,41 @@ pub fn clone_from(url: &str, reference: &str, dest: &Path) -> Result<(), PkgErro
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[test]
+    fn safe_cache_component_accepts_real_names_and_rejects_escapes() {
+        // Real GitHub users, repos, and version refs, including a leading-dot
+        // directory name (a normal segment, unlike `.`/`..`).
+        for ok in [
+            "martian56",
+            "raven-http",
+            "raven.rs",
+            "v1.2.3",
+            "v1.0.0-rc.1",
+            "a_b",
+            ".config",
+        ] {
+            assert!(is_safe_cache_component(ok), "should accept `{ok}`");
+        }
+        // Empty, current/parent refs, separators, a drive colon, and control
+        // characters cannot be a single in-tree segment.
+        for bad in [
+            "", ".", "..", "a/b", "a\\b", "C:", "../x", "a\nb", "a\u{0}b",
+        ] {
+            assert!(!is_safe_cache_component(bad), "should reject `{bad:?}`");
+        }
+    }
+
+    #[test]
+    fn clone_from_refuses_a_parent_reference_in_the_dest() {
+        let dest = Path::new("cache/github.com/../../escape@v1");
+        let err = clone_from("https://example.invalid", "v1", dest)
+            .expect_err("must reject a `..` cache path");
+        assert!(
+            matches!(err, PkgError::UnsafeCachePath { .. }),
+            "got {err:?}"
+        );
+    }
 
     fn unique_temp(tag: &str) -> PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -255,12 +255,14 @@ impl GithubPath {
         let user = parts.next()?.to_string();
         let repo = parts.next()?.to_string();
         let subpath: Vec<String> = parts.map(|s| s.to_string()).collect();
-        // Every segment becomes a directory name under the cache, so reject an
-        // empty, `.`, `..`, or backslash-bearing segment that could escape it.
-        let unsafe_segment = |s: &str| s.is_empty() || s == "." || s == ".." || s.contains('\\');
-        if unsafe_segment(&user)
-            || unsafe_segment(&repo)
-            || subpath.iter().any(|s| unsafe_segment(s))
+        // Every segment becomes a directory name under the cache, so each must
+        // be a single, in-tree path component (no separator, `..`, drive colon,
+        // or control character) that cannot escape the cache root.
+        if !crate::pkg::is_safe_cache_component(&user)
+            || !crate::pkg::is_safe_cache_component(&repo)
+            || !subpath
+                .iter()
+                .all(|s| crate::pkg::is_safe_cache_component(s))
         {
             return None;
         }


### PR DESCRIPTION
A dependency's `user`, `repo`, and `version` each become a directory name under the shared cache (`<root>/<host>/<user>/<repo>@<version>`), but they were validated unevenly: `GithubPath::parse` rejected an empty/`.`/`..`/backslash segment, and the lock rejected a version with a separator or `..`, yet neither rejected control characters or a Windows drive/stream colon. A malicious transitive dependency could use the gaps to steer cache directory creation.

This adds a single shared `pkg::is_safe_cache_component` check (non-empty, not `.` or `..`, and free of a path separator, a `:` colon, or a control character) and applies it to `user`/`repo`/subpath in `GithubPath::parse` and to the resolved version in the lock. As defense in depth, `fetch_in` and `clone_from` refuse a cache destination that still contains a `..` component before creating any directory.

Added unit tests for the component check (real names accepted; escapes, colons, and control characters rejected) and for the `clone_from` guard. The full library suite still passes.

Fixes #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened cache path validation to prevent unsafe directory names from being used.
  * Downloads and clones now refuse paths containing parent-directory components, reducing the risk of writing outside the cache location.
  * Dependency references with unsafe characters or control symbols are now rejected earlier with clearer errors.

* **Chores**
  * Updated the release version to **2.18.180** and added a changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->