### PR TITLE
docs: rvpm getting-started page matches the current CLI

### DIFF
--- a/docs/getting-started/rvpm-and-format.md
+++ b/docs/getting-started/rvpm-and-format.md
@@ -1,17 +1,26 @@
 # rvpm (project tool) and formatting
 
-**rvpm** is the Raven project helper shipped with the toolchain (same repository as `raven`). It discovers a project by walking upward from the current directory until it finds `rv.toml`.
+**rvpm** is the Raven project helper shipped with the toolchain (same repository as `raven`). It works on the package in the current directory, loading `rv.toml` from there.
 
 ## Commands
 
 | Command | Description |
 |--------|-------------|
-| `rvpm init [name]` | Create a new project: `rv.toml`, `src/main.rv`, `rv_env/`, optional `.gitignore`. |
-| `rvpm run` | Run `raven` on `src/main.rv` from the project root (requires `raven` on `PATH`). |
-| `rvpm fmt [paths...]` | Format `.rv` files (defaults to `src/` when run inside a project). |
-| `rvpm fmt --check` | Exit with failure if any file would change (CI / pre-commit). |
+| `rvpm init [name]` | Scaffold a new package in the current directory (`--lib` for a library). |
+| `rvpm new <name>` | Scaffold a new package in a fresh `<name>/` directory (`--lib`). |
+| `rvpm add <pkg>` | Add a dependency to `rv.toml`, then resolve and write `rv.lock`. |
+| `rvpm install` | Resolve `rv.toml` against `rv.lock` and fill the cache. |
+| `rvpm update [pkg]` | Re-resolve `rv.toml` and rewrite `rv.lock` for one package or all. |
+| `rvpm build` | Compile `src/main.rv` to a binary, or type-check a `lib.rv` library. |
+| `rvpm run [args]` | Build the application then run it, forwarding `args`. |
+| `rvpm test` | Run `fun test_*()` tests in `*_test.rv` files. |
+| `rvpm doc` | Generate Markdown API docs into `target/doc`. |
+| `rvpm fmt [paths]` | Format `.rv` files in place (`--check` to verify only). |
+| `rvpm fetch <pkg>` | Fetch `github.com/<user>/<repo>@<version>` into the shared cache. |
+| `rvpm lock` | Generate or validate `rv.lock` for the current package. |
+| `rvpm cache <sub>` | Inspect or clear the shared package cache (`dir`/`list`/`clean`). |
 
-`rvpm install` and `rvpm add` are reserved for future package management; they are not implemented yet.
+`rvpm init` scaffolds `rv.toml`, a `.gitignore`, and `src/main.rv` (an application) or `lib.rv` (with `--lib`).
 
 ## `rv.toml`
 
@@ -24,7 +33,7 @@ version = "0.1.0"
 authors = []
 
 [dependencies]
-# math = "1.0"
+# "github.com/user/raven-math" = "1.0"
 ```
 
 ### Optional `[fmt]` section
@@ -33,27 +42,27 @@ Configure the pretty-printer used by `rvpm fmt`:
 
 ```toml
 [fmt]
-indent_width = 4   # spaces per indent level (1–16, default 4)
+indent_width = 4   # spaces per indent level (1-16, default 4)
 wrap_width = 100   # soft wrap width (40-200, default 100)
 ```
 
-If `[fmt]` is missing or a value is out of range, defaults apply. When you run `rvpm fmt` outside a project (or with no discoverable `rv.toml`), formatting uses defaults only.
+If `[fmt]` (or one of its fields) is missing, the default applies. A value outside its documented range is an error, not silently clamped. When you run `rvpm fmt` outside a package (no `rv.toml`), formatting uses the defaults.
 
 Formatting **preserves** `//` and `/* */` comments by carrying them in the AST; long lines and signatures are wrapped according to `wrap_width` and `indent_width`.
 
 ## Typical workflow
 
 ```bash
-rvpm init my_app
-cd my_app
-rvpm run              # execute src/main.rv
-rvpm fmt              # format sources under src/
+rvpm init my_app      # scaffold rv.toml, .gitignore, src/main.rv here
+rvpm run              # build and run src/main.rv
+rvpm fmt              # format sources in place
 rvpm fmt --check      # verify formatting in CI
+rvpm test             # run *_test.rv tests
 ```
 
-For single files without a project, you can still run the formatter explicitly from code or tooling that calls `raven`’s format API; `rvpm fmt` accepts explicit file or directory paths.
+`rvpm fmt` accepts explicit file or directory paths; with none, it formats the `.rv` files of the current package.
 
 ## See also
 
-- [Quick Start](quick-start.md) — first program and `raven` CLI
-- [RVPM design notes](../RVPM_DESIGN.md) — broader package-manager plans
+- [Quick Start](quick-start.md) - first program and `raven` CLI
+- [RVPM design notes](../RVPM_DESIGN.md) - broader package-manager plans


### PR DESCRIPTION
The published `docs/getting-started/rvpm-and-format.md` page (under Getting Started in `mkdocs.yml`) described an older rvpm, so following it gave the wrong command set, project layout, and formatting behavior. Corrected:

- The command table now lists the implemented commands (`init`, `new`, `add`, `install`, `update`, `build`, `run`, `test`, `doc`, `fmt`, `fetch`, `lock`, `cache`); the false "install and add are reserved / not implemented" note is removed.
- Project discovery now says rvpm works on the package in the current directory (it loads `rv.toml` from there), not by walking upward.
- The `init` scaffold list matches what is created (`rv.toml`, `.gitignore`, `src/main.rv` or `lib.rv`), not `rv_env/`.
- The `[fmt]` section notes that an out-of-range width is now an error, not silently clamped.

Docs-only change.

Fixes #722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the getting started guide to match current `rvpm` behavior and command coverage.
  * Expanded the command reference and clarified formatting defaults, range handling, and behavior outside a package.
  * Refreshed the example package configuration and typical workflow steps for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->