### PR TITLE
fs: create_dir_all does not corrupt Windows UNC paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.214] - 2026-06-25
+
+### Fixed
+
+- `std/fs.create_dir_all` no longer corrupts a Windows UNC path. It split the path on `/` and rebuilt it, turning a leading `//server/share` into `/server/share` rooted on the current drive, so it created directories in the wrong place and returned `Ok`. It now hands the whole path to the OS through `create_dir`, which already creates every missing parent and resolves UNC paths, drive letters, and `..` correctly (#675).
+
 ## [2.18.213] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.213"
+version = "2.18.214"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.213"
+version = "2.18.214"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.213"
+version = "2.18.214"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/stdlib/std/fs.rv
+++ b/stdlib/std/fs.rv
@@ -138,27 +138,13 @@ fun is_symlink(path: String) -> Bool {
 }
 
 // Create `path` and every missing parent directory, like `mkdir -p`. An
-// already-existing directory in the chain is not an error.
+// already-existing directory in the chain is not an error. The OS resolves the
+// path: splitting and rebuilding it in Raven mishandled a Windows UNC path
+// (`//server/share`), rebuilding it as `/server/share` rooted on the current
+// drive, so the whole path is handed to `create_dir`, which already creates
+// every missing parent.
 fun create_dir_all(path: String) -> Result<Bool, Error> {
-    let abs = path.starts_with("/")
-    let prefix = ""
-    for seg in path.split("/") {
-        if seg.length() > 0 {
-            if prefix.length() == 0 {
-                if abs {
-                    prefix = "/".concat(seg)
-                } else {
-                    prefix = seg
-                }
-            } else {
-                prefix = prefix.concat("/").concat(seg)
-            }
-            if is_dir(prefix) == false {
-                let _made = create_dir(prefix)?
-            }
-        }
-    }
-    return Ok(true)
+    return create_dir(path)
 }
 
 // Read a whole file and split it into lines (handling CRLF).


### PR DESCRIPTION
`std/fs.create_dir_all` split the path on `/` and rebuilt it segment by segment. A leading `//server/share` (a Windows UNC path) lost a slash and became `/server/share`, rooted on the current drive: the function created directories in the wrong location, returned `Ok(true)`, and left the requested UNC path absent.

The runtime's `create_dir` already maps to `std::fs::create_dir_all`, which creates every missing parent and lets the OS resolve UNC paths, drive letters, and `..`. `create_dir_all` now hands it the whole path instead of rebuilding the path in Raven.

Verified on Windows: a nested path (`a/b/c`) is still created, and `create_dir_all("//nonexistent-server/share/x")` now returns an error and creates no local directory, where before it would silently create the path on the current drive.

Fixes #675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `create_dir_all` so it correctly handles Windows UNC paths, drive-letter paths, and `..` segments without corrupting the path.
  * Directory creation now preserves the full path when creating missing parent folders, improving reliability across platforms.

* **Chores**
  * Updated the package version to **2.18.214**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->