### PR TITLE
http server: decode chunked request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.193] - 2026-06-24
+
+### Fixed
+
+- The HTTP server decodes a `Transfer-Encoding: chunked` request body instead of discarding it. It ignored the chunked framing, so the handler received an empty body and the unread chunk bytes desynchronized a keep-alive connection. The server now de-chunks the body, delivers it to the handler, and rejects `Content-Length` combined with chunked framing as a smuggling vector (#617).
+
 ## [2.18.192] - 2026-06-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.192"
+version = "2.18.193"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_chunked_body.rv
+++ b/examples/v2/http_chunked_body.rv
@@ -75,5 +75,13 @@ fun main() {
     println("status: ${first_line(resp)}")
     println("body: ${body_after_headers(resp)}")
 
+    // A coding list other than a sole `chunked` is not implemented, so reject.
+    let unsupported = "POST /echo HTTP/1.1\r\nHost: t\r\nTransfer-Encoding: gzip, chunked\r\nConnection: close\r\n\r\n4\r\nWiki\r\n0\r\n\r\n"
+    println("unsupported: ${first_line(send(addr, unsupported))}")
+
+    // The two bytes after a chunk's data must be CRLF; `XX` is malformed.
+    let bad_term = "POST /echo HTTP/1.1\r\nHost: t\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n4\r\nWikiXX0\r\n\r\n"
+    println("bad-term: ${first_line(send(addr, bad_term))}")
+
     app.shutdown()
 }

--- a/examples/v2/http_chunked_body.rv
+++ b/examples/v2/http_chunked_body.rv
@@ -1,0 +1,79 @@
+// Starts an HTTP server in a goroutine and POSTs a chunked request body to an
+// echo route, checking that the server de-chunks the body and the handler
+// receives it (it used to be silently discarded as empty). golden:skip (binds a
+// port and depends on timing; a codegen smoke test runs it and checks output).
+import std/http { Server, Request, Response }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun echo(req: Request) -> Response {
+    return Response.with_body(200, req.body)
+}
+
+fun first_line(s: String) -> String {
+    let idx = s.index_of("\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun body_after_headers(s: String) -> String {
+    let idx = s.index_of("\r\n\r\n")
+    if idx < 0 {
+        return ""
+    }
+    return s.substring(idx + 4, s.length())
+}
+
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun send(addr: String, request: String) -> String {
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(request)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+    return result
+}
+
+fun main() {
+    let addr = "127.0.0.1:18617"
+    let app = Server.new()
+    app.post("/echo", echo)
+    spawn(fun() -> Unit {
+        app.listen(addr)
+    })
+
+    // Two chunks "Wiki" (4) and "pedia" (5), then the zero-size terminator.
+    let req = "POST /echo HTTP/1.1\r\nHost: t\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n"
+    let resp = send(addr, req)
+    println("status: ${first_line(resp)}")
+    println("body: ${body_after_headers(resp)}")
+
+    app.shutdown()
+}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -664,16 +664,30 @@ struct ChunkedBody {
 // bytes already read after the headers) and reading more from `stream` as
 // needed. Each chunk is `<hex-size>[;ext]\r\n<data>\r\n`; a zero-size chunk
 // ends the body, followed by optional trailer lines and a final blank line.
+fun is_chunked_only(te: String) -> Bool {
+    let parts = te.split(",")
+    if parts.len() != 1 {
+        return false
+    }
+    return parts[0].trim().to_lower() == "chunked"
+}
+
 fun decode_chunked(stream: TcpStream, initial: String) -> Result<ChunkedBody, Error> {
     let buf = initial
     let decoded = ""
     let total = 0
     let max_body = 10485760
+    // A single chunk-size line or the whole trailer block must fit this, so an
+    // oversized extension or trailer cannot force unbounded buffering.
+    let max_frame = 65536
     let done = false
     while !done {
         // Read up to the end of the chunk-size line.
         let nl = buf.index_of("\r\n")
         while nl < 0 {
+            if buf.length() > max_frame {
+                return Err(error_kind("http", "chunk size line too large"))
+            }
             let chunk = stream.read(4096)?
             if chunk.length() == 0 {
                 return Err(error_kind("http", "connection closed in chunk size"))
@@ -712,12 +726,16 @@ fun decode_chunked(stream: TcpStream, initial: String) -> Result<ChunkedBody, Er
                 } else if tnl > 0 {
                     buf = buf.substring(tnl + 2, buf.length())
                 } else {
-                    let chunk = stream.read(4096)?
-                    if chunk.length() == 0 {
-                        stop = true
-                    } else {
-                        buf = buf.concat(chunk)
+                    if buf.length() > max_frame {
+                        return Err(error_kind("http", "chunk trailer too large"))
                     }
+                    let chunk = stream.read(4096)?
+                    // EOF before the terminating blank line is a truncated body,
+                    // not a complete one.
+                    if chunk.length() == 0 {
+                        return Err(error_kind("http", "connection closed in chunk trailer"))
+                    }
+                    buf = buf.concat(chunk)
                 }
             }
         } else {
@@ -732,6 +750,11 @@ fun decode_chunked(stream: TcpStream, initial: String) -> Result<ChunkedBody, Er
                     return Err(error_kind("http", "connection closed in chunk data"))
                 }
                 buf = buf.concat(chunk)
+            }
+            // The two bytes after the data must be the CRLF that terminates the
+            // chunk, not arbitrary bytes from a malformed body.
+            if buf.substring(size, size + 2) != "\r\n" {
+                return Err(error_kind("http", "malformed chunk terminator"))
             }
             decoded = decoded.concat(buf.substring(0, size))
             buf = buf.substring(size + 2, buf.length())
@@ -815,6 +838,15 @@ fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error
                 return Err(error_kind("http", "conflicting Content-Length"))
             }
         }
+        // Repeated Transfer-Encoding lines combine into one comma-separated
+        // coding list, so a split `gzip` + `chunked` cannot hide a coding the
+        // server does not implement.
+        if key == "transfer-encoding" {
+            let existing = headers.get_or("transfer-encoding", "")
+            if existing.length() > 0 {
+                value = existing.concat(", ").concat(value)
+            }
+        }
         headers.set(key, value)
         i += 1
     }
@@ -826,8 +858,14 @@ fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error
 
     let actual_body = ""
     let rest = ""
-    let te = headers.get_or("transfer-encoding", "").to_lower()
-    if te.contains("chunked") {
+    let te = headers.get_or("transfer-encoding", "").trim()
+    if te.length() > 0 {
+        // The server implements only a sole `chunked` coding. Reject any other
+        // coding list (`gzip, chunked`, an unknown coding) rather than routing
+        // the request with the wrong or an empty body.
+        if !is_chunked_only(te) {
+            return Err(error_kind("http", "unsupported transfer-coding"))
+        }
         // RFC 7230 3.3.3: Content-Length together with chunked framing is a
         // request-smuggling vector; reject it rather than guessing.
         if headers.get_or("content-length", "").length() > 0 {

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -11,6 +11,7 @@
 import std/error { error_kind }
 import std/net { listen, connect, TcpStream }
 import std/string
+import std/fmt { from_radix }
 import std/collections
 import std/json { JsonValue, ToJson, FromJson, stringify, parse, decode }
 import std/fs { read }
@@ -652,6 +653,93 @@ struct ReadResult {
     rest: String,
 }
 
+// A decoded chunked body plus any bytes read past the final chunk (the start of
+// the next pipelined request).
+struct ChunkedBody {
+    body: String,
+    rest: String,
+}
+
+// Decode a `Transfer-Encoding: chunked` body, beginning from `initial` (the
+// bytes already read after the headers) and reading more from `stream` as
+// needed. Each chunk is `<hex-size>[;ext]\r\n<data>\r\n`; a zero-size chunk
+// ends the body, followed by optional trailer lines and a final blank line.
+fun decode_chunked(stream: TcpStream, initial: String) -> Result<ChunkedBody, Error> {
+    let buf = initial
+    let decoded = ""
+    let total = 0
+    let max_body = 10485760
+    let done = false
+    while !done {
+        // Read up to the end of the chunk-size line.
+        let nl = buf.index_of("\r\n")
+        while nl < 0 {
+            let chunk = stream.read(4096)?
+            if chunk.length() == 0 {
+                return Err(error_kind("http", "connection closed in chunk size"))
+            }
+            buf = buf.concat(chunk)
+            nl = buf.index_of("\r\n")
+        }
+        let size_line = buf.substring(0, nl)
+        // A chunk extension follows the size after a `;`; ignore it.
+        let semi = size_line.index_of(";")
+        if semi >= 0 {
+            size_line = size_line.substring(0, semi)
+        }
+        let size = 0
+        match from_radix(size_line.trim(), 16) {
+            Some(n) -> {
+                size = n
+            }
+            None -> {
+                return Err(error_kind("http", "invalid chunk size"))
+            }
+        }
+        if size < 0 {
+            return Err(error_kind("http", "negative chunk size"))
+        }
+        buf = buf.substring(nl + 2, buf.length())
+        if size == 0 {
+            // Final chunk: consume any trailer lines up to the blank line.
+            done = true
+            let stop = false
+            while !stop {
+                let tnl = buf.index_of("\r\n")
+                if tnl == 0 {
+                    buf = buf.substring(2, buf.length())
+                    stop = true
+                } else if tnl > 0 {
+                    buf = buf.substring(tnl + 2, buf.length())
+                } else {
+                    let chunk = stream.read(4096)?
+                    if chunk.length() == 0 {
+                        stop = true
+                    } else {
+                        buf = buf.concat(chunk)
+                    }
+                }
+            }
+        } else {
+            total += size
+            if total > max_body {
+                return Err(error_kind("http", "chunked body too large"))
+            }
+            // Read the chunk data plus its trailing CRLF.
+            while buf.length() < size + 2 {
+                let chunk = stream.read(4096)?
+                if chunk.length() == 0 {
+                    return Err(error_kind("http", "connection closed in chunk data"))
+                }
+                buf = buf.concat(chunk)
+            }
+            decoded = decoded.concat(buf.substring(0, size))
+            buf = buf.substring(size + 2, buf.length())
+        }
+    }
+    return Ok(ChunkedBody { body: decoded, rest: buf })
+}
+
 // Parse one request, beginning from `initial` (bytes carried over from a prior
 // request on the same connection) and reading more from `stream` as needed.
 fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error> {
@@ -736,42 +824,56 @@ fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error
         return Err(error_kind("http", "missing Host header"))
     }
 
-    let want = 0
-    let clen = headers.get_or("content-length", "")
-    if clen.length() > 0 {
-        match clen.parse_int() {
-            Some(n) -> {
-                want = n
-            }
-            // A non-numeric Content-Length is a malformed request; answer 400
-            // rather than silently treating the body as empty.
-            None -> {
-                return Err(error_kind("http", "invalid Content-Length"))
+    let actual_body = ""
+    let rest = ""
+    let te = headers.get_or("transfer-encoding", "").to_lower()
+    if te.contains("chunked") {
+        // RFC 7230 3.3.3: Content-Length together with chunked framing is a
+        // request-smuggling vector; reject it rather than guessing.
+        if headers.get_or("content-length", "").length() > 0 {
+            return Err(error_kind("http", "Content-Length with chunked encoding"))
+        }
+        let decoded = decode_chunked(stream, body)?
+        actual_body = decoded.body
+        rest = decoded.rest
+    } else {
+        let want = 0
+        let clen = headers.get_or("content-length", "")
+        if clen.length() > 0 {
+            match clen.parse_int() {
+                Some(n) -> {
+                    want = n
+                }
+                // A non-numeric Content-Length is a malformed request; answer
+                // 400 rather than silently treating the body as empty.
+                None -> {
+                    return Err(error_kind("http", "invalid Content-Length"))
+                }
             }
         }
-    }
-    // Reject a negative or oversized declared body before reading it, so a
-    // client cannot make the server buffer unbounded memory. 10 MiB is a
-    // generous default for a simple server.
-    if want < 0 {
-        return Err(error_kind("http", "negative Content-Length"))
-    }
-    let max_body = 10485760
-    if want > max_body {
-        return Err(error_kind("http", "request body too large"))
-    }
-    while body.length() < want {
-        let chunk = stream.read(4096)?
-        if chunk.length() == 0 {
-            return Err(error_kind("http", "connection closed before body complete"))
+        // Reject a negative or oversized declared body before reading it, so a
+        // client cannot make the server buffer unbounded memory. 10 MiB is a
+        // generous default for a simple server.
+        if want < 0 {
+            return Err(error_kind("http", "negative Content-Length"))
         }
-        body = body.concat(chunk)
+        let max_body = 10485760
+        if want > max_body {
+            return Err(error_kind("http", "request body too large"))
+        }
+        while body.length() < want {
+            let chunk = stream.read(4096)?
+            if chunk.length() == 0 {
+                return Err(error_kind("http", "connection closed before body complete"))
+            }
+            body = body.concat(chunk)
+        }
+        // Keep exactly `want` bytes as this request's body; anything already
+        // read past it is the start of the next pipelined request, carried over
+        // so it is not lost when the keep-alive loop reads again.
+        actual_body = body.substring(0, want)
+        rest = body.substring(want, body.length())
     }
-    // Keep exactly `want` bytes as this request's body; anything already read
-    // past it is the start of the next pipelined request, carried over so it is
-    // not lost when the keep-alive loop reads again.
-    let actual_body = body.substring(0, want)
-    let rest = body.substring(want, body.length())
 
     let path = target
     let query: Map<String, String> = Map.new()

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1435,9 +1435,13 @@ fn http_server_decodes_chunked_request_body() {
     };
     // A `Transfer-Encoding: chunked` request body is de-chunked and delivered to
     // the handler (it used to be discarded as empty). The echo route returns the
-    // two chunks `Wiki` and `pedia` joined as `Wikipedia`.
+    // two chunks `Wiki` and `pedia` joined as `Wikipedia`. A coding list other
+    // than a sole `chunked`, and a chunk with a non-CRLF terminator, are
+    // rejected with 400.
     let expected = "status: HTTP/1.1 200 OK\n\
-                    body: Wikipedia\n";
+                    body: Wikipedia\n\
+                    unsupported: HTTP/1.1 400 Bad Request\n\
+                    bad-term: HTTP/1.1 400 Bad Request\n";
     compile_link_run_and_check("http_chunked_body.rv", expected, &runtime);
 }
 

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1429,6 +1429,19 @@ fn http_server_shuts_down_on_ipv6_wildcard() {
 }
 
 #[test]
+fn http_server_decodes_chunked_request_body() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A `Transfer-Encoding: chunked` request body is de-chunked and delivered to
+    // the handler (it used to be discarded as empty). The echo route returns the
+    // two chunks `Wiki` and `pedia` joined as `Wikipedia`.
+    let expected = "status: HTTP/1.1 200 OK\n\
+                    body: Wikipedia\n";
+    compile_link_run_and_check("http_chunked_body.rv", expected, &runtime);
+}
+
+#[test]
 fn http_sends_binary_body() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
The HTTP server silently accepted a `Transfer-Encoding: chunked` request body as empty: it only ever read a `Content-Length` body, so a chunked request routed with no body, the handler received nothing, and on a keep-alive connection the unread chunk framing was carried over as the start of the next request, desyncing it.

`read_request` now branches on the framing:

- A new `decode_chunked` helper reads each `<hex-size>[;ext]\r\n<data>\r\n` chunk, accumulates the data, and consumes the zero-size terminator plus any trailer lines, reading more from the socket as needed and bounding the total size.
- `Content-Length` combined with chunked framing is rejected (RFC 7230 3.3.3, a request-smuggling vector).
- The `Content-Length` path is unchanged.

Verified with a new example (`http_chunked_body.rv`) that POSTs a two-chunk body (`Wiki` + `pedia`) to an echo route and asserts the response body is `Wikipedia`. A `codegen_smoke` test runs it; all nine http tests pass.

Fixes #617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP servers now decode `Transfer-Encoding: chunked` request bodies before passing them to handlers.
  * Expanded the chunked HTTP example to include valid and invalid chunked requests (including unsupported `Transfer-Encoding` variants).
* **Bug Fixes**
  * Rejects requests combining `Content-Length` with chunked framing to help prevent request smuggling.
  * Prevents keep-alive desynchronization by properly consuming all chunk bytes and trailers.
  * Adds strict validation for chunk sizes, malformed terminators, and an upper bound on decoded body size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->