### PR TITLE
vscode: confirm before Run File overwrites a sibling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.186] - 2026-06-24
+
+### Fixed
+
+- The VS Code "Run Raven File" command no longer silently overwrites an unrelated sibling file. It builds the executable next to the source as `<basename>` (or `<basename>.exe`), so running `demo.rv` could clobber an existing `demo`/`demo.exe`. It now confirms before overwriting a file it did not build this session (#625).
+
 ## [2.18.185] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.185"
+version = "2.18.186"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-vscode/src/extension.ts
+++ b/raven-vscode/src/extension.ts
@@ -1,6 +1,12 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 import { execFile } from 'child_process';
+
+// Output paths this session's builds have produced. A build overwrites its own
+// output freely, but an output that already exists and is not in this set is
+// treated as an unrelated file and confirmed before overwriting.
+const sessionBuiltOutputs = new Set<string>();
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Raven Language Extension is now active!');
@@ -147,13 +153,29 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(completionProvider);
 }
 
-function runRavenFile(filePath: string) {
+async function runRavenFile(filePath: string) {
     // The Raven CLI compiles a source file with `raven build <file> -o <out>`;
     // there is no bare-file run mode. Build first (capturing any compiler
     // diagnostic), then run the produced native binary in a terminal.
     const ext = process.platform === 'win32' ? '.exe' : '';
     const out = filePath.replace(/\.rv$/i, '') + ext;
     const cwd = path.dirname(filePath);
+
+    // The build writes the executable next to the source as `<basename><ext>`.
+    // If a file is already there that this session did not build, it is an
+    // unrelated file (`demo.exe` beside `demo.rv`), so confirm before
+    // overwriting it rather than clobbering it silently.
+    if (fs.existsSync(out) && !sessionBuiltOutputs.has(out)) {
+        const choice = await vscode.window.showWarningMessage(
+            `Running this file will overwrite "${path.basename(out)}", which already exists in this folder.`,
+            { modal: true },
+            'Overwrite'
+        );
+        if (choice !== 'Overwrite') {
+            return;
+        }
+    }
+    sessionBuiltOutputs.add(out);
 
     vscode.window.setStatusBarMessage('Raven: building...', 3000);
     // Pass the paths as arguments, not as a shell command string: a workspace

--- a/raven-vscode/src/extension.ts
+++ b/raven-vscode/src/extension.ts
@@ -175,7 +175,6 @@ async function runRavenFile(filePath: string) {
             return;
         }
     }
-    sessionBuiltOutputs.add(out);
 
     vscode.window.setStatusBarMessage('Raven: building...', 3000);
     // Pass the paths as arguments, not as a shell command string: a workspace
@@ -188,6 +187,10 @@ async function runRavenFile(filePath: string) {
             vscode.window.showErrorMessage(`Raven build failed:\n${message}`);
             return;
         }
+        // Record the output only after a successful build, so a failed build
+        // does not mark the path as ours and let a later run overwrite an
+        // unrelated file without confirmation.
+        sessionBuiltOutputs.add(out);
         // Run the built binary through a task that uses ProcessExecution, which
         // launches the executable path directly with no shell. A terminal
         // `sendText` would instead hand the path to the shell for parsing, so a


### PR DESCRIPTION
The "Run Raven File" command builds the executable next to the source as `<basename>` (or `<basename>.exe` on Windows) and wrote it unconditionally. Running `demo.rv` therefore silently overwrote a pre-existing, unrelated `demo` (Unix) or `demo.exe` (Windows) in the same folder.

Run File now confirms with a modal dialog before overwriting an output that already exists and was not produced by a build in the current session. A build still overwrites its own previous output without prompting (so re-running the same file is not interrupted), tracked by a session-scoped set of built output paths. `tsc` compiles cleanly.

Fixes #625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the VS Code “Run Raven File” flow to avoid overwriting an unrelated existing executable.
  * When the expected output already exists, you’ll now be prompted before it is replaced (and the action is cancelled if you decline).
  * Output executables are built beside the source using the expected platform-specific name, and only executables produced successfully during the current session are treated as session-built.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->