### PR TITLE
http server: correct status reason phrase and HEAD responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.189] - 2026-06-24
+
+### Fixed
+
+- The HTTP server returns a correct reason phrase for any status code. `reason_phrase` defaulted to `OK`, so a `503` was written as `503 OK`; it now covers the common codes and falls back to a class phrase (`Server Error` for 5xx, and so on) for an unknown code (#642).
+- The HTTP server omits the body of a HEAD response, which previously carried the full GET body. The response still reports the `Content-Length` a GET would return, but writes no body (#619).
+
 ## [2.18.188] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.188"
+version = "2.18.189"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_server_reason_head.rv
+++ b/examples/v2/http_server_reason_head.rv
@@ -1,0 +1,84 @@
+// Starts an HTTP server in a goroutine and probes it over a raw TCP socket to
+// check two things: an unusual status code gets the right reason phrase (not a
+// blanket "OK"), and a HEAD response carries the headers but no body.
+// golden:skip (binds a port and depends on timing, so it is not diffed by the
+// golden suite; run it directly to verify the server response path).
+import std/http { Server, Response, Request, Method }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun down(req: Request) -> Response {
+    return Response.with_body(503, "unavailable")
+}
+
+fun first_line(s: String) -> String {
+    let idx = s.index_of("\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun body_after_headers(s: String) -> String {
+    let idx = s.index_of("\r\n\r\n")
+    if idx < 0 {
+        return ""
+    }
+    return s.substring(idx + 4, s.length())
+}
+
+// Connect with a few retries so a slow server bind does not race the probe.
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun send(addr: String, request: String) -> String {
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(request)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+    return result
+}
+
+fun main() {
+    let addr = "127.0.0.1:18642"
+    let app = Server.new()
+    app.get("/x", down)
+    app.route(Method.Head, "/x", down)
+    spawn(fun() -> Unit {
+        app.listen(addr)
+    })
+
+    let get_resp = send(addr, "GET /x HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
+    println("GET status: ${first_line(get_resp)}")
+    println("GET body: ${body_after_headers(get_resp)}")
+
+    let head_resp = send(addr, "HEAD /x HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
+    println("HEAD status: ${first_line(head_resp)}")
+    println("HEAD body empty: ${body_after_headers(head_resp) == ""}")
+
+    app.shutdown()
+}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -509,7 +509,11 @@ fun serve_connection(server: Server, stream: TcpStream) {
                 if server.is_stopping() {
                     keep = false
                 }
-                write_response(stream, resp, keep)
+                let is_head = match req.method {
+                    Head -> true,
+                    _ -> false,
+                }
+                write_response(stream, resp, keep, is_head)
                 if server.access_log {
                     let method = req.method.to_string().to_upper()
                     print("${method} ${req.path} ${resp.status}")
@@ -524,7 +528,7 @@ fun serve_connection(server: Server, stream: TcpStream) {
                 // A failed read after one or more served requests is just an
                 // idle or closed keep-alive connection, closed silently.
                 if served == 0 {
-                    write_response(stream, Response.bad_request("Bad Request"), false)
+                    write_response(stream, Response.bad_request("Bad Request"), false, false)
                     if server.access_log {
                         print("- - 400")
                     }
@@ -762,7 +766,8 @@ fun decode_query_part(s: String) -> String {
 
 // Write `resp` to `stream` as an HTTP/1.1 response, framing it with
 // Content-Length and closing the connection after.
-fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool) {
+fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head: Bool) {
+    // Content-Length always reports what a GET would return, even for HEAD.
     resp.headers.set("Content-Length", resp.body.length().to_string())
     if keep_alive {
         resp.headers.set("Connection", "keep-alive")
@@ -779,11 +784,17 @@ fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool) {
         block = block.concat(k).concat(": ").concat(resp.headers.get_or(k, "")).concat("\r\n")
         i += 1
     }
-    let out = line.concat(block).concat("\r\n").concat(resp.body)
+    // A response to a HEAD request carries the headers but no body.
+    let out = line.concat(block).concat("\r\n")
+    if !is_head {
+        out = out.concat(resp.body)
+    }
     let _ = stream.write(out)
 }
 
-// The reason phrase for a status code (a small common set; defaults to "OK").
+// The reason phrase for a status code. Covers the common codes; an unknown
+// code falls back to a phrase for its class (`Server Error` for 5xx, and so on)
+// rather than a misleading `OK`, so a 503 is never labelled `503 OK`.
 fun reason_phrase(status: Int) -> String {
     if status == 200 {
         return "OK"
@@ -791,22 +802,76 @@ fun reason_phrase(status: Int) -> String {
     if status == 201 {
         return "Created"
     }
+    if status == 202 {
+        return "Accepted"
+    }
     if status == 204 {
         return "No Content"
+    }
+    if status == 301 {
+        return "Moved Permanently"
     }
     if status == 302 {
         return "Found"
     }
+    if status == 304 {
+        return "Not Modified"
+    }
     if status == 400 {
         return "Bad Request"
+    }
+    if status == 401 {
+        return "Unauthorized"
+    }
+    if status == 403 {
+        return "Forbidden"
     }
     if status == 404 {
         return "Not Found"
     }
+    if status == 405 {
+        return "Method Not Allowed"
+    }
+    if status == 409 {
+        return "Conflict"
+    }
+    if status == 422 {
+        return "Unprocessable Entity"
+    }
+    if status == 429 {
+        return "Too Many Requests"
+    }
     if status == 500 {
         return "Internal Server Error"
     }
-    return "OK"
+    if status == 501 {
+        return "Not Implemented"
+    }
+    if status == 502 {
+        return "Bad Gateway"
+    }
+    if status == 503 {
+        return "Service Unavailable"
+    }
+    if status == 504 {
+        return "Gateway Timeout"
+    }
+    if status >= 100 && status < 200 {
+        return "Informational"
+    }
+    if status >= 200 && status < 300 {
+        return "Success"
+    }
+    if status >= 300 && status < 400 {
+        return "Redirection"
+    }
+    if status >= 400 && status < 500 {
+        return "Client Error"
+    }
+    if status >= 500 && status < 600 {
+        return "Server Error"
+    }
+    return "Unknown"
 }
 
 // Serve the `:file` capture of a `Server.static` route from its directory.

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1362,6 +1362,22 @@ fn http_keeps_repeated_headers() {
 }
 
 #[test]
+fn http_server_reason_and_head_responses() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // The Raven program is both server and client: it starts the HTTP server in
+    // a goroutine and probes it over a raw TCP socket. It checks that an unusual
+    // status code gets the right reason phrase (503 is "Service Unavailable",
+    // not a blanket "OK") and that a HEAD response carries no body.
+    let expected = "GET status: HTTP/1.1 503 Service Unavailable\n\
+                    GET body: unavailable\n\
+                    HEAD status: HTTP/1.1 503 Service Unavailable\n\
+                    HEAD body empty: true\n";
+    compile_link_run_and_check("http_server_reason_head.rv", expected, &runtime);
+}
+
+#[test]
 fn http_sends_binary_body() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Two HTTP server response bugs:

- **#642** `reason_phrase` returned `OK` for any status it did not list, so the server wrote `503 OK`, `429 OK`, and so on. It now covers the common codes and, for an unknown code, falls back to a phrase for the status class (`Informational`, `Success`, `Redirection`, `Client Error`, `Server Error`) instead of a misleading `OK`.
- **#619** `write_response` always wrote the body, so a HEAD response carried the full body a GET would return. It now reports the same `Content-Length` a GET would, but writes no body; `serve_connection` threads whether the request was HEAD.

Verified end to end with a new self-contained example (`examples/v2/http_server_reason_head.rv`): it starts the server in a goroutine and probes it over a raw TCP socket, asserting `GET /x` -> `HTTP/1.1 503 Service Unavailable` with a body and `HEAD /x` -> the same status line with an empty body. A `codegen_smoke` test compiles, links, runs it, and checks the output. The existing http client tests still pass.

Fixes #642
Fixes #619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an HTTP example and end-to-end check that verifies status text and `HEAD` response behavior.
* **Bug Fixes**
  * HTTP responses now show the correct reason phrase for each status code, including `503 Service Unavailable`.
  * `HEAD` requests now return headers without a response body, while keeping content length consistent.
* **Tests**
  * Added smoke coverage for the updated HTTP response behavior.
* **Chores**
  * Bumped the workspace version to `2.18.189`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->