### PR TITLE
random: weighted_choice ignores non-positive weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.202] - 2026-06-25
+
+### Fixed
+
+- `Rng.weighted_choice` ignores non-positive weights instead of summing them. A negative weight was added to the total and the cumulative sum, which could shrink the total to zero or below (making every draw return `None`) or leave a later positive item unreachable; only positive weights now contribute, so a non-positive weight is simply never drawn (#737).
+
 ## [2.18.201] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.201"
+version = "2.18.202"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/random_weighted_choice.rv
+++ b/examples/v2/random_weighted_choice.rv
@@ -1,0 +1,37 @@
+// weighted_choice must ignore non-positive weights rather than summing them: a
+// negative weight beside positive ones used to shrink the total to <= 0 and make
+// every draw return None, hiding the reachable positive items.
+import std/random
+import std/io { println }
+
+fun main() {
+    let rng = Rng.new(0)
+    let xs = ["a", "b", "c"]
+    // b carries a negative weight; only a and c can be drawn.
+    let weights = [1, 0 - 5, 2]
+
+    let drew_b = false
+    let none = 0
+    let drew_c = 0
+    let i = 0
+    while i < 1000 {
+        match rng.weighted_choice(xs, weights) {
+            Some(v) -> {
+                if v == "b" {
+                    drew_b = true
+                }
+                if v == "c" {
+                    drew_c = drew_c + 1
+                }
+            }
+            None -> {
+                none = none + 1
+            }
+        }
+        i = i + 1
+    }
+
+    println("never None: ${none == 0}")
+    println("negative-weight item never drawn: ${!drew_b}")
+    println("positive item past it reachable: ${drew_c > 0}")
+}

--- a/examples/v2/random_weighted_choice.rv.out
+++ b/examples/v2/random_weighted_choice.rv.out
@@ -1,0 +1,3 @@
+never None: true
+negative-weight item never drawn: true
+positive item past it reachable: true

--- a/stdlib/std/random.rv
+++ b/stdlib/std/random.rv
@@ -144,17 +144,22 @@ impl Rng {
         if weights.len() < count {
             count = weights.len()
         }
-        // Saturate the running sum so a set of large positive weights does not
-        // wrap past i64 into a non-positive total and lose the whole draw.
+        // A non-positive weight contributes nothing and is never drawn: counting
+        // a negative weight would shrink the total and the cumulative sum, leaving
+        // a later positive item unreachable. Only positive weights are summed, and
+        // the sum saturates so a set of large weights does not wrap past i64 into
+        // a non-positive total and lose the whole draw.
         let max = 9223372036854775807
         let total = 0
         let i = 0
         while i < count {
             let w = weights.get(i)
-            if w > 0 && total > max - w {
-                total = max
-            } else {
-                total = total + w
+            if w > 0 {
+                if total > max - w {
+                    total = max
+                } else {
+                    total = total + w
+                }
             }
             i = i + 1
         }
@@ -166,13 +171,15 @@ impl Rng {
         let j = 0
         while j < count {
             let w = weights.get(j)
-            if w > 0 && acc > max - w {
-                acc = max
-            } else {
-                acc = acc + w
-            }
-            if r < acc {
-                return Some(xs.get(j))
+            if w > 0 {
+                if acc > max - w {
+                    acc = max
+                } else {
+                    acc = acc + w
+                }
+                if r < acc {
+                    return Some(xs.get(j))
+                }
             }
             j = j + 1
         }


### PR DESCRIPTION
`Rng.weighted_choice` added every weight (including negative ones) to its total and cumulative sum. A negative weight could shrink the total to zero or below, making every draw return `None`, or leave a positive-weight item past it unreachable, so the result was not proportional to the positive weights.

```raven
rng.weighted_choice(["a", "b", "c"], [1, 0 - 5, 2])   // total was -2, always None
```

Only positive weights now contribute to the total and the cumulative sum, and a non-positive weight is skipped in the selection loop, so it is simply never drawn (its bucket has zero width). A draw is now proportional to the positive weights and `c` above is reachable.

Verified by `random_weighted_choice.rv` (golden example): with a negative middle weight, no draw returns `None`, the negative-weight item is never drawn, and the positive item past it is reachable.

Fixes #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `weighted_choice` now ignores non-positive weights, so negative values no longer distort selection and make later valid options unreachable.
  * Random selection is now more reliable when some entries have zero or negative weights.

* **Examples**
  * Added an example showing how weighted random selection behaves when non-positive weights are present.

* **Chores**
  * Updated the package version to `2.18.202`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->