### PR TITLE
runtime: publish the goroutine yielder on the resuming worker, not across suspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.18.225] - 2026-06-26
+
+### Fixed
+
+- The goroutine scheduler corrupted its per-thread current-yielder slot when a goroutine resumed on a different worker than the one it suspended on. The slot was republished from inside the coroutine after `yielder.suspend()`, but the optimizer treats the thread-local base as constant within a function (a function never changes threads in ordinary code), so on a release build the write could land in the suspending thread's slot while the resuming thread's slot stayed stale. The next suspend on the resuming thread then read a null or wrong yielder, crashing concurrent programs (notably a server under load) with a segfault or a `suspend_current called with no running coroutine` panic. The worker now republishes the yielder on the resuming thread before each resume, so the slot is never written across a thread migration. This was release-only and timing-dependent, so it surfaced under sustained concurrent load. (#603)
+
 ## [2.18.224] - 2026-06-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.224"
+version = "2.18.225"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.224"
+version = "2.18.225"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.224"
+version = "2.18.225"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/raven-runtime/src/sched.rs
+++ b/raven-runtime/src/sched.rs
@@ -54,6 +54,18 @@ struct Goroutine {
     /// would free it and the values it captured. Null for goroutine 0 (main),
     /// which has no spawn closure.
     spawn_root: *mut u8,
+    /// This goroutine's `corosensei` yielder, published by the coroutine body on
+    /// its first run and stable for the goroutine's life (one closure call, one
+    /// yielder reference). The worker republishes it into the per-thread
+    /// `CURRENT_YIELDER` slot before each resume, so the slot is always written on
+    /// the resuming thread. Republishing from inside the coroutine *after*
+    /// `yielder.suspend()` instead is unsound: the coroutine can resume on a
+    /// different worker than it suspended on, and the optimizer caches the
+    /// thread-local base across the suspend (it assumes a function never changes
+    /// threads), so the write lands in the old thread's slot and the new thread's
+    /// slot stays stale, crashing the next suspend. Null until the first run, and
+    /// for goroutine 0 (main), which suspends via a condvar, not a yielder.
+    yielder: *const GoYielder,
 }
 
 /// A channel: a bounded queue of pointer-width value slots plus the wait
@@ -241,6 +253,7 @@ impl Scheduler {
                 coro: None,
                 roots: (Vec::new(), Vec::new(), Vec::new()),
                 spawn_root: std::ptr::null_mut(),
+                yielder: std::ptr::null(),
             },
         );
         Scheduler {
@@ -308,9 +321,20 @@ pub extern "C" fn raven_go_spawn(closure: *mut Closure) {
     let env_addr = env as usize;
 
     let coro = Coroutine::new(move |yielder: &GoYielder, _input: ()| {
-        // Publish this goroutine's yielder so its channel ops and
-        // `yield_now` can suspend back to the scheduler.
-        CURRENT_YIELDER.with(|y| y.set(yielder as *const GoYielder));
+        // Publish this goroutine's yielder so its channel ops and `yield_now`
+        // can suspend back to the scheduler. Set the per-thread slot for this
+        // first run, and record the (stable) pointer in the goroutine so the
+        // worker republishes it on the resuming thread before every later resume
+        // (see `Goroutine::yielder`); the coroutine never writes the slot across
+        // a suspend itself, where a thread migration would corrupt it.
+        let yp = yielder as *const GoYielder;
+        CURRENT_YIELDER.with(|y| y.set(yp));
+        let gid = CURRENT_GOROUTINE.with(|c| c.get());
+        with_sched(|sched| {
+            if let Some(g) = sched.goroutines.get_mut(&gid) {
+                g.yielder = yp;
+            }
+        });
         // The closure body is `extern "C" fn(env)`.
         // SAFETY: spawn's contract guarantees a `fun() -> Unit` lifted
         // body taking the capture env.
@@ -334,6 +358,7 @@ pub extern "C" fn raven_go_spawn(closure: *mut Closure) {
                 // Root the closure so it and its captures survive until and
                 // while the goroutine runs.
                 spawn_root: closure as *mut u8,
+                yielder: std::ptr::null(),
             },
         );
         sched.ready.push_back(id);
@@ -454,15 +479,17 @@ fn run_goroutine(id: usize) {
             .unwrap_or_default()
     });
     install_root_chain(saved);
-    let mut coro = with_sched(|sched| {
-        sched
-            .goroutines
-            .get_mut(&id)
-            .expect("live goroutine")
-            .coro
-            .take()
-            .expect("coroutine handle")
+    let (mut coro, yielder) = with_sched(|sched| {
+        let g = sched.goroutines.get_mut(&id).expect("live goroutine");
+        (g.coro.take().expect("coroutine handle"), g.yielder)
     });
+    // Republish the yielder into this worker's per-thread slot before resuming,
+    // so a goroutine that suspended on another worker finds its slot correct on
+    // this one. Null on the very first run, where the coroutine body sets the
+    // slot itself. See `Goroutine::yielder`.
+    if !yielder.is_null() {
+        CURRENT_YIELDER.with(|y| y.set(yielder));
+    }
     let result = coro.resume(());
     // Save this goroutine's live roots and clear `running` before leaving the
     // running state, so once the collector may proceed the saved chain is
@@ -515,9 +542,12 @@ fn suspend_current(reason: Suspend) {
     // coroutine, valid for the duration of the body.
     let yielder = unsafe { &*yielder };
     yielder.suspend(reason);
-    // On resume, re-publish our yielder: the scheduler may have run other
-    // goroutines that overwrote the shared slot.
-    CURRENT_YIELDER.with(|y| y.set(yielder as *const GoYielder));
+    // Do not republish the slot here. On resume this body may be running on a
+    // different worker than it suspended on, and writing the thread-local across
+    // the suspend can land in the wrong thread's slot (the optimizer treats the
+    // TLS base as thread-constant within a function). The worker republishes the
+    // slot on the resuming thread before each resume instead (see `run_goroutine`
+    // and `Goroutine::yielder`).
 }
 
 /// Cooperative yield point. A spawned goroutine yields its worker to another


### PR DESCRIPTION
Fixes the release-only crash where a Raven server (or any sustained-concurrency program) segfaults or panics with `suspend_current called with no running coroutine` under load. This is #603.

### Root cause

A goroutine can suspend on one worker thread and resume on another. The scheduler republished its `corosensei` yielder into the per-thread `CURRENT_YIELDER` thread-local from *inside* the coroutine, immediately after `yielder.suspend()` returned:

```rust
yielder.suspend(reason);
CURRENT_YIELDER.with(|y| y.set(yielder ...)); // runs on the *resuming* thread
```

The optimizer treats a thread-local's base address as constant within a function, because ordinary code never changes threads mid-function. A `corosensei` stack switch breaks that assumption: the code after `suspend()` can run on a different OS thread than the code before it. On a release build the optimizer can reuse the pre-suspend thread-local base for the post-suspend write, so the republish lands in the *suspending* thread's slot while the *resuming* thread's slot stays stale. The resuming thread's next `suspend_current` then reads a null or wrong yielder and crashes.

This is why it was release-only (the optimization), timing-dependent (needs a migration between specific workers), and only seen under sustained concurrent load (enough goroutines churning across workers to migrate).

### Investigation notes (re-characterizes #603)

#603's suspected area was the GC stop-the-world mark. The evidence here points elsewhere:
- Reproduces with **4 concurrent connections** (well under core count), so it is not the elastic worker pool and not load-volume specific.
- Reproduces with `RAVEN_GC_THRESHOLD` set past any reachable heap size, i.e. **with collections disabled**, so it is not the GC mark race.
- Disappears entirely with LTO off, consistent with an optimizer-dependent thread-local hazard.
- The crash sites (`suspend_current` null yielder; segfault in the yielder) are both explained by a corrupt/stale yielder pointer.

### Fix

Record the yielder (stable for the goroutine's life, one closure call) on its first run, and have the worker republish it on the resuming thread before each `resume`. `suspend_current` no longer writes the slot after suspending, so the thread-local is never written across a migration.

### Verification

- The SQLite board test app, which crashed reliably on 2.18.224 under concurrent load, now survives **19,200 requests across 40 concurrent connections x 6 rounds** with zero crashes.
- The #407 held-connection behavior is preserved (30 idle keep-alive connections, fresh requests still served).
- `raven-runtime` unit tests (123), `concurrency_soak`, `gc_rooting_stress`, and `codegen_smoke` (96) all pass.

A deterministic CI regression test is not feasible: the bug only manifests on an optimized (release/LTO) build with the right thread-migration timing, and `cargo test` builds the runtime in debug, which never reproduces it. The structural change (no thread-local write across a suspend) is the guard.

Fixes #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare scheduler issue that could cause crashes or panics when a task resumed on a different worker thread than the one it suspended on.
  * Improved task resumption handling to make cross-thread execution more reliable under load.

* **Chores**
  * Updated the release version to **2.18.225**.
  * Added a changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->