### PR TITLE
[codex] fix base32 padding validation

### DIFF
--- a/examples/v2/encoding_padding_validation.rv
+++ b/examples/v2/encoding_padding_validation.rv
@@ -1,6 +1,6 @@
 // The base64 and base32 decoders reject malformed padding: padding before the
-// final group, data after padding, and a partial (non-aligned) group, while
-// valid encodings still round-trip.
+// final group, data after padding, impossible base32 final groups, and a
+// partial (non-aligned) group, while valid encodings still round-trip.
 import std/encoding { base64_encode, base64_decode, base32_encode, base32_decode }
 fun rt64(s: String) -> Bool {
     return match base64_decode(base64_encode(s)) {
@@ -33,5 +33,7 @@ fun main() {
     print("rt32 abcd: ${rt32("abcd")}")
     print("b64 midpad rejected: ${rej64("QQ==QQ==")}")
     print("b32 after-pad rejected: ${rej32("AA======AA======")}")
+    print("b32 padding-only rejected: ${rej32("========")}")
+    print("b32 one-symbol rejected: ${rej32("M=======")}")
     print("b32 partial rejected: ${rej32("AAA")}")
 }

--- a/examples/v2/encoding_padding_validation.rv.out
+++ b/examples/v2/encoding_padding_validation.rv.out
@@ -4,4 +4,6 @@ rt32 hello: true
 rt32 abcd: true
 b64 midpad rejected: true
 b32 after-pad rejected: true
+b32 padding-only rejected: true
+b32 one-symbol rejected: true
 b32 partial rejected: true

--- a/stdlib/std/encoding.rv
+++ b/stdlib/std/encoding.rv
@@ -372,8 +372,6 @@ fun base32_encode(s: String) -> String {
     return out
 }
 
-// Decode an RFC 4648 base32 string. Padding and non-alphabet bytes are
-// skipped. The inverse of `base32_encode`.
 // Inverse of base32_encode. Trailing `=` is padding; any other non-alphabet
 // byte is an Err rather than being silently skipped.
 fun base32_decode(s: String) -> Result<String, Error> {
@@ -387,12 +385,14 @@ fun base32_decode(s: String) -> Result<String, Error> {
     let acc = 0
     let bits = 0
     let seen_pad = false
+    let pad_count = 0
     let i = 0
     while i < n {
         let b = __str_byte_at(s, i)
         if b == 61 {
             // `=` padding: no more data bits follow, and nothing may come after.
             seen_pad = true
+            pad_count = pad_count + 1
         } else {
             if seen_pad {
                 return Err(encoding_error("base32 data after padding"))
@@ -410,6 +410,9 @@ fun base32_decode(s: String) -> Result<String, Error> {
             }
         }
         i = i + 1
+    }
+    if pad_count != 0 && pad_count != 1 && pad_count != 3 && pad_count != 4 && pad_count != 6 {
+        return Err(encoding_error("base32 padding is malformed"))
     }
     return Ok(out)
 }


### PR DESCRIPTION
Fixes #838.

## Summary

- reject impossible RFC 4648 base32 trailing padding counts
- keep existing data-after-padding and bad-length validation behavior
- add golden coverage for padding-only and one-symbol padded inputs

## Validation

- `cargo build`
- `cargo test encoding_program_compiles_and_runs -- --nocapture`
- direct build/run of `examples/v2/encoding_padding_validation.rv`
- `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened base32 decoding so malformed padding is now rejected more consistently.
  * Invalid inputs with extra data after padding, impossible final groups, or incorrect padding-only forms now fail validation.
  * Added coverage for additional malformed base32 examples to confirm these cases are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->