### PR TITLE
fix: scroll the Quick Start code block instead of overflowing the page

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -567,6 +567,9 @@ body {
     line-height: 1.6;
     color: var(--white);
     text-align: left;
+    /* Scroll a long command/comment line within the box instead of letting it
+       push the page wider than the viewport on mobile. */
+    overflow-x: auto;
 }
 
 /* Documentation Section */


### PR DESCRIPTION
The Quick Start (install) code block broke mobile layout: its long comment lines pushed the whole page wider than the viewport, causing horizontal scroll of the entire page.

## Cause

`.install-code pre` had `overflow-x: visible`. With content (~346px, the `# Compile a source file...` comment) wider than its box (~295px) and no scroll container anywhere up the ancestor chain, the code painted past the viewport edge and added ~11px to the page width on a 375px screen.

The hero (`.code-content`) and examples (`.code-example pre`) blocks already had `overflow-x: auto`; the install block was the only one missing it.

## Fix

Give `.install-code pre` `overflow-x: auto` so a long line scrolls within the box, consistent with the other code blocks. One declaration.

## Verified with Playwright

Measured every element against the viewport at 375px and 320px:
- Page horizontal overflow: **11px to 0px**.
- All four example tabs (basics/traits/sumtypes/concurrency) scroll within their boxes; none paint past the viewport.
- No unclipped element extends past the viewport at 305-375px.

Quick Start now shows a horizontal scrollbar inside the block, left-aligned, with the page no longer overflowing.

Note: `web/` is not in the CI path filter, so no CI run is expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block display on mobile so long lines no longer stretch the page width.
  * Code samples now scroll horizontally within their container instead of causing viewport overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->