### PR TITLE
random: gen_range_float never returns the excluded upper endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.203] - 2026-06-25
+
+### Fixed
+
+- `Rng.gen_range_float(lo, hi)` no longer returns the excluded upper endpoint `hi`. The convex-combination interpolation could round onto `hi`, especially when `lo` and `hi` are adjacent floats; it now re-draws until the result falls below `hi` (bounded, falling back to `lo`), keeping the interval half-open while staying finite for very wide ranges (#738).
+
 ## [2.18.202] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.202"
+version = "2.18.203"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/random_range_float_endpoint.rv
+++ b/examples/v2/random_range_float_endpoint.rv
@@ -1,0 +1,24 @@
+// gen_range_float must never return the excluded upper endpoint, even when lo
+// and hi are adjacent floats so the convex combination rounds onto hi. With
+// hi just above 1.0, every draw must stay strictly below hi (and at or above lo).
+import std/random
+import std/io { println }
+
+fun main() {
+    let rng = Rng.new(0)
+    let lo = 1.0
+    let hi = 1.0000000000000002
+    let in_range = true
+    let i = 0
+    while i < 1000 {
+        let v = rng.gen_range_float(lo, hi)
+        if v < lo || v >= hi {
+            in_range = false
+        }
+        i = i + 1
+    }
+    println(match in_range {
+        true -> "all below hi",
+        false -> "hit excluded endpoint",
+    })
+}

--- a/examples/v2/random_range_float_endpoint.rv.out
+++ b/examples/v2/random_range_float_endpoint.rv.out
@@ -1,0 +1,1 @@
+all below hi

--- a/stdlib/std/random.rv
+++ b/stdlib/std/random.rv
@@ -101,12 +101,28 @@ impl Rng {
         }
     }
 
-    // A float in [lo, hi). Interpolating as lo*(1-t) + hi*t keeps the result
-    // a convex combination of the endpoints, so it stays finite even when
-    // hi - lo would overflow to infinity for a very wide range.
+    // A float in [lo, hi). Interpolating as lo*(1-t) + hi*t keeps the result a
+    // convex combination of the endpoints, so it stays finite even when hi - lo
+    // would overflow to infinity for a very wide range. Rounding can still land
+    // the combination on the excluded endpoint hi (common when lo and hi are
+    // adjacent floats), so re-draw until it falls below hi. A draw lands in range
+    // with high probability, so this resolves in a draw or two; the loop is
+    // bounded so it always terminates, falling back to lo (the one value an empty
+    // or inverted range can yield).
     fun gen_range_float(self, lo: Float, hi: Float) -> Float {
-        let t = self.next_float()
-        return lo * (1.0 - t) + hi * t
+        if hi <= lo {
+            return lo
+        }
+        let attempts = 0
+        while attempts < 64 {
+            let t = self.next_float()
+            let r = lo * (1.0 - t) + hi * t
+            if r < hi {
+                return r
+            }
+            attempts = attempts + 1
+        }
+        return lo
     }
 
     // `n` elements drawn from `xs` without replacement, in random order. If


### PR DESCRIPTION
`Rng.gen_range_float(lo, hi)` documents the half-open interval `[lo, hi)`, but the convex-combination interpolation `lo*(1-t) + hi*t` could round onto `hi`. This is common when `lo` and `hi` are adjacent representable floats, where many `t` values round the result up to the excluded endpoint.

The function now re-draws until the result falls below `hi`. A draw lands in range with high probability, so it resolves in a draw or two; the loop is bounded (and falls back to `lo`) so it always terminates. The convex combination is kept, so a very wide range whose width would overflow to infinity still stays finite.

Verified by `random_range_float_endpoint.rv` (1000 draws over `[1.0, 1.0000000000000002)` all stay below `hi`); the existing wide-range example (`random_range_float_wide.rv`) is unchanged.

Fixes #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floating-point random range generation so the upper bound is no longer returned, keeping results within the expected half-open interval.
  * Improved behavior for very wide or adjacent float ranges to avoid rare boundary issues and ensure values stay finite.
* **Chores**
  * Updated the package version to `2.18.203`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->