### PR TITLE
feat: add tls.upgrade for STARTTLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Raven are documented in this file.
 
 ### Added
 
-- `std/tls`: client-side TLS. `connect(addr, server_name)` opens a connection verified against the bundled Mozilla root store, and `TlsStream` reads and writes encrypted bytes with the same `String` buffer and `Result`/`Error` model as `std/net`. A `TlsConfig` builder covers private CAs (`add_ca_file`), mutual TLS client certificates (`client_cert`), and a development-only `insecure_skip_verify`. Backed by rustls with the ring provider in the runtime; no compiler changes. This is the transport layer for upcoming database and cache client libraries (Redis, Postgres, MySQL). Outbound `https://` through the `std/http` client already worked (it is backed by ureq) and is unchanged. See `docs/v2/specs/std-tls.md`. (#828)
+- `std/tls`: client-side TLS. `connect(addr, server_name)` opens a connection verified against the bundled Mozilla root store, and `TlsStream` reads and writes encrypted bytes with the same `String` buffer and `Result`/`Error` model as `std/net`. A `TlsConfig` builder covers private CAs (`add_ca_file`), mutual TLS client certificates (`client_cert`), and a development-only `insecure_skip_verify`. `upgrade(stream, server_name)` turns an already-connected `std/net` TCP stream into TLS on the same socket, for protocols that negotiate in plaintext first and then start TLS (Postgres SSLRequest, MySQL, SMTP STARTTLS). Backed by rustls with the ring provider in the runtime; no compiler changes. This is the transport layer for upcoming database and cache client libraries (Redis, Postgres, MySQL). Outbound `https://` through the `std/http` client already worked (it is backed by ureq) and is unchanged. See `docs/v2/specs/std-tls.md`. (#828)
 
 ## [2.18.225] - 2026-06-26
 

--- a/docs/v2/specs/std-tls.md
+++ b/docs/v2/specs/std-tls.md
@@ -14,7 +14,7 @@ Postgres, or MySQL over an encrypted socket.
 ## Import
 
 ```rust
-import std/tls { connect, connect_with, config }
+import std/tls { connect, connect_with, upgrade, upgrade_with, config }
 ```
 
 The methods on `TlsStream` and `TlsConfig` come in with the types and need no

--- a/docs/v2/specs/std-tls.md
+++ b/docs/v2/specs/std-tls.md
@@ -46,6 +46,22 @@ checks that the certificate matches `server_name`, which is also sent as SNI.
   encrypted, but the peer is not authenticated, so this is for local
   development only.
 
+## STARTTLS upgrade
+
+`connect` does its own TCP connect, so it is for TLS from the first byte (HTTPS,
+Redis over TLS). Some protocols instead open a plaintext socket, exchange a
+start-TLS step, and then turn that same socket into TLS: Postgres (SSLRequest),
+MySQL, and SMTP STARTTLS. For those, connect with `std/net`, perform the
+protocol's negotiation, then call `upgrade(stream, server_name)` (or
+`upgrade_with` for a custom config) to run the handshake over the existing
+socket and get back a `TlsStream`.
+
+The `std/net` stream is consumed by an upgrade: on success its socket moves into
+the returned `TlsStream`, and on failure the connection is closed. Do not use
+the original `TcpStream` afterward. The config and SNI are validated before the
+socket is taken, so an upgrade that fails on a bad config leaves the original
+stream usable.
+
 ## Error model
 
 Fallible operations return `Result<T, Error>`. The error is an std/error `Error`
@@ -82,6 +98,7 @@ raven_tls_config_client_cert(cfg, cert_path, key_path) -> i64
 raven_tls_config_insecure_skip_verify(cfg, on)
 raven_tls_config_free(cfg)
 raven_tls_connect(addr, server_name, cfg) -> i64
+raven_tls_upgrade(net_stream_id, server_name, cfg) -> i64
 raven_tls_read(stream_id, max) -> String
 raven_tls_write(stream_id, data) -> i64
 raven_tls_close(stream_id)

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -281,6 +281,20 @@ fn net_insert(sock: Socket) -> i64 {
     id
 }
 
+/// Remove a connected TCP stream from the registry and return ownership of the
+/// socket, so another subsystem can take it over (std/tls upgrade for STARTTLS).
+/// Returns None if the id is unknown or names a listener, leaving the registry
+/// unchanged in that case.
+pub(crate) fn net_take_stream(id: i64) -> Option<TcpStream> {
+    let mut reg = net_registry().lock().unwrap();
+    if matches!(reg.get(&id), Some(Socket::Stream(_))) {
+        if let Some(Socket::Stream(stream)) = reg.remove(&id) {
+            return Some(stream);
+        }
+    }
+    None
+}
+
 /// Allocate `size` bytes aligned to `align`.
 ///
 /// Returns null on allocation failure or invalid layout. The current

--- a/raven-runtime/src/tls.rs
+++ b/raven-runtime/src/tls.rs
@@ -196,6 +196,51 @@ pub extern "C" fn raven_tls_config_free(cfg: i64) {
     cfg_registry().lock().unwrap().remove(&cfg);
 }
 
+/// Resolve a config id (0 = default) and an SNI name into the rustls config and
+/// server name a connection needs, without touching the network.
+fn prepare(
+    sni: &str,
+    cfg: i64,
+) -> Result<(Arc<ClientConfig>, ServerName<'static>), std::string::String> {
+    let spec = if cfg == 0 {
+        TlsConfigSpec::default()
+    } else {
+        match cfg_registry().lock().unwrap().get(&cfg) {
+            Some(s) => s.clone(),
+            None => return Err("unknown tls config id".to_string()),
+        }
+    };
+    let config = build_client_config(&spec)?;
+    let server =
+        ServerName::try_from(sni.to_string()).map_err(|_| format!("invalid server name: {sni}"))?;
+    Ok((config, server))
+}
+
+/// Run the TLS handshake to completion over `tcp`. Caller wraps this in
+/// `gc::blocking`.
+fn drive_handshake(
+    conn: &mut ClientConnection,
+    tcp: &mut TcpStream,
+) -> Result<(), std::string::String> {
+    while conn.is_handshaking() {
+        let (rd, wr) = conn.complete_io(tcp).map_err(|e| e.to_string())?;
+        if rd == 0 && wr == 0 && conn.is_handshaking() {
+            return Err("tls handshake stalled".to_string());
+        }
+    }
+    Ok(())
+}
+
+/// Register an established stream and return its id.
+fn register_stream(stream: TlsStream) -> i64 {
+    let id = next_id();
+    tls_registry()
+        .lock()
+        .unwrap()
+        .insert(id, Arc::new(Mutex::new(stream)));
+    id
+}
+
 #[no_mangle]
 pub extern "C" fn raven_tls_connect(
     addr: *const object::String,
@@ -216,28 +261,10 @@ pub extern "C" fn raven_tls_connect(
             return 0;
         }
     };
-    let spec = if cfg == 0 {
-        TlsConfigSpec::default()
-    } else {
-        match cfg_registry().lock().unwrap().get(&cfg) {
-            Some(s) => s.clone(),
-            None => {
-                set_error("unknown tls config id".to_string());
-                return 0;
-            }
-        }
-    };
-    let config = match build_client_config(&spec) {
-        Ok(c) => c,
+    let (config, server) = match prepare(&sni, cfg) {
+        Ok(v) => v,
         Err(e) => {
             set_error(e);
-            return 0;
-        }
-    };
-    let server = match ServerName::try_from(sni.clone()) {
-        Ok(s) => s,
-        Err(_) => {
-            set_error(format!("invalid server name: {sni}"));
             return 0;
         }
     };
@@ -245,24 +272,67 @@ pub extern "C" fn raven_tls_connect(
     let result = crate::gc::blocking(|| -> Result<TlsStream, std::string::String> {
         let mut conn = ClientConnection::new(config, server).map_err(|e| e.to_string())?;
         let mut tcp = TcpStream::connect(&addr).map_err(|e| e.to_string())?;
-        while conn.is_handshaking() {
-            let (rd, wr) = conn.complete_io(&mut tcp).map_err(|e| e.to_string())?;
-            if rd == 0 && wr == 0 && conn.is_handshaking() {
-                return Err("tls handshake stalled".to_string());
-            }
-        }
+        drive_handshake(&mut conn, &mut tcp)?;
         Ok(StreamOwned::new(conn, tcp))
     });
 
     match result {
         Ok(stream) => {
-            let id = next_id();
-            tls_registry()
-                .lock()
-                .unwrap()
-                .insert(id, Arc::new(Mutex::new(stream)));
             clear_error();
-            id
+            register_stream(stream)
+        }
+        Err(e) => {
+            set_error(e);
+            0
+        }
+    }
+}
+
+/// Upgrade an already-connected `std/net` TCP stream to TLS in place, for
+/// protocols that negotiate in plaintext first and then start TLS on the same
+/// socket (Postgres SSLRequest, MySQL, SMTP STARTTLS). The net stream id is
+/// consumed: on success its socket moves into the returned TLS stream, and on
+/// failure the connection is closed. Config and SNI are validated before the
+/// socket is taken, so a bad config leaves the net stream usable.
+#[no_mangle]
+pub extern "C" fn raven_tls_upgrade(
+    net_stream_id: i64,
+    server_name: *const object::String,
+    cfg: i64,
+) -> i64 {
+    let sni = match read_str(server_name) {
+        Some(s) => s,
+        None => {
+            set_error("server_name is not valid UTF-8".to_string());
+            return 0;
+        }
+    };
+    let (config, server) = match prepare(&sni, cfg) {
+        Ok(v) => v,
+        Err(e) => {
+            set_error(e);
+            return 0;
+        }
+    };
+    let tcp = match crate::net_take_stream(net_stream_id) {
+        Some(t) => t,
+        None => {
+            set_error("not a connected net stream id".to_string());
+            return 0;
+        }
+    };
+
+    let result = crate::gc::blocking(|| -> Result<TlsStream, std::string::String> {
+        let mut conn = ClientConnection::new(config, server).map_err(|e| e.to_string())?;
+        let mut tcp = tcp;
+        drive_handshake(&mut conn, &mut tcp)?;
+        Ok(StreamOwned::new(conn, tcp))
+    });
+
+    match result {
+        Ok(stream) => {
+            clear_error();
+            register_stream(stream)
         }
         Err(e) => {
             set_error(e);
@@ -540,6 +610,13 @@ mod tests {
     fn connect_rejects_unreadable_addr() {
         // A null addr fails before any socket work and leaves the failure id 0.
         let id = raven_tls_connect(std::ptr::null(), std::ptr::null(), 0);
+        assert_eq!(id, 0);
+    }
+
+    #[test]
+    fn upgrade_rejects_unreadable_server_name() {
+        // A null server_name fails before the net stream is taken, id 0.
+        let id = raven_tls_upgrade(999_999, std::ptr::null(), 0);
         assert_eq!(id, 0);
     }
 

--- a/stdlib/std/tls.rv
+++ b/stdlib/std/tls.rv
@@ -12,6 +12,7 @@
 // connect_with. See docs/v2/specs/std-tls.md.
 
 import std/error { error_kind }
+import std/net { TcpStream }
 import std/string
 
 // An established TLS connection. The id keys the runtime's TLS registry.
@@ -33,6 +34,7 @@ extern "C" {
     fun raven_tls_config_insecure_skip_verify(cfg: Int, on: Bool)
     fun raven_tls_config_free(cfg: Int)
     fun raven_tls_connect(addr: String, server_name: String, cfg: Int) -> Int
+    fun raven_tls_upgrade(net_stream_id: Int, server_name: String, cfg: Int) -> Int
     fun raven_tls_read(stream_id: Int, max: Int) -> String
     fun raven_tls_write(stream_id: Int, data: String) -> Int
     fun raven_tls_close(stream_id: Int)
@@ -69,6 +71,39 @@ fun connect_with(addr: String, server_name: String, cfg: TlsConfig) -> Result<Tl
     }
     if raven_tls_last_error().length() > 0 {
         return Err(tls_error("connect"))
+    }
+    return Ok(TlsStream { id })
+}
+
+// Upgrade an already-connected plaintext TCP stream to a verified TLS stream on
+// the same socket, for protocols that negotiate in the clear and then start TLS
+// (Postgres SSLRequest, MySQL, SMTP STARTTLS): connect with std/net, exchange
+// the protocol's start-TLS step, then call this. `server_name` is the host for
+// SNI and verification. The original stream is consumed: do not use it again.
+fun upgrade(stream: TcpStream, server_name: String) -> Result<TlsStream, Error> {
+    let id = raven_tls_upgrade(stream.id, server_name, 0)
+    if id == 0 {
+        return Err(tls_error("upgrade"))
+    }
+    if raven_tls_last_error().length() > 0 {
+        return Err(tls_error("upgrade"))
+    }
+    return Ok(TlsStream { id })
+}
+
+// Upgrade using a custom TlsConfig (private CA, client certificate, or a
+// dev-only skip of verification). See upgrade.
+fun upgrade_with(
+    stream: TcpStream,
+    server_name: String,
+    cfg: TlsConfig,
+) -> Result<TlsStream, Error> {
+    let id = raven_tls_upgrade(stream.id, server_name, cfg.id)
+    if id == 0 {
+        return Err(tls_error("upgrade"))
+    }
+    if raven_tls_last_error().length() > 0 {
+        return Err(tls_error("upgrade"))
     }
     return Ok(TlsStream { id })
 }


### PR DESCRIPTION
Adds `tls.upgrade` so protocols that negotiate in plaintext and then start TLS on the same socket (Postgres `SSLRequest`, MySQL, SMTP STARTTLS) can be built. Part of the unreleased 2.19.0; no version bump. Refs #828.

## Why

`tls.connect` does its own TCP connect, so it only covers TLS from the first byte (HTTPS, Redis-over-TLS). Postgres and MySQL don't work that way: the client opens a plaintext socket, sends a start-TLS request, reads the server's go-ahead, and upgrades that **same** connection to TLS. Without an upgrade path you can't write `raven-postgres`/`raven-mysql`.

## API

```rust
import std/net { connect }
import std/tls { upgrade }

let tcp = connect("db:5432")?       // plaintext
// ... send Postgres SSLRequest, read the server's 'S' ...
let tls = upgrade(tcp, "db")?       // same socket, now encrypted
```

`upgrade(stream, server_name)` (and `upgrade_with` for a custom config) take an already-connected `std/net` `TcpStream`, run the handshake over it, and return a `TlsStream`. The original stream is consumed: on success its socket moves into the `TlsStream`; on failure the connection is closed. Config and SNI are validated **before** the socket is taken, so an upgrade that fails on a bad config leaves the original stream usable.

## Runtime

A new `pub(crate) net_take_stream` hands a connected socket out of the `std/net` registry into the tls module. The shared config-build / handshake-drive / register steps are factored out of `connect` so both paths use them.

## Verification

`net.connect` to `example.com:443` then `tls.upgrade` over the same socket returns `HTTP/1.1 200 OK` (port 443 speaks TLS from byte 0, which exercises the handshake-over-an-existing-socket path). `connect` still passes after the refactor; added a no-network unit test for the upgrade error path. fmt + clippy clean.

## Note

This also confirms a bundled stdlib module can import another's type: `std/tls` now imports `std/net`'s `TcpStream`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for upgrading an existing plaintext TCP connection to TLS.
  * Introduced new `std/tls` APIs: `upgrade` (default TLS settings) and `upgrade_with` (custom TLS config).
* **Documentation**
  * Expanded the TLS specification and release notes to describe the STARTTLS-style upgrade flow and semantics.
* **Bug Fixes**
  * Improved upgrade validation and error handling so invalid server names fail before consuming the network stream, with clearer failure/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->