### PR TITLE
fix: const inference, library module qualifiers, qualified-type diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.19.1] - 2026-06-27
+
+### Fixed
+
+- Module-level `const` now infers its type from a literal initializer, like a module-level `let`. `const HOST = "127.0.0.1"` previously failed to parse (`expected ':'`) and required an explicit annotation. (#833)
+- A bare stdlib import used through a qualifier (`import std/net` then `net.connect(...)`) now resolves when the file is imported as a library, not only in a main file. The merge pass records the bare-import alias so the qualified call is rewritten to the stdlib's namespaced symbol; previously a library file failed with `cannot find net in scope`. (#831)
+- A module-qualified type name (`net.TcpStream`), which is not supported, now reports an actionable error pointing at the selector import (`import std/net { TcpStream }`) in both annotation and struct-literal position, instead of an opaque `expected expression` or type error. (#832)
+
 ## [2.19.0] - 2026-06-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.19.0"
+version = "2.19.1"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.19.0"
+version = "2.19.1"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.19.0"
+version = "2.19.1"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/qualimport/lib.rv
+++ b/examples/v2/qualimport/lib.rv
@@ -1,0 +1,11 @@
+// A library module that reaches a stdlib free function through a bare module
+// import and a qualified call (`fmt.repeat`). Regression for #831: this must
+// resolve when the file is merged in as a library, not only in a main file.
+
+import std/fmt
+import std/string
+
+fun banner(text: String) -> String {
+    let bar = fmt.repeat("=", 3)
+    return bar.concat(text).concat(bar)
+}

--- a/examples/v2/qualimport/main.rv
+++ b/examples/v2/qualimport/main.rv
@@ -1,0 +1,6 @@
+import std/io { println }
+import "./lib" { banner }
+
+fun main() {
+    println(banner("hi"))
+}

--- a/src/ast/decl.rs
+++ b/src/ast/decl.rs
@@ -236,7 +236,9 @@ pub enum ImportSource {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Const {
     pub name: String,
-    pub ty: Type,
+    /// `None` when the type is left to be inferred from the initializer (a
+    /// literal), mirroring a module-level `let`.
+    pub ty: Option<Type>,
     pub value: Expr,
     pub span: Span,
 }

--- a/src/ast/pretty.rs
+++ b/src/ast/pretty.rs
@@ -229,7 +229,12 @@ fn pretty_decl(buf: &mut String, decl: &Decl, depth: usize) {
             buf.push_str(")\n");
         }
         DeclKind::Const(c) => {
-            writeln!(buf, "(const {}: {} =", quote(&c.name), pretty_type(&c.ty)).unwrap();
+            match &c.ty {
+                Some(t) => {
+                    writeln!(buf, "(const {}: {} =", quote(&c.name), pretty_type(t)).unwrap()
+                }
+                None => writeln!(buf, "(const {} =", quote(&c.name)).unwrap(),
+            }
             pretty_expr(buf, &c.value, depth + 1);
             indent(buf, depth);
             buf.push_str(")\n");

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -670,7 +670,10 @@ impl Printer<'_> {
     }
 
     fn const_decl(&mut self, c: &Const) -> Option<String> {
-        let prefix = format!("const {}: {} = ", c.name, render_type(&c.ty));
+        let prefix = match &c.ty {
+            Some(t) => format!("const {}: {} = ", c.name, render_type(t)),
+            None => format!("const {} = ", c.name),
+        };
         let value = self.render_expr_col(&c.value, prefix.chars().count());
         self.line(&format!("{}{}", prefix, value));
         self.take_trailing_comment(self.line_of(c.span.end))

--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -331,7 +331,10 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
                 ));
             }
             let scope = GenericScope::new();
-            let ty = resolve_ty_for_decl(&c.ty, cx, &scope)?;
+            let ty = match &c.ty {
+                Some(t) => resolve_ty_for_decl(t, cx, &scope)?,
+                None => cx.ty_at(&c.value.span),
+            };
             let value = expr::lower_expr(&c.value, &ty, cx)?;
             Ok(Some(HirItem {
                 span: decl.span.clone(),

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -633,8 +633,13 @@ impl Parser {
     fn parse_const_decl(&mut self) -> ParseResult<Decl> {
         let start = self.advance().span; // const
         let (name, _) = self.expect_ident("identifier")?;
-        self.expect(&TokenKind::Colon, "`:`")?;
-        let ty = self.parse_type()?;
+        // The type annotation is optional: an unannotated `const` infers its
+        // type from a literal initializer, like a module-level `let`.
+        let ty = if self.eat(&TokenKind::Colon) {
+            Some(self.parse_type()?)
+        } else {
+            None
+        };
         self.expect(&TokenKind::Eq, "`=`")?;
         self.skip_newlines();
         let value = self.parse_expr()?;

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -296,6 +296,25 @@ impl Parser {
                             span,
                         };
                     } else {
+                        // A `{` right after a field access whose receiver is a
+                        // bare name (`net.TcpStream { ... }`) is an attempted
+                        // module-qualified struct literal, which is not
+                        // supported. Diagnose it instead of failing later on the
+                        // unexpected `{`. The `no_struct_literal` guard keeps
+                        // loop/if/match heads (`for x in a.b { }`) from tripping.
+                        if !self.no_struct_literal && matches!(self.peek_kind(), TokenKind::LBrace)
+                        {
+                            if let ExprKind::Ident { name: module, .. } = &expr.kind {
+                                return Err(RavenError::parse(
+                                    ParseError::Custom(format!(
+                                        "module-qualified type names like `{module}.{name}` are \
+                                         not supported; import the type with a selector, for \
+                                         example `import std/<module> {{ {name} }}`"
+                                    )),
+                                    name_span,
+                                ));
+                            }
+                        }
                         let span = merge_spans(&expr.span, &name_span);
                         expr = Expr {
                             kind: ExprKind::Field {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -896,6 +896,31 @@ fn parses_const_decl() {
         panic!()
     };
     assert_eq!(c.name, "PI");
+    assert!(c.ty.is_some());
+}
+
+#[test]
+fn parses_const_decl_without_type_annotation() {
+    // Regression for #833: a module-level `const` may omit the type and infer
+    // it from the initializer, like a module-level `let`.
+    let f = parse_ok("const HOST = \"127.0.0.1\"\n");
+    let DeclKind::Const(c) = &f.items[0].kind else {
+        panic!()
+    };
+    assert_eq!(c.name, "HOST");
+    assert!(c.ty.is_none());
+}
+
+#[test]
+fn module_qualified_struct_literal_is_a_clear_error() {
+    // Regression for #832: `net.TcpStream { ... }` reports an actionable error
+    // pointing at the selector import, not a bare "expected expression".
+    let err = parse_err("fun main() { let s = net.TcpStream { id: 0 } }\n");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("module-qualified type names") && msg.contains("selector"),
+        "got: {msg}"
+    );
 }
 
 // ----- block expressions and newline handling -----

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -416,6 +416,12 @@ pub fn expand_with_stdlib_ctx(
         for ext in external_modules {
             let key = external_module_key(&ext.host, &ext.user, &ext.repo, &ext.source_path);
             let mut rename = external_import_rename_map(&ext.file, ctx);
+            // A bare stdlib import (`import std/net`, no selectors) used through a
+            // qualifier inside an external package, the same #831 case as the
+            // local path above.
+            for (alias_key, target_key) in whole_module_stdlib_alias_renames(&ext.file) {
+                rename.insert(alias_key, target_key);
+            }
             // A whole-module alias (`import "github.com/x/b" as dep`) inside an
             // external module is recorded too, so a qualified `dep.fn()` resolves
             // to b's namespaced symbol after the import declaration is stripped.

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -380,6 +380,14 @@ pub fn expand_with_stdlib_ctx(
         {
             rename.insert(alias_key, target_key);
         }
+        // A bare stdlib import (`import std/net`, no selectors) makes `net.fn()`
+        // usable. Record the implicit alias so the merge rewrites the qualified
+        // call to the stdlib's namespaced symbol. Without this the qualifier
+        // resolves in a main file (whose import declarations are kept) but not in
+        // a merged library file, where the import is stripped (issue #831).
+        for (alias_key, target_key) in whole_module_stdlib_alias_renames(&module_file) {
+            rename.insert(alias_key, target_key);
+        }
         for name in top_level_fn_names(&module_file) {
             rename.insert(name.clone(), mangle_local_fn(&key, &name));
         }
@@ -595,7 +603,9 @@ fn merge_module_items(
             }
             DeclKind::Const(c) => {
                 rename_decl(&mut c.name, rename);
-                rewrite_type(&mut c.ty, rename);
+                if let Some(t) = &mut c.ty {
+                    rewrite_type(t, rename);
+                }
                 rewrite_expr(&mut c.value, rename);
             }
             DeclKind::Let(l) => {
@@ -803,6 +813,43 @@ fn whole_module_alias_renames(
             let key = local_module_key(&loaded.canonical_path);
             out.push((alias_rename_key(alias), key));
         }
+    }
+    out
+}
+
+/// Collect bare stdlib imports (`import std/net`, no selector list) as
+/// `(alias rename key, "std.<module>" target key)` pairs, so a qualified
+/// `net.fn()` call is rewritten to the stdlib's namespaced symbol
+/// (`mangle_local_fn("std.net", "fn")` equals `mangle_stdlib_fn("net", "fn")`).
+/// The implicit alias is the explicit `as` name or the last path segment,
+/// matching `bind_import`. Mirrors [`whole_module_alias_renames`] for the
+/// stdlib case so qualified access works in a merged library file too.
+fn whole_module_stdlib_alias_renames(file: &File) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for decl in &file.items {
+        let DeclKind::Import(import) = &decl.kind else {
+            continue;
+        };
+        if !import.selectors.is_empty() {
+            continue;
+        }
+        let ImportSource::Std(segments) = &import.source else {
+            continue;
+        };
+        let Some(module) = segments.first() else {
+            continue;
+        };
+        if parse_bundled_module(module).is_err() {
+            continue;
+        }
+        let alias = import.alias.clone().unwrap_or_else(|| {
+            segments
+                .last()
+                .cloned()
+                .unwrap_or_else(|| module.to_string())
+        });
+        let target_key = format!("std{sep}{module}", sep = NAMESPACE_SEP);
+        out.push((alias_rename_key(&alias), target_key));
     }
     out
 }

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -657,7 +657,7 @@ fn walk_type_path(
     // A module-qualified type name (`net.TcpStream`) is not supported: a module
     // alias names no type. Report it here with a pointer to the selector import,
     // instead of accepting the alias and failing later as an opaque type error.
-    if path.segments.len() > 1 && matches!(binding, Binding::ImportAlias(_)) {
+    if path.segments.len() > 1 && matches!(&binding, Binding::ImportAlias(_)) {
         let member = &path.segments[1].name;
         return Err(RavenError::resolve(
             ResolveError::Other(format!(

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -81,7 +81,9 @@ fn walk_decl(
             }
         }
         DeclKind::Const(c) => {
-            walk_type(&c.ty, scope, map)?;
+            if let Some(t) = &c.ty {
+                walk_type(t, scope, map)?;
+            }
             walk_expr(&c.value, scope, map)?;
         }
         DeclKind::Let(l) => {
@@ -652,6 +654,20 @@ fn walk_type_path(
         )
     })?;
     let binding = entry.binding.clone();
+    // A module-qualified type name (`net.TcpStream`) is not supported: a module
+    // alias names no type. Report it here with a pointer to the selector import,
+    // instead of accepting the alias and failing later as an opaque type error.
+    if path.segments.len() > 1 && matches!(binding, Binding::ImportAlias(_)) {
+        let member = &path.segments[1].name;
+        return Err(RavenError::resolve(
+            ResolveError::Other(format!(
+                "module-qualified type names like `{}.{member}` are not supported; \
+                 import the type with a selector, for example `import std/<module> {{ {member} }}`",
+                head.name
+            )),
+            head.span.clone(),
+        ));
+    }
     map.bind_use(&head.span, binding);
     for g in &head.generics {
         walk_type(g, scope, map)?;

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -161,7 +161,25 @@ pub fn collect_declarations(
             }
             DeclKind::Const(c) => {
                 let scope = GenericScope::new();
-                let ty = resolve_ty(&c.ty, resolved, env, None, &scope)?;
+                let ty = match &c.ty {
+                    Some(t) => resolve_ty(t, resolved, env, None, &scope)?,
+                    // An unannotated `const` infers its type from a literal
+                    // initializer, like a module-level `let`. A `const` requires
+                    // a constant initializer, so a non-literal one is reported
+                    // separately during lowering; ask for an annotation here.
+                    None => match literal_ty_of(&c.value) {
+                        Some(t) => t,
+                        None => {
+                            return Err(RavenError::ty(
+                                TypeError::Custom(format!(
+                                    "cannot infer the type of `const {0}` from this initializer; add a type annotation, for example `const {0}: SomeType = ...`",
+                                    c.name
+                                )),
+                                c.span.clone(),
+                            ));
+                        }
+                    },
+                };
                 env.consts.insert(id, ty);
             }
             DeclKind::Let(l) => {

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -119,6 +119,19 @@ fn multifile_local_imports_compile_and_run() {
 }
 
 #[test]
+fn library_qualified_stdlib_import_compiles_and_run() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Regression for #831: a library file (`./lib`) reaches a stdlib free
+    // function through a bare module import plus a qualified call
+    // (`import std/fmt` then `fmt.repeat`). The qualifier must resolve when the
+    // file is merged in as a library, which previously failed with "cannot find
+    // `fmt` in scope" (it only worked in a main file). Prints `=== hi ===`.
+    compile_link_run_and_check("qualimport/main.rv", "===hi===\n", &runtime);
+}
+
+#[test]
 fn struct_program_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
Three compiler ergonomics fixes found while writing the `raven-postgres` package. Fixes #831, #832, #833.

## #833 - module-level `const` inference
`Const.ty` becomes `Option<Type>`. An unannotated module-level `const` now infers its type from a literal initializer, exactly like a module-level `let` already did (parser, type collector, and HIR lowering). A non-inferable initializer asks for an annotation with a clear message.

```raven
const HOST = "127.0.0.1"   // was: error: expected `:`, found `=`
const PORT = 5432
```

## #831 - bare module qualifier in an imported library
A bare `import std/net` used through a qualifier (`net.connect(...)`) resolved in a main file but failed with `cannot find net in scope` when the file was imported as a library. A main file keeps its import declarations (so the alias binding exists); a library file has them stripped during the module merge, and the merge's rename map skipped bare imports.

Fix: `whole_module_stdlib_alias_renames` records the bare-import alias (`net` -> `std.net`) in the local-module merge, so the qualified call is rewritten to the stdlib's namespaced symbol the same way local `import "./b" as dep` aliases already are.

## #832 - module-qualified type names
`net.TcpStream` (a module-qualified type) is not supported by the language. It previously failed with an opaque `expected expression, found :` (struct-literal position) or a confusing downstream type error (annotation position). Both now report:

> module-qualified type names like `net.TcpStream` are not supported; import the type with a selector, for example `import std/<module> { TcpStream }`

Annotation/parameter/field position is caught in the resolver (`walk_type_path`, when a multi-segment type path's head is a module alias); struct-literal position is caught in the parser (a `{` after a bare-ident field access, guarded by `no_struct_literal` so `for x in a.b { }` is unaffected). Full qualified-type support is intentionally out of scope (the design excludes `m.Type`).

## Tests
- Parser: `const` without annotation parses with `ty: None`; qualified struct literal yields the clear error.
- `tests/codegen_smoke.rs`: a new multi-file fixture (`examples/v2/qualimport/`) where a library reaches `fmt.repeat` through a bare `import std/fmt` + qualifier, compiles, links, and runs.
- Full suite green: 628 lib tests, golden, 96 codegen, no regressions. fmt + clippy clean.

Patch release 2.19.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Module-level `const` declarations can now omit an explicit type, and supported literal values will infer it automatically.
  - Added a new example demonstrating qualified standard library imports working correctly in library vs entrypoint contexts.

- **Bug Fixes**
  - Fixed standard library import resolution when code is loaded as a library.
  - Improved diagnostics for unsupported module-qualified type names, with clearer instructions for using selector-style imports.
  - `const` formatting and type handling are now consistent whether the type is present or inferred.

- **Tests**
  - Added a regression smoke test covering the qualified stdlib import example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->