### PR TITLE
release: treat the version input as data, not shell code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,23 @@ jobs:
       - name: Resolve version
         id: version
         shell: bash
+        env:
+          # Pass the dispatch input through the environment, not string
+          # interpolation, so a value with a quote or command separator cannot
+          # break out of the assignment and run as shell.
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [ "${{ github.ref_type }}" = "tag" ]; then
             v="${GITHUB_REF_NAME#v}"
           else
-            v="${{ github.event.inputs.version }}"
+            v="${INPUT_VERSION}"
+          fi
+          # The version becomes part of file names and an MSI ProductVersion, so
+          # accept only version characters. This also rejects any value crafted
+          # to escape a later shell or PowerShell assignment.
+          if ! [[ "$v" =~ ^[0-9A-Za-z.+_-]+$ ]]; then
+            echo "invalid release version: $v" >&2
+            exit 1
           fi
           echo "value=$v" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $v"
@@ -66,8 +78,10 @@ jobs:
       - name: Stage tarball (Unix)
         if: runner.os != 'Windows'
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
-          v="${{ steps.version.outputs.value }}"
+          v="$VERSION"
           dir="raven-$v-${{ matrix.target }}"
           bindir="target/${{ matrix.target }}/release"
           mkdir -p "stage/$dir"
@@ -92,8 +106,10 @@ jobs:
       - name: Stage zip (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
-          $v = "${{ steps.version.outputs.value }}"
+          $v = $env:VERSION
           $dir = "raven-$v-${{ matrix.target }}"
           $bindir = "target/${{ matrix.target }}/release"
           New-Item -ItemType Directory -Force -Path "stage/$dir" | Out-Null
@@ -134,10 +150,12 @@ jobs:
       - name: Build Windows MSI
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
           choco install wixtoolset --version 3.14.0 --allow-downgrade --yes
           cargo install cargo-wix --locked
-          $v = "${{ steps.version.outputs.value }}"
+          $v = $env:VERSION
           # An MSI ProductVersion must be numeric (X.Y.Z), so strip any
           # prerelease suffix (for example 2.0.0-rc1 becomes 2.0.0). The
           # filename keeps the full version label.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,12 @@ jobs:
           else
             v="${INPUT_VERSION}"
           fi
-          # The version becomes part of file names and an MSI ProductVersion, so
-          # accept only version characters. This also rejects any value crafted
-          # to escape a later shell or PowerShell assignment.
-          if ! [[ "$v" =~ ^[0-9A-Za-z.+_-]+$ ]]; then
+          # Accept only `X.Y.Z` with an optional `-prerelease` suffix: the MSI
+          # ProductVersion must be numeric `X.Y.Z` and only a `-...` suffix is
+          # stripped later, so reject other shapes (build metadata, underscores)
+          # here instead of failing deep in cargo wix. This also rejects any
+          # value crafted to escape a later shell or PowerShell assignment.
+          if ! [[ "$v" =~ ^[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "invalid release version: $v" >&2
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.184] - 2026-06-24
+
+### Fixed
+
+- The release workflow no longer interpolates the manual `version` dispatch input directly into shell and PowerShell source. The input is passed through the environment and validated against an allowed character set before use, and every later staging step reads the resolved version from the environment too, so a value with a quote or command separator can no longer run as code on the release runners (#632).
+
 ## [2.18.183] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.183"
+version = "2.18.184"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
The manual release `version` dispatch input was interpolated directly into the Bash and PowerShell `run:` blocks in `.github/workflows/release.yml`. A value such as `"; <command>; #` broke out of the `v="..."` assignment and executed arbitrary commands on both the Unix and Windows release runners, and the same unvalidated value was re-interpolated during archive and MSI staging.

The fix treats the version as data:

- The `Resolve version` step receives the dispatch input through `env: INPUT_VERSION` (not `${{ ... }}` interpolation) and validates the resolved version against `^[0-9A-Za-z.+_-]+$`, failing the job on anything else. This also rejects ordinary malformed version text that would otherwise break staging unpredictably.
- Every later step that needs the version (`Stage tarball`, `Stage zip`, `Build Windows MSI`) reads it from `env: VERSION` rather than interpolating `steps.version.outputs.value` into the script body.

After the change, the only `${{ ... }}` references to the version are in `env:` declarations, never inside a `run:` block. The workflow YAML still parses.

Fixes #632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened the release process so manually entered version values are validated and handled safely before packaging.
  * Updated staging and MSI version propagation for Unix/Windows builds to reduce the risk of malformed input being interpreted as code.
* **Chores**
  * Bumped the project version to **2.18.184**.
  * Added a changelog entry describing the improved release workflow safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->