### PR TITLE
manifest: reject [fmt] widths outside their documented bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.208] - 2026-06-25
+
+### Fixed
+
+- The `rv.toml` manifest rejects `[fmt]` widths outside their documented bounds instead of accepting any value. `indent_width` must be 1..=16 and `wrap_width` must be 40..=200 (the ranges the docs state); a value outside the range is now an `invalid value for [fmt]....` error rather than being silently used (#721).
+
 ## [2.18.207] - 2026-06-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.207"
+version = "2.18.208"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -44,6 +44,14 @@ pub const DEFAULT_INDENT_WIDTH: u32 = 4;
 /// The default `[fmt].wrap_width` when the section or field is absent.
 pub const DEFAULT_WRAP_WIDTH: u32 = 100;
 
+/// The inclusive bounds for `[fmt].indent_width`, matching the documented range.
+pub const MIN_INDENT_WIDTH: u32 = 1;
+pub const MAX_INDENT_WIDTH: u32 = 16;
+
+/// The inclusive bounds for `[fmt].wrap_width`, matching the documented range.
+pub const MIN_WRAP_WIDTH: u32 = 40;
+pub const MAX_WRAP_WIDTH: u32 = 200;
+
 /// A parsed `rv.toml` manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Manifest {
@@ -284,13 +292,37 @@ impl Manifest {
             })
             .unwrap_or_default();
 
-        let fmt = raw
-            .fmt
-            .map(|f| Fmt {
-                indent_width: f.indent_width.unwrap_or(DEFAULT_INDENT_WIDTH),
-                wrap_width: f.wrap_width.unwrap_or(DEFAULT_WRAP_WIDTH),
-            })
-            .unwrap_or_default();
+        let fmt = match raw.fmt {
+            Some(f) => {
+                let indent_width = f.indent_width.unwrap_or(DEFAULT_INDENT_WIDTH);
+                if !(MIN_INDENT_WIDTH..=MAX_INDENT_WIDTH).contains(&indent_width) {
+                    return Err(ManifestError::InvalidValue {
+                        section: "fmt".to_string(),
+                        field: "indent_width".to_string(),
+                        message: format!(
+                            "must be between {} and {}",
+                            MIN_INDENT_WIDTH, MAX_INDENT_WIDTH
+                        ),
+                    });
+                }
+                let wrap_width = f.wrap_width.unwrap_or(DEFAULT_WRAP_WIDTH);
+                if !(MIN_WRAP_WIDTH..=MAX_WRAP_WIDTH).contains(&wrap_width) {
+                    return Err(ManifestError::InvalidValue {
+                        section: "fmt".to_string(),
+                        field: "wrap_width".to_string(),
+                        message: format!(
+                            "must be between {} and {}",
+                            MIN_WRAP_WIDTH, MAX_WRAP_WIDTH
+                        ),
+                    });
+                }
+                Fmt {
+                    indent_width,
+                    wrap_width,
+                }
+            }
+            None => Fmt::default(),
+        };
 
         Ok(Manifest {
             package: Package {
@@ -395,6 +427,22 @@ version = "0.0.1"
         assert_eq!(m.ffi, Ffi::default());
         assert_eq!(m.fmt.indent_width, DEFAULT_INDENT_WIDTH);
         assert_eq!(m.fmt.wrap_width, DEFAULT_WRAP_WIDTH);
+    }
+
+    #[test]
+    fn fmt_widths_outside_bounds_are_rejected() {
+        let indent_too_big =
+            "[package]\nname = \"x\"\nversion = \"0.0.1\"\n[fmt]\nindent_width = 100\n";
+        assert!(Manifest::from_toml_str(indent_too_big).is_err());
+        let wrap_too_small =
+            "[package]\nname = \"x\"\nversion = \"0.0.1\"\n[fmt]\nwrap_width = 10\n";
+        assert!(Manifest::from_toml_str(wrap_too_small).is_err());
+        // The documented bounds (indent 1..=16, wrap 40..=200) parse fine.
+        let in_bounds =
+            "[package]\nname = \"x\"\nversion = \"0.0.1\"\n[fmt]\nindent_width = 16\nwrap_width = 200\n";
+        let m = Manifest::from_toml_str(in_bounds).expect("in-bounds widths parse");
+        assert_eq!(m.fmt.indent_width, 16);
+        assert_eq!(m.fmt.wrap_width, 200);
     }
 
     #[test]


### PR DESCRIPTION
The `rv.toml` manifest read `[fmt].indent_width` and `[fmt].wrap_width` and used whatever value was given, even though the docs document bounds (`indent_width` 1-16, `wrap_width` 40-200). An out-of-range value was silently accepted and passed to the formatter.

The manifest now validates both against their documented ranges (`indent_width` `1..=16`, `wrap_width` `40..=200`) and returns an `invalid value for [fmt]....` error for anything outside, consistent with the other manifest validation. In-bounds values still parse.

Fixes #721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for `rv.toml` formatting settings so out-of-range `indent_width` and `wrap_width` values now return a clear error instead of being accepted silently.
  * Accepted values at the documented boundaries continue to work as expected.

* **Chores**
  * Updated the package version to **2.18.208**.
  * Added a changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->