### PR TITLE
rvpm: drop exact-duplicate rv.lock entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.183] - 2026-06-24
+
+### Fixed
+
+- A duplicated `[[package]]` block in `rv.lock` no longer compiles a dependency's FFI sources twice. Loading a lock now drops exact-duplicate entries, so a repeated identical block is collapsed to one and a dependency with an `[ffi]` source is not gathered twice (which previously made the linker fail with duplicate definitions). A genuine conflict (one source pinned to two versions) is still rejected (#649).
+
 ## [2.18.182] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.182"
+version = "2.18.183"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -320,6 +320,14 @@ impl LockFile {
             })
             .collect();
         sort_packages(&mut packages);
+        // Drop exact-duplicate entries. The sort puts identical packages
+        // adjacent, so `dedup` collapses a lock that repeats the same
+        // `(source, version, hash)` block. Without this a duplicated entry is
+        // gathered twice during a build, so a dependency's FFI C sources are
+        // compiled twice and the linker fails with duplicate definitions. A
+        // genuine conflict (one source at two versions) survives and is caught
+        // by [`conflicting_versions`].
+        packages.dedup();
         Ok(LockFile {
             version: raw.version,
             packages,
@@ -1105,6 +1113,18 @@ mod tests {
         assert_eq!(parsed.packages[0].source, "github.com/acme/bar");
         assert_eq!(parsed.packages[1].source, "github.com/acme/foo");
         assert_eq!(parsed.version, LOCK_VERSION);
+    }
+
+    #[test]
+    fn from_toml_drops_exact_duplicate_entries() {
+        // A lock that repeats an identical package block parses to a single
+        // entry, so a dependency's FFI sources are not compiled twice.
+        let text = "version = 1\n\
+            \n[[package]]\nsource = \"github.com/acme/dup\"\nversion = \"v1\"\nhash = \"sha256:aa\"\n\
+            \n[[package]]\nsource = \"github.com/acme/dup\"\nversion = \"v1\"\nhash = \"sha256:aa\"\n";
+        let parsed = LockFile::from_toml_str(text).expect("parse");
+        assert_eq!(parsed.packages.len(), 1, "duplicate entry is collapsed");
+        assert_eq!(parsed.packages[0].source, "github.com/acme/dup");
     }
 
     #[test]


### PR DESCRIPTION
`rv.lock` could contain a duplicated identical `[[package]]` block. The conflict check only rejects one source pinned to two distinct versions, so a repeated identical entry was considered valid. During a build, native inputs are gathered once per lock entry, so a dependency with an `[ffi]` source had its C file compiled twice and the linker failed with duplicate definitions.

Loading a lock now drops exact-duplicate entries: the existing sort already places identical `(source, version, hash)` blocks adjacent, so a `dedup` collapses a repeated block to a single entry. A genuine conflict (one source at two different versions) has non-equal entries, survives the dedup, and is still rejected by the conflicting-versions check.

Added a unit test that a lock repeating an identical block parses to one entry.

Fixes #649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate identical package entries in lock files could be processed twice.
  * Builds now ignore exact duplicate package records while still rejecting real version conflicts.
* **Chores**
  * Updated the project version to `2.18.183`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->