### PR TITLE
runtime: clamp negative substring bounds to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.198] - 2026-06-25
+
+### Fixed
+
+- `String.substring` clamps negative bounds to 0 instead of converting them to a huge unsigned index. The runtime took the bounds as unsigned, so a negative `start` or `end` became a pointer-sized value that clamped to the string length and gave the wrong slice; the bounds are now signed and clamped into `0..length` as documented (#556).
+
 ## [2.18.196] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.196"
+version = "2.18.198"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/object/string.rs
+++ b/raven-runtime/src/object/string.rs
@@ -246,23 +246,23 @@ pub extern "C" fn raven_string_cmp(a: *const String, b: *const String) -> i64 {
 }
 
 /// Allocate a fresh `String` holding the half-open byte range
-/// `[start, end)` of `s`. The bounds are clamped to `0..=len` and a
-/// `start` past `end` yields an empty string, so the function never
-/// reads out of range. The range is in bytes; slicing through the
-/// middle of a multi-byte UTF-8 sequence produces a string whose bytes
-/// are not valid UTF-8, which the byte-oriented `std/string` surface
-/// documents as the caller's responsibility.
+/// `[start, end)` of `s`. The bounds are signed and clamped to
+/// `0..=len` (a negative bound clamps to 0), and a `start` past `end`
+/// yields an empty string, so the function never reads out of range.
+/// The range is in bytes; slicing through the middle of a multi-byte
+/// UTF-8 sequence produces a string whose bytes are not valid UTF-8,
+/// which the byte-oriented `std/string` surface documents as the
+/// caller's responsibility.
 ///
 /// Backs the `__str_substring` compiler intrinsic.
 #[no_mangle]
-pub extern "C" fn raven_string_substring(
-    s: *const String,
-    start: usize,
-    end: usize,
-) -> *mut String {
+pub extern "C" fn raven_string_substring(s: *const String, start: i64, end: i64) -> *mut String {
     let len = raven_string_len(s) as usize;
-    let start = start.min(len);
-    let end = end.min(len);
+    // A Raven Int is signed, so the bounds arrive as `i64`. Clamp each into
+    // `0..=len`: a negative bound clamps up to 0 and an over-long one clamps down
+    // to `len`, matching the documented `0..length` clamping.
+    let start = start.clamp(0, len as i64) as usize;
+    let end = end.clamp(0, len as i64) as usize;
     if start >= end {
         return raven_string_new(0);
     }
@@ -660,12 +660,19 @@ mod tests {
         assert_eq!(read(empty), "");
         let whole = raven_string_substring(s, 0, 5);
         assert_eq!(read(whole), "hello");
+        // A negative bound clamps to 0, not to a huge unsigned index (#556).
+        let neg_start = raven_string_substring(s, -1, 4);
+        assert_eq!(read(neg_start), "hell");
+        let neg_end = raven_string_substring(s, 1, -1);
+        assert_eq!(read(neg_end), "");
         unsafe {
             drop_string_for_test(s);
             drop_string_for_test(mid);
             drop_string_for_test(tail);
             drop_string_for_test(empty);
             drop_string_for_test(whole);
+            drop_string_for_test(neg_start);
+            drop_string_for_test(neg_end);
         }
     }
 


### PR DESCRIPTION
`String.substring` took its bounds as unsigned in the runtime, so a negative index was reinterpreted as a huge pointer-sized value that clamped to the string length, giving the wrong slice:

```raven
"abc".substring(-1, 2)   // was "", should be "ab"
"abc".substring(1, -1)   // was "bc", should be ""
```

`raven_string_substring` now takes the bounds as `i64` and clamps each into `0..=len`, so a negative bound clamps to 0 as the `std/string` surface documents. The codegen already passes the bounds as pointer-sized (64-bit) values, so only the runtime's interpretation changes. Added negative-bound cases to the runtime test.

Fixes #556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `substring` behavior when `start`/`end` are negative or out of range by clamping them within the string length.
  * Ensured cases where `start` is at/after `end` return an empty result instead of producing incorrect slices.
* **Chores**
  * Bumped the project version to **2.18.198**.
  * Updated the changelog with the latest patch release entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->