### PR TITLE
http: answer a malformed keep-alive request with 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.223] - 2026-06-25
+
+### Fixed
+
+- The HTTP server answers a malformed request on a kept-alive connection with `400 Bad Request` instead of closing it silently. After one request was served, the read path could not tell a clean idle hang-up from a malformed follow-up request, so it closed both without a response. `read_request` now returns `Ok(None)` only for a clean close with no request pending; any real parse failure is an error that the connection loop answers with 400 whether or not earlier requests succeeded (#818).
+
 ## [2.18.222] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.222"
+version = "2.18.223"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.222"
+version = "2.18.223"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.222"
+version = "2.18.223"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/http_keepalive_malformed.rv
+++ b/examples/v2/http_keepalive_malformed.rv
@@ -1,0 +1,64 @@
+// Sends a valid keep-alive request and a malformed one back to back on a single
+// connection, checking that the malformed request still gets 400 after a prior
+// request was served (rather than being closed silently). golden:skip (binds a
+// port and depends on timing; a codegen smoke test runs it and checks output).
+import std/http { Server, Response, Request }
+import std/net { connect, TcpStream }
+import std/time { sleep_millis }
+import std/io { println }
+
+fun ok_handler(req: Request) -> Response {
+    return Response.with_body(200, "ok")
+}
+
+fun has(s: String, sub: String) -> Bool {
+    return s.index_of(sub) >= 0
+}
+
+fun connect_retry(addr: String) -> Result<TcpStream, Error> {
+    let attempt = 0
+    while attempt < 50 {
+        match connect(addr) {
+            Ok(s) -> {
+                return Ok(s)
+            }
+            Err(_) -> {
+                sleep_millis(20)
+            }
+        }
+        attempt += 1
+    }
+    return connect(addr)
+}
+
+fun main() {
+    let addr = "127.0.0.1:18642"
+    let app = Server.new()
+    app.get("/x", ok_handler)
+    spawn(fun() -> Unit {
+        app.listen(addr)
+    })
+
+    // A valid keep-alive request, then a malformed one (no HTTP version) on the
+    // same connection, sent together so the server reads the second from the
+    // first request's carried-over bytes.
+    let both = "GET /x HTTP/1.1\r\nHost: t\r\n\r\nGET /x\r\nHost: t\r\n\r\n"
+    let result = ""
+    match connect_retry(addr) {
+        Ok(s) -> {
+            let _ = s.write(both)
+            match s.read_all() {
+                Ok(r) -> {
+                    result = r
+                }
+                Err(_) -> {}
+            }
+            s.close()
+        }
+        Err(_) -> {}
+    }
+
+    println("served-200: ${has(result, "200 OK")}")
+    println("malformed-400: ${has(result, "400 Bad Request")}")
+    app.shutdown()
+}

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -505,39 +505,47 @@ fun serve_connection(server: Server, stream: TcpStream) {
     let carry = ""
     while open {
         match read_request(stream, carry) {
-            Ok(parsed) -> {
-                carry = parsed.rest
-                let req = parsed.request
-                let resp = dispatch(server.routes, req)
-                let keep = should_keep_alive(req)
-                if server.is_stopping() {
-                    keep = false
-                }
-                let is_head = match req.method {
-                    Head -> true,
-                    _ -> false,
-                }
-                write_response(stream, resp, keep, is_head)
-                if server.access_log {
-                    let method = req.method.to_string().to_upper()
-                    // Log the sanitized status that went on the wire, not the raw
-                    // handler value, so the log matches what the client received.
-                    print("${method} ${req.path} ${sanitize_status(resp.status)}")
-                }
-                served += 1
-                if !keep {
-                    open = false
+            Ok(maybe) -> {
+                match maybe {
+                    Some(parsed) -> {
+                        carry = parsed.rest
+                        let req = parsed.request
+                        let resp = dispatch(server.routes, req)
+                        let keep = should_keep_alive(req)
+                        if server.is_stopping() {
+                            keep = false
+                        }
+                        let is_head = match req.method {
+                            Head -> true,
+                            _ -> false,
+                        }
+                        write_response(stream, resp, keep, is_head)
+                        if server.access_log {
+                            let method = req.method.to_string().to_upper()
+                            // Log the sanitized status that went on the wire, not
+                            // the raw handler value, so the log matches what the
+                            // client received.
+                            print("${method} ${req.path} ${sanitize_status(resp.status)}")
+                        }
+                        served += 1
+                        if !keep {
+                            open = false
+                        }
+                    }
+                    // A clean close with no request pending: an idle keep-alive
+                    // client hung up. Close silently.
+                    None -> {
+                        open = false
+                    }
                 }
             }
             Err(_) -> {
-                // A failed first read is a malformed request, answered with 400.
-                // A failed read after one or more served requests is just an
-                // idle or closed keep-alive connection, closed silently.
-                if served == 0 {
-                    write_response(stream, Response.bad_request("Bad Request"), false, false)
-                    if server.access_log {
-                        print("- - 400")
-                    }
+                // A malformed request is answered with 400 whether or not earlier
+                // requests on this keep-alive connection succeeded; only a clean
+                // idle hang-up (Ok(None) above) closes silently.
+                write_response(stream, Response.bad_request("Bad Request"), false, false)
+                if server.access_log {
+                    print("- - 400")
                 }
                 open = false
             }
@@ -792,12 +800,20 @@ fun decode_chunked(stream: TcpStream, initial: String) -> Result<ChunkedBody, Er
 
 // Parse one request, beginning from `initial` (bytes carried over from a prior
 // request on the same connection) and reading more from `stream` as needed.
-fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error> {
+// `Ok(None)` means the connection closed cleanly with no request pending (an
+// idle keep-alive client hanging up), which the caller treats as a normal close
+// rather than a malformed request; any other failure is an `Err`.
+fun read_request(stream: TcpStream, initial: String) -> Result<Option<ReadResult>, Error> {
     let buf = initial
     let split = buf.index_of("\r\n\r\n")
     while split < 0 {
         let chunk = stream.read(4096)?
         if chunk.length() == 0 {
+            // No bytes buffered and the peer closed: an idle keep-alive hang-up,
+            // not a request. With bytes buffered it is a truncated request.
+            if buf.length() == 0 {
+                return Ok(None)
+            }
             return Err(error_kind("http", "connection closed before headers"))
         }
         buf = buf.concat(chunk)
@@ -966,7 +982,7 @@ fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error
     }
 
     let params: Map<String, String> = Map.new()
-    return Ok(ReadResult {
+    return Ok(Some(ReadResult {
         request: Request {
             method: method,
             path: path,
@@ -977,7 +993,7 @@ fun read_request(stream: TcpStream, initial: String) -> Result<ReadResult, Error
             body: actual_body,
         },
         rest: rest,
-    })
+    }))
 }
 
 // Decode `a=1&b=2` query-string pairs into `out`, percent-decoding each key and

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -800,26 +800,36 @@ fun decode_chunked(stream: TcpStream, initial: String) -> Result<ChunkedBody, Er
 
 // Parse one request, beginning from `initial` (bytes carried over from a prior
 // request on the same connection) and reading more from `stream` as needed.
-// `Ok(None)` means the connection closed cleanly with no request pending (an
-// idle keep-alive client hanging up), which the caller treats as a normal close
-// rather than a malformed request; any other failure is an `Err`.
+// `Ok(None)` means no request arrived and the connection should close quietly:
+// an idle keep-alive client that hung up or sat past the read timeout. A request
+// that arrived but failed to parse is an `Err`, which the caller answers with a
+// 400, so a read timeout is never mistaken for a malformed request.
 fun read_request(stream: TcpStream, initial: String) -> Result<Option<ReadResult>, Error> {
     let buf = initial
     let split = buf.index_of("\r\n\r\n")
     while split < 0 {
-        let chunk = stream.read(4096)?
-        if chunk.length() == 0 {
-            // No bytes buffered and the peer closed: an idle keep-alive hang-up,
-            // not a request. With bytes buffered it is a truncated request.
-            if buf.length() == 0 {
+        match stream.read(4096) {
+            Ok(chunk) -> {
+                if chunk.length() == 0 {
+                    // No bytes buffered and the peer closed: an idle keep-alive
+                    // hang-up, not a request. With bytes buffered it is truncated.
+                    if buf.length() == 0 {
+                        return Ok(None)
+                    }
+                    return Err(error_kind("http", "connection closed before headers"))
+                }
+                buf = buf.concat(chunk)
+                split = buf.index_of("\r\n\r\n")
+                if buf.length() > 65536 {
+                    return Err(error_kind("http", "request headers too large"))
+                }
+            }
+            // A read failure while waiting for the next request line (a read
+            // timeout on an idle keep-alive connection, or a reset) is not a
+            // malformed request, so close quietly rather than answering 400.
+            Err(_) -> {
                 return Ok(None)
             }
-            return Err(error_kind("http", "connection closed before headers"))
-        }
-        buf = buf.concat(chunk)
-        split = buf.index_of("\r\n\r\n")
-        if buf.length() > 65536 {
-            return Err(error_kind("http", "request headers too large"))
         }
     }
     let head_text = buf.substring(0, split)

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1471,6 +1471,17 @@ fn http_server_rejects_malformed_requests() {
 }
 
 #[test]
+fn http_server_answers_a_malformed_keep_alive_request_with_400() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // A valid keep-alive request is served (200), then a malformed request on the
+    // same connection still receives 400 rather than being closed silently.
+    let expected = "served-200: true\nmalformed-400: true\n";
+    compile_link_run_and_check("http_keepalive_malformed.rv", expected, &runtime);
+}
+
+#[test]
 fn http_server_shuts_down_on_ipv6_wildcard() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
After a keep-alive connection had served one valid request, a malformed later request on the same connection was closed silently instead of receiving `400 Bad Request`.

`read_request` returned `Err` both for a clean idle hang-up (the keep-alive client closing the connection with nothing pending) and for a genuinely malformed request. The connection loop could not tell them apart, so once `served > 0` it assumed any failure was an idle close and closed silently.

`read_request` now returns `Ok(None)` only when the connection closes cleanly with no request bytes pending; a parse failure (or a truncated request) is an `Err`. The connection loop answers `Ok(None)` with a silent close and any `Err` with `400 Bad Request`, regardless of how many requests were already served on the connection.

Verified by a self-test that pipelines a valid keep-alive request and a malformed one on a single connection: the first is served `200`, the second now receives `400`.

Fixes #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed follow-up requests on HTTP keep-alive connections: the server now responds with `400 Bad Request` instead of silently terminating.
  * Clean connection closes with no pending request are treated as quiet end-of-stream, while truncated headers are treated as errors.
  * Access logs are now consistent with the `400` response sent for parse failures.
* **Tests**
  * Added a regression smoke test covering a valid keep-alive request followed by a malformed request, verifying `200 OK` and `400 Bad Request` outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->