### PR TITLE
HTTP response builder: validate header names and strip control bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.200] - 2026-06-25
+
+### Fixed
+
+- The HTTP response builder rejects an invalid field name and strips control bytes from a field value, instead of sending them unchanged. `Response.header` removed only CR and LF, so a handler could set a name with a space or other forbidden byte, or a value with a NUL or other control byte, and produce a malformed response clients may reject or parse inconsistently. A name that is not a valid HTTP token is now dropped, and a value's C0 controls and DEL (except HTAB) are stripped (#742).
+
 ## [2.18.199] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.199"
+version = "2.18.200"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_server_header_validation.rv
+++ b/examples/v2/http_server_header_validation.rv
@@ -1,0 +1,76 @@
+// Starts an HTTP server in a goroutine and probes it over a raw TCP socket to
+// check that the response builder rejects an invalid field name and strips
+// control bytes from a field value, so a handler cannot frame a malformed
+// response or inject extra headers.
+// golden:skip (binds a port and depends on timing, so it is not diffed by the
+// golden suite; run it directly to verify the server response path).
+import std/http { Server, Response, Request }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun handler(req: Request) -> Response {
+    return Response.text("body")
+        .header("Bad Name", "dropped")
+        .header("X-Ctrl", "a".concat(__str_from_byte(1)).concat("b"))
+        .header("X-Good", "fine")
+}
+
+fun headers_block(s: String) -> String {
+    let idx = s.index_of("\r\n\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun send(addr: String, request: String) -> String {
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(request)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+    return result
+}
+
+fun main() {
+    let addr = "127.0.0.1:19478"
+    let app = Server.new()
+    app.get("/", handler)
+    spawn(fun() -> Unit {
+        app.listen(addr)
+    })
+
+    let resp = send(addr, "GET / HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n")
+    let block = headers_block(resp)
+    println("bad-name dropped: ${block.index_of("Bad Name") < 0}")
+    println("good present: ${block.index_of("X-Good: fine") >= 0}")
+    println("control stripped: ${block.index_of("X-Ctrl: ab") >= 0}")
+
+    app.shutdown()
+}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -281,14 +281,16 @@ impl Response {
         return Response.with_body(302, "").header("Location", location)
     }
 
-    // Set a response header, returning self so calls chain. A header name or
-    // value must never contain CR or LF: those characters frame the header
-    // block, so an untrusted value carrying them could inject extra headers or
-    // split the response. Strip them before storing.
+    // Set a response header, returning self so calls chain. A name that is not a
+    // valid HTTP field token (it has a space, control, or separator byte) is
+    // dropped, and control bytes are stripped from the value (HTAB excepted).
+    // Either would otherwise frame a malformed response or inject extra headers,
+    // since CR/LF and other controls have meaning in the header block.
     fun header(self, name: String, value: String) -> Response {
-        let clean_name = name.replace("\r", "").replace("\n", "")
-        let clean_value = value.replace("\r", "").replace("\n", "")
-        self.headers.set(clean_name, clean_value)
+        if !is_valid_field_name(name) {
+            return self
+        }
+        self.headers.set(name, sanitize_field_value(value))
         return self
     }
 
@@ -989,6 +991,56 @@ fun sanitize_status(status: Int) -> Int {
         return 500
     }
     return status
+}
+
+// True if `b` is an HTTP token character (RFC 7230): a letter, digit, or one of
+// the punctuation marks a field name may contain. A field name is `1*tchar`, so
+// a space, control, or separator byte makes the name invalid.
+fun is_tchar(b: Int) -> Bool {
+    if b >= 65 && b <= 90 {
+        return true
+    }
+    if b >= 97 && b <= 122 {
+        return true
+    }
+    if b >= 48 && b <= 57 {
+        return true
+    }
+    // ! # $ % & ' * + - . ^ _ ` | ~
+    return b == 33 || b == 35 || b == 36 || b == 37 || b == 38 || b == 39 || b == 42 || b == 43
+        || b == 45 || b == 46 || b == 94 || b == 95 || b == 96 || b == 124 || b == 126
+}
+
+// A field name is valid when it is non-empty and every byte is a token character.
+fun is_valid_field_name(name: String) -> Bool {
+    if name.length() == 0 {
+        return false
+    }
+    let i = 0
+    while i < name.length() {
+        if !is_tchar(__str_byte_at(name, i)) {
+            return false
+        }
+        i += 1
+    }
+    return true
+}
+
+// Strip the bytes a field value must not contain: the C0 controls and DEL,
+// except HTAB which is allowed. The visible bytes and obs-text (0x80..0xFF) are
+// kept, so a normal value is unchanged.
+fun sanitize_field_value(value: String) -> String {
+    let out = ""
+    let i = 0
+    while i < value.length() {
+        let b = __str_byte_at(value, i)
+        let forbidden = (b < 32 && b != 9) || b == 127
+        if !forbidden {
+            out = out.concat(value.substring(i, i + 1))
+        }
+        i += 1
+    }
+    return out
 }
 
 // Remove every header whose name matches `lower_name` (already lowercase),

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1378,6 +1378,20 @@ fn http_server_reason_and_head_responses() {
 }
 
 #[test]
+fn http_server_validates_response_headers() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Regression for #742: the response builder drops a header with an invalid
+    // field name and strips control bytes from a value, so a handler cannot frame
+    // a malformed response or inject extra headers.
+    let expected = "bad-name dropped: true\n\
+                    good present: true\n\
+                    control stripped: true\n";
+    compile_link_run_and_check("http_server_header_validation.rv", expected, &runtime);
+}
+
+#[test]
 fn http_server_sanitizes_invalid_status_codes() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
`Response.header` removed only CR and LF, so a handler could set a field name with a space (or other byte forbidden in a token) or a value with a NUL (or other control byte), and `write_response` sent them unchanged, producing a malformed response clients may reject or parse inconsistently:

```raven
Response.text("body")
    .header("Bad Name", "ok")          // space is not a token char
    .header("X-Nul", __str_from_byte(0))   // NUL is a forbidden control
```

`header` now drops a header whose name is not a valid HTTP token (`1*tchar`, RFC 7230) and strips the C0 control bytes and DEL from the value, keeping HTAB and the visible/obs-text bytes. CR/LF stripping is subsumed (they are neither token chars nor allowed value bytes).

Verified end to end by `http_server_header_validation.rv` (server plus raw-socket client) and a codegen smoke test: a space-named header is dropped, a control byte in a value is removed, and a normal header passes through.

Fixes #742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an HTTP server example and smoke test that demonstrate header validation behavior.
* **Bug Fixes**
  * Improved HTTP response header handling to drop invalid header names.
  * Header values now have unsafe control characters removed, while still allowing tabs.
  * This helps prevent malformed HTTP responses caused by forbidden header bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->