### PR TITLE
rvpm: encode Windows-forbidden characters in cache version names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.217] - 2026-06-25
+
+### Fixed
+
+- rvpm encodes a dependency version's Windows-forbidden filename characters (`<`, `>`, `"`, `|`, and also `?`/`*`) when forming the cache directory name. These pass `git check-ref-format`, so a Git-valid branch or tag using them previously failed on Windows before the fetch; each is now percent-encoded into the cache component the same way `/` and `%` already are (#811).
+
 ## [2.18.216] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.216"
+version = "2.18.217"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.216"
+version = "2.18.217"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.216"
+version = "2.18.217"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/pkg/mod.rs
+++ b/src/pkg/mod.rs
@@ -128,11 +128,27 @@ pub fn cache_dir_in(root: &Path, host: &str, user: &str, repo: &str, version: &s
 }
 
 /// Percent-encode the characters that would break a version's use as a single
-/// cache directory component. A `/` (valid in a Git branch ref like
-/// `release/2.x`) becomes `%2F`; `%` itself is encoded first so the mapping is
-/// reversible and collision-free.
+/// cache directory component. A `/` is valid in a Git branch ref
+/// (`release/2.x`); `<`, `>`, `"`, and `|` pass `git check-ref-format` but are
+/// forbidden in a Windows filename, so a Git-valid ref using them would fail on
+/// Windows before the fetch. Each becomes a `%XX` escape; `%` itself is encoded
+/// first so the mapping is reversible and collision-free.
 fn encode_cache_version(version: &str) -> String {
-    version.replace('%', "%25").replace('/', "%2F")
+    let mut out = String::with_capacity(version.len());
+    for c in version.chars() {
+        match c {
+            '%' => out.push_str("%25"),
+            '/' => out.push_str("%2F"),
+            '<' => out.push_str("%3C"),
+            '>' => out.push_str("%3E"),
+            '"' => out.push_str("%22"),
+            '|' => out.push_str("%7C"),
+            '?' => out.push_str("%3F"),
+            '*' => out.push_str("%2A"),
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 /// Whether `r` is safe to use as a Git ref that becomes a cache version. Unlike
@@ -502,6 +518,13 @@ mod tests {
         // A `%` in the ref is encoded first, so the mapping cannot collide.
         let pct = cache_dir_in(root, "github.com", "acme", "demo", "a%2Fb");
         assert_eq!(pct.file_name().unwrap().to_str().unwrap(), "demo@a%252Fb");
+        // Characters that pass `git check-ref-format` but are forbidden in a
+        // Windows filename are encoded too, so a Git-valid ref is a usable name.
+        let win = cache_dir_in(root, "github.com", "acme", "demo", "feat<x>\"y|z?*");
+        assert_eq!(
+            win.file_name().unwrap().to_str().unwrap(),
+            "demo@feat%3Cx%3E%22y%7Cz%3F%2A"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The cache directory name percent-encodes a dependency version's `/` and `%` (added for slash-bearing branch refs), but not the characters that pass `git check-ref-format` yet are forbidden in a Windows filename: `<`, `>`, `"`, and `|`. A Git-valid branch or tag using one of those failed on Windows when rvpm tried to create the cache directory, before it ever reached the remote.

`encode_cache_version` now percent-encodes those characters as well (plus `?` and `*`, also Windows-reserved), so the `<repo>@<version>` cache entry is always a valid single component. The original ref is still used for the git fetch.

Fixes #811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache directory naming so dependency versions with Windows-forbidden characters (including `?` and `*`) are safely encoded.
  * Improved handling of Git refs that previously could fail on Windows before fetching, reducing cache-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->