### PR TITLE
http server: graceful shutdown wakes an IPv6 wildcard listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.192] - 2026-06-24
+
+### Fixed
+
+- `Server.shutdown()` wakes a server bound to an IPv6 wildcard address. The wakeup helper split the address on the first colon, which mangles a bracketed IPv6 address (`[::]:8080`), so the throwaway self-connection went to an unreachable address and `listen` blocked forever. It now parses a bracketed host and rewrites the IPv6 wildcard `[::]` to the loopback `[::1]`, which the wildcard listener accepts (#643).
+
 ## [2.18.191] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.191"
+version = "2.18.192"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_ipv6_shutdown.rv
+++ b/examples/v2/http_ipv6_shutdown.rv
@@ -1,0 +1,68 @@
+// Binds the HTTP server to the IPv6 wildcard `[::]`, serves one request over
+// IPv6 loopback to confirm the bind, then shuts it down. The graceful shutdown
+// must wake the blocked `accept`, so `listen` returns and the program prints a
+// final line; before the fix the wakeup address was misparsed and shutdown hung
+// forever. golden:skip (binds a port and depends on timing; a codegen smoke
+// test runs it and checks output).
+import std/http { Server, Response, Request }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun ok_handler(req: Request) -> Response {
+    return Response.with_body(200, "ok")
+}
+
+fun first_line(s: String) -> String {
+    let idx = s.index_of("\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun status_of(addr: String, request: String) -> String {
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(request)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+    return first_line(result)
+}
+
+fun main() {
+    let app = Server.new()
+    app.get("/x", ok_handler)
+    spawn(fun() -> Unit {
+        let resp = status_of("[::1]:18643", "GET /x HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
+        println("served: ${resp}")
+        app.shutdown()
+    })
+    app.listen("[::]:18643")
+    println("listen returned")
+}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -556,6 +556,22 @@ fun should_keep_alive(req: Request) -> Bool {
 // wildcard `0.0.0.0` (or an empty host) is not reachable by that address, but
 // its port is reachable on loopback; a concrete bound host is reachable as is.
 fun wakeup_addr(addr: String) -> String {
+    // An IPv6 address is bracketed (`[host]:port`), and its host part itself
+    // contains colons, so the IPv4 split on the first colon does not apply. A
+    // wildcard `[::]` (or `[::0]`) is not connectable, so rewrite it to the IPv6
+    // loopback `[::1]`, which the wildcard listener accepts.
+    if addr.starts_with("[") {
+        let close = addr.index_of("]")
+        if close < 0 {
+            return addr
+        }
+        let host = addr.substring(1, close)
+        let port = addr.substring(close + 1, addr.length())
+        if host == "::" || host == "::0" || host == "0:0:0:0:0:0:0:0" {
+            return "[::1]".concat(port)
+        }
+        return addr
+    }
     let colon = addr.index_of(":")
     if colon < 0 {
         return addr

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1411,6 +1411,24 @@ fn http_server_rejects_malformed_requests() {
 }
 
 #[test]
+fn http_server_shuts_down_on_ipv6_wildcard() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // The graceful-shutdown wakeup must reach a server bound to the IPv6
+    // wildcard `[::]`. Skip on a runner without IPv6 loopback (where binding
+    // `[::1]` fails), so the test never hangs waiting on an address it cannot
+    // reach; where IPv6 is present the program serves one request and then
+    // shuts down, so `listen` returns instead of blocking forever.
+    if std::net::TcpListener::bind("[::1]:0").is_err() {
+        return;
+    }
+    let expected = "served: HTTP/1.1 200 OK\n\
+                    listen returned\n";
+    compile_link_run_and_check("http_ipv6_shutdown.rv", expected, &runtime);
+}
+
+#[test]
 fn http_sends_binary_body() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`Server.shutdown()` cannot wake a server bound to an IPv6 wildcard like `[::]:8080`. Shutdown sets the stopping flag, then opens a throwaway connection to unblock the listener's blocking `accept`. The `wakeup_addr` helper split the address on the *first* colon, so for `[::]:8080` it took the host as `[` and never rewrote the wildcard. The self-connect went to an unreachable address, its error was ignored, and `listen` stayed blocked forever.

`wakeup_addr` now recognizes a bracketed IPv6 address (`[host]:port`) and rewrites the wildcard `[::]` (or `[::0]`) to the IPv6 loopback `[::1]`, which the wildcard listener accepts. The IPv4 path is unchanged.

Verified with a new example (`http_ipv6_shutdown.rv`) that binds `[::]`, serves one request over `[::1]`, and shuts down so `listen` returns. A `codegen_smoke` test runs it, guarded to skip on a runner without IPv6 loopback so it never hangs on an unreachable address.

Fixes #643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server shutdown so it no longer hangs when listening on IPv6 wildcard addresses.
  * Improved handling of IPv6 listener addresses to ensure shutdown wakeups reach the server reliably.

* **New Features**
  * Added an example demonstrating HTTP server shutdown behavior on IPv6 wildcard bindings.

* **Tests**
  * Added coverage for IPv6 shutdown behavior to verify the server returns cleanly after handling a request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->