### PR TITLE
HTTP server: clamp out-of-range response status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.199] - 2026-06-25
+
+### Fixed
+
+- The HTTP server replaces an out-of-range response status code with 500 instead of writing it into the status line verbatim. `Response.status_code` accepts any `Int`, so a handler could emit a malformed status line like `HTTP/1.1 -1 OK`; the server now frames the wire status from a value clamped to the valid 100..599 range (#741).
+
 ## [2.18.198] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.198"
+version = "2.18.199"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_server_invalid_status.rv
+++ b/examples/v2/http_server_invalid_status.rv
@@ -1,0 +1,76 @@
+// Starts an HTTP server in a goroutine and probes it over a raw TCP socket to
+// check that a handler's out-of-range status code does not produce a malformed
+// status line: an invalid code is replaced with 500.
+// golden:skip (binds a port and depends on timing, so it is not diffed by the
+// golden suite; run it directly to verify the server response path).
+import std/http { Server, Response, Request }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun negative(req: Request) -> Response {
+    return Response.text("body").status_code(0 - 1)
+}
+
+fun huge(req: Request) -> Response {
+    return Response.text("body").status_code(99999)
+}
+
+fun first_line(s: String) -> String {
+    let idx = s.index_of("\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun send(addr: String, request: String) -> String {
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(request)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+    return result
+}
+
+fun main() {
+    let addr = "127.0.0.1:19477"
+    let app = Server.new()
+    app.get("/neg", negative)
+    app.get("/big", huge)
+    spawn(fun() -> Unit {
+        app.listen(addr)
+    })
+
+    let neg = send(addr, "GET /neg HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
+    println("negative: ${first_line(neg)}")
+    let big = send(addr, "GET /big HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
+    println("huge: ${first_line(big)}")
+
+    app.shutdown()
+}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -518,7 +518,9 @@ fun serve_connection(server: Server, stream: TcpStream) {
                 write_response(stream, resp, keep, is_head)
                 if server.access_log {
                     let method = req.method.to_string().to_upper()
-                    print("${method} ${req.path} ${resp.status}")
+                    // Log the sanitized status that went on the wire, not the raw
+                    // handler value, so the log matches what the client received.
+                    print("${method} ${req.path} ${sanitize_status(resp.status)}")
                 }
                 served += 1
                 if !keep {

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -979,6 +979,16 @@ fun status_forbids_content_length(status: Int) -> Bool {
     return status == 204
 }
 
+// A valid HTTP status code is three digits, 100 through 599. A handler can set
+// any Int through `status_code`, so an out-of-range value (which would frame a
+// malformed status line like `HTTP/1.1 -1 OK`) is replaced with 500.
+fun sanitize_status(status: Int) -> Int {
+    if status < 100 || status > 599 {
+        return 500
+    }
+    return status
+}
+
 // Remove every header whose name matches `lower_name` (already lowercase),
 // compared case-insensitively since HTTP field names are case-insensitive.
 fun remove_header_ci(headers: Map<String, String>, lower_name: String) {
@@ -995,13 +1005,16 @@ fun remove_header_ci(headers: Map<String, String>, lower_name: String) {
 // Write `resp` to `stream` as an HTTP/1.1 response, framing it with
 // Content-Length and closing the connection after.
 fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head: Bool) {
+    // Frame the wire status from a sanitized code, so a handler's out-of-range
+    // status cannot produce a malformed status line.
+    let code = sanitize_status(resp.status)
     // The server frames every response with Content-Length and never uses chunked
     // transfer, so a handler-set framing header must not override that. Clear both
     // (case-insensitively), then set the authoritative Content-Length unless the
     // status forbids it (1xx, 204).
     remove_header_ci(resp.headers, "content-length")
     remove_header_ci(resp.headers, "transfer-encoding")
-    if !status_forbids_content_length(resp.status) {
+    if !status_forbids_content_length(code) {
         // Content-Length always reports what a GET would return, even for HEAD.
         resp.headers.set("Content-Length", resp.body.length().to_string())
     }
@@ -1010,8 +1023,8 @@ fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head:
     } else {
         resp.headers.set("Connection", "close")
     }
-    let status_line = "HTTP/1.1 ".concat(resp.status.to_string()).concat(" ")
-    let line = status_line.concat(reason_phrase(resp.status)).concat("\r\n")
+    let status_line = "HTTP/1.1 ".concat(code.to_string()).concat(" ")
+    let line = status_line.concat(reason_phrase(code)).concat("\r\n")
     let block = ""
     let keys = resp.headers.keys()
     let i = 0
@@ -1023,7 +1036,7 @@ fun write_response(stream: TcpStream, resp: Response, keep_alive: Bool, is_head:
     // A response to a HEAD request, or one whose status forbids a body, carries
     // the headers but no body.
     let out = line.concat(block).concat("\r\n")
-    if !is_head && !status_forbids_body(resp.status) {
+    if !is_head && !status_forbids_body(code) {
         out = out.concat(resp.body)
     }
     let _ = stream.write(out)

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1378,6 +1378,18 @@ fn http_server_reason_and_head_responses() {
 }
 
 #[test]
+fn http_server_sanitizes_invalid_status_codes() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Regression for #741: a handler's out-of-range status code must not produce
+    // a malformed status line; an invalid code is replaced with 500.
+    let expected = "negative: HTTP/1.1 500 Internal Server Error\n\
+                    huge: HTTP/1.1 500 Internal Server Error\n";
+    compile_link_run_and_check("http_server_invalid_status.rv", expected, &runtime);
+}
+
+#[test]
 fn http_server_omits_body_for_bodyless_status() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`Response.status_code` accepts any `Int`, and the server wrote that value directly into the response status line, so a handler could emit a response that is not valid HTTP:

```raven
fun broken(req: Request) -> Response {
    return Response.text("body").status_code(0 - 1)   // HTTP/1.1 -1 OK
}
```

`write_response` now frames the wire status from a sanitized code: a value outside the valid 100..599 range is replaced with 500 (Internal Server Error), and the reason phrase and body-omission rules follow the sanitized code. A negative or over-large status now serializes as `HTTP/1.1 500 Internal Server Error`.

Verified end to end by `http_server_invalid_status.rv` (server plus raw-socket client) and a codegen smoke test.

Fixes #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP server now clamps out-of-range handler status codes (outside `100..599`) to `500 Internal Server Error`, preventing malformed status lines.
  * Access logs now reflect the sanitized status code used in the response.
* **New Features**
  * Added a runnable example that exercises invalid status code responses over raw HTTP.
* **Tests**
  * Added a smoke test that compiles and runs the new example and verifies `500 Internal Server Error` formatting for both invalid cases.
* **Chores**
  * Updated release version to `2.18.199`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->