### PR TITLE
macros: reject template repetitions with no metavariable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.222] - 2026-06-25
+
+### Fixed
+
+- A macro template repetition that contains only literal tokens is now rejected at definition instead of silently expanding zero times. A template repetition expands once per matched item, and that count comes from a metavariable bound by a matcher repetition; a repetition of only literals has no such metavariable, so `($(foo),*) => { [$(1),*] }` used to drop every match and produce an empty result. It now reports a clear error pointing at the repetition (#666).
+
 ## [2.18.221] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.221"
+version = "2.18.222"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.221"
+version = "2.18.222"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.221"
+version = "2.18.222"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -663,6 +663,23 @@ fn parse_template(slice: &[Token], name: &str) -> Result<Vec<TemplateItem>, Rave
                         ))
                     }
                 }
+                // A template repetition expands once per matched item, and that
+                // count comes from a metavariable bound by a matcher repetition.
+                // A repetition of only literal tokens has no such metavariable,
+                // so its count is unknowable and it would silently expand zero
+                // times; reject it rather than drop the matched items.
+                if template_meta_names(&sub).is_empty() {
+                    return Err(err(
+                        slice[i].span.clone(),
+                        format!(
+                            "macro `{}`: a template repetition `$( ... )` must reference a \
+                             metavariable, which sets how many times it expands; a repetition \
+                             of only literal tokens has no count. Capture the repeated items \
+                             with a metavariable (for example `$( $x ),*`) and reference it here",
+                            name
+                        ),
+                    ));
+                }
                 items.push(TemplateItem::Rep { sub, sep });
                 i = marker + 1;
             }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1452,7 +1452,7 @@ fn validate_template_rep_counts(
     items: &[TemplateItem],
     seq_bound: &std::collections::HashSet<String>,
     name: &str,
-    span: &Span,
+    fallback: &Span,
 ) -> Result<(), RavenError> {
     for it in items {
         if let TemplateItem::Rep { sub, .. } = it {
@@ -1460,8 +1460,11 @@ fn validate_template_rep_counts(
                 .iter()
                 .any(|m| seq_bound.contains(m));
             if !refs_seq {
+                // Point at the offending repetition (its first concrete token),
+                // falling back to the template brace when it holds no token span.
+                let at = first_template_token_span(sub).unwrap_or_else(|| fallback.clone());
                 return Err(err(
-                    span.clone(),
+                    at,
                     format!(
                         "macro `{}`: a template repetition `$( ... )` must reference a \
                          metavariable captured by a matcher repetition, which sets how many \
@@ -1471,10 +1474,28 @@ fn validate_template_rep_counts(
                     ),
                 ));
             }
-            validate_template_rep_counts(sub, seq_bound, name, span)?;
+            validate_template_rep_counts(sub, seq_bound, name, fallback)?;
         }
     }
     Ok(())
+}
+
+/// The span of the first concrete token in a template slice, used to anchor a
+/// repetition diagnostic on the repetition itself. A metavariable carries no
+/// token span, so a slice of only metavariables yields `None`.
+fn first_template_token_span(items: &[TemplateItem]) -> Option<Span> {
+    for it in items {
+        match it {
+            TemplateItem::Token(t) => return Some(t.span.clone()),
+            TemplateItem::Rep { sub, .. } => {
+                if let Some(s) = first_template_token_span(sub) {
+                    return Some(s);
+                }
+            }
+            TemplateItem::Meta(_) => {}
+        }
+    }
+    None
 }
 
 /// Find the matching close bracket for the open bracket at `open`. Supports

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -495,6 +495,13 @@ fn parse_rules(inner: &[Token], name: &str, span: &Span) -> Result<Vec<Rule>, Ra
                 ));
             }
         }
+        // A template repetition expands once per matched item, and that count
+        // comes from a metavariable a matcher repetition captured as a sequence.
+        // A repetition that references no such metavariable (only literals, or
+        // only metavariables bound outside a matcher repetition) has no count and
+        // would silently expand zero times; reject it.
+        let seq_bound = matcher_seq_bound_metas(&matcher);
+        validate_template_rep_counts(&template, &seq_bound, name, &inner[j].span)?;
         rules.push(Rule { matcher, template });
         i = tclose + 1;
     }
@@ -662,23 +669,6 @@ fn parse_template(slice: &[Token], name: &str) -> Result<Vec<TemplateItem>, Rave
                         ),
                         ))
                     }
