### PR TITLE
http server: large timeout does not overflow into disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.190] - 2026-06-24
+
+### Fixed
+
+- A large HTTP server timeout no longer silently disables timeouts. `with_timeout`, `with_read_timeout`, and `with_write_timeout` computed `seconds * 1000`, which overflowed for a large `seconds` and wrapped to a non-positive value the server reads as "disabled". The conversion now saturates to a large positive bound, so a big timeout stays in effect; a normal value is exact and a non-positive value disables the timeout (#683).
+
 ## [2.18.189] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.189"
+version = "2.18.190"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_timeout_overflow.rv
+++ b/examples/v2/http_timeout_overflow.rv
@@ -1,0 +1,19 @@
+// A huge per-connection timeout used to overflow `seconds * 1000` into a
+// negative value, which the server reads back as a disabled timeout. The
+// conversion now saturates, so a large timeout stays a large positive bound and
+// a normal value is exact. golden:skip (kept as a focused demo; a codegen smoke
+// test runs it and checks the output).
+import std/http { Server }
+import std/io { println }
+
+fun main() {
+    let huge = Server.new().with_timeout(9999999999999999)
+    println("huge read positive: ${huge.read_timeout_ms > 0}")
+    println("huge write positive: ${huge.write_timeout_ms > 0}")
+
+    let normal = Server.new().with_read_timeout(5)
+    println("normal read ms: ${normal.read_timeout_ms}")
+
+    let disabled = Server.new().with_timeout(0)
+    println("disabled read ms: ${disabled.read_timeout_ms}")
+}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -380,25 +380,26 @@ impl Server {
     }
 
     // Set the read and write timeouts to `seconds` each, returning self so it
-    // chains. `0` disables both (a request or response may then block forever
-    // on a slow client). A read timeout bounds how long the server waits for
-    // the client to send its request; a write timeout bounds sending the
-    // response. The default is 30 seconds.
+    // chains. `0` (or a negative value) disables both (a request or response may
+    // then block forever on a slow client). A read timeout bounds how long the
+    // server waits for the client to send its request; a write timeout bounds
+    // sending the response. The default is 30 seconds.
     fun with_timeout(self, seconds: Int) -> Server {
-        self.read_timeout_ms = seconds * 1000
-        self.write_timeout_ms = seconds * 1000
+        let ms = timeout_ms(seconds)
+        self.read_timeout_ms = ms
+        self.write_timeout_ms = ms
         return self
     }
 
     // Set only the read timeout, in seconds (`0` disables it). See `with_timeout`.
     fun with_read_timeout(self, seconds: Int) -> Server {
-        self.read_timeout_ms = seconds * 1000
+        self.read_timeout_ms = timeout_ms(seconds)
         return self
     }
 
     // Set only the write timeout, in seconds (`0` disables it). See `with_timeout`.
     fun with_write_timeout(self, seconds: Int) -> Server {
-        self.write_timeout_ms = seconds * 1000
+        self.write_timeout_ms = timeout_ms(seconds)
         return self
     }
 
@@ -790,6 +791,22 @@ fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head:
         out = out.concat(resp.body)
     }
     let _ = stream.write(out)
+}
+
+// Convert a timeout in seconds to milliseconds without overflowing. A value so
+// large that `seconds * 1000` would wrap past the Int range (and read back as a
+// non-positive, "disabled" timeout) is clamped to a very large bound instead. A
+// non-positive `seconds` disables the timeout (0).
+fun timeout_ms(seconds: Int) -> Int {
+    if seconds <= 0 {
+        return 0
+    }
+    // Int is 64-bit, so 9223372036854775 is floor(max / 1000): anything larger
+    // would overflow when multiplied by 1000.
+    if seconds > 9223372036854775 {
+        return 9223372036854775000
+    }
+    return seconds * 1000
 }
 
 // The reason phrase for a status code. Covers the common codes; an unknown

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1378,6 +1378,21 @@ fn http_server_reason_and_head_responses() {
 }
 
 #[test]
+fn http_server_timeout_does_not_overflow() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A huge timeout in seconds must not overflow `seconds * 1000` into a
+    // negative, disabled timeout: it saturates to a large positive bound, while
+    // a normal value stays exact and zero disables the timeout.
+    let expected = "huge read positive: true\n\
+                    huge write positive: true\n\
+                    normal read ms: 5000\n\
+                    disabled read ms: 0\n";
+    compile_link_run_and_check("http_timeout_overflow.rv", expected, &runtime);
+}
+
+#[test]
 fn http_sends_binary_body() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`Server.with_timeout`, `with_read_timeout`, and `with_write_timeout` set the timeout field to `seconds * 1000`. For a large `seconds` that multiplication overflows the 64-bit `Int` and wraps to a non-positive value, which the accept loop reads as "timeout disabled" (`read_timeout_ms > 0` is false). So asking for a very long timeout silently turned timeouts off.

The three setters now convert through a saturating `timeout_ms` helper: a value past `floor(Int::MAX / 1000)` clamps to a large positive millisecond bound, a normal value is exact (`5` -> `5000`), and a non-positive value disables the timeout (`0`).

Verified with a new example (`http_timeout_overflow.rv`) and a `codegen_smoke` test that builds and runs it, asserting a huge timeout stays positive, a normal one is exact, and zero disables.

Fixes #683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP server timeout handling so very large timeout values no longer overflow into a disabled state.
  * Non-positive timeout values still disable timeouts as expected.
  * Added coverage to confirm large, normal, and zero timeout values behave correctly.

* **New Features**
  * Added an example demonstrating the corrected timeout behavior.

* **Chores**
  * Bumped the workspace version to `2.18.190`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->