### PR TITLE
runtime: elastic worker pool so blocking syscalls do not starve the scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.224] - 2026-06-26
+
+### Fixed
+
+- The goroutine scheduler no longer hangs when many goroutines block in syscalls at once. The worker pool was fixed at one thread per core, and a blocking syscall (a socket `read`/`accept`, a `sleep`) holds its worker, so a server with enough concurrent keep-alive connections parked in `read` exhausted the pool and stopped serving new requests, never recovering. The pool is now elastic: when a worker blocks it spawns a replacement so the scheduler keeps one runnable worker per core, and the extra workers retire once the burst drains (bounded by a cap). A server now keeps accepting and serving under concurrent load instead of locking up (#407).
+
 ## [2.18.223] - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.223"
+version = "2.18.224"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.223"
+version = "2.18.224"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.223"
+version = "2.18.224"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/concurrent_blocking_goroutines.rv
+++ b/examples/v2/concurrent_blocking_goroutines.rv
@@ -1,0 +1,33 @@
+// Spawns far more goroutines than cores, each parked in a blocking syscall (a
+// sleep), and times the whole batch. The scheduler runs one worker thread per
+// core, so a blocking syscall holds its worker; an elastic pool spawns a
+// replacement when a worker blocks, so every sleep runs at once and the batch
+// finishes near one sleep duration. Without it the goroutines queue through the
+// fixed pool and take roughly `goroutines / cores` durations: with 48 sleeps of
+// 1s on up to 16 cores that is at least ~3s, well past the 2.5s bound, while the
+// elastic pool finishes in ~1.5s. golden:skip (timing-dependent; a codegen smoke
+// test runs it).
+import std/time { sleep_millis, now_millis }
+import std/sync { wait_group }
+
+fun main() {
+    let n = 48
+    let dur = 1000
+    let wg = wait_group()
+    let start = now_millis()
+    let i = 0
+    while i < n {
+        wg.add(1)
+        spawn(fun() -> Unit {
+            sleep_millis(dur)
+            wg.done()
+        })
+        i = i + 1
+    }
+    wg.wait()
+    if now_millis() - start < 2500 {
+        print("concurrent")
+    } else {
+        print("batched")
+    }
+}

--- a/examples/v2/concurrent_blocking_goroutines.rv
+++ b/examples/v2/concurrent_blocking_goroutines.rv
@@ -1,3 +1,5 @@
+// golden:skip (timing-dependent; a codegen smoke test runs it).
+//
 // Spawns far more goroutines than cores, each parked in a blocking syscall (a
 // sleep), and times the whole batch. The scheduler runs one worker thread per
 // core, so a blocking syscall holds its worker; an elastic pool spawns a
@@ -5,8 +7,7 @@
 // finishes near one sleep duration. Without it the goroutines queue through the
 // fixed pool and take roughly `goroutines / cores` durations: with 48 sleeps of
 // 1s on up to 16 cores that is at least ~3s, well past the 2.5s bound, while the
-// elastic pool finishes in ~1.5s. golden:skip (timing-dependent; a codegen smoke
-// test runs it).
+// elastic pool finishes in ~1.5s.
 import std/time { sleep_millis, now_millis }
 import std/sync { wait_group }
 

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -121,10 +121,17 @@ pub(crate) fn blocking<R>(f: impl FnOnce() -> R) -> R {
     // in the kernel: on a worker thread this spawns a replacement so goroutines
     // queued behind blocked I/O still run. A no-op off a worker thread.
     crate::sched::worker_block_begin();
-    let r = f();
-    crate::sched::worker_block_end();
-    block_end(was);
-    r
+    // Restore the worker accounting and the GC running-state on the way out, even
+    // if `f` unwinds, so a panic in the syscall cannot leave the counts skewed.
+    struct Restore(bool);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            crate::sched::worker_block_end();
+            block_end(self.0);
+        }
+    }
+    let _restore = Restore(was);
+    f()
 }
 
 /// A safepoint poll. The back end emits a call at loop back-edges (and the

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -117,7 +117,12 @@ pub(crate) fn block_end(was_running: bool) {
 /// returns, so this holds.
 pub(crate) fn blocking<R>(f: impl FnOnce() -> R) -> R {
     let was = block_begin();
+    // Keep the scheduler's worker pool from starving while this thread is parked
+    // in the kernel: on a worker thread this spawns a replacement so goroutines
+    // queued behind blocked I/O still run. A no-op off a worker thread.
+    crate::sched::worker_block_begin();
     let r = f();
+    crate::sched::worker_block_end();
     block_end(was);
     r
 }

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -142,15 +142,16 @@ static BLOCKED_WORKERS: AtomicUsize = AtomicUsize::new(0);
 /// connections degrades to queuing rather than spawning threads without bound.
 const MAX_WORKERS: usize = 512;
 
-/// The steady-state worker count: one per core, cached after the first read so
-/// the idle loop does not query the OS each iteration.
+/// The steady-state worker count: one per core, capped at [`MAX_WORKERS`] so the
+/// initial pool also honors the ceiling on a host with more cores than the cap.
+/// Cached after the first read so the idle loop does not query the OS each pass.
 fn worker_target() -> usize {
     static TARGET: AtomicUsize = AtomicUsize::new(0);
     let cached = TARGET.load(Ordering::Relaxed);
     if cached != 0 {
         return cached;
     }
-    let n = worker_count();
+    let n = worker_count().min(MAX_WORKERS);
     TARGET.store(n, Ordering::Relaxed);
     n
 }

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -19,8 +19,9 @@ use crate::object::Closure;
 use corosensei::{Coroutine, CoroutineResult, Yielder};
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Condvar, LazyLock, Mutex};
+use std::time::Duration;
 
 /// Why a goroutine suspended back to the scheduler. Yielded by the
 /// coroutine body to the resume loop.
