### PR TITLE
tycheck: reject unary & (address-of) instead of treating it as identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.204] - 2026-06-25
+
+### Fixed
+
+- Unary `&` (address-of) is rejected at type-check instead of behaving as a silent identity operator. Code generation returned the operand unchanged, so `&x` compiled to `x` while looking like it took a reference; Raven has no reference or pointer type for it to produce, so the type checker now reports it as unsupported (#720).
+
 ## [2.18.203] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.203"
+version = "2.18.204"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -1478,7 +1478,17 @@ impl<'a, 'b> Checker<'a, 'b> {
                 self.unify(&Ty::Bool, &t, &operand.span)?;
                 Ok(Ty::Bool)
             }
-            UnaryOp::Ref => Ok(t),
+            // Raven has no reference or pointer type, so there is nothing for an
+            // address-of to produce. Accepting it silently (returning the operand
+            // unchanged) made `&x` a misleading no-op, so reject it instead.
+            UnaryOp::Ref => Err(RavenError::ty(
+                TypeError::Custom(
+                    "unary `&` (address-of) is not supported: Raven has no reference \
+                     or pointer type for it to produce"
+                        .into(),
+                ),
+                operand.span.clone(),
+            )),
         }
     }
 

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -86,6 +86,21 @@ fn generic_arg_violating_a_bound_is_rejected() {
 }
 
 #[test]
+fn unary_address_of_is_rejected() {
+    // Unary `&` has no reference or pointer type to produce, so it is rejected
+    // rather than silently returning the operand (issue #720).
+    let err = check("fun main() {\n    let x = 41\n    let y = &x\n}\n").unwrap_err();
+    match err {
+        RavenError::Type(b, _, _) => assert!(
+            matches!(*b, TypeError::Custom(ref m) if m.contains("address-of")),
+            "got: {:?}",
+            b
+        ),
+        other => panic!("expected a type error, got {:?}", other),
+    }
+}
+
+#[test]
 fn inferred_type_violating_a_bound_is_rejected() {
     // A call that infers a type argument violating the bound is rejected the
     // moment the inference variable resolves to a concrete type, not deferred


### PR DESCRIPTION
Unary `&` was accepted for any expression, type-checked as the operand's type, and code generation returned the operand unchanged. So `&x` compiled to `x` and behaved as a silent identity operator:

```raven
let x = 41
let y = &x      // y was just 41, not a reference
print(y + 1)    // printed 42
```

Raven has no reference or pointer type for an address-of to produce (FFI pointers are opaque and have no such operation), so the type checker now reports unary `&` as unsupported rather than miscompiling it. Binary `&` (bitwise AND) is unaffected.

Fixes #720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Address-of (`&`) is now rejected during type checking instead of compiling as if it were a no-op.
  - Improved the error message so unsupported use of `&` is reported clearly at the relevant source location.
  - Added test coverage to confirm this invalid syntax is consistently rejected.
- **Chores**
  - Updated the project version to **2.18.204**.
  - Added a changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->