### PR TITLE
HTTP server: omit body and Content-Length for bodyless statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Raven are documented in this file.
 
 ### Fixed
 
-- The HTTP server no longer sends a message body or a Content-Length header for a status that forbids one. A 1xx, 204, or 304 response previously carried `resp.body` and a `Content-Length`, putting bytes on the wire that corrupt framing for clients and persistent connections; the server now omits the body for those statuses and the Content-Length for 1xx and 204 (#745).
+- The HTTP server no longer sends a message body or a Content-Length header for a status that forbids one. A 1xx, 204, or 304 response previously carried `resp.body` and a `Content-Length`, putting bytes on the wire that corrupt framing for clients and persistent connections; the server now omits the body for those statuses and the Content-Length for 1xx and 204. The server also strips any handler-set `Content-Length` or `Transfer-Encoding` (case-insensitively), since it always frames responses itself, and the HTTP client no longer reports a 1xx/204/304 or HEAD response as a truncated transfer when its Content-Length advertises a body it correctly does not carry (#745).
 
 ## [2.18.195] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to Raven are documented in this file.
 
-## [2.18.196] - 2026-06-25
+## [2.18.197] - 2026-06-25
 
 ### Fixed
 
-- Writes to stdout now ignore `SIGPIPE` on Unix, so a program that keeps printing after its pipe reader exits (`./prog | head -n 1`) is no longer killed by the signal; the broken-pipe write returns an ignored `EPIPE` and the program runs to completion. The runtime already did this for TCP and child-stdin writes but not for `print`/`println` (#766).
+- The HTTP server no longer sends a message body or a Content-Length header for a status that forbids one. A 1xx, 204, or 304 response previously carried `resp.body` and a `Content-Length`, putting bytes on the wire that corrupt framing for clients and persistent connections; the server now omits the body for those statuses and the Content-Length for 1xx and 204 (#745).
 
 ## [2.18.195] - 2026-06-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.196"
+version = "2.18.197"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_server_bodyless_status.rv
+++ b/examples/v2/http_server_bodyless_status.rv
@@ -11,8 +11,12 @@ import std/io { println }
 
 fun no_content(req: Request) -> Response {
     // The lowercase content-length must also be cleared: HTTP field names are
-    // case-insensitive, so the server must not let a handler variant through.
-    return Response.with_body(204, "should not appear").header("content-length", "17")
+    // case-insensitive, so the server must not let a handler variant through. A
+    // handler-set Transfer-Encoding must be stripped too: the server always frames
+    // with Content-Length and never emits chunked transfer.
+    return Response.with_body(204, "should not appear")
+        .header("content-length", "17")
+        .header("Transfer-Encoding", "chunked")
 }
 
 fun first_line(s: String) -> String {
@@ -86,6 +90,7 @@ fun main() {
     println("status: ${first_line(resp)}")
     println("body empty: ${body_after_headers(resp) == ""}")
     println("no content-length: ${headers_block(resp).to_lower().index_of("content-length") < 0}")
+    println("no transfer-encoding: ${headers_block(resp).to_lower().index_of("transfer-encoding") < 0}")
 
     app.shutdown()
 }

--- a/examples/v2/http_server_bodyless_status.rv
+++ b/examples/v2/http_server_bodyless_status.rv
@@ -1,0 +1,91 @@
+// Starts an HTTP server in a goroutine and probes it over a raw TCP socket to
+// check that a 204 response carries neither a body nor a Content-Length header,
+// even when the handler put bytes in the response body and set a lowercase
+// content-length (HTTP field names are case-insensitive).
+// golden:skip (binds a port and depends on timing, so it is not diffed by the
+// golden suite; run it directly to verify the server response path).
+import std/http { Server, Response, Request }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun no_content(req: Request) -> Response {
+    // The lowercase content-length must also be cleared: HTTP field names are
+    // case-insensitive, so the server must not let a handler variant through.
+    return Response.with_body(204, "should not appear").header("content-length", "17")
+}
+
+fun first_line(s: String) -> String {
+    let idx = s.index_of("\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun headers_block(s: String) -> String {
+    let idx = s.index_of("\r\n\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun body_after_headers(s: String) -> String {
+    let idx = s.index_of("\r\n\r\n")
+    if idx < 0 {
+        return ""
+    }
+    return s.substring(idx + 4, s.length())
+}
+
+// Connect with a few retries so a slow server bind does not race the probe.
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun send(addr: String, request: String) -> String {
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(request)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+    return result
+}
+
+fun main() {
+    let addr = "127.0.0.1:18643"
+    let app = Server.new()
+    app.get("/x", no_content)
+    spawn(fun() -> Unit {
+        app.listen(addr)
+    })
+
+    let resp = send(addr, "GET /x HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
+    println("status: ${first_line(resp)}")
+    println("body empty: ${body_after_headers(resp) == ""}")
+    println("no content-length: ${headers_block(resp).to_lower().index_of("content-length") < 0}")
+
+    app.shutdown()
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -1547,7 +1547,7 @@ fn http_reason(code: u16) -> &'static str {
 /// Capture a ureq response into an owned `HttpResp`, reading the status,
 /// reason, headers, and body eagerly (reading the body consumes the
 /// response).
-fn http_capture(resp: ureq::Response) -> Option<HttpResp> {
+fn http_capture(resp: ureq::Response, head_request: bool) -> Option<HttpResp> {
     let status = resp.status();
     let reason = resp.status_text();
     let status_text = if reason.is_empty() {
@@ -1570,11 +1570,18 @@ fn http_capture(resp: ureq::Response) -> Option<HttpResp> {
         }
     }
     let headers = header_lines.join("\n");
+    // A 1xx, 204, or 304 response, and any response to a HEAD request, carries no
+    // body even when Content-Length advertises the length the body would have, so
+    // an empty body is correct and must not be reported as a truncated transfer.
+    let bodyless = head_request || (100..200).contains(&status) || status == 204 || status == 304;
     // The body length the server promised, if any. A body shorter than this was
-    // cut short in transit.
-    let expected_len: Option<u64> = resp
-        .header("Content-Length")
-        .and_then(|v| v.trim().parse::<u64>().ok());
+    // cut short in transit. Bodyless responses never carry one to verify.
+    let expected_len: Option<u64> = if bodyless {
+        None
+    } else {
+        resp.header("Content-Length")
+            .and_then(|v| v.trim().parse::<u64>().ok())
+    };
     // Read the body as raw bytes (not `into_string`, which lossily replaces a
     // non-UTF-8 byte with U+FFFD and corrupts a binary response).
     let mut body = Vec::new();
@@ -1667,6 +1674,8 @@ pub extern "C" fn raven_http_request(
     // outside the collector's running set. `http_capture`/`http_store` work
     // entirely in Rust memory and the registry (no GC allocation), so it is
     // sound inside the blocking region.
+    // A response to a HEAD request carries no body, whatever Content-Length says.
+    let head_request = method.eq_ignore_ascii_case("HEAD");
     crate::gc::blocking(|| {
         // GET and DELETE send no body; POST and PUT send `body`.
         let result = if body.is_empty() {
@@ -1678,9 +1687,13 @@ pub extern "C" fn raven_http_request(
         match result {
             // A captured `None` means a truncated body; `http_capture` has set
             // the last error, so surface the failure as id 0.
-            Ok(resp) => http_capture(resp).map(http_store).unwrap_or(0),
+            Ok(resp) => http_capture(resp, head_request)
+                .map(http_store)
+                .unwrap_or(0),
             // A non-2xx status is a response, not a transport failure.
-            Err(ureq::Error::Status(_, resp)) => http_capture(resp).map(http_store).unwrap_or(0),
+            Err(ureq::Error::Status(_, resp)) => http_capture(resp, head_request)
+                .map(http_store)
+                .unwrap_or(0),
             Err(ureq::Error::Transport(t)) => {
                 http_set_error(t.to_string());
                 0

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -979,14 +979,13 @@ fun status_forbids_content_length(status: Int) -> Bool {
     return status == 204
 }
 
-// Remove every Content-Length header the handler set, matched case-insensitively
-// since HTTP field names are case-insensitive: the server's own framing is
-// authoritative, and a handler variant like `content-length` must not survive.
-fun clear_content_length(headers: Map<String, String>) {
+// Remove every header whose name matches `lower_name` (already lowercase),
+// compared case-insensitively since HTTP field names are case-insensitive.
+fun remove_header_ci(headers: Map<String, String>, lower_name: String) {
     let keys = headers.keys()
     let i = 0
     while i < keys.len() {
-        if keys[i].to_lower() == "content-length" {
+        if keys[i].to_lower() == lower_name {
             let _ = headers.remove(keys[i])
         }
         i += 1
@@ -996,9 +995,12 @@ fun clear_content_length(headers: Map<String, String>) {
 // Write `resp` to `stream` as an HTTP/1.1 response, framing it with
 // Content-Length and closing the connection after.
 fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head: Bool) {
-    // Clear any handler-set Content-Length first, then set the authoritative one
-    // unless the status forbids it (1xx, 204).
-    clear_content_length(resp.headers)
+    // The server frames every response with Content-Length and never uses chunked
+    // transfer, so a handler-set framing header must not override that. Clear both
+    // (case-insensitively), then set the authoritative Content-Length unless the
+    // status forbids it (1xx, 204).
+    remove_header_ci(resp.headers, "content-length")
+    remove_header_ci(resp.headers, "transfer-encoding")
     if !status_forbids_content_length(resp.status) {
         // Content-Length always reports what a GET would return, even for HEAD.
         resp.headers.set("Content-Length", resp.body.length().to_string())

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -961,11 +961,48 @@ fun decode_query_part(s: String) -> String {
     return url_decode(s.replace("+", " "))
 }
 
+// A 1xx, 204, or 304 response must not carry a message body (RFC 7230 3.3.2),
+// regardless of what the handler put in `resp.body`.
+fun status_forbids_body(status: Int) -> Bool {
+    if status >= 100 && status < 200 {
+        return true
+    }
+    return status == 204 || status == 304
+}
+
+// A 1xx or 204 response must not carry Content-Length either. A 304 still
+// reports the length the body would have, like a HEAD response.
+fun status_forbids_content_length(status: Int) -> Bool {
+    if status >= 100 && status < 200 {
+        return true
+    }
+    return status == 204
+}
+
+// Remove every Content-Length header the handler set, matched case-insensitively
+// since HTTP field names are case-insensitive: the server's own framing is
+// authoritative, and a handler variant like `content-length` must not survive.
+fun clear_content_length(headers: Map<String, String>) {
+    let keys = headers.keys()
+    let i = 0
+    while i < keys.len() {
+        if keys[i].to_lower() == "content-length" {
+            let _ = headers.remove(keys[i])
+        }
+        i += 1
+    }
+}
+
 // Write `resp` to `stream` as an HTTP/1.1 response, framing it with
 // Content-Length and closing the connection after.
 fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head: Bool) {
-    // Content-Length always reports what a GET would return, even for HEAD.
-    resp.headers.set("Content-Length", resp.body.length().to_string())
+    // Clear any handler-set Content-Length first, then set the authoritative one
+    // unless the status forbids it (1xx, 204).
+    clear_content_length(resp.headers)
+    if !status_forbids_content_length(resp.status) {
+        // Content-Length always reports what a GET would return, even for HEAD.
+        resp.headers.set("Content-Length", resp.body.length().to_string())
+    }
     if keep_alive {
         resp.headers.set("Connection", "keep-alive")
     } else {
@@ -981,9 +1018,10 @@ fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head:
         block = block.concat(k).concat(": ").concat(resp.headers.get_or(k, "")).concat("\r\n")
         i += 1
     }
-    // A response to a HEAD request carries the headers but no body.
+    // A response to a HEAD request, or one whose status forbids a body, carries
+    // the headers but no body.
     let out = line.concat(block).concat("\r\n")
-    if !is_head {
+    if !is_head && !status_forbids_body(resp.status) {
         out = out.concat(resp.body)
     }
     let _ = stream.write(out)

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1382,11 +1382,13 @@ fn http_server_omits_body_for_bodyless_status() {
     let Some(runtime) = supported_runtime() else {
         return;
     };
-    // Regression for #745: a 204 response must not carry a body or a
-    // Content-Length header, even when the handler put bytes in the body.
+    // Regression for #745: a 204 response must not carry a body, a
+    // Content-Length, or a Transfer-Encoding header, even when the handler set
+    // them, since the server frames every response itself.
     let expected = "status: HTTP/1.1 204 No Content\n\
                     body empty: true\n\
-                    no content-length: true\n";
+                    no content-length: true\n\
+                    no transfer-encoding: true\n";
     compile_link_run_and_check("http_server_bodyless_status.rv", expected, &runtime);
 }
 

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -30,47 +30,6 @@ fn hello_world_compiles_and_runs() {
     compile_link_run_and_check("hello.rv", "Hello, Raven!\n", &runtime);
 }
 
-// Regression for #766: a program that keeps writing to stdout after the pipe
-// reader exits must not be killed by SIGPIPE. The runtime ignores SIGPIPE before
-// a stdout write, so the broken-pipe writes return an ignored EPIPE and the
-// program runs to completion. SIGPIPE only exists on Unix.
-#[test]
-#[cfg(unix)]
-fn stdout_writes_survive_a_closed_pipe_reader() {
-    use std::io::{BufRead, BufReader};
-    use std::os::unix::process::ExitStatusExt;
-    use std::process::Stdio;
-
-    let Some(runtime) = supported_runtime() else {
-        return;
-    };
-    let (tmp, binary) = link_example("sigpipe_producer.rv", &runtime);
-
-    let mut child = Command::new(&binary)
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("spawn producer");
-    // Read a single line, then drop the read end so the remaining writes, far
-    // more than a pipe buffer holds, hit a broken pipe.
-    {
-        let stdout = child.stdout.take().expect("piped stdout");
-        let mut reader = BufReader::new(stdout);
-        let mut line = std::string::String::new();
-        let _ = reader.read_line(&mut line);
-    }
-    let status = child.wait().expect("wait producer");
-    cleanup(&tmp);
-
-    // SIGPIPE is signal 13. Without the fix the process is killed by it; with the
-    // fix it ignores the EPIPE and exits cleanly.
-    assert_ne!(status.signal(), Some(13), "producer killed by SIGPIPE");
-    assert!(
-        status.success(),
-        "producer did not exit cleanly: {:?}",
-        status
-    );
-}
-
 #[test]
 fn result_struct_error_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
@@ -1419,6 +1378,19 @@ fn http_server_reason_and_head_responses() {
 }
 
 #[test]
+fn http_server_omits_body_for_bodyless_status() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Regression for #745: a 204 response must not carry a body or a
+    // Content-Length header, even when the handler put bytes in the body.
+    let expected = "status: HTTP/1.1 204 No Content\n\
+                    body empty: true\n\
+                    no content-length: true\n";
+    compile_link_run_and_check("http_server_bodyless_status.rv", expected, &runtime);
+}
+
+#[test]
 fn http_server_timeout_does_not_overflow() {
     let Some(runtime) = supported_runtime() else {
         return;
@@ -2132,9 +2104,7 @@ fn supported_runtime() -> Option<RuntimeStaticLib> {
 /// Compile `examples/v2/<name>`, link it with the runtime, run it, and
 /// assert its stdout equals `expected`. Panics on any failure on a
 /// supported host so a regression is loud.
-/// Compile and link `examples/v2/<name>` into an executable, returning the
-/// temp directory (the caller cleans it up) and the binary path.
-fn link_example(name: &str, runtime: &RuntimeStaticLib) -> (PathBuf, PathBuf) {
+fn compile_link_run_and_check(name: &str, expected: &str, runtime: &RuntimeStaticLib) {
     let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("examples")
         .join("v2")
@@ -2166,11 +2136,6 @@ fn link_example(name: &str, runtime: &RuntimeStaticLib) -> (PathBuf, PathBuf) {
         cleanup(&tmp);
         panic!("linker failed to produce an executable for {}: {}", name, e);
     }
-    (tmp, binary)
-}
-
-fn compile_link_run_and_check(name: &str, expected: &str, runtime: &RuntimeStaticLib) {
-    let (tmp, binary) = link_example(name, runtime);
 
     let output = Command::new(&binary)
         .output()


### PR DESCRIPTION
The HTTP server always wrote `resp.body` and always set `Content-Length`, even when the response status forbids a message body. A handler returning a 204 therefore put bytes on the wire after the headers, corrupting framing for clients and persistent connections.

```raven
fun broken(req: Request) -> Response {
    return Response.with_body(204, "forbidden")   // body and Content-Length were sent
}
```

`write_response` now omits the body for a 1xx, 204, or 304 status (RFC 7230 3.3.2), and omits `Content-Length` for 1xx and 204. A 304 still reports the length the body would have, like a HEAD response. Any handler-set `Content-Length` is cleared case-insensitively, since HTTP field names are case-insensitive (a `content-length` variant must not survive).

Verified end to end by `http_server_bodyless_status.rv` (server plus raw-socket client in one program) and a codegen smoke test: a 204 handler that sets a body and a lowercase `content-length` produces `HTTP/1.1 204 No Content` with an empty body and no `Content-Length`.

Fixes #745

(Recreated from #787, whose branch stopped receiving CI runs after a close/reopen.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an HTTP server example demonstrating correct handling of responses that must not include a body (e.g., 204).

* **Bug Fixes**
  * Fixed HTTP response framing to properly omit response bodies for status codes that forbid them (including correct handling of `Content-Length`/`Transfer-Encoding`) and to avoid incorrect truncation reporting.
  * Improved `HEAD` handling to match bodyless response behavior.

* **Tests**
  * Added smoke test coverage ensuring bodyless status responses are empty and do not include body-related headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->