### PR TITLE
HTTP server: honor close in a multi-token Connection header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.201] - 2026-06-25
+
+### Fixed
+
+- The HTTP server honors a `close` token in a multi-token `Connection` header. It compared the whole header value as one string, so an HTTP/1.1 `Connection: keep-alive, close` was treated as keep-alive and the connection was retained against the client's request; the value is now split into comma-separated tokens and each is checked, so a `close` beside any other option closes the connection (#744).
+
 ## [2.18.200] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.200"
+version = "2.18.201"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_server_connection_tokens.rv
+++ b/examples/v2/http_server_connection_tokens.rv
@@ -70,6 +70,9 @@ fun main() {
     println("keep-alive+close closes: ${closes(r1)}")
     let r2 = send(addr, "GET / HTTP/1.1\r\nHost: t\r\nConnection: close, x\r\n\r\n")
     println("close+x closes: ${closes(r2)}")
+    // A close on one Connection line beside a keep-alive on another must combine.
+    let r3 = send(addr, "GET / HTTP/1.1\r\nHost: t\r\nConnection: close\r\nConnection: keep-alive\r\n\r\n")
+    println("split close closes: ${closes(r3)}")
 
     app.shutdown()
 }

--- a/examples/v2/http_server_connection_tokens.rv
+++ b/examples/v2/http_server_connection_tokens.rv
@@ -1,0 +1,75 @@
+// Starts an HTTP server in a goroutine and probes it over a raw TCP socket to
+// check that a `close` token in a multi-token Connection header is honored:
+// `keep-alive, close` and `close, x` must both close the connection, not keep it.
+// golden:skip (binds a port and depends on timing, so it is not diffed by the
+// golden suite; run it directly to verify the server response path).
+import std/http { Server, Response, Request }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun ok(req: Request) -> Response {
+    return Response.text("body")
+}
+
+fun headers_block(s: String) -> String {
+    let idx = s.index_of("\r\n\r\n")
+    if idx < 0 {
+        return s
+    }
+    return s.substring(0, idx)
+}
+
+fun closes(resp: String) -> Bool {
+    return headers_block(resp).to_lower().index_of("connection: close") >= 0
+}
+
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun send(addr: String, request: String) -> String {
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(request)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+    return result
+}
+
+fun main() {
+    let addr = "127.0.0.1:19479"
+    let app = Server.new()
+    app.get("/", ok)
+    spawn(fun() -> Unit {
+        app.listen(addr)
+    })
+
+    let r1 = send(addr, "GET / HTTP/1.1\r\nHost: t\r\nConnection: keep-alive, close\r\n\r\n")
+    println("keep-alive+close closes: ${closes(r1)}")
+    let r2 = send(addr, "GET / HTTP/1.1\r\nHost: t\r\nConnection: close, x\r\n\r\n")
+    println("close+x closes: ${closes(r2)}")
+
+    app.shutdown()
+}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -859,11 +859,13 @@ fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error
                 return Err(error_kind("http", "conflicting Content-Length"))
             }
         }
-        // Repeated Transfer-Encoding lines combine into one comma-separated
-        // coding list, so a split `gzip` + `chunked` cannot hide a coding the
-        // server does not implement.
-        if key == "transfer-encoding" {
-            let existing = headers.get_or("transfer-encoding", "")
+        // Repeated Transfer-Encoding or Connection lines combine into one
+        // comma-separated list, so a split set of options is seen whole: a
+        // `gzip` + `chunked` coding cannot hide a coding the server does not
+        // implement, and a `close` on one line beside a `keep-alive` on another
+        // is still honored as a close.
+        if key == "transfer-encoding" || key == "connection" {
+            let existing = headers.get_or(key, "")
             if existing.length() > 0 {
                 value = existing.concat(", ").concat(value)
             }

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -546,15 +546,32 @@ fun serve_connection(server: Server, stream: TcpStream) {
     stream.close()
 }
 
+// Whether the `Connection` header value carries `token` as one of its
+// comma-separated options, compared after trimming each. The whole value cannot
+// be compared directly: `keep-alive, close` lists two options, and a `close`
+// beside another option must still be honored.
+fun connection_has_token(conn: String, token: String) -> Bool {
+    let parts = conn.split(",")
+    let i = 0
+    while i < parts.len() {
+        if parts[i].trim() == token {
+            return true
+        }
+        i += 1
+    }
+    return false
+}
+
 // Whether to keep the connection open for another request. HTTP/1.1 keeps it
-// open unless the client sent `Connection: close`; HTTP/1.0 closes it unless
-// the client sent `Connection: keep-alive`.
+// open unless the client sent a `close` option; HTTP/1.0 closes it unless the
+// client sent a `keep-alive` option. The `Connection` header is a list of
+// tokens, so each is checked individually.
 fun should_keep_alive(req: Request) -> Bool {
     let conn = req.header("connection").to_lower()
     if req.version == "HTTP/1.0" {
-        return conn == "keep-alive"
+        return connection_has_token(conn, "keep-alive")
     }
-    return conn != "close"
+    return !connection_has_token(conn, "close")
 }
 
 // A connectable address for the shutdown wakeup. A server bound to the

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1396,10 +1396,12 @@ fn http_server_honors_close_in_multi_token_connection() {
     let Some(runtime) = supported_runtime() else {
         return;
     };
-    // Regression for #744: a `close` token beside another Connection option must
-    // still close the connection, not be ignored.
+    // Regression for #744: a `close` token beside another Connection option,
+    // whether on the same line or a repeated Connection line, must still close
+    // the connection, not be ignored.
     let expected = "keep-alive+close closes: true\n\
-                    close+x closes: true\n";
+                    close+x closes: true\n\
+                    split close closes: true\n";
     compile_link_run_and_check("http_server_connection_tokens.rv", expected, &runtime);
 }
 

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1392,6 +1392,18 @@ fn http_server_validates_response_headers() {
 }
 
 #[test]
+fn http_server_honors_close_in_multi_token_connection() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Regression for #744: a `close` token beside another Connection option must
+    // still close the connection, not be ignored.
+    let expected = "keep-alive+close closes: true\n\
+                    close+x closes: true\n";
+    compile_link_run_and_check("http_server_connection_tokens.rv", expected, &runtime);
+}
+
+#[test]
 fn http_server_sanitizes_invalid_status_codes() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
The server compared the whole `Connection` header value as one string, so an HTTP/1.1 `Connection: keep-alive, close` was read as keep-alive and the connection was retained even though the client asked to close it.

```text
GET / HTTP/1.1
Connection: keep-alive, close      # the close token was ignored
```

`should_keep_alive` now splits the `Connection` value into its comma-separated tokens and checks each, so a `close` beside any other option closes the connection (and an HTTP/1.0 `keep-alive` token is recognized the same way).

Verified end to end by `http_server_connection_tokens.rv` (server plus raw-socket client) and a codegen smoke test: `keep-alive, close` and `close, x` both produce a `Connection: close` response.

Fixes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP connections now reliably close when `Connection` includes a `close` token, even alongside other options (e.g., `keep-alive, close` and mixed/repeated forms).
  * Keep-alive decisions now correctly interpret comma-separated `Connection` header tokens across HTTP versions.
* **Tests**
  * Added a regression smoke test covering multi-token `Connection` header handling to prevent future regressions.
* **Chores**
  * Updated the release version to **2.18.201**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->