### PR TITLE
fix: keep code blocks left-aligned on mobile

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -355,6 +355,9 @@ body {
     font-family: 'Fira Code', 'Monaco', 'Consolas', monospace;
     font-size: var(--font-size-sm);
     line-height: 1.6;
+    /* Keep code left aligned so its indentation survives even when an ancestor
+       (the hero container on mobile) is centered. */
+    text-align: left;
 }
 
 .code-content code {
@@ -479,6 +482,7 @@ body {
     font-size: var(--font-size-sm);
     line-height: 1.6;
     overflow-x: auto;
+    text-align: left;
 }
 
 .code-example code {
@@ -562,6 +566,7 @@ body {
     font-size: var(--font-size-sm);
     line-height: 1.6;
     color: var(--white);
+    text-align: left;
 }
 
 /* Documentation Section */


### PR DESCRIPTION
The hero code block lost its formatting on mobile: every line was centered, so the indentation collapsed.

## Cause

`.hero-container` is centered on mobile (`text-align: center !important` in the `max-width: 768px` query). `text-align` inherits, so it reached the code `<pre>`, and centering whitespace-preserved `<pre>` content centers each line individually, which visually destroys the indentation.

## Fix

Set `text-align: left` on the three code `<pre>` rules (hero `.code-content pre`, `.code-example pre`, `.install-code pre`). A child's own `text-align` always wins over an inherited value, so the code stays left-aligned under any centered ancestor, on every viewport. Three lines, no markup change.

## Verified

Rendered at a 390px mobile viewport (headless browser): the hero block shows `fun main()` at column 0 with the `let`/`for`/`print` bodies correctly indented, and the examples block is left-aligned with horizontal scroll for long lines. Matches the desktop layout.

Note: CI path filters do not include `web/`, so no CI run is expected for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted code block alignment so code snippets remain left-aligned in more contexts, including mobile and container-centered layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->