### PR TITLE
manifest: reject dependency keys with a subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.210] - 2026-06-25
+
+### Fixed
+
+- The `rv.toml` manifest rejects a dependency key with a subpath (`github.com/<user>/<repo>/<sub>`). A dependency identifies a whole repository, but a subpath key was accepted and recorded in the lock as the source, while import resolution looks up the bare repository identity, so the lock entry could never be matched. A dependency key must now be a bare `github.com/<user>/<repo>` (#718).
+
 ## [2.18.209] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.209"
+version = "2.18.210"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.209"
+version = "2.18.210"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.209"
+version = "2.18.210"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -276,6 +276,14 @@ impl Manifest {
         for (key, constraint) in raw.dependencies {
             let github = GithubPath::parse(&key)
                 .ok_or_else(|| ManifestError::InvalidDependencyKey { key: key.clone() })?;
+            // A dependency identifies a whole repository, so its key must be a
+            // bare `github.com/<user>/<repo>`. A subpath (`.../repo/lib`) would
+            // be recorded in the lock as the source, but import resolution looks
+            // up the repository identity `github.com/<user>/<repo>`, so the lock
+            // entry could never be matched.
+            if !github.subpath.is_empty() {
+                return Err(ManifestError::InvalidDependencyKey { key });
+            }
             dependencies.push(Dependency {
                 path: key,
                 github,
@@ -443,6 +451,18 @@ version = "0.0.1"
         let m = Manifest::from_toml_str(in_bounds).expect("in-bounds widths parse");
         assert_eq!(m.fmt.indent_width, 16);
         assert_eq!(m.fmt.wrap_width, 200);
+    }
+
+    #[test]
+    fn dependency_subpath_key_is_rejected() {
+        // A dependency key with a subpath cannot be matched to a lock entry, so
+        // it is rejected (issue #718).
+        let with_subpath = "[package]\nname = \"x\"\nversion = \"0.0.1\"\n[dependencies]\n\"github.com/acme/demo/lib\" = \"1.0\"\n";
+        assert!(Manifest::from_toml_str(with_subpath).is_err());
+        // A bare repository key is accepted.
+        let bare = "[package]\nname = \"x\"\nversion = \"0.0.1\"\n[dependencies]\n\"github.com/acme/demo\" = \"1.0\"\n";
+        let m = Manifest::from_toml_str(bare).expect("bare dependency key parses");
+        assert_eq!(m.dependencies.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
The manifest parser accepted dependency keys with an import subpath, such as `github.com/acme/demo/lib`. Lock generation then recorded that whole path as the package source, but external import resolution always looks up the repository identity `github.com/acme/demo`, so it could never find the lock entry rvpm had just generated: the manifest and lock steps succeeded, but the matching import could not build.

A dependency key now must be a bare `github.com/<user>/<repo>`. A key whose parsed `GithubPath` has a non-empty subpath is rejected as an invalid dependency key. A subpath is still valid in an `import` statement (to import a module inside a repository); only the dependency *declaration* must name the repository.

Fixes #718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency entries in manifests now reject repository paths with extra subpaths, helping ensure imports match the correct lockfile entries.
  * Bare repository identifiers remain valid for dependencies, reducing confusion when configuring package references.
* **Chores**
  * Updated the release version to 2.18.210.
  * Added a changelog entry for the manifest validation update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->