### PR TITLE
build: keep Cargo.lock in sync with the workspace version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.209] - 2026-06-25
+
+### Fixed
+
+- `Cargo.lock` is kept in sync with the workspace version, so `cargo build --locked` (and `cargo install --locked`) works against a clean checkout. The committed lock had drifted behind the manifest version because routine builds rewrite it locally but CI never committed it; the lock now records the current version and is updated alongside future version bumps (#764).
+
 ## [2.18.208] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.174"
+version = "2.18.209"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.174"
+version = "2.18.209"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.208"
+version = "2.18.209"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
The committed `Cargo.lock` recorded the `raven` and `raven-runtime` packages at an old workspace version (`2.18.174`) while `Cargo.toml` had moved well past it. `cargo build --locked` and `cargo install --locked` therefore refused to build a clean checkout, because the lock did not match the manifest.

CI runs a plain `cargo build`, which silently rewrites the lock in the runner and never commits it, so the drift was invisible to CI. This updates the lock to the current version; future version bumps update `Cargo.lock` in the same commit so it cannot drift again.

`cargo build --locked` succeeds with this change.

Fixes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a lockfile/version mismatch so locked builds and installs now work from a clean checkout.
  * Corrected a lock drift issue to keep the project metadata aligned with the current release.

* **Chores**
  * Updated the project version to **2.18.209**.
  * Added a changelog entry for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->