-                }
-                // A template repetition expands once per matched item, and that
-                // count comes from a metavariable bound by a matcher repetition.
-                // A repetition of only literal tokens has no such metavariable,
-                // so its count is unknowable and it would silently expand zero
-                // times; reject it rather than drop the matched items.
-                if template_meta_names(&sub).is_empty() {
-                    return Err(err(
-                        slice[i].span.clone(),
-                        format!(
-                            "macro `{}`: a template repetition `$( ... )` must reference a \
-                             metavariable, which sets how many times it expands; a repetition \
-                             of only literal tokens has no count. Capture the repeated items \
-                             with a metavariable (for example `$( $x ),*`) and reference it here",
-                            name
-                        ),
-                    ));
                 }
                 items.push(TemplateItem::Rep { sub, sep });
                 i = marker + 1;
@@ -1428,6 +1418,63 @@ fn template_meta_names(items: &[TemplateItem]) -> Vec<String> {
         }
     }
     out
+}
+
+/// The matcher metavariables captured as a sequence, that is, bound somewhere
+/// under a matcher repetition. Only these carry a repetition count a template
+/// repetition can expand against; a metavariable bound outside every repetition
+/// is a single capture.
+fn matcher_seq_bound_metas(items: &[MatchItem]) -> std::collections::HashSet<String> {
+    fn walk(items: &[MatchItem], under_rep: bool, out: &mut std::collections::HashSet<String>) {
+        for it in items {
+            match it {
+                MatchItem::Meta { name, .. } => {
+                    if under_rep {
+                        out.insert(name.clone());
+                    }
+                }
+                MatchItem::Rep { sub, .. } => walk(sub, true, out),
+                MatchItem::Literal(_) => {}
+            }
+        }
+    }
+    let mut out = std::collections::HashSet::new();
+    walk(items, false, &mut out);
+    out
+}
+
+/// Reject a template repetition whose count cannot be determined: it must
+/// reference at least one metavariable a matcher repetition captured as a
+/// sequence. A repetition of only literals, or one referencing only single-bound
+/// metavariables, would silently expand zero times. Nested repetitions are
+/// checked recursively.
+fn validate_template_rep_counts(
+    items: &[TemplateItem],
+    seq_bound: &std::collections::HashSet<String>,
+    name: &str,
+    span: &Span,
+) -> Result<(), RavenError> {
+    for it in items {
+        if let TemplateItem::Rep { sub, .. } = it {
+            let refs_seq = template_meta_names(sub)
+                .iter()
+                .any(|m| seq_bound.contains(m));
+            if !refs_seq {
+                return Err(err(
+                    span.clone(),
+                    format!(
+                        "macro `{}`: a template repetition `$( ... )` must reference a \
+                         metavariable captured by a matcher repetition, which sets how many \
+                         times it expands; a repetition with no such metavariable has no count. \
+                         Capture the repeated items with `$( $x:expr ),*` and reference `$x` here",
+                        name
+                    ),
+                ));
+            }
+            validate_template_rep_counts(sub, seq_bound, name, span)?;
+        }
+    }
+    Ok(())
 }
 
 /// Find the matching close bracket for the open bracket at `open`. Supports

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -310,6 +310,19 @@ fn plus_repetition_matches_multiple() {
 }
 
 #[test]
+fn literal_only_template_repetition_is_rejected() {
+    // A template repetition with no metavariable has no count to repeat, so it
+    // would silently expand zero times; the macro definition is rejected.
+    let src = "macro ones { ($(foo),*) => { [$(1),*] } }\nlet xs = ones!(foo, foo)\n";
+    let e = expand_tokens(&lex(src)).expect_err("a literal-only template repetition has no count");
+    assert!(
+        format!("{}", e).contains("must reference a metavariable"),
+        "got: {}",
+        e
+    );
+}
+
+#[test]
 fn repetition_can_be_followed_by_a_matcher_item() {
     // The repetition's last element stops before the `;` that follows the
     // repetition, so the trailing `; $t` matches and the rule applies.


### PR DESCRIPTION
A macro template repetition that contains only literal tokens silently expanded zero times, dropping every matched item:

```raven
macro ones { ($(foo),*) => { [$(1),*] } }
let xs: List<Int> = ones!(foo, foo, foo)   // produced [], len 0
```

A template repetition expands once per matched item, and that count comes from a metavariable bound by a matcher repetition. A repetition of only literals has no metavariable, so there is no count to repeat. Rather than discard the matched items and emit valid-but-wrong code, the macro definition is now rejected with a clear error that points at the repetition and suggests capturing the items with a metavariable. This matches the constraint declarative macro systems such as Rust's enforce.

A valid metavariable repetition (`$($x:expr),*` -> `[$($x),*]`) is unaffected.

Fixes #666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Macro template repetitions containing only literal tokens are now rejected at definition time, with a clearer error pointing to the problematic repetition.
  - Prevents invalid patterns from expanding silently and improves macro error diagnosis.

- **Tests**
  - Added coverage to confirm literal-only macro repetitions are rejected during expansion.

- **Chores**
  - Updated the release version to **2.18.222** and refreshed the changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->