### PR TITLE
http: tighten server request validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.219] - 2026-06-25
+
+### Fixed
+
+- The HTTP server rejects more malformed requests with 400 instead of routing them: a header field name that is not a valid token (a space or tab inside or before the name) (#812), a request with more than one `Host` header (#814), a chunk size with a leading sign or surrounding whitespace (#816), and a `Content-Length` with a leading `+` or `-` sign (#817). Numeric request fields are now validated as strict digit/hex strings rather than passed to a lenient integer parse.
+
 ## [2.18.218] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.218"
+version = "2.18.219"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.218"
+version = "2.18.219"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.218"
+version = "2.18.219"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_request_validation.rv
+++ b/examples/v2/http_request_validation.rv
@@ -79,5 +79,17 @@ fun main() {
     let low_method = "get /x HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n"
     println("low-method: ${status_of(addr, low_method)}")
 
+    let bad_name = "GET /x HTTP/1.1\r\nHost: t\r\nBad Name: v\r\nConnection: close\r\n\r\n"
+    println("bad-name: ${status_of(addr, bad_name)}")
+
+    let dup_host = "GET /x HTTP/1.1\r\nHost: a\r\nHost: b\r\nConnection: close\r\n\r\n"
+    println("dup-host: ${status_of(addr, dup_host)}")
+
+    let plus_clen = "POST /x HTTP/1.1\r\nHost: t\r\nContent-Length: +1\r\nConnection: close\r\n\r\nx"
+    println("plus-clen: ${status_of(addr, plus_clen)}")
+
+    let bad_chunk = "POST /x HTTP/1.1\r\nHost: t\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n+5\r\nhello\r\n0\r\n\r\n"
+    println("bad-chunk: ${status_of(addr, bad_chunk)}")
+
     app.shutdown()
 }

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -722,8 +722,14 @@ fun decode_chunked(stream: TcpStream, initial: String) -> Result<ChunkedBody, Er
         if semi >= 0 {
             size_line = size_line.substring(0, semi)
         }
+        // A chunk size is one or more hex digits, nothing else: reject a leading
+        // sign or any surrounding whitespace (`+a`, ` a`, `a `) rather than
+        // trimming it away and accepting it.
+        if !is_hex_digits(size_line) {
+            return Err(error_kind("http", "invalid chunk size"))
+        }
         let size = 0
-        match from_radix(size_line.trim(), 16) {
+        match from_radix(size_line, 16) {
             Some(n) -> {
                 size = n
             }
@@ -840,15 +846,24 @@ fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error
         if line.starts_with(" ") || line.starts_with("\t") {
             return Err(error_kind("http", "obsolete header line folding"))
         }
-        // Every header is `name: value`; a line with no colon, or an empty
-        // name, is malformed.
+        // Every header is `name: value`; a line with no colon is malformed.
         let colon = line.index_of(":")
         if colon <= 0 {
             return Err(error_kind("http", "malformed header line"))
         }
-        let key = line.substring(0, colon).trim().to_lower()
-        if key.length() == 0 {
-            return Err(error_kind("http", "empty header name"))
+        // The field name is a token: it must be non-empty and every byte a token
+        // character, with no surrounding whitespace (a space or tab inside or
+        // before the name, like `X Foo:` or `Host :`, is malformed). Validate the
+        // raw name before lowercasing it for the lookup key.
+        let raw_name = line.substring(0, colon)
+        if !is_valid_field_name(raw_name) {
+            return Err(error_kind("http", "invalid header field name"))
+        }
+        let key = raw_name.to_lower()
+        // HTTP/1.1 allows exactly one Host header; a second is a routing and
+        // request-smuggling ambiguity, so reject a duplicate.
+        if key == "host" && headers.has("host") {
+            return Err(error_kind("http", "duplicate Host header"))
         }
         let value = line.substring(colon + 1, line.length()).trim()
         // Two Content-Length headers with different values are a request
@@ -901,6 +916,12 @@ fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error
         let want = 0
         let clen = headers.get_or("content-length", "")
         if clen.length() > 0 {
+            // Content-Length is one or more decimal digits, nothing else: reject a
+            // leading sign (`+5`, `-5`) or any surrounding whitespace rather than
+            // letting a lenient integer parse accept it.
+            if !is_all_digits(clen) {
+                return Err(error_kind("http", "invalid Content-Length"))
+            }
             match clen.parse_int() {
                 Some(n) -> {
                     want = n
@@ -1028,6 +1049,43 @@ fun is_tchar(b: Int) -> Bool {
     // ! # $ % & ' * + - . ^ _ ` | ~
     return b == 33 || b == 35 || b == 36 || b == 37 || b == 38 || b == 39 || b == 42 || b == 43
         || b == 45 || b == 46 || b == 94 || b == 95 || b == 96 || b == 124 || b == 126
+}
+
+// Non-empty and every byte an ASCII decimal digit. Used to validate a numeric
+// header field (Content-Length) strictly, with no sign or whitespace.
+fun is_all_digits(s: String) -> Bool {
+    if s.length() == 0 {
+        return false
+    }
+    let i = 0
+    while i < s.length() {
+        let b = __str_byte_at(s, i)
+        if b < 48 || b > 57 {
+            return false
+        }
+        i += 1
+    }
+    return true
+}
+
+// Non-empty and every byte an ASCII hex digit (`0-9`, `a-f`, `A-F`). Used to
+// validate a chunk size strictly, with no sign or surrounding whitespace.
+fun is_hex_digits(s: String) -> Bool {
+    if s.length() == 0 {
+        return false
+    }
+    let i = 0
+    while i < s.length() {
+        let b = __str_byte_at(s, i)
+        let digit = b >= 48 && b <= 57
+        let lower = b >= 97 && b <= 102
+        let upper = b >= 65 && b <= 70
+        if !(digit || lower || upper) {
+            return false
+        }
+        i += 1
+    }
+    return true
 }
 
 // A field name is valid when it is non-empty and every byte is a token character.

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1453,15 +1453,20 @@ fn http_server_rejects_malformed_requests() {
         return;
     };
     // A valid request is served, while a request line with the wrong token
-    // count, a header with no colon, two conflicting Content-Length headers, and
-    // an HTTP/1.1 request with no Host are each rejected with 400 instead of
-    // being parsed loosely.
+    // count, a header with no colon, two conflicting Content-Length headers, an
+    // HTTP/1.1 request with no Host, a lowercase method, a header name with a
+    // space, a duplicate Host, a plus-signed Content-Length, and a plus-signed
+    // chunk size are each rejected with 400 instead of being parsed loosely.
     let expected = "valid: HTTP/1.1 200 OK\n\
                     bad-line: HTTP/1.1 400 Bad Request\n\
                     no-colon: HTTP/1.1 400 Bad Request\n\
                     dup-clen: HTTP/1.1 400 Bad Request\n\
                     no-host: HTTP/1.1 400 Bad Request\n\
-                    low-method: HTTP/1.1 400 Bad Request\n";
+                    low-method: HTTP/1.1 400 Bad Request\n\
+                    bad-name: HTTP/1.1 400 Bad Request\n\
+                    dup-host: HTTP/1.1 400 Bad Request\n\
+                    plus-clen: HTTP/1.1 400 Bad Request\n\
+                    bad-chunk: HTTP/1.1 400 Bad Request\n";
     compile_link_run_and_check("http_request_validation.rv", expected, &runtime);
 }
 


### PR DESCRIPTION
The HTTP server accepted several malformed request forms that an HTTP/1.1 parser must reject, routing them to the handler with a 200 instead of answering 400. This hardens four cases:

- **Header field name** (#812): the name must be a token. A space or tab inside or before the name (`X Foo:`, `Host :`) is now rejected instead of trimmed and accepted.
- **Duplicate Host** (#814): HTTP/1.1 allows exactly one `Host` header; a second is now rejected as a routing and smuggling ambiguity.
- **Chunk size** (#816): a chunked chunk-size line must be hex digits only. A leading sign or surrounding whitespace (`+5`, ` 5`) is rejected rather than trimmed away.
- **Content-Length** (#817): the value must be decimal digits only. A leading `+`/`-` sign is rejected rather than accepted by a lenient integer parse.

Numeric request fields are validated with strict digit/hex helpers before parsing. The `http_request_validation` self-test (a server probed over raw TCP) is extended to cover all four cases; all return 400.

Fixes #812
Fixes #814
Fixes #816
Fixes #817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP requests with malformed headers, duplicate `Host` headers, invalid `Content-Length` values, or broken chunked bodies are now rejected with `400 Bad Request`.
  * Request parsing is stricter for numeric fields, so signed or whitespace-padded values are no longer accepted.
  * Invalid header names are now detected more reliably, improving server behavior for malformed requests.

* **Chores**
  * Version updated to **2.18.219**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->