### PR TITLE
encoding: base64/base32 decoders reject malformed padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.205] - 2026-06-25
+
+### Fixed
+
+- The base64 and base32 decoders reject malformed padding rather than accepting it. `base64_decode` now rejects a `=` before the final group and a third-position pad without a fourth (`X=Z=`); `base32_decode` now requires a length that is a multiple of 8 (a partial group was silently dropped) and rejects data after a padding byte (#434).
+
 ## [2.18.204] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.204"
+version = "2.18.205"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/std-encoding.md
+++ b/docs/v2/specs/std-encoding.md
@@ -32,8 +32,8 @@ fun main() {
 | `hex_encode(s: String)` | `String` | each input byte to two lowercase hex digits |
 | `hex_decode(s: String)` | `Result<String, Error>` | inverse; accepts lower, upper, or mixed; Err on an odd length or a non-hex byte |
 | `base64_encode(s: String)` | `String` | standard alphabet (`A-Z a-z 0-9 + /`), `=` padding |
-| `base64_decode(s: String)` | `Result<String, Error>` | inverse; honors `=` padding; Err on a bad length or a non-alphabet byte |
-| `base32_decode(s: String)` | `Result<String, Error>` | inverse; honors `=` padding; Err on a non-alphabet byte |
+| `base64_decode(s: String)` | `Result<String, Error>` | inverse; honors `=` padding; Err on a bad length, a non-alphabet byte, or misplaced padding |
+| `base32_decode(s: String)` | `Result<String, Error>` | inverse; honors `=` padding; Err on a bad length, a non-alphabet byte, or data after padding |
 
 ## Known vectors
 
@@ -48,10 +48,12 @@ The decoders reject malformed input with an `Err` rather than silently
 producing wrong bytes:
 
 - `hex_decode`: an odd length, or any byte outside `0-9 a-f A-F`, is an `Err`.
-- `base64_decode`: a length that is not a multiple of four, or any byte outside
-  the alphabet other than `=` padding, is an `Err`.
-- `base32_decode`: any byte outside the alphabet other than `=` padding is an
-  `Err`.
+- `base64_decode`: a length that is not a multiple of four, any byte outside
+  the alphabet other than `=` padding, or padding before the final group (or a
+  third-position pad without a fourth), is an `Err`.
+- `base32_decode`: a length that is not a multiple of eight, any byte outside
+  the alphabet other than `=` padding, or any data byte after a padding byte, is
+  an `Err`.
 
 ## Out of scope
 

--- a/examples/v2/encoding_padding_validation.rv
+++ b/examples/v2/encoding_padding_validation.rv
@@ -1,0 +1,37 @@
+// The base64 and base32 decoders reject malformed padding: padding before the
+// final group, data after padding, and a partial (non-aligned) group, while
+// valid encodings still round-trip.
+import std/encoding { base64_encode, base64_decode, base32_encode, base32_decode }
+fun rt64(s: String) -> Bool {
+    return match base64_decode(base64_encode(s)) {
+        Ok(d) -> d == s,
+        Err(_) -> false,
+    }
+}
+fun rt32(s: String) -> Bool {
+    return match base32_decode(base32_encode(s)) {
+        Ok(d) -> d == s,
+        Err(_) -> false,
+    }
+}
+fun rej64(s: String) -> Bool {
+    return match base64_decode(s) {
+        Ok(_) -> false,
+        Err(_) -> true,
+    }
+}
+fun rej32(s: String) -> Bool {
+    return match base32_decode(s) {
+        Ok(_) -> false,
+        Err(_) -> true,
+    }
+}
+fun main() {
+    print("rt64 hello: ${rt64("hello")}")
+    print("rt64 abc: ${rt64("abc")}")
+    print("rt32 hello: ${rt32("hello")}")
+    print("rt32 abcd: ${rt32("abcd")}")
+    print("b64 midpad rejected: ${rej64("QQ==QQ==")}")
+    print("b32 after-pad rejected: ${rej32("AA======AA======")}")
+    print("b32 partial rejected: ${rej32("AAA")}")
+}

--- a/examples/v2/encoding_padding_validation.rv.out
+++ b/examples/v2/encoding_padding_validation.rv.out
@@ -1,0 +1,7 @@
+rt64 hello: true
+rt64 abc: true
+rt32 hello: true
+rt32 abcd: true
+b64 midpad rejected: true
+b32 after-pad rejected: true
+b32 partial rejected: true

--- a/stdlib/std/encoding.rv
+++ b/stdlib/std/encoding.rv
@@ -179,6 +179,16 @@ fun base64_decode(s: String) -> Result<String, Error> {
         if c3 != 61 && v3 < 0 {
             return Err(encoding_error("base64 input has a non-alphabet character"))
         }
+        // Padding (`=`) is valid only in the final group, and a pad in the third
+        // position requires one in the fourth too (`XY==`, never `X=Z=`).
+        if c2 == 61 || c3 == 61 {
+            if i + 4 != n {
+                return Err(encoding_error("base64 padding before the final group"))
+            }
+            if c2 == 61 && c3 != 61 {
+                return Err(encoding_error("base64 padding is malformed"))
+            }
+        }
         let o0 = ((v0 << 2) | (v1 >> 4)) & 255
         out = __str_concat(out, __str_from_byte(o0))
         if c2 != 61 {
@@ -368,16 +378,25 @@ fun base32_encode(s: String) -> String {
 // byte is an Err rather than being silently skipped.
 fun base32_decode(s: String) -> Result<String, Error> {
     let n = __str_len(s)
+    // base32_encode always pads to a multiple of 8, so a different length is a
+    // truncated (partial) group rather than valid input.
+    if n % 8 != 0 {
+        return Err(encoding_error("base32 input length is not a multiple of 8"))
+    }
     let out = ""
     let acc = 0
     let bits = 0
+    let seen_pad = false
     let i = 0
     while i < n {
         let b = __str_byte_at(s, i)
         if b == 61 {
-            // `=` padding: no more data bits follow.
-            i = i + 1
+            // `=` padding: no more data bits follow, and nothing may come after.
+            seen_pad = true
         } else {
+            if seen_pad {
+                return Err(encoding_error("base32 data after padding"))
+            }
             let v = base32_value(b)
             if v < 0 {
                 return Err(encoding_error("base32 input has a non-alphabet character"))
@@ -389,8 +408,8 @@ fun base32_decode(s: String) -> Result<String, Error> {
                 let byte = (acc >> bits) & 255
                 out = __str_concat(out, __str_from_byte(byte))
             }
-            i = i + 1
         }
+        i = i + 1
     }
     return Ok(out)
 }


### PR DESCRIPTION
The encoding decoders return a `Result` and reject bad lengths and non-alphabet characters, but two padding cases slipped through:

- `base64_decode` accepted a `=` before the final group (`QQ==QQ==`) and a third-position pad without a fourth (`X=Z=`).
- `base32_decode` silently dropped a partial group (any length not a multiple of 8) and accepted data after a padding byte.

`base64_decode` now rejects padding before the final group and a malformed `XY=Z` pad. `base32_decode` requires a length that is a multiple of 8 (which `base32_encode` always produces) and rejects any data after a padding byte. Valid encodings still round-trip.

Verified by `encoding_padding_validation.rv` (golden example): round-trips for padded and unpadded-length inputs succeed, while `QQ==QQ==`, data-after-padding, and a partial base32 group are all rejected.

Fixes #434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Base64 decoding now enforces stricter `=` padding validation, rejecting malformed padding and misplacement cases.
  * Base32 decoding now rejects invalid input lengths and any data after `=` padding, improving consistency for malformed inputs.
* **Documentation**
  * Updated the standard encoding spec to include `base32_decode` and clarified invalid-input rules for base64/base32.
* **Tests**
  * Added an example demonstrating correct encode/decode round-trips and rejection of malformed padding.
* **Chores**
  * Bumped version to `2.18.205` and updated the changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->