### PR TITLE
feat: add std/tls client TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.19.0] - 2026-06-27
+
+### Added
+
+- `std/tls`: client-side TLS. `connect(addr, server_name)` opens a connection verified against the bundled Mozilla root store, and `TlsStream` reads and writes encrypted bytes with the same `String` buffer and `Result`/`Error` model as `std/net`. A `TlsConfig` builder covers private CAs (`add_ca_file`), mutual TLS client certificates (`client_cert`), and a development-only `insecure_skip_verify`. Backed by rustls with the ring provider in the runtime; no compiler changes. This is the transport layer for upcoming database and cache client libraries (Redis, Postgres, MySQL). Outbound `https://` through the `std/http` client already worked (it is backed by ureq) and is unchanged. See `docs/v2/specs/std-tls.md`. (#828)
+
 ## [2.18.225] - 2026-06-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.18.225"
+version = "2.19.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,13 +575,16 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.18.225"
+version = "2.19.0"
 dependencies = [
  "chrono",
  "corosensei",
  "libc",
  "regex",
+ "rustls",
+ "rustls-pemfile",
  "ureq",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -659,6 +662,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.18.225"
+version = "2.19.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/std-tls.md
+++ b/docs/v2/specs/std-tls.md
@@ -1,0 +1,114 @@
+# std/tls Spec
+
+Client-side TLS: opening a verified TLS connection, reading and writing
+encrypted bytes, and a configuration builder for private CAs, client
+certificates (mutual TLS), and a development-only skip of verification. The
+primitives bind the raven-runtime C ABI; the wrappers add the Result/Error
+model and the handle types in pure Raven, mirroring `std/net`.
+
+For outbound HTTPS the `std/http` client already speaks TLS (it is backed by
+`ureq` with rustls), so `get("https://...")` needs nothing from this module.
+`std/tls` is for raw TLS streams: speaking a binary protocol such as Redis,
+Postgres, or MySQL over an encrypted socket.
+
+## Import
+
+```rust
+import std/tls { connect, connect_with, config }
+```
+
+The methods on `TlsStream` and `TlsConfig` come in with the types and need no
+separate selector.
+
+## Handle registry model
+
+A live TLS session cannot cross the FFI boundary, so the runtime keeps it in a
+process-wide registry keyed by an incrementing `i64` id and hands Raven only
+that id. `TlsStream { id: Int }` and `TlsConfig { id: Int }` wrap the id. Ids
+start at 1; an id of 0 is the failure sentinel paired with a set last-error.
+A TLS session is stateful and, unlike a raw socket fd, cannot be cloned per
+read, so each connection is held behind its own mutex: one goroutine should own
+a given `TlsStream` at a time.
+
+## Trust and crypto
+
+TLS is `rustls` with the `ring` crypto provider. The default configuration
+verifies the server against the bundled Mozilla root store (`webpki-roots`) and
+checks that the certificate matches `server_name`, which is also sent as SNI.
+
+`TlsConfig` adjusts that:
+
+- `add_ca_file(path)` trusts the PEM certificate(s) in `path` in addition to the
+  bundled roots, for a server signed by a private CA.
+- `client_cert(cert_path, key_path)` presents a client certificate chain and
+  private key (PEM) for mutual TLS.
+- `insecure_skip_verify()` accepts any certificate. The session is still
+  encrypted, but the peer is not authenticated, so this is for local
+  development only.
+
+## Error model
+
+Fallible operations return `Result<T, Error>`. The error is an std/error `Error`
+tagged with kind `"tls"`, built as a struct literal, its message a short context
+prefix (the operation name) joined to the runtime error text. As in `std/net`,
+no error structs cross the FFI: the runtime keeps a thread-local last-error
+string that a fallible op clears on success and sets on failure, and
+`raven_tls_last_error()` returns it. An id of 0 from a connect, a negative count
+from a write, or a non-empty last error becomes an `Err`.
+
+## Bytes
+
+Reads and writes carry bytes in a `String` buffer, the same convention `std/net`
+uses today. `read(max)` returns up to `max` decrypted bytes (a clean close
+yields `Ok("")`); `write(data)` encrypts and sends every byte and returns the
+count. A dedicated bytes type is future work tracked with the database-client
+libraries.
+
+## Scheduler integration
+
+The TCP connect, the TLS handshake, and every read and write run inside the
+runtime's `gc::blocking` bracket, the same one `std/net` uses. A goroutine
+waiting on TLS I/O therefore hands its worker back to the scheduler (which keeps
+the worker pool at one runnable thread per core) and parks at a GC safepoint, so
+many TLS connections can run across the worker pool at once.
+
+## C ABI surface
+
+```
+raven_tls_last_error() -> String
+raven_tls_config_new() -> i64
+raven_tls_config_add_ca_file(cfg, path) -> i64
+raven_tls_config_client_cert(cfg, cert_path, key_path) -> i64
+raven_tls_config_insecure_skip_verify(cfg, on)
+raven_tls_config_free(cfg)
+raven_tls_connect(addr, server_name, cfg) -> i64
+raven_tls_read(stream_id, max) -> String
+raven_tls_write(stream_id, data) -> i64
+raven_tls_close(stream_id)
+raven_tls_set_read_timeout_ms(stream_id, ms)
+raven_tls_set_write_timeout_ms(stream_id, ms)
+```
+
+A `cfg` of 0 in `raven_tls_connect` selects the default verifying configuration,
+so the common path needs no config handle.
+
+## Example
+
+```rust
+import std/io { println }
+import std/tls { connect }
+
+fun main() {
+    match connect("example.com:443", "example.com") {
+        Ok(stream) -> {
+            let _ = stream.write("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
+            match stream.read(64) {
+                Ok(data) -> println(data.trim()),
+                Err(e) -> println("read: ${e.message()}"),
+            }
+            stream.close()
+        },
+        Err(e) -> println("connect: ${e.message()}"),
+    }
+}
+```

--- a/examples/tls_client.rv
+++ b/examples/tls_client.rv
@@ -1,0 +1,48 @@
+// golden:skip
+// Reaches the network (example.com:443), so it is excluded from the golden
+// output suite. Run it directly: raven build examples/tls_client.rv -o tls_client
+
+import std/io { println }
+import std/tls { connect, connect_with, config }
+import std/string
+
+// Fetch the first line of a response over a verified TLS connection.
+fun fetch_verified() {
+    match connect("example.com:443", "example.com") {
+        Ok(stream) -> {
+            let _ = stream.write("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
+            match stream.read(32) {
+                Ok(data) -> println("verified: ${data.trim()}"),
+                Err(e) -> println("read: ${e.message()}"),
+            }
+            stream.close()
+        },
+        Err(e) -> println("connect: ${e.message()}"),
+    }
+}
+
+// A custom config: here, a development-only skip of verification. For a private
+// CA use config().add_ca_file("ca.pem"); for mutual TLS add
+// .client_cert("client.pem", "client.key").
+fun fetch_with_config() {
+    let cfg = config().insecure_skip_verify()
+    match connect_with("self-signed.badssl.com:443", "self-signed.badssl.com", cfg) {
+        Ok(stream) -> {
+            let _ = stream.write(
+                "GET / HTTP/1.1\r\nHost: self-signed.badssl.com\r\nConnection: close\r\n\r\n",
+            )
+            match stream.read(32) {
+                Ok(data) -> println("skip-verify: ${data.trim()}"),
+                Err(e) -> println("read: ${e.message()}"),
+            }
+            stream.close()
+        },
+        Err(e) -> println("connect: ${e.message()}"),
+    }
+    cfg.free()
+}
+
+fun main() {
+    fetch_verified()
+    fetch_with_config()
+}

--- a/raven-runtime/Cargo.toml
+++ b/raven-runtime/Cargo.toml
@@ -15,7 +15,10 @@ name = "raven_runtime"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 corosensei = "0.3.4"
 regex = "1"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls-pemfile = "2"
 ureq = "2.12"
+webpki-roots = "0.26"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -21,6 +21,7 @@ pub mod reflect;
 pub mod roots;
 pub mod sched;
 pub mod stw;
+pub mod tls;
 
 pub use gc::{
     raven_defer_enter_frame, raven_defer_push, raven_defer_run_frame, raven_gc_alloc,

--- a/raven-runtime/src/tls.rs
+++ b/raven-runtime/src/tls.rs
@@ -1,0 +1,555 @@
+//! Client-side TLS for compiled Raven programs, backing `std/tls`.
+//!
+//! Mirrors `std/net`'s C ABI conventions: each connection and each config lives
+//! in a global registry keyed by an opaque `i64` id (0 means failure), inputs
+//! and outputs cross as `object::String` byte buffers, and failures are left in
+//! a thread-local last-error slot the Raven wrapper reads after every call.
+//!
+//! TLS is `rustls` with the `ring` crypto provider and the bundled Mozilla root
+//! store (`webpki-roots`). A connection is a `StreamOwned<ClientConnection,
+//! TcpStream>` behind its own mutex, since a TLS session is stateful and cannot
+//! be cloned per-read the way a raw socket fd is. Every blocking handshake and
+//! read/write is wrapped in `gc::blocking`, the same bracket `std/net` uses, so
+//! a goroutine waiting on TLS I/O cooperates with the elastic worker pool and
+//! parks at a GC safepoint.
+
+use crate::object;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
+use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::slice;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+type TlsStream = StreamOwned<ClientConnection, TcpStream>;
+type TlsEntry = Arc<Mutex<TlsStream>>;
+
+/// Live TLS connections, keyed by the id handed to Raven.
+fn tls_registry() -> &'static Mutex<HashMap<i64, TlsEntry>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<i64, TlsEntry>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// A client configuration built up by the `raven_tls_config_*` setters and read
+/// once when a connect turns it into an `Arc<ClientConfig>`.
+#[derive(Default, Clone)]
+struct TlsConfigSpec {
+    extra_ca_pems: Vec<Vec<u8>>,
+    client_cert_pem: Option<Vec<u8>>,
+    client_key_pem: Option<Vec<u8>>,
+    skip_verify: bool,
+}
+
+fn cfg_registry() -> &'static Mutex<HashMap<i64, TlsConfigSpec>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<i64, TlsConfigSpec>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Ids start at 1 so 0 stays free as the failure sentinel. Streams and configs
+/// share the counter; they live in separate maps, so the values never collide.
+fn next_id() -> i64 {
+    static NEXT_ID: AtomicI64 = AtomicI64::new(1);
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+thread_local! {
+    static TLS_LAST_ERROR: RefCell<std::string::String> =
+        const { RefCell::new(std::string::String::new()) };
+}
+
+fn set_error(msg: std::string::String) {
+    TLS_LAST_ERROR.with(|e| *e.borrow_mut() = msg);
+}
+
+fn clear_error() {
+    TLS_LAST_ERROR.with(|e| e.borrow_mut().clear());
+}
+
+/// Read an incoming Raven `String` as an owned UTF-8 string, or `None` if it is
+/// not valid UTF-8. A null or empty string reads as `""`.
+fn read_str(s: *const object::String) -> Option<std::string::String> {
+    if s.is_null() {
+        return None;
+    }
+    let ptr = object::raven_string_bytes(s);
+    let len = object::raven_string_len(s) as usize;
+    if ptr.is_null() {
+        return Some(std::string::String::new());
+    }
+    let bytes = unsafe { slice::from_raw_parts(ptr, len) };
+    std::str::from_utf8(bytes).ok().map(|s| s.to_string())
+}
+
+fn empty_string() -> *mut object::String {
+    object::raven_string_from_bytes(std::ptr::null(), 0)
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_last_error() -> *mut object::String {
+    TLS_LAST_ERROR.with(|e| {
+        let msg = e.borrow();
+        object::raven_string_from_bytes(msg.as_ptr(), msg.len())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_config_new() -> i64 {
+    let id = next_id();
+    cfg_registry()
+        .lock()
+        .unwrap()
+        .insert(id, TlsConfigSpec::default());
+    clear_error();
+    id
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_config_add_ca_file(cfg: i64, path: *const object::String) -> i64 {
+    let path = match read_str(path) {
+        Some(p) => p,
+        None => {
+            set_error("ca path is not valid UTF-8".to_string());
+            return 0;
+        }
+    };
+    let pem = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            set_error(format!("read CA file: {e}"));
+            return 0;
+        }
+    };
+    match cfg_registry().lock().unwrap().get_mut(&cfg) {
+        Some(spec) => {
+            spec.extra_ca_pems.push(pem);
+            clear_error();
+            1
+        }
+        None => {
+            set_error("unknown tls config id".to_string());
+            0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_config_client_cert(
+    cfg: i64,
+    cert_path: *const object::String,
+    key_path: *const object::String,
+) -> i64 {
+    let cert_path = match read_str(cert_path) {
+        Some(p) => p,
+        None => {
+            set_error("client cert path is not valid UTF-8".to_string());
+            return 0;
+        }
+    };
+    let key_path = match read_str(key_path) {
+        Some(p) => p,
+        None => {
+            set_error("client key path is not valid UTF-8".to_string());
+            return 0;
+        }
+    };
+    let cert = match std::fs::read(&cert_path) {
+        Ok(b) => b,
+        Err(e) => {
+            set_error(format!("read client cert: {e}"));
+            return 0;
+        }
+    };
+    let key = match std::fs::read(&key_path) {
+        Ok(b) => b,
+        Err(e) => {
+            set_error(format!("read client key: {e}"));
+            return 0;
+        }
+    };
+    match cfg_registry().lock().unwrap().get_mut(&cfg) {
+        Some(spec) => {
+            spec.client_cert_pem = Some(cert);
+            spec.client_key_pem = Some(key);
+            clear_error();
+            1
+        }
+        None => {
+            set_error("unknown tls config id".to_string());
+            0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_config_insecure_skip_verify(cfg: i64, on: bool) {
+    if let Some(spec) = cfg_registry().lock().unwrap().get_mut(&cfg) {
+        spec.skip_verify = on;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_config_free(cfg: i64) {
+    cfg_registry().lock().unwrap().remove(&cfg);
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_connect(
+    addr: *const object::String,
+    server_name: *const object::String,
+    cfg: i64,
+) -> i64 {
+    let addr = match read_str(addr) {
+        Some(a) => a,
+        None => {
+            set_error("addr is not valid UTF-8".to_string());
+            return 0;
+        }
+    };
+    let sni = match read_str(server_name) {
+        Some(s) => s,
+        None => {
+            set_error("server_name is not valid UTF-8".to_string());
+            return 0;
+        }
+    };
+    let spec = if cfg == 0 {
+        TlsConfigSpec::default()
+    } else {
+        match cfg_registry().lock().unwrap().get(&cfg) {
+            Some(s) => s.clone(),
+            None => {
+                set_error("unknown tls config id".to_string());
+                return 0;
+            }
+        }
+    };
+    let config = match build_client_config(&spec) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(e);
+            return 0;
+        }
+    };
+    let server = match ServerName::try_from(sni.clone()) {
+        Ok(s) => s,
+        Err(_) => {
+            set_error(format!("invalid server name: {sni}"));
+            return 0;
+        }
+    };
+
+    let result = crate::gc::blocking(|| -> Result<TlsStream, std::string::String> {
+        let mut conn = ClientConnection::new(config, server).map_err(|e| e.to_string())?;
+        let mut tcp = TcpStream::connect(&addr).map_err(|e| e.to_string())?;
+        while conn.is_handshaking() {
+            let (rd, wr) = conn.complete_io(&mut tcp).map_err(|e| e.to_string())?;
+            if rd == 0 && wr == 0 && conn.is_handshaking() {
+                return Err("tls handshake stalled".to_string());
+            }
+        }
+        Ok(StreamOwned::new(conn, tcp))
+    });
+
+    match result {
+        Ok(stream) => {
+            let id = next_id();
+            tls_registry()
+                .lock()
+                .unwrap()
+                .insert(id, Arc::new(Mutex::new(stream)));
+            clear_error();
+            id
+        }
+        Err(e) => {
+            set_error(e);
+            0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_read(stream_id: i64, max: i64) -> *mut object::String {
+    if max < 0 {
+        set_error("read size must be non-negative".to_string());
+        return empty_string();
+    }
+    let cap = max as usize;
+    let entry = match tls_registry().lock().unwrap().get(&stream_id).cloned() {
+        Some(e) => e,
+        None => {
+            set_error("unknown tls stream id".to_string());
+            return empty_string();
+        }
+    };
+    let result = {
+        let mut guard = entry.lock().unwrap();
+        crate::gc::blocking(|| -> Result<Vec<u8>, std::string::String> {
+            let mut buf: Vec<u8> = Vec::new();
+            buf.try_reserve_exact(cap)
+                .map_err(|_| "read size too large to allocate".to_string())?;
+            buf.resize(cap, 0);
+            let n = guard.read(&mut buf).map_err(|e| e.to_string())?;
+            buf.truncate(n);
+            Ok(buf)
+        })
+    };
+    match result {
+        Ok(bytes) => {
+            clear_error();
+            object::raven_string_from_bytes(bytes.as_ptr(), bytes.len())
+        }
+        Err(e) => {
+            set_error(e);
+            empty_string()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_write(stream_id: i64, data: *const object::String) -> i64 {
+    let ptr = object::raven_string_bytes(data);
+    let len = object::raven_string_len(data) as usize;
+    let bytes: &[u8] = if ptr.is_null() || len == 0 {
+        &[]
+    } else {
+        unsafe { slice::from_raw_parts(ptr, len) }
+    };
+    let entry = match tls_registry().lock().unwrap().get(&stream_id).cloned() {
+        Some(e) => e,
+        None => {
+            set_error("unknown tls stream id".to_string());
+            return -1;
+        }
+    };
+    let result = {
+        let mut guard = entry.lock().unwrap();
+        crate::gc::blocking(|| {
+            guard
+                .write_all(bytes)
+                .and_then(|()| guard.flush())
+                .map(|()| bytes.len() as i64)
+                .map_err(|e| e.to_string())
+        })
+    };
+    match result {
+        Ok(n) => {
+            clear_error();
+            n
+        }
+        Err(e) => {
+            set_error(e);
+            -1
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_close(stream_id: i64) {
+    let entry = tls_registry().lock().unwrap().remove(&stream_id);
+    if let Some(entry) = entry {
+        if let Ok(mut guard) = entry.lock() {
+            guard.conn.send_close_notify();
+            let _ = guard.flush();
+            let _ = guard.sock.shutdown(std::net::Shutdown::Both);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_set_read_timeout_ms(stream_id: i64, ms: i64) {
+    if let Some(entry) = tls_registry().lock().unwrap().get(&stream_id).cloned() {
+        if let Ok(guard) = entry.lock() {
+            let d = if ms <= 0 {
+                None
+            } else {
+                Some(Duration::from_millis(ms as u64))
+            };
+            let _ = guard.sock.set_read_timeout(d);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn raven_tls_set_write_timeout_ms(stream_id: i64, ms: i64) {
+    if let Some(entry) = tls_registry().lock().unwrap().get(&stream_id).cloned() {
+        if let Ok(guard) = entry.lock() {
+            let d = if ms <= 0 {
+                None
+            } else {
+                Some(Duration::from_millis(ms as u64))
+            };
+            let _ = guard.sock.set_write_timeout(d);
+        }
+    }
+}
+
+/// Install the `ring` crypto provider as the process default once, so the
+/// `ClientConfig` builder and connections use it.
+fn ensure_provider() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+fn load_certs(pem: &[u8]) -> Result<Vec<CertificateDer<'static>>, std::string::String> {
+    let mut rd = std::io::BufReader::new(pem);
+    let mut out = Vec::new();
+    for c in rustls_pemfile::certs(&mut rd) {
+        out.push(c.map_err(|e| e.to_string())?);
+    }
+    if out.is_empty() {
+        return Err("no certificates found in PEM".to_string());
+    }
+    Ok(out)
+}
+
+fn load_key(pem: &[u8]) -> Result<PrivateKeyDer<'static>, std::string::String> {
+    let mut rd = std::io::BufReader::new(pem);
+    match rustls_pemfile::private_key(&mut rd).map_err(|e| e.to_string())? {
+        Some(k) => Ok(k),
+        None => Err("no private key found in PEM".to_string()),
+    }
+}
+
+fn build_client_config(spec: &TlsConfigSpec) -> Result<Arc<ClientConfig>, std::string::String> {
+    ensure_provider();
+    let mut roots = RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    for pem in &spec.extra_ca_pems {
+        for cert in load_certs(pem)? {
+            roots.add(cert).map_err(|e| e.to_string())?;
+        }
+    }
+    let builder = ClientConfig::builder();
+    let config = if spec.skip_verify {
+        let provider = rustls::crypto::CryptoProvider::get_default()
+            .cloned()
+            .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
+        let verifier = Arc::new(NoCertVerifier { provider });
+        let b = builder
+            .dangerous()
+            .with_custom_certificate_verifier(verifier);
+        finish_auth(b, spec)?
+    } else {
+        let b = builder.with_root_certificates(roots);
+        finish_auth(b, spec)?
+    };
+    Ok(Arc::new(config))
+}
+
+fn finish_auth(
+    b: rustls::ConfigBuilder<ClientConfig, rustls::client::WantsClientCert>,
+    spec: &TlsConfigSpec,
+) -> Result<ClientConfig, std::string::String> {
+    match (&spec.client_cert_pem, &spec.client_key_pem) {
+        (Some(cert), Some(key)) => {
+            let certs = load_certs(cert)?;
+            let key = load_key(key)?;
+            b.with_client_auth_cert(certs, key)
+                .map_err(|e| e.to_string())
+        }
+        _ => Ok(b.with_no_client_auth()),
+    }
+}
+
+/// A verifier that accepts any certificate, for `insecure_skip_verify`. It still
+/// checks the handshake signatures against the crypto provider, so the session
+/// is encrypted; it just does not authenticate the peer. Development only.
+#[derive(Debug)]
+struct NoCertVerifier {
+    provider: Arc<rustls::crypto::CryptoProvider>,
+}
+
+impl rustls::client::danger::ServerCertVerifier for NoCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Registry and error paths that need neither the network nor the GC heap
+    // (none of these construct an `object::String`). The handshake itself is
+    // covered end to end by the std/tls examples.
+
+    #[test]
+    fn config_new_allocates_and_free_removes() {
+        let id = raven_tls_config_new();
+        assert!(id > 0, "config id must be a non-zero handle");
+        assert!(cfg_registry().lock().unwrap().contains_key(&id));
+        raven_tls_config_free(id);
+        assert!(!cfg_registry().lock().unwrap().contains_key(&id));
+    }
+
+    #[test]
+    fn config_setters_tolerate_unknown_ids() {
+        // No-ops, must not panic on a stale or never-issued id.
+        raven_tls_config_insecure_skip_verify(999_999, true);
+        raven_tls_config_free(999_999);
+    }
+
+    #[test]
+    fn connect_rejects_unreadable_addr() {
+        // A null addr fails before any socket work and leaves the failure id 0.
+        let id = raven_tls_connect(std::ptr::null(), std::ptr::null(), 0);
+        assert_eq!(id, 0);
+    }
+
+    #[test]
+    fn io_on_unknown_stream_id_reports_failure() {
+        // write returns the -1 failure sentinel for an unknown stream, without
+        // constructing a result String.
+        assert_eq!(raven_tls_write(999_999, std::ptr::null()), -1);
+        // Timeout setters are no-ops on an unknown id.
+        raven_tls_set_read_timeout_ms(999_999, 1000);
+        raven_tls_set_write_timeout_ms(999_999, 0);
+    }
+}

--- a/src/resolve/imports.rs
+++ b/src/resolve/imports.rs
@@ -97,6 +97,7 @@ pub const STDLIB_MODULES: &[&str] = &[
     "process",
     "ffi",
     "sync",
+    "tls",
 ];
 
 /// Resolve every import declaration in `file`, inserting alias /

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -68,6 +68,7 @@ pub const BUNDLED_MODULES: &[(&str, &str)] = &[
     ("ffi", include_str!("../../stdlib/std/ffi.rv")),
     ("test", include_str!("../../stdlib/std/test.rv")),
     ("sync", include_str!("../../stdlib/std/sync.rv")),
+    ("tls", include_str!("../../stdlib/std/tls.rv")),
 ];
 
 /// The prelude module that is implicitly imported into every program.

--- a/stdlib/std/tls.rv
+++ b/stdlib/std/tls.rv
@@ -1,0 +1,160 @@
+// std/tls: client-side TLS over the raven-runtime C ABI. Like std/net, the
+// runtime keeps each TLS connection in a registry keyed by an opaque integer id
+// and hands Raven that id; TlsStream wraps it. Reads and writes carry bytes in a
+// String buffer, the same convention std/net uses. Fallible ops return
+// Result<T, Error> tagged kind "tls" via the runtime's thread-local last-error
+// slot. TLS I/O blocks by suspending the goroutine to the scheduler, so a
+// program can run many TLS connections across the worker pool at once.
+//
+// The default connect verifies the server against the bundled Mozilla root
+// store and sends `server_name` for SNI. For a private CA, a client certificate
+// (mTLS), or a dev-only skip of verification, build a TlsConfig and use
+// connect_with. See docs/v2/specs/std-tls.md.
+
+import std/error { error_kind }
+import std/string
+
+// An established TLS connection. The id keys the runtime's TLS registry.
+struct TlsStream {
+    id: Int,
+}
+
+// A client TLS configuration, built up with the methods below and handed to
+// connect_with. The id keys the runtime's TLS config registry.
+struct TlsConfig {
+    id: Int,
+}
+
+extern "C" {
+    fun raven_tls_last_error() -> String
+    fun raven_tls_config_new() -> Int
+    fun raven_tls_config_add_ca_file(cfg: Int, path: String) -> Int
+    fun raven_tls_config_client_cert(cfg: Int, cert_path: String, key_path: String) -> Int
+    fun raven_tls_config_insecure_skip_verify(cfg: Int, on: Bool)
+    fun raven_tls_config_free(cfg: Int)
+    fun raven_tls_connect(addr: String, server_name: String, cfg: Int) -> Int
+    fun raven_tls_read(stream_id: Int, max: Int) -> String
+    fun raven_tls_write(stream_id: Int, data: String) -> Int
+    fun raven_tls_close(stream_id: Int)
+    fun raven_tls_set_read_timeout_ms(stream_id: Int, ms: Int)
+    fun raven_tls_set_write_timeout_ms(stream_id: Int, ms: Int)
+}
+
+// An Error tagged with kind "tls", its message a context prefix joined to the
+// runtime's last-error text.
+fun tls_error(ctx: String) -> Error {
+    return error_kind("tls", ctx.concat(": ").concat(raven_tls_last_error()))
+}
+
+// Connect a verified TLS stream to `addr` ("host:port"), presenting
+// `server_name` for SNI and certificate verification against the bundled root
+// store. For most public services `server_name` is the host part of `addr`.
+fun connect(addr: String, server_name: String) -> Result<TlsStream, Error> {
+    let id = raven_tls_connect(addr, server_name, 0)
+    if id == 0 {
+        return Err(tls_error("connect"))
+    }
+    if raven_tls_last_error().length() > 0 {
+        return Err(tls_error("connect"))
+    }
+    return Ok(TlsStream { id })
+}
+
+// Connect using a custom TlsConfig (private CA, client certificate, or a
+// dev-only skip of verification).
+fun connect_with(addr: String, server_name: String, cfg: TlsConfig) -> Result<TlsStream, Error> {
+    let id = raven_tls_connect(addr, server_name, cfg.id)
+    if id == 0 {
+        return Err(tls_error("connect"))
+    }
+    if raven_tls_last_error().length() > 0 {
+        return Err(tls_error("connect"))
+    }
+    return Ok(TlsStream { id })
+}
+
+// Start a new client TLS configuration. It verifies against the bundled root
+// store until you change that with a builder method below.
+fun config() -> TlsConfig {
+    return TlsConfig { id: raven_tls_config_new() }
+}
+
+impl TlsConfig {
+    // Trust the PEM certificate(s) in `path` in addition to the bundled roots,
+    // for a server signed by a private CA. Returns self so calls can chain.
+    fun add_ca_file(self, path: String) -> TlsConfig {
+        let _ = raven_tls_config_add_ca_file(self.id, path)
+        return self
+    }
+
+    // Present a client certificate for mutual TLS. `cert_path` is the PEM
+    // certificate chain, `key_path` the PEM private key. Returns self.
+    fun client_cert(self, cert_path: String, key_path: String) -> TlsConfig {
+        let _ = raven_tls_config_client_cert(self.id, cert_path, key_path)
+        return self
+    }
+
+    // Disable certificate verification. For local development only: this makes
+    // the connection trivially interceptable. Returns self.
+    fun insecure_skip_verify(self) -> TlsConfig {
+        raven_tls_config_insecure_skip_verify(self.id, true)
+        return self
+    }
+
+    // Release the config's runtime registry entry. A connect copies what it
+    // needs, so a config can be freed once no more connects will use it.
+    fun free(self) {
+        raven_tls_config_free(self.id)
+    }
+}
+
+impl TlsStream {
+    // Read up to `max` decrypted bytes, returning them as a String byte buffer.
+    // A clean close yields Ok("").
+    fun read(self, max: Int) -> Result<String, Error> {
+        let data = raven_tls_read(self.id, max)
+        if raven_tls_last_error().length() > 0 {
+            return Err(tls_error("read"))
+        }
+        return Ok(data)
+    }
+
+    // Read until the peer closes the connection, accumulating every decrypted
+    // byte into one String. Reads in 4 KiB chunks.
+    fun read_all(self) -> Result<String, Error> {
+        let out = ""
+        let chunk = self.read(4096)?
+        while chunk.length() > 0 {
+            out = out.concat(chunk)
+            chunk = self.read(4096)?
+        }
+        return Ok(out)
+    }
+
+    // Encrypt and write all bytes of `data`, returning the count written.
+    fun write(self, data: String) -> Result<Int, Error> {
+        let n = raven_tls_write(self.id, data)
+        if n < 0 {
+            return Err(tls_error("write"))
+        }
+        if raven_tls_last_error().length() > 0 {
+            return Err(tls_error("write"))
+        }
+        return Ok(n)
+    }
+
+    // Set the read timeout in milliseconds. A value of 0 means no timeout.
+    fun set_read_timeout_ms(self, ms: Int) {
+        raven_tls_set_read_timeout_ms(self.id, ms)
+    }
+
+    // Set the write timeout in milliseconds. A value of 0 means no timeout.
+    fun set_write_timeout_ms(self, ms: Int) {
+        raven_tls_set_write_timeout_ms(self.id, ms)
+    }
+
+    // Send a close-notify and release the runtime-side connection.
+    fun close(self) {
+        raven_tls_close(self.id)
+    }
+}


### PR DESCRIPTION
Adds client-side TLS so Raven programs can speak TLS-secured protocols. This is the transport layer for the upcoming database and cache client libraries (Redis, Postgres, MySQL). Fixes #828.

## What's here

- **`std/tls`** (new stdlib module): `connect(addr, server_name)` opens a connection verified against the bundled Mozilla root store; `connect_with(addr, server_name, config)` uses a custom config. `TlsStream` has `read`/`read_all`/`write`/`close` and timeouts, all with the same `String` byte buffer and `Result<T, Error>` (kind `"tls"`) model as `std/net`. A fluent `TlsConfig` builder covers `add_ca_file` (private CA), `client_cert` (mutual TLS), and `insecure_skip_verify` (development only).
- **Runtime** (`raven-runtime/src/tls.rs`): rustls with the `ring` provider and `webpki-roots`. Mirrors `std/net`'s conventions: an `i64`-keyed registry for streams and configs, a thread-local last-error slot, and every handshake / read / write wrapped in `gc::blocking` so a goroutine on TLS I/O cooperates with the elastic worker pool and parks at a GC safepoint. No compiler changes.
- **Docs + example**: `docs/v2/specs/std-tls.md` and `examples/tls_client.rv` (network-dependent, so `golden:skip`).

## Why no `Conn` enum for http

The `std/http` **client** already speaks `https://`: it is backed by `ureq`, which already pulls in rustls. Confirmed with a live `get("https://example.com")` returning 200. So `std/tls` is scoped to raw TLS streams, which is what the DB protocols actually need; http needs nothing.

## Verification

Built a debug toolchain and ran real handshakes:
- Verified `GET` to `example.com:443` returns `HTTP/1.1 200 OK`.
- An untrusted self-signed cert (`self-signed.badssl.com`) is **rejected** by default.
- `insecure_skip_verify` lets that same connection through (proves the override, and that verification is real).
- `http.get("https://example.com")` returns 200 (ureq path).
- **8 concurrent TLS connections across goroutines all complete**, confirming the `gc::blocking` scheduler integration (the connection-pool use case).
- No-network unit tests cover the registry and error paths.

## Scope

In scope: client TLS, `std/tls`, confirming `https` for the http client.

Follow-ups (out of scope): server-side TLS termination, ALPN / HTTP-2, and a dedicated `Bytes` type to replace `String`-as-bytes for binary protocols (worth settling before the DB libraries lock in on `String`).

## Packaging

None needed: the stdlib is embedded in the binaries via `include_str!`, and the new runtime crates compile into the shipped `libraven_runtime` static lib.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client-side TLS support for standard library networking, including secure connections, custom CA certificates, mutual TLS, and a development-only insecure mode.
  * Introduced TLS stream read/write, timeout controls, connection closing, and error reporting.
  * Added a TLS client example showing verified and custom-configured connections.
* **Documentation**
  * Added a specification covering TLS usage, configuration, error behavior, and API details.
* **Chores**
  * Bumped the package version to `2.19.0`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->