### PR TITLE
runtime: ignore SIGPIPE before stdout writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.196] - 2026-06-25
+
+### Fixed
+
+- Writes to stdout now ignore `SIGPIPE` on Unix, so a program that keeps printing after its pipe reader exits (`./prog | head -n 1`) is no longer killed by the signal; the broken-pipe write returns an ignored `EPIPE` and the program runs to completion. The runtime already did this for TCP and child-stdin writes but not for `print`/`println` (#766).
+
 ## [2.18.195] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.195"
+version = "2.18.196"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/sigpipe_producer.rv
+++ b/examples/v2/sigpipe_producer.rv
@@ -1,0 +1,14 @@
+// golden:skip - drives the SIGPIPE regression test in codegen_smoke.rs
+// (stdout_writes_survive_a_closed_pipe_reader). Writes far more than a pipe
+// buffer holds, so a reader that exits after one line leaves the rest of the
+// writes hitting a broken pipe; the runtime must ignore SIGPIPE so the program
+// runs to completion instead of being killed.
+import std/io { println }
+
+fun main() {
+    let i = 0
+    while i < 100000 {
+        println("line")
+        i = i + 1
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -367,6 +367,9 @@ pub extern "C" fn raven_print_str(ptr: *const u8, len: usize) {
     if len == 0 || ptr.is_null() {
         return;
     }
+    // Writing to stdout after its pipe reader has exited would raise SIGPIPE and
+    // kill the program; ignore it so the write returns an ignored EPIPE instead.
+    ignore_sigpipe();
     // SAFETY: caller guarantees the slice is initialized.
     let bytes = unsafe { slice::from_raw_parts(ptr, len) };
     let stdout = io::stdout();
@@ -383,6 +386,9 @@ pub extern "C" fn raven_print_str(ptr: *const u8, len: usize) {
 /// zero.
 #[no_mangle]
 pub extern "C" fn raven_println_str(ptr: *const u8, len: usize) {
+    // See `raven_print_str`: ignore SIGPIPE so a closed stdout reader cannot
+    // terminate the program mid-write.
+    ignore_sigpipe();
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     if len > 0 && !ptr.is_null() {

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -30,6 +30,47 @@ fn hello_world_compiles_and_runs() {
     compile_link_run_and_check("hello.rv", "Hello, Raven!\n", &runtime);
 }
 
+// Regression for #766: a program that keeps writing to stdout after the pipe
+// reader exits must not be killed by SIGPIPE. The runtime ignores SIGPIPE before
+// a stdout write, so the broken-pipe writes return an ignored EPIPE and the
+// program runs to completion. SIGPIPE only exists on Unix.
+#[test]
+#[cfg(unix)]
+fn stdout_writes_survive_a_closed_pipe_reader() {
+    use std::io::{BufRead, BufReader};
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::Stdio;
+
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    let (tmp, binary) = link_example("sigpipe_producer.rv", &runtime);
+
+    let mut child = Command::new(&binary)
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn producer");
+    // Read a single line, then drop the read end so the remaining writes, far
+    // more than a pipe buffer holds, hit a broken pipe.
+    {
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut reader = BufReader::new(stdout);
+        let mut line = std::string::String::new();
+        let _ = reader.read_line(&mut line);
+    }
+    let status = child.wait().expect("wait producer");
+    cleanup(&tmp);
+
+    // SIGPIPE is signal 13. Without the fix the process is killed by it; with the
+    // fix it ignores the EPIPE and exits cleanly.
+    assert_ne!(status.signal(), Some(13), "producer killed by SIGPIPE");
+    assert!(
+        status.success(),
+        "producer did not exit cleanly: {:?}",
+        status
+    );
+}
+
 #[test]
 fn result_struct_error_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
@@ -2091,7 +2132,9 @@ fn supported_runtime() -> Option<RuntimeStaticLib> {
 /// Compile `examples/v2/<name>`, link it with the runtime, run it, and
 /// assert its stdout equals `expected`. Panics on any failure on a
 /// supported host so a regression is loud.
-fn compile_link_run_and_check(name: &str, expected: &str, runtime: &RuntimeStaticLib) {
+/// Compile and link `examples/v2/<name>` into an executable, returning the
+/// temp directory (the caller cleans it up) and the binary path.
+fn link_example(name: &str, runtime: &RuntimeStaticLib) -> (PathBuf, PathBuf) {
     let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("examples")
         .join("v2")
@@ -2123,6 +2166,11 @@ fn compile_link_run_and_check(name: &str, expected: &str, runtime: &RuntimeStati
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }
+    (tmp, binary)
+}
+
+fn compile_link_run_and_check(name: &str, expected: &str, runtime: &RuntimeStaticLib) {
+    let (tmp, binary) = link_example(name, runtime);
 
     let output = Command::new(&binary)
         .output()


### PR DESCRIPTION
`print` and `println` wrote to stdout without ignoring `SIGPIPE`, so on Unix a program that keeps printing after its pipe reader has exited is killed by the signal:

```sh
raven build pipe.rv -o pipe
./pipe | head -n 1     # producer dies from SIGPIPE
```

The runtime already ignored `SIGPIPE` (process-wide, via a `Once`) before TCP and child-stdin writes, but not before stdout writes. `raven_print_str` and `raven_println_str` now call the same `ignore_sigpipe()` guard, so a broken-pipe write returns an `EPIPE` the writer already discards and the program runs to completion instead of being killed.

Added a Unix-gated end-to-end test (`stdout_writes_survive_a_closed_pipe_reader`) that builds a producer writing far more than a pipe buffer holds, reads one line, drops the read end, and asserts the process is not killed by signal 13 and exits cleanly. `SIGPIPE` only exists on Unix, so the test is `#[cfg(unix)]`.

Fixes #766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unix apps that write to standard output now continue running even if the reader closes early, instead of being terminated by a broken-pipe signal.
  * Added regression coverage to ensure repeated stdout writes complete successfully in this scenario.

* **Tests**
  * Added a new Unix-only smoke test for closed-pipe stdout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->