### PR TITLE
docs: correct the std/sync scheduler comment

### DIFF
--- a/stdlib/std/sync.rv
+++ b/stdlib/std/sync.rv
@@ -1,9 +1,9 @@
-// std/sync: goroutine-style concurrency over the raven-runtime cooperative
-// scheduler. A Channel wraps an opaque runtime id, the same registry
-// pattern std/net uses for sockets. send and recv block by yielding to the
-// scheduler when the channel is full or empty. This slice carries Int
-// values; a goroutine body is started with the `spawn` keyword. See
-// docs/v2/specs/concurrency.md.
+// std/sync: goroutine-style concurrency over the raven-runtime scheduler,
+// which runs goroutines in parallel on a per-core worker pool. A Channel wraps
+// an opaque runtime id, the same registry pattern std/net uses for sockets.
+// send and recv block (suspending the goroutine back to the scheduler) when the
+// channel is full or empty. This slice carries Int values; a goroutine body is
+// started with the `spawn` keyword. See docs/v2/specs/concurrency.md.
 
 extern "C" {
     fun raven_channel_new() -> Int


### PR DESCRIPTION
The `stdlib/std/sync.rv` header described the scheduler as cooperative. Since the M:N scheduler runs goroutines in parallel on a per-core worker pool (and a goroutine can resume on a different worker than it suspended on), the wording is corrected to match. Comment-only; no behavior change.

Follow-up to the skill doc update that flagged the same stale phrasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `std/sync` overview to better describe its concurrency model and how goroutines run in parallel across a per-core worker pool.
  * Clarified the module’s behavior in the top-level documentation without changing any APIs or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->