### PR TITLE
HTTP server: omit body and Content-Length for bodyless statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.197] - 2026-06-25
+
+### Fixed
+
+- The HTTP server no longer sends a message body or a Content-Length header for a status that forbids one. A 1xx, 204, or 304 response previously carried `resp.body` and a `Content-Length`, putting bytes on the wire that corrupt framing for clients and persistent connections; the server now omits the body for those statuses and the Content-Length for 1xx and 204 (#745).
+
 ## [2.18.195] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.195"
+version = "2.18.197"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_server_bodyless_status.rv
+++ b/examples/v2/http_server_bodyless_status.rv
@@ -1,0 +1,88 @@
+// Starts an HTTP server in a goroutine and probes it over a raw TCP socket to
+// check that a 204 response carries neither a body nor a Content-Length header,
+// even when the handler put bytes in the response body.
+// golden:skip (binds a port and depends on timing, so it is not diffed by the
+// golden suite; run it directly to verify the server response path).
+import std/http { Server, Response, Request }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun no_content(req: Request) -> Response {
+    return Response.with_body(204, "should not appear")
+}
+
+fun first_line(s: String) -> String {
+    let idx = s.index_of("\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun headers_block(s: String) -> String {
+    let idx = s.index_of("\r\n\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun body_after_headers(s: String) -> String {
+    let idx = s.index_of("\r\n\r\n")
+    if idx < 0 {
+        return ""
+    }
+    return s.substring(idx + 4, s.length())
+}
+
+// Connect with a few retries so a slow server bind does not race the probe.
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun send(addr: String, request: String) -> String {
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(request)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+    return result
+}
+
+fun main() {
+    let addr = "127.0.0.1:18643"
+    let app = Server.new()
+    app.get("/x", no_content)
+    spawn(fun() -> Unit {
+        app.listen(addr)
+    })
+
+    let resp = send(addr, "GET /x HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
+    println("status: ${first_line(resp)}")
+    println("body empty: ${body_after_headers(resp) == ""}")
+    println("no content-length: ${headers_block(resp).index_of("Content-Length") < 0}")
+
+    app.shutdown()
+}

--- a/examples/v2/http_server_bodyless_status.rv
+++ b/examples/v2/http_server_bodyless_status.rv
@@ -9,7 +9,9 @@ import std/time { sleep_millis }
 import std/io { println }
 
 fun no_content(req: Request) -> Response {
-    return Response.with_body(204, "should not appear")
+    // The lowercase content-length must also be cleared: HTTP field names are
+    // case-insensitive, so the server must not let a handler variant through.
+    return Response.with_body(204, "should not appear").header("content-length", "17")
 }
 
 fun first_line(s: String) -> String {
@@ -82,7 +84,7 @@ fun main() {
     let resp = send(addr, "GET /x HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
     println("status: ${first_line(resp)}")
     println("body empty: ${body_after_headers(resp) == ""}")
-    println("no content-length: ${headers_block(resp).index_of("Content-Length") < 0}")
+    println("no content-length: ${headers_block(resp).to_lower().index_of("content-length") < 0}")
 
     app.shutdown()
 }

--- a/examples/v2/http_server_bodyless_status.rv
+++ b/examples/v2/http_server_bodyless_status.rv
@@ -1,6 +1,7 @@
 // Starts an HTTP server in a goroutine and probes it over a raw TCP socket to
 // check that a 204 response carries neither a body nor a Content-Length header,
-// even when the handler put bytes in the response body.
+// even when the handler put bytes in the response body and set a lowercase
+// content-length (HTTP field names are case-insensitive).
 // golden:skip (binds a port and depends on timing, so it is not diffed by the
 // golden suite; run it directly to verify the server response path).
 import std/http { Server, Response, Request }

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -979,13 +979,27 @@ fun status_forbids_content_length(status: Int) -> Bool {
     return status == 204
 }
 
+// Remove every Content-Length header the handler set, matched case-insensitively
+// since HTTP field names are case-insensitive: the server's own framing is
+// authoritative, and a handler variant like `content-length` must not survive.
+fun clear_content_length(headers: Map<String, String>) {
+    let keys = headers.keys()
+    let i = 0
+    while i < keys.len() {
+        if keys[i].to_lower() == "content-length" {
+            let _ = headers.remove(keys[i])
+        }
+        i += 1
+    }
+}
+
 // Write `resp` to `stream` as an HTTP/1.1 response, framing it with
 // Content-Length and closing the connection after.
 fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head: Bool) {
-    if status_forbids_content_length(resp.status) {
-        // Clear any Content-Length the handler set: the status forbids it.
-        let _ = resp.headers.remove("Content-Length")
-    } else {
+    // Clear any handler-set Content-Length first, then set the authoritative one
+    // unless the status forbids it (1xx, 204).
+    clear_content_length(resp.headers)
+    if !status_forbids_content_length(resp.status) {
         // Content-Length always reports what a GET would return, even for HEAD.
         resp.headers.set("Content-Length", resp.body.length().to_string())
     }

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -961,11 +961,34 @@ fun decode_query_part(s: String) -> String {
     return url_decode(s.replace("+", " "))
 }
 
+// A 1xx, 204, or 304 response must not carry a message body (RFC 7230 3.3.2),
+// regardless of what the handler put in `resp.body`.
+fun status_forbids_body(status: Int) -> Bool {
+    if status >= 100 && status < 200 {
+        return true
+    }
+    return status == 204 || status == 304
+}
+
+// A 1xx or 204 response must not carry Content-Length either. A 304 still
+// reports the length the body would have, like a HEAD response.
+fun status_forbids_content_length(status: Int) -> Bool {
+    if status >= 100 && status < 200 {
+        return true
+    }
+    return status == 204
+}
+
 // Write `resp` to `stream` as an HTTP/1.1 response, framing it with
 // Content-Length and closing the connection after.
 fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head: Bool) {
-    // Content-Length always reports what a GET would return, even for HEAD.
-    resp.headers.set("Content-Length", resp.body.length().to_string())
+    if status_forbids_content_length(resp.status) {
+        // Clear any Content-Length the handler set: the status forbids it.
+        let _ = resp.headers.remove("Content-Length")
+    } else {
+        // Content-Length always reports what a GET would return, even for HEAD.
+        resp.headers.set("Content-Length", resp.body.length().to_string())
+    }
     if keep_alive {
         resp.headers.set("Connection", "keep-alive")
     } else {
@@ -981,9 +1004,10 @@ fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head:
         block = block.concat(k).concat(": ").concat(resp.headers.get_or(k, "")).concat("\r\n")
         i += 1
     }
-    // A response to a HEAD request carries the headers but no body.
+    // A response to a HEAD request, or one whose status forbids a body, carries
+    // the headers but no body.
     let out = line.concat(block).concat("\r\n")
-    if !is_head {
+    if !is_head && !status_forbids_body(resp.status) {
         out = out.concat(resp.body)
     }
     let _ = stream.write(out)

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1378,6 +1378,19 @@ fn http_server_reason_and_head_responses() {
 }
 
 #[test]
+fn http_server_omits_body_for_bodyless_status() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Regression for #745: a 204 response must not carry a body or a
+    // Content-Length header, even when the handler put bytes in the body.
+    let expected = "status: HTTP/1.1 204 No Content\n\
+                    body empty: true\n\
+                    no content-length: true\n";
+    compile_link_run_and_check("http_server_bodyless_status.rv", expected, &runtime);
+}
+
+#[test]
 fn http_server_timeout_does_not_overflow() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
The HTTP server always wrote `resp.body` and always set `Content-Length`, even when the response status forbids a message body. A handler returning a 204 therefore put bytes on the wire after the headers, corrupting framing for clients and persistent connections.

```raven
fun broken(req: Request) -> Response {
    return Response.with_body(204, "forbidden")   // body and Content-Length were sent
}
```

`write_response` now omits the body for a 1xx, 204, or 304 status (RFC 7230 3.3.2), and omits `Content-Length` for 1xx and 204 (clearing any the handler set). A 304 still reports the length the body would have, like a HEAD response.

Verified end to end by `http_server_bodyless_status.rv` (server plus raw-socket client in one program) and a codegen smoke test: a 204 handler that sets a body produces `HTTP/1.1 204 No Content` with an empty body and no `Content-Length`.

Fixes #745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP server now complies with bodyless status rules by omitting response bodies for `1xx`, `204`, and `304`, including when the request is `HEAD`.
  * For `1xx` and `204`, responses no longer include a `Content-Length` header, avoiding client framing issues.
* **Tests**
  * Added an end-to-end HTTP smoke test to confirm `204` produces no body and no `Content-Length`.
* **Examples**
  * Updated/added an HTTP server example that validates the corrected `204` response formatting over a raw TCP probe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->