### PR TITLE
vscode: Run File does not pass paths through a shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.185] - 2026-06-24
+
+### Fixed
+
+- The VS Code "Run Raven File" command no longer passes the source path through a shell. It built `raven build "<path>"` as a command string and invoked the binary with a double-quoted path, so a workspace file name containing `$(...)` or backticks executed that command on Run (PowerShell expands `$(...)` even inside double quotes). The build now runs `raven` with `execFile` and an argument array (no shell), and the produced binary is invoked through a single-quoted path so the shell treats it as literal text (#622).
+
 ## [2.18.184] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.184"
+version = "2.18.185"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-vscode/src/extension.ts
+++ b/raven-vscode/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Raven Language Extension is now active!');
@@ -156,16 +156,27 @@ function runRavenFile(filePath: string) {
     const cwd = path.dirname(filePath);
 
     vscode.window.setStatusBarMessage('Raven: building...', 3000);
-    exec(`raven build "${filePath}" -o "${out}"`, { cwd }, (err, _stdout, stderr) => {
+    // Pass the paths as arguments, not as a shell command string: a workspace
+    // file name can contain shell metacharacters (`$(...)`, backticks), and a
+    // command string would execute them. `execFile` runs `raven` directly with
+    // no shell.
+    execFile('raven', ['build', filePath, '-o', out], { cwd }, (err, _stdout, stderr) => {
         if (err) {
             const message = (stderr && stderr.trim()) || err.message;
             vscode.window.showErrorMessage(`Raven build failed:\n${message}`);
             return;
         }
         const terminal = vscode.window.createTerminal('Raven');
-        // On Windows the default integrated terminal is PowerShell, where a
-        // quoted path must be invoked with the call operator `&`.
-        const invoke = process.platform === 'win32' ? `& "${out}"` : `"${out}"`;
+        // Invoke the built binary through the terminal with the path single
+        // quoted so the shell treats it as literal text. Single quotes do not
+        // expand `$(...)` in POSIX shells, and on Windows PowerShell (which
+        // would expand `$(...)` even inside double quotes) a single-quoted path
+        // invoked with the call operator `&` is literal. Embedded single quotes
+        // are escaped per shell.
+        const invoke =
+            process.platform === 'win32'
+                ? `& '${out.replace(/'/g, "''")}'`
+                : `'${out.replace(/'/g, "'\\''")}'`;
         terminal.sendText(invoke);
         terminal.show();
     });

--- a/raven-vscode/src/extension.ts
+++ b/raven-vscode/src/extension.ts
@@ -166,19 +166,19 @@ function runRavenFile(filePath: string) {
             vscode.window.showErrorMessage(`Raven build failed:\n${message}`);
             return;
         }
-        const terminal = vscode.window.createTerminal('Raven');
-        // Invoke the built binary through the terminal with the path single
-        // quoted so the shell treats it as literal text. Single quotes do not
-        // expand `$(...)` in POSIX shells, and on Windows PowerShell (which
-        // would expand `$(...)` even inside double quotes) a single-quoted path
-        // invoked with the call operator `&` is literal. Embedded single quotes
-        // are escaped per shell.
-        const invoke =
-            process.platform === 'win32'
-                ? `& '${out.replace(/'/g, "''")}'`
-                : `'${out.replace(/'/g, "'\\''")}'`;
-        terminal.sendText(invoke);
-        terminal.show();
+        // Run the built binary through a task that uses ProcessExecution, which
+        // launches the executable path directly with no shell. A terminal
+        // `sendText` would instead hand the path to the shell for parsing, so a
+        // path containing shell metacharacters could execute as a command.
+        const execution = new vscode.ProcessExecution(out, [], { cwd });
+        const task = new vscode.Task(
+            { type: 'raven-run' },
+            vscode.TaskScope.Workspace,
+            'Run Raven program',
+            'raven',
+            execution
+        );
+        vscode.tasks.executeTask(task);
     });
 }
 


### PR DESCRIPTION
The VS Code "Run Raven File" command built a shell command string from the source path:

```ts
exec(`raven build "${filePath}" -o "${out}"`, { cwd }, ...)
```

A workspace can contain a file whose name has shell metacharacters, so a name like `source-$(mkdir -p /tmp/pwned).rv` executed that command when the user clicked Run. The follow-up `terminal.sendText(`& "${out}"`)` had the same problem, and PowerShell expands `$(...)` even inside double quotes.

The build now runs `raven` via `execFile` with an argument array, so no shell parses the path at all. The produced binary is invoked through a single-quoted path (single quotes are literal in both POSIX shells and PowerShell), with embedded single quotes escaped per shell. `tsc` compiles cleanly.

Fixes #622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety for the VS Code “Run Raven File” command by avoiding shell-based command execution.
  * Prevented workspace filenames with special characters (for example, `$(...)` or backticks) from triggering unintended shell behavior.
  * Updated how the built Raven executable is launched for more reliable path handling across platforms.

* **Chores**
  * Bumped the workspace version to **2.18.185**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->