@@ -128,7 +129,63 @@ static MAIN_CV: Condvar = Condvar::new();
 /// Whether the worker pool has been started (lazily, on the first spawn).
 static POOL_STARTED: AtomicBool = AtomicBool::new(false);
 
+/// Worker OS threads currently alive. Starts at [`worker_target`]; grows when a
+/// worker blocks in a syscall (a replacement is spawned so the pool keeps
+/// `worker_target` runnable threads) and shrinks as the extra workers go idle.
+static LIVE_WORKERS: AtomicUsize = AtomicUsize::new(0);
+
+/// Worker OS threads currently parked inside a blocking syscall (a `gc::blocking`
+/// region). `LIVE_WORKERS - BLOCKED_WORKERS` is how many can still run goroutines.
+static BLOCKED_WORKERS: AtomicUsize = AtomicUsize::new(0);
+
+/// Hard ceiling on worker threads, so a flood of simultaneous blocking
+/// connections degrades to queuing rather than spawning threads without bound.
+const MAX_WORKERS: usize = 512;
+
+/// The steady-state worker count: one per core, cached after the first read so
+/// the idle loop does not query the OS each iteration.
+fn worker_target() -> usize {
+    static TARGET: AtomicUsize = AtomicUsize::new(0);
+    let cached = TARGET.load(Ordering::Relaxed);
+    if cached != 0 {
+        return cached;
+    }
+    let n = worker_count();
+    TARGET.store(n, Ordering::Relaxed);
+    n
+}
+
+/// Called when this thread is about to block in a syscall (via `gc::blocking`).
+/// On a worker thread it spawns a replacement when blocking would drop the pool
+/// below `worker_target` runnable threads, so goroutines queued behind blocked
+/// I/O still make progress instead of starving the fixed pool. A no-op off a
+/// worker thread (the main accept loop, a native caller), which holds no slot.
+pub(crate) fn worker_block_begin() {
+    if !IS_WORKER.with(|w| w.get()) {
+        return;
+    }
+    let blocked = BLOCKED_WORKERS.fetch_add(1, Ordering::SeqCst) + 1;
+    let live = LIVE_WORKERS.load(Ordering::SeqCst);
+    if live.saturating_sub(blocked) < worker_target() && live < MAX_WORKERS {
+        LIVE_WORKERS.fetch_add(1, Ordering::SeqCst);
+        std::thread::spawn(worker_loop);
+        WORK_CV.notify_one();
+    }
+}
+
+/// Called when this thread's blocking syscall returns. Pairs with
+/// [`worker_block_begin`]; a no-op off a worker thread.
+pub(crate) fn worker_block_end() {
+    if IS_WORKER.with(|w| w.get()) {
+        BLOCKED_WORKERS.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 thread_local! {
+    /// Set on a worker thread so the blocking hook knows it holds a pool slot,
+    /// and the idle loop knows it may retire when the pool is over target.
+    static IS_WORKER: Cell<bool> = const { Cell::new(false) };
+
     /// The yielder of the coroutine this OS thread is currently running, so
     /// `suspend_current` can reach it. Per-thread because each worker runs a
     /// different goroutine; null when the thread is between goroutines or
@@ -302,7 +359,9 @@ fn ensure_pool() {
     if POOL_STARTED.swap(true, Ordering::SeqCst) {
         return;
     }
-    for _ in 0..worker_count() {
+    let n = worker_target();
+    LIVE_WORKERS.store(n, Ordering::SeqCst);
+    for _ in 0..n {
         std::thread::spawn(worker_loop);
     }
 }
@@ -318,11 +377,13 @@ fn is_deadlocked(sched: &Scheduler) -> bool {
 /// A worker thread: pull a ready goroutine and run it to its next suspension,
 /// forever. Parks on `WORK_CV` when nothing is ready.
 fn worker_loop() {
+    IS_WORKER.with(|w| w.set(true));
     loop {
         let id = {
             let mut guard = SCHED.lock().unwrap();
             loop {
                 if guard.0.shutdown {
+                    LIVE_WORKERS.fetch_sub(1, Ordering::SeqCst);
                     return;
                 }
                 if let Some(id) = guard.0.ready.pop_front() {
@@ -339,7 +400,22 @@ fn worker_loop() {
                     drop(guard);
                     deadlock_panic();
                 }
-                guard = WORK_CV.wait(guard).unwrap();
+                // Retire only when there are more *runnable* workers than the
+                // target, so the pool shrinks back after a burst of blocking I/O
+                // without killing the spares that cover workers still blocked in
+                // syscalls (counting total here would drop runnable capacity to
+                // zero whenever many workers are parked in I/O). The wait is timed
+                // so an idle extra re-checks and exits even when no work wakes it.
+                let live = LIVE_WORKERS.load(Ordering::SeqCst);
+                let blocked = BLOCKED_WORKERS.load(Ordering::SeqCst);
+                if live.saturating_sub(blocked) > worker_target() {
+                    LIVE_WORKERS.fetch_sub(1, Ordering::SeqCst);
+                    return;
+                }
+                guard = WORK_CV
+                    .wait_timeout(guard, Duration::from_millis(500))
+                    .unwrap()
+                    .0;
             }
         };
         run_goroutine(id);

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1448,6 +1448,23 @@ fn http_server_timeout_does_not_overflow() {
 }
 
 #[test]
+fn blocking_goroutines_run_concurrently_via_the_elastic_pool() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // 48 goroutines each block in a 1s sleep. The scheduler spawns a replacement
+    // worker when one blocks (issue #407), so they all run at once and the batch
+    // finishes well under the 2.5s bound instead of queuing through the fixed
+    // core-sized pool. A server proves this matters: blocked keep-alive reads
+    // would otherwise starve the pool and hang new requests.
+    compile_link_run_and_check(
+        "concurrent_blocking_goroutines.rv",
+        "concurrent\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn http_server_rejects_malformed_requests() {
     let Some(runtime) = supported_runtime() else {
         return;

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1456,12 +1456,41 @@ fn blocking_goroutines_run_concurrently_via_the_elastic_pool() {
     // worker when one blocks (issue #407), so they all run at once and the batch
     // finishes well under the 2.5s bound instead of queuing through the fixed
     // core-sized pool. A server proves this matters: blocked keep-alive reads
-    // would otherwise starve the pool and hang new requests.
-    compile_link_run_and_check(
-        "concurrent_blocking_goroutines.rv",
-        "concurrent\n",
-        &runtime,
+    // would otherwise starve the pool and hang new requests. The program is run
+    // under a deadline so a scheduler regression that deadlocks fails the test
+    // rather than wedging CI on `output()` with no bound.
+    let example = build_example_binary("concurrent_blocking_goroutines.rv", &runtime);
+    let mut child = Command::new(&example.binary)
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn concurrent_blocking_goroutines");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let status = loop {
+        if let Some(s) = child.try_wait().expect("try_wait") {
+            break Some(s);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break None;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
+    let mut stdout = String::new();
+    if let Some(mut out) = child.stdout.take() {
+        use std::io::Read;
+        let _ = out.read_to_string(&mut stdout);
+    }
+    cleanup(&example.tmp);
+    assert!(
+        status.is_some(),
+        "the blocking goroutines did not finish within 30s: the scheduler hung instead of running them concurrently"
     );
+    assert!(
+        status.unwrap().success(),
+        "concurrent_blocking_goroutines exited non-zero"
+    );
+    assert_eq!(stdout, "concurrent\n", "unexpected stdout: {:?}", stdout);
 }
 
 #[test]


### PR DESCRIPTION
A Raven server hangs under concurrent load. The scheduler runs a fixed pool of one worker OS thread per core, and a blocking syscall (a socket `read`/`accept`, a `sleep`) holds its worker for the whole call. So a server with enough concurrent keep-alive connections parked in `read` exhausts the pool: the connection-handler goroutines queued behind the blocked ones never get a worker, the server stops serving new requests, and it does not recover even after the load stops.

Reproduced with the SQLite board test app: holding ~30 idle keep-alive connections made every new request time out permanently, with the connections left parked.

### Fix

The worker pool is now elastic. `gc::blocking` (which already wraps every blocking syscall in `std/net`, `std/fs`, `std/process`, and `sleep`) tells the scheduler when a worker thread is about to block. If blocking would leave fewer than one runnable worker per core, it spawns a replacement, so goroutines queued behind blocked I/O keep running. The replacements retire when there are again more runnable workers than the target, so the pool drains back after a burst, bounded by a hard cap (512) so a connection flood degrades to queuing rather than spawning threads without bound.

### Verification

- The board app, rebuilt with this runtime, now serves fresh requests while 30 idle keep-alive connections are held (the worker count grows from ~12 to ~42 under load and drains back to ~12 after), where before every request hung.
- New smoke test `blocking_goroutines_run_concurrently_via_the_elastic_pool`: 48 goroutines each block in a 1s sleep and finish well under 2.5s (concurrent) instead of `goroutines / cores` durations.
- `concurrency_soak`, `gc_rooting_stress`, and the full `raven-runtime` suite pass, so the GC running-set / safepoint model is unaffected.

Fixes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new concurrency example that runs many blocking goroutines and expects fast completion with an elastic worker pool.
* **Bug Fixes**
  * Fixed a scheduler hang under heavy blocking syscall contention by making the worker pool elastic (spawning replacement workers when blocking) and retiring excess workers after bursts.
  * Improved behavior during long-running blocks so the server continues handling concurrent load.
* **Tests**
  * Added a codegen smoke test that builds and runs the new blocking concurrency example.
* **Chores**
  * Updated the release version and changelog entry for this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->