### PR TITLE
web: fix mobile behavior, accessibility, and the deploy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.188] - 2026-06-24
+
+### Fixed
+
+- The website deploy script reports failure when triggering the deployment fails, instead of warning and exiting `0` so the workflow looked successful (#626).
+- The website hero no longer keeps applying parallax on mobile: the scroll listener now skips the transform on small viewports, matching the mobile setup that clears it (#627).
+- The responsive example-tab rule under `@media (max-width: 480px)` targets the real `.tab-btn` class, so the full-width mobile tab layout applies (#628).
+- The mobile navigation toggle is keyboard operable: it carries a button role, focus, an accessible name, and `aria-expanded`, and responds to Enter and Space (#629).
+- The double-tap zoom guard only cancels when both taps hit the same element, so quickly tapping two different controls no longer loses the second tap (#630).
+- The website Basics example imports `std/collections`, which its map literal requires, so copying it compiles (#631).
+
 ## [2.18.187] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.187"
+version = "2.18.188"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/web/deploy.py
+++ b/web/deploy.py
@@ -88,9 +88,10 @@ def main():
         print(f"✓ Deployment triggered successfully")
         print(f"  Status: {status}")
     except Exception as e:
-        print(f"⚠ Warning: Could not trigger deployment: {e}")
-        print("Files have been uploaded. Deployment may start automatically.")
-    
+        print(f"✗ Error: Could not trigger deployment: {e}")
+        print("Files were uploaded, but the deployment was not triggered.")
+        sys.exit(1)
+
     print("\n" + "=" * 50)
     print("✅ Deployment process completed!")
     if domain:

--- a/web/index.html
+++ b/web/index.html
@@ -18,14 +18,14 @@
                 <div class="logo-icon">🐦‍⬛</div>
                 <span class="logo-text">Raven</span>
             </div>
-            <div class="nav-links">
+            <div class="nav-links" id="primary-navigation">
                 <a href="#features" class="nav-link">Features</a>
                 <a href="#examples" class="nav-link">Examples</a>
                 <a href="#download" class="nav-link">Download</a>
                 <a href="#docs" class="nav-link">Documentation</a>
                 <a href="https://github.com/martian56/raven" class="nav-link github-link" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
-            <div class="nav-toggle">
+            <div class="nav-toggle" role="button" tabindex="0" aria-label="Toggle navigation menu" aria-controls="primary-navigation" aria-expanded="false">
                 <span></span>
                 <span></span>
                 <span></span>
@@ -152,7 +152,10 @@
             <div class="examples-content">
                 <div class="tab-content active" id="basics">
                     <div class="code-example">
-                        <pre><code><span class="comment">// Inferred types, no semicolons</span>
+                        <pre><code><span class="comment">// A map literal needs the collections module</span>
+<span class="keyword">import</span> std/collections
+
+<span class="comment">// Inferred types, no semicolons</span>
 <span class="keyword">let</span> <span class="variable">name</span> <span class="operator">=</span> <span class="string">"Raven"</span>
 <span class="keyword">let</span> <span class="variable">version</span> <span class="operator">=</span> <span class="number">2</span>
 

--- a/web/script.js
+++ b/web/script.js
@@ -28,43 +28,49 @@ document.addEventListener('DOMContentLoaded', function() {
     const navLinks = document.querySelector('.nav-links');
     
     if (navToggle && navLinks) {
-        navToggle.addEventListener('click', function() {
-            navLinks.classList.toggle('active');
-            navToggle.classList.toggle('active');
-            
-            // Prevent body scroll when menu is open
-            if (navLinks.classList.contains('active')) {
-                document.body.style.overflow = 'hidden';
-            } else {
-                document.body.style.overflow = '';
+        // Centralize the menu state so the toggle's `aria-expanded`, the active
+        // classes, and the body scroll lock never drift apart.
+        function setMenu(open) {
+            navLinks.classList.toggle('active', open);
+            navToggle.classList.toggle('active', open);
+            navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+            document.body.style.overflow = open ? 'hidden' : '';
+        }
+
+        function toggleMenu() {
+            setMenu(!navLinks.classList.contains('active'));
+        }
+
+        navToggle.addEventListener('click', toggleMenu);
+
+        // The toggle is a `div` with a button role, so it must respond to the
+        // keyboard like a native button: Enter and Space activate it.
+        navToggle.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                e.preventDefault();
+                toggleMenu();
             }
         });
-        
+
         // Close mobile menu when clicking on a link
         const mobileNavLinks = navLinks.querySelectorAll('.nav-link');
         mobileNavLinks.forEach(link => {
             link.addEventListener('click', function() {
-                navLinks.classList.remove('active');
-                navToggle.classList.remove('active');
-                document.body.style.overflow = '';
+                setMenu(false);
             });
         });
-        
+
         // Close mobile menu when clicking outside
         document.addEventListener('click', function(e) {
             if (!navToggle.contains(e.target) && !navLinks.contains(e.target)) {
-                navLinks.classList.remove('active');
-                navToggle.classList.remove('active');
-                document.body.style.overflow = '';
+                setMenu(false);
             }
         });
-        
+
         // Close mobile menu on window resize (if screen becomes larger)
         window.addEventListener('resize', function() {
             if (window.innerWidth > 768) {
-                navLinks.classList.remove('active');
-                navToggle.classList.remove('active');
-                document.body.style.overflow = '';
+                setMenu(false);
             }
         });
     }
@@ -224,6 +230,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const hero = document.querySelector('.hero');
     if (hero) {
         window.addEventListener('scroll', function() {
+            // Parallax is disabled on mobile for performance, so the scroll
+            // listener must also skip it there; otherwise it keeps applying a
+            // transform that the mobile setup cleared. `isMobile` is a hoisted
+            // function declaration, so it is callable here.
+            if (isMobile()) {
+                return;
+            }
             const scrolled = window.pageYOffset;
             const rate = scrolled * -0.5;
             hero.style.transform = `translateY(${rate}px)`;
@@ -317,14 +330,18 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
     
-    // Prevent zoom on double tap for iOS
+    // Prevent zoom on double tap for iOS. Only cancel when both taps land on
+    // the same element, so quickly tapping two different controls does not lose
+    // the second tap's default action to a false double-tap.
     let lastTouchEnd = 0;
+    let lastTouchTarget = null;
     document.addEventListener('touchend', function(event) {
         const now = (new Date()).getTime();
-        if (now - lastTouchEnd <= 300) {
+        if (now - lastTouchEnd <= 300 && event.target === lastTouchTarget) {
             event.preventDefault();
         }
         lastTouchEnd = now;
+        lastTouchTarget = event.target;
     }, false);
     
     // Optimize scroll performance on mobile

--- a/web/style.css
+++ b/web/style.css
@@ -912,7 +912,7 @@ body {
         width: 100%;
     }
     
-    .tab-button {
+    .tab-btn {
         width: 100%;
         max-width: 200px;
         padding: var(--spacing-3) var(--spacing-4);


### PR DESCRIPTION
A cluster of website fixes, all under `web/`:

- **#626** `deploy.py` caught a failure from `deploy_website()`, printed a warning, then reported completion and exited `0`, so the deploy workflow looked successful even when the deployment was never triggered. It now exits non-zero on that failure.
- **#627** The mobile setup clears the hero parallax transform, but the scroll listener kept reapplying it. The listener now returns early on mobile viewports, so parallax stays off there.
- **#628** The `@media (max-width: 480px)` rule targeted `.tab-button`; every tab uses `.tab-btn`, so the full-width mobile layout never applied. Fixed the selector.
- **#629** The mobile nav toggle was a bare `div`. It now has `role="button"`, `tabindex="0"`, an `aria-label`, `aria-controls`, and `aria-expanded`, and a keydown handler activates it with Enter/Space. The open/close state is centralized so the class, scroll lock, and `aria-expanded` stay in sync.
- **#630** The double-tap zoom guard cancelled any second `touchend` within 300 ms regardless of target, so tapping two different controls quickly lost the second tap. It now only cancels when both taps hit the same element.
- **#631** The Basics code example uses a map literal but omitted `import std/collections`, which the compiler requires (it even suggests that exact line). Added the import so copying the example compiles.

These are bundled as one PR to avoid running a full CI build per trivial website change. `deploy.py` parses, `script.js` passes `node --check`.

Fixes #626
Fixes #627
Fixes #628
Fixes #629
Fixes #630
Fixes #631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fixed**
  * Improved mobile navigation accessibility and keyboard support.
  * Corrected mobile tab styling so responsive widths and padding apply properly.
  * Adjusted hero animation behavior on mobile devices.
  * Refined double-tap zoom prevention on iOS.
  * Deployment failures now stop clearly with a visible error message.
  * Updated the Basics example with the required import for map literals.
  * Added the latest release entry and version update to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->