### PR TITLE
stdlib: parse_float and JSON parsing preserve negative zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.206] - 2026-06-25
+
+### Fixed
+
+- `String.parse_float` and JSON number parsing preserve the sign of negative zero. Both negated a negative input by subtracting from `0.0`, and `0.0 - 0.0` is `+0.0`, so `-0.0` (and JSON `-0`) lost its sign; they now negate by multiplying by `-1.0`, which keeps `-0.0` (#740).
+
 ## [2.18.205] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.205"
+version = "2.18.206"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/negative_zero.rv
+++ b/examples/v2/negative_zero.rv
@@ -1,0 +1,27 @@
+// parse_float and JSON number parsing preserve the sign of negative zero:
+// negating by multiplying by -1 keeps -0.0, where subtracting from 0 would
+// collapse it to +0.0. 1.0 / -0.0 is -inf, so a negative reciprocal proves
+// the sign survived.
+import std/json { parse, JsonValue }
+fun pf(s: String) -> Bool {
+    return match s.parse_float() {
+        Some(x) -> 1.0 / x < 0.0,
+        None -> false,
+    }
+}
+fun jn(s: String) -> Bool {
+    return match parse(s) {
+        Ok(v) -> match v {
+            Number(x) -> 1.0 / x < 0.0,
+            _ -> false,
+        },
+        Err(_) -> false,
+    }
+}
+fun main() {
+    print("parse_float -0.0 neg: ${pf("-0.0")}")
+    print("parse_float 0.0 pos: ${pf("0.0") == false}")
+    print("json -0 neg: ${jn("-0")}")
+    print("json -0.0 neg: ${jn("-0.0")}")
+    print("json 0 pos: ${jn("0") == false}")
+}

--- a/examples/v2/negative_zero.rv.out
+++ b/examples/v2/negative_zero.rv.out
@@ -1,0 +1,5 @@
+parse_float -0.0 neg: true
+parse_float 0.0 pos: true
+json -0 neg: true
+json -0.0 neg: true
+json 0 pos: true

--- a/stdlib/std/json.rv
+++ b/stdlib/std/json.rv
@@ -305,7 +305,9 @@ fun parse_number(c: Cursor) -> Result<Float, Error> {
         }
     }
     if negative {
-        value = 0.0 - value
+        // Multiply by -1 rather than subtract from 0, so `-0` and `-0.0` keep
+        // their sign: `0.0 - 0.0` is `+0.0`, but `0.0 * -1.0` is `-0.0`.
+        value = value * (0.0 - 1.0)
     }
     return Ok(value)
 }

--- a/stdlib/std/string.rv
+++ b/stdlib/std/string.rv
@@ -554,7 +554,9 @@ impl String {
             return None
         }
         if neg {
-            return Some(0.0 - value)
+            // Multiply by -1 rather than subtract from 0, so a value of 0.0 keeps
+            // its sign: `0.0 - 0.0` is `+0.0`, but `0.0 * -1.0` is `-0.0`.
+            return Some(value * (0.0 - 1.0))
         }
         return Some(value)
     }


### PR DESCRIPTION
`String.parse_float` and JSON number parsing both negated a negative input by subtracting it from `0.0`. In IEEE 754, `0.0 - 0.0` is `+0.0`, so `-0.0` (and JSON `-0`) lost its sign and came back as positive zero.

Both now negate by multiplying by `-1.0`, since `0.0 * -1.0` is `-0.0`, preserving the sign.

Verified by `negative_zero.rv` (golden example): `parse_float("-0.0")`, JSON `-0`, and JSON `-0.0` all yield a value whose reciprocal is `-inf` (so the sign survived), while `0.0` stays positive.

Fixes #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Negative zero is now preserved when parsing floating-point values from strings and JSON.
  * Inputs like `-0.0` and `-0` now keep their negative sign instead of becoming plain `0.0`.
  * Added an example demonstrating the expected results for positive and negative zero parsing.

* **Chores**
  * Updated the workspace version to `2.18.206`.
  * Added a changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->