### PR TITLE
rvpm: accept slash-bearing branch names as dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.215] - 2026-06-25
+
+### Fixed
+
+- rvpm accepts a dependency version that is a slash-bearing Git branch name (`feature/parser`, `release/2.x`). The lock resolver rejected every `/` to keep the cache path a single component; it now validates the ref per slash-separated segment and the cache layer percent-encodes the slash into the directory name, while the original ref is used for the Git fetch (#723).
+
 ## [2.18.214] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.214"
+version = "2.18.215"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.214"
+version = "2.18.215"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.214"
+version = "2.18.215"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -674,10 +674,11 @@ fn resolved_ref(dep: &crate::manifest::Dependency) -> Result<String, LockError> 
             source: dep_source(&dep.path),
         });
     }
-    // The version becomes a directory name under the cache, so it must be a
-    // single, in-tree path component: reject a separator, `..`, drive colon, or
-    // control character that could climb out of the cache root.
-    if !crate::pkg::is_safe_cache_component(r) {
+    // The version is a Git ref (a tag or branch) that becomes a cache directory
+    // name. A branch ref may contain `/` (`feature/parser`), so it is validated
+    // as a ref (each `/`-segment is in-tree and safe) and percent-encoded by the
+    // cache layer, rather than rejected outright for the separator.
+    if !crate::pkg::is_safe_ref(r) {
         return Err(LockError::InvalidConstraint {
             source: dep_source(&dep.path),
             value: r.to_string(),

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -142,8 +142,9 @@ pub enum LockError {
     },
     /// A dependency constraint was not a usable git ref (empty).
     EmptyConstraint { source: String },
-    /// A dependency constraint held a path separator or `..`, which could
-    /// escape the cache directory when used as a directory name.
+    /// A dependency constraint was not a usable git ref: a `/`-separated segment
+    /// was empty (a leading, trailing, or doubled slash), `.` or `..`, or held a
+    /// drive colon or control byte, any of which could escape the cache root.
     InvalidConstraint { source: String, value: String },
     /// A pinned tree hash did not match the fetched tree.
     HashMismatch {
@@ -187,7 +188,7 @@ impl fmt::Display for LockError {
             ),
             LockError::InvalidConstraint { source, value } => write!(
                 f,
-                "dependency '{}' has an invalid version '{}': a version may not contain a path separator or '..'",
+                "dependency '{}' has an invalid version '{}': each '/'-separated segment must be a non-empty in-tree name (no '.', '..', drive colon, or control character)",
                 source, value
             ),
             LockError::HashMismatch {

--- a/src/pkg/mod.rs
+++ b/src/pkg/mod.rs
@@ -117,10 +117,32 @@ pub fn cache_dir(host: &str, user: &str, repo: &str, version: &str) -> PathBuf {
 /// The cache directory for one package version under an explicit cache
 /// root. Threading the root explicitly lets callers (and tests) avoid the
 /// global `RVPM_CACHE_DIR` environment variable and the races it brings.
+///
+/// The version becomes part of a single directory name (`<repo>@<version>`), so
+/// a slash in a branch ref (`feature/parser`) is percent-encoded to keep it one
+/// component. The git operations receive the original version, not this name.
 pub fn cache_dir_in(root: &Path, host: &str, user: &str, repo: &str, version: &str) -> PathBuf {
     root.join(host)
         .join(user)
-        .join(format!("{}@{}", repo, version))
+        .join(format!("{}@{}", repo, encode_cache_version(version)))
+}
+
+/// Percent-encode the characters that would break a version's use as a single
+/// cache directory component. A `/` (valid in a Git branch ref like
+/// `release/2.x`) becomes `%2F`; `%` itself is encoded first so the mapping is
+/// reversible and collision-free.
+fn encode_cache_version(version: &str) -> String {
+    version.replace('%', "%25").replace('/', "%2F")
+}
+
+/// Whether `r` is safe to use as a Git ref that becomes a cache version. Unlike
+/// a single cache component, a ref may contain `/` (a branch like
+/// `feature/parser`), so each `/`-separated segment must be a safe component:
+/// this rejects an empty segment (a leading, trailing, or doubled slash), `.`
+/// or `..`, and a drive colon or control character, while allowing the slashes
+/// between segments.
+pub fn is_safe_ref(r: &str) -> bool {
+    !r.is_empty() && r.split('/').all(is_safe_cache_component)
 }
 
 /// Whether `s` is safe to use as a single path component under the package
@@ -454,6 +476,32 @@ mod tests {
         ] {
             assert!(!is_safe_cache_component(bad), "should reject `{bad:?}`");
         }
+    }
+
+    #[test]
+    fn safe_ref_allows_slashed_branch_names() {
+        // A branch ref may contain `/`; each segment must still be safe.
+        for ok in ["v1.2.3", "feature/parser", "release/2.x", "fix/windows"] {
+            assert!(is_safe_ref(ok), "should accept `{ok}`");
+        }
+        // A separator escape, an empty segment, or `..` is still rejected.
+        for bad in ["", "../x", "a/../b", "feature/", "/leading", "a//b"] {
+            assert!(!is_safe_ref(bad), "should reject `{bad:?}`");
+        }
+    }
+
+    #[test]
+    fn cache_dir_encodes_a_slashed_version_into_one_component() {
+        let root = Path::new("/cache");
+        let dir = cache_dir_in(root, "github.com", "acme", "demo", "feature/parser");
+        // The `@version` stays a single component: the slash is percent-encoded.
+        assert_eq!(
+            dir.file_name().unwrap().to_str().unwrap(),
+            "demo@feature%2Fparser"
+        );
+        // A `%` in the ref is encoded first, so the mapping cannot collide.
+        let pct = cache_dir_in(root, "github.com", "acme", "demo", "a%2Fb");
+        assert_eq!(pct.file_name().unwrap().to_str().unwrap(), "demo@a%252Fb");
     }
 
     #[test]


### PR DESCRIPTION
rvpm rejected valid Git branch names that contain `/`. The manifest and CLI describe a dependency version as a literal tag or branch, but `resolved_ref` rejected every path separator to protect the cache path, so `feature/parser`, `release/2.x`, and `fix/windows` could not be used as a Raven dependency constraint.

The version is validated as a ref now (`is_safe_ref`: each `/`-separated segment must be a safe in-tree component, so `..`, an empty segment, a drive colon, and control bytes are still rejected, but the slashes between segments are allowed). The cache layer percent-encodes the slash (`feature/parser` becomes the directory `demo@feature%2Fparser`, a single component), while the original ref is passed to the git fetch.

Fixes #723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for dependency version references that use Git branch names containing `/` (e.g., `feature/parser`, `release/2.x`).
  * Strengthened validation to reject unsafe/invalid ref segments (including empty segments and `.`/`..`), with clearer error behavior.
  * Fixed cache directory naming so slash-containing refs don’t create unintended path components, while Git operations still use the original ref.
* **Tests**
  * Added coverage for slash-containing refs and cache directory encoding.
* **Documentation**
  * Updated the changelog with this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->