### PR TITLE
vscode: FFI type highlighting matches the compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.187] - 2026-06-24
+
+### Fixed
+
+- The VS Code grammar's FFI type list matches the compiler. It highlighted `CChar` and `CVoid`, which the type checker rejects, and omitted the supported `CString` alias. The grammar and the completion list now cover exactly `CInt`, `CLong`, `CSize`, `CStr`, `CString`, `CPtr`, `CFloat`, `CDouble`, and `CFnPtr` (#624).
+
 ## [2.18.186] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.186"
+version = "2.18.187"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-vscode/src/extension.ts
+++ b/raven-vscode/src/extension.ts
@@ -123,7 +123,7 @@ export function activate(context: vscode.ExtensionContext) {
             const types = [
                 'Int', 'Float', 'Bool', 'String', 'Char', 'Unit', 'Any',
                 'Option', 'Result', 'List', 'Map', 'Set', 'Channel',
-                'CInt', 'CLong', 'CSize', 'CStr', 'CPtr', 'CFloat', 'CDouble', 'CFnPtr'
+                'CInt', 'CLong', 'CSize', 'CStr', 'CString', 'CPtr', 'CFloat', 'CDouble', 'CFnPtr'
             ];
 
             const completions: vscode.CompletionItem[] = [];

--- a/raven-vscode/syntaxes/raven.tmLanguage.json
+++ b/raven-vscode/syntaxes/raven.tmLanguage.json
@@ -280,7 +280,7 @@
         },
         {
           "name": "support.type.ffi.raven",
-          "match": "\\b(CInt|CLong|CSize|CStr|CPtr|CDouble|CChar|CFloat|CVoid|CFnPtr)\\b"
+          "match": "\\b(CInt|CLong|CSize|CStr|CString|CPtr|CDouble|CFloat|CFnPtr)\\b"
         },
         {
           "name": "entity.name.type.raven",


### PR DESCRIPTION
The VS Code grammar's `support.type.ffi.raven` match listed `CChar` and `CVoid`, which the type checker rejects (`cannot find CChar in scope`), and omitted the supported `CString` alias (the compiler accepts `CString` as an alias for `CStr`).

The grammar match and the extension's completion type list now cover exactly the C scalar types the compiler resolves: `CInt`, `CLong`, `CSize`, `CStr`, `CString`, `CPtr`, `CFloat`, `CDouble`, `CFnPtr` (see `src/tycheck/collect.rs`). The grammar JSON parses and the extension compiles.

Fixes #624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VS Code type completion and syntax highlighting to better match supported FFI types.
  * Removed unsupported entries and added the `CString` alias to the available FFI type list.

* **Chores**
  * Bumped the package version to `2.18.187`.
  * Added a changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->