### PR TITLE
Fix package boundary edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.19.17] - 2026-07-03
+
+### Fixed
+
+- Local modules that import a dependency as a whole module now keep the dependency's default alias after merge, so qualified calls such as `dep.value()` resolve from imported local modules. (#854)
+
+## [2.19.16] - 2026-07-03
+
+### Fixed
+
+- External packages that import another package as a whole module now keep the default package alias after merge, so dependency-qualified calls resolve without requiring an explicit `as` alias. (#853)
+
+## [2.19.15] - 2026-07-03
+
+### Fixed
+
+- External package files now load and rewrite local sibling imports such as `import "./util" { value }`, so cached packages can split code across local modules without unresolved symbols. (#852)
+
+## [2.19.14] - 2026-07-03
+
+### Fixed
+
+- Package names now reject Windows reserved device names such as `con`, `nul`, `com1`, and `lpt9`, preventing scaffolded or built packages from creating unusable output paths. (#851)
+
+## [2.19.13] - 2026-07-03
+
+### Fixed
+
+- `std/process.run` and `run_with_input` now reject arguments containing NUL bytes before joining argv for the runtime, preventing one Raven argument from being split into multiple child-process arguments. (#850)
+
+## [2.19.12] - 2026-07-03
+
+### Fixed
+
+- External package imports now verify existing cached source paths against the canonical package root, blocking relative-path, symlink, and junction escapes from the rvpm cache entry. (#849)
+
+## [2.19.11] - 2026-07-03
+
+### Fixed
+
+- `[ffi].sources` entries are now required to stay inside their package root, including after canonicalizing existing paths, so dependency manifests cannot compile C sources through traversal or links outside the package. (#848)
+
 ## [2.19.10] - 2026-07-02
 
 ### Fixed
@@ -696,15 +738,11 @@ All notable changes to Raven are documented in this file.
 
 ## [2.18.120] - 2026-06-16
 
-Continuing the codex-review fix batch (one patch per issue).
-
 ### Fixed
 
 - The formatter honors `[fmt].wrap_width`: an argument list, collection literal, or function signature whose single-line form would exceed the wrap width is broken onto multiple lines (one element or parameter per line). `rvpm fmt` reads the width from the manifest. Previously `wrap_width` was parsed but ignored (#581).
 
 ## [2.18.119] - 2026-06-16
-
-Continuing the codex-review fix batch (one patch per issue).
 
 ### Fixed
 
@@ -714,8 +752,6 @@ Continuing the codex-review fix batch (one patch per issue).
 
 ## [2.18.116] - 2026-06-16
 
-Continuing the codex-review fix batch (one patch per issue).
-
 ### Fixed
 
 - The doc extractor counts only structural braces when capturing a `struct`/`enum`/`trait` block, skipping braces inside comments, strings, and char literals so a brace in a doc comment no longer truncates the declaration (#577).
@@ -724,8 +760,6 @@ Continuing the codex-review fix batch (one patch per issue).
 - Comment scanning skips `${ ... }` interpolations as a unit, so a string nested in an interpolation no longer ends the outer literal early and mis-scans a following comment (#580).
 
 ## [2.18.112] - 2026-06-15
-
-Continuing the codex-review fix batch (one patch per issue).
 
 ### Fixed
 
@@ -738,8 +772,6 @@ Continuing the codex-review fix batch (one patch per issue).
 
 ## [2.18.106] - 2026-06-15
 
-Continuing the codex-review fix batch (one patch per issue).
-
 ### Fixed
 
 - A positive integer literal above Int's maximum (`9223372036854775808`) is now a parse error instead of silently compiling as `Int::MIN`; `-9223372036854775808` still parses as `Int::MIN` (#543).
@@ -750,8 +782,6 @@ Continuing the codex-review fix batch (one patch per issue).
 
 ## [2.18.101] - 2026-06-15
 
-Continuing the codex-review fix batch (one patch per issue).
-
 ### Fixed
 
 - `std/fs` write/append now write the raw bytes of a Raven String, so binary or non-UTF-8 content is no longer rejected (#561).
@@ -761,8 +791,8 @@ Continuing the codex-review fix batch (one patch per issue).
 
 ## [2.18.94] - 2026-06-15
 
-A batch of fixes from a full-codebase review (codex). The version is bumped one
-patch per issue fixed across this and the two preceding batches.
+A batch of fixes from a full-codebase review. The version is bumped one patch
+per issue fixed across this and the two preceding batches.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.19.10"
+version = "2.19.17"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.19.10"
+version = "2.19.17"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.19.10"
+version = "2.19.17"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/proc_nul_arg_parent.rv
+++ b/examples/v2/proc_nul_arg_parent.rv
@@ -1,0 +1,14 @@
+// golden:skip - std/process NUL argv validation, checked in codegen_smoke.rs.
+// `std/process.run` should reject an argument containing a NUL byte before
+// passing the joined argv buffer to the runtime.
+import std/process { run }
+import std/io { println }
+import std/string
+
+fun main() {
+    let bad = "left".concat(__str_from_byte(0)).concat("right")
+    match run("definitely-not-a-raven-test-program", [bad]) {
+        Ok(_) -> println("unexpected ok"),
+        Err(e) -> println(e.message()),
+    }
+}

--- a/examples/v2/stdlib_robustness.rv
+++ b/examples/v2/stdlib_robustness.rv
@@ -1,4 +1,4 @@
-// Regressions for codex-review stdlib robustness fixes: non-finite float
+// Regressions for stdlib robustness fixes: non-finite float
 // formatting (#555), a capped parse_float exponent (#427), and JSON validation
 // of leading zeros and raw control bytes (#558). Prints:
 //   inf

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -178,7 +178,7 @@ fn cmd_new(args: &[String]) -> Result<(), String> {
         .unwrap_or(target.as_str());
     if !raven::manifest::is_valid_package_name(name) {
         return Err(format!(
-            "'{}' is not a valid package name; use only ASCII letters, digits, '-', and '_'",
+            "'{}' is not a valid package name; use only ASCII letters, digits, '-', and '_', and avoid reserved Windows device names",
             name
         ));
     }

--- a/src/manifest/init.rs
+++ b/src/manifest/init.rs
@@ -40,7 +40,7 @@ impl std::fmt::Display for InitError {
             }
             InitError::InvalidName(name) => write!(
                 f,
-                "'{}' is not a valid package name; use only ASCII letters, digits, '-', and '_'",
+                "'{}' is not a valid package name; use only ASCII letters, digits, '-', and '_', and avoid reserved Windows device names",
                 name
             ),
             InitError::Io(e) => write!(f, "{}", e),

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -29,13 +29,23 @@ pub const ACCEPTED_EDITIONS: &[&str] = &["v2", "2026"];
 /// Whether `name` is a valid package name: a non-empty run of ASCII letters,
 /// digits, `-`, and `_` that does not start with `-`. The name is interpolated
 /// into scaffolded source and joined onto the output directory as a binary
-/// name, so a path separator or `..` must be rejected to prevent traversal.
+/// name, so a path separator, `..`, or Windows device filename must be rejected.
 pub fn is_valid_package_name(name: &str) -> bool {
     !name.is_empty()
         && !name.starts_with('-')
+        && !is_windows_reserved_package_name(name)
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+fn is_windows_reserved_package_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(lower.as_str(), "con" | "prn" | "aux" | "nul")
+        || (lower.len() == 4
+            && (lower.starts_with("com") || lower.starts_with("lpt"))
+            && lower.as_bytes()[3].is_ascii_digit()
+            && lower.as_bytes()[3] != b'0')
 }
 
 /// The default `[fmt].indent_width` when the section or field is absent.
@@ -251,7 +261,7 @@ impl Manifest {
             return Err(ManifestError::InvalidValue {
                 section: "package".to_string(),
                 field: "name".to_string(),
-                message: "must contain only ASCII letters, digits, '-', and '_', and may not start with '-' (the name is used as a file and output binary name)".to_string(),
+                message: "must contain only ASCII letters, digits, '-', and '_', may not start with '-', and may not be a reserved Windows device name (the name is used as a file and output binary name)".to_string(),
             });
         }
         let edition = match raw_pkg.edition {
@@ -371,6 +381,11 @@ mod tests {
         assert!(!is_valid_package_name("-leading"));
         assert!(!is_valid_package_name(""));
         assert!(!is_valid_package_name("has space"));
+        assert!(!is_valid_package_name("con"));
+        assert!(!is_valid_package_name("COM1"));
+        assert!(!is_valid_package_name("lpt9"));
+        assert!(is_valid_package_name("com10"));
+        assert!(is_valid_package_name("console"));
     }
 
     #[test]

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -15,7 +15,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::codegen::linker;
 use crate::driver::{self, DriverError};
@@ -52,6 +52,8 @@ pub enum OpError {
     Lock(LockError),
     /// `update` named a package that is not a dependency in `rv.toml`.
     UnknownPackage(String),
+    /// An `[ffi].sources` entry would read outside the package root.
+    UnsafeFfiSource { base: PathBuf, source: String },
     /// Neither entry file (`src/main.rv` for an application nor `lib.rv` for a
     /// library) was found.
     MissingEntry(PathBuf),
@@ -85,6 +87,12 @@ impl fmt::Display for OpError {
             OpError::UnknownPackage(p) => {
                 write!(f, "'{}' is not a dependency in rv.toml", p)
             }
+            OpError::UnsafeFfiSource { base, source } => write!(
+                f,
+                "invalid [ffi].sources entry '{}' under '{}': source paths must stay inside the package root",
+                source,
+                base.display()
+            ),
             OpError::MissingEntry(p) => {
                 let root = p.parent().and_then(|s| s.parent());
                 match root {
@@ -250,7 +258,7 @@ fn gather_native_link(
         &mut sources,
         &mut libs,
         &mut link_args,
-    );
+    )?;
 
     // Each dependency's [ffi], resolved against its cache directory, so a
     // package can bundle its own C and a consumer needs nothing installed.
@@ -262,7 +270,7 @@ fn gather_native_link(
         let dep_manifest = dir.join(MANIFEST_FILE_NAME);
         if dep_manifest.exists() {
             if let Ok(dep) = Manifest::load(&dep_manifest) {
-                collect_ffi(&dep.ffi, &dir, &mut sources, &mut libs, &mut link_args);
+                collect_ffi(&dep.ffi, &dir, &mut sources, &mut libs, &mut link_args)?;
             }
         }
     }
@@ -285,12 +293,52 @@ fn collect_ffi(
     sources: &mut Vec<PathBuf>,
     libs: &mut Vec<String>,
     link_args: &mut Vec<String>,
-) {
+) -> Result<(), OpError> {
     for source in &ffi.sources {
-        sources.push(base.join(source));
+        sources.push(checked_ffi_source(base, source)?);
     }
     libs.extend(ffi.libs.iter().cloned());
     link_args.extend(ffi.link_args.iter().cloned());
+    Ok(())
+}
+
+fn checked_ffi_source(base: &Path, source: &str) -> Result<PathBuf, OpError> {
+    let rel = Path::new(source);
+    let escapes_lexically = rel.components().any(|c| {
+        matches!(
+            c,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    });
+    if rel.is_absolute() || escapes_lexically {
+        return Err(OpError::UnsafeFfiSource {
+            base: base.to_path_buf(),
+            source: source.to_string(),
+        });
+    }
+
+    let candidate = base.join(rel);
+    if candidate.exists() {
+        let base_canon = base.canonicalize().map_err(|source| OpError::Io {
+            action: "canonicalize package root".to_string(),
+            path: base.to_path_buf(),
+            source,
+        })?;
+        let candidate_canon = candidate.canonicalize().map_err(|source| OpError::Io {
+            action: "canonicalize ffi source".to_string(),
+            path: candidate.clone(),
+            source,
+        })?;
+        if !candidate_canon.starts_with(&base_canon) {
+            return Err(OpError::UnsafeFfiSource {
+                base: base.to_path_buf(),
+                source: source.to_string(),
+            });
+        }
+        return Ok(candidate);
+    }
+
+    Ok(candidate)
 }
 
 /// What an install did, for reporting.
@@ -1032,6 +1080,84 @@ mod tests {
 
     const APP_MANIFEST: &str =
         "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n# keep this comment\n";
+
+    #[test]
+    fn collect_ffi_rejects_parent_dir_source() {
+        let proj = TempProject::new("ffi-parent");
+        let ffi = Ffi {
+            sources: vec!["../outside.c".to_string()],
+            ..Ffi::default()
+        };
+        let mut sources = Vec::new();
+        let mut libs = Vec::new();
+        let mut link_args = Vec::new();
+
+        let err =
+            collect_ffi(&ffi, &proj.root, &mut sources, &mut libs, &mut link_args).unwrap_err();
+
+        assert!(
+            matches!(&err, OpError::UnsafeFfiSource { source, .. } if source == "../outside.c"),
+            "expected an unsafe ffi source error, got {err:?}"
+        );
+        assert!(sources.is_empty());
+    }
+
+    #[test]
+    fn collect_ffi_accepts_existing_in_tree_source() {
+        let proj = TempProject::new("ffi-inside");
+        std::fs::create_dir_all(proj.root.join("c")).expect("mkdir c");
+        std::fs::write(
+            proj.root.join("c/native.c"),
+            "int raven_native(void){return 1;}\n",
+        )
+        .expect("write c source");
+        let ffi = Ffi {
+            sources: vec!["c/native.c".to_string()],
+            libs: vec!["m".to_string()],
+            link_args: vec!["-Wl,--as-needed".to_string()],
+        };
+        let mut sources = Vec::new();
+        let mut libs = Vec::new();
+        let mut link_args = Vec::new();
+
+        collect_ffi(&ffi, &proj.root, &mut sources, &mut libs, &mut link_args)
+            .expect("in-tree source");
+
+        assert_eq!(sources.len(), 1);
+        assert!(sources[0].ends_with("c/native.c") || sources[0].ends_with("c\\native.c"));
+        assert_eq!(libs, vec!["m".to_string()]);
+        assert_eq!(link_args, vec!["-Wl,--as-needed".to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_ffi_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+        let proj = TempProject::new("ffi-link");
+        let outside = TempProject::new("ffi-outside");
+        std::fs::write(
+            outside.root.join("native.c"),
+            "int outside(void){return 0;}\n",
+        )
+        .expect("write outside source");
+        symlink(outside.root.join("native.c"), proj.root.join("native.c"))
+            .expect("create source symlink");
+        let ffi = Ffi {
+            sources: vec!["native.c".to_string()],
+            ..Ffi::default()
+        };
+        let mut sources = Vec::new();
+        let mut libs = Vec::new();
+        let mut link_args = Vec::new();
+
+        let err =
+            collect_ffi(&ffi, &proj.root, &mut sources, &mut libs, &mut link_args).unwrap_err();
+
+        assert!(
+            matches!(&err, OpError::UnsafeFfiSource { source, .. } if source == "native.c"),
+            "expected a symlink escape error, got {err:?}"
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -178,6 +178,34 @@ impl PackageContext {
         self.locked_versions.get(&source.to_ascii_lowercase())
     }
 
+    fn package_dir(&self, source: &str) -> Option<PathBuf> {
+        let (canonical, version) = self.locked(source)?;
+        let gh = GithubPath::parse(canonical)?;
+        Some(crate::pkg::cache_dir_in(
+            &self.cache_root,
+            &gh.host,
+            &gh.user,
+            &gh.repo,
+            version,
+        ))
+    }
+
+    fn checked_package_path(&self, source: &str, candidate: PathBuf) -> Option<PathBuf> {
+        if !candidate.exists() {
+            return Some(candidate);
+        }
+
+        let package_dir = self.package_dir(source)?;
+        let cache_root = self.cache_root.canonicalize().ok()?;
+        let package_root = package_dir.canonicalize().ok()?;
+        if !package_root.starts_with(&cache_root) {
+            return None;
+        }
+
+        let resolved = candidate.canonicalize().ok()?;
+        resolved.starts_with(&package_root).then_some(resolved)
+    }
+
     /// Resolve the cached `.rv` source file for a `github.com/<user>/<repo>`
     /// path (the `source` key in the lock) and an import `subpath`.
     ///
@@ -189,10 +217,7 @@ impl PackageContext {
     /// `<cachedir>/util/text.rv`. Returns the resolved file path, or `None`
     /// when the package is not pinned in the lock.
     pub fn external_source_path(&self, source: &str, subpath: &[String]) -> Option<PathBuf> {
-        let (canonical, version) = self.locked(source)?;
-        let gh = GithubPath::parse(canonical)?;
-        let dir = crate::pkg::cache_dir_in(&self.cache_root, &gh.host, &gh.user, &gh.repo, version);
-        let mut file = dir;
+        let mut file = self.package_dir(source)?;
         if subpath.is_empty() {
             file.push("lib.rv");
         } else {
@@ -201,17 +226,29 @@ impl PackageContext {
             }
             file.push(format!("{}.rv", subpath[subpath.len() - 1]));
         }
-        Some(file)
+        self.checked_package_path(source, file)
+    }
+
+    fn external_local_source_path(
+        &self,
+        source: &str,
+        importing: &Path,
+        target: &str,
+    ) -> Option<PathBuf> {
+        let parent = importing.parent().unwrap_or_else(|| Path::new("."));
+        let mut path = parent.join(target);
+        if path.extension().is_none() {
+            path.set_extension("rv");
+        }
+        self.checked_package_path(source, path)
     }
 
     /// The path to a cached package's own `rv.toml`, used to read its
     /// transitive dependencies. Returns `None` when the package is not
     /// pinned in the lock.
     fn package_manifest_path(&self, source: &str) -> Option<PathBuf> {
-        let (canonical, version) = self.locked(source)?;
-        let gh = GithubPath::parse(canonical)?;
-        let dir = crate::pkg::cache_dir_in(&self.cache_root, &gh.host, &gh.user, &gh.repo, version);
-        Some(dir.join("rv.toml"))
+        let path = self.package_dir(source)?.join("rv.toml");
+        self.checked_package_path(source, path)
     }
 }
 
@@ -368,8 +405,11 @@ pub fn expand_with_stdlib_ctx(
         // than left unresolved. `import_rename_map` cannot do this on its own
         // because it has no package context.
         if let Some(ctx) = ctx {
-            for (selector, symbol) in external_import_rename_map(&module_file, ctx) {
+            for (selector, symbol) in external_import_rename_map(&module_file, ctx, None) {
                 rename.insert(selector, symbol);
+            }
+            for (alias_key, target_key) in whole_module_external_alias_renames(&module_file, ctx) {
+                rename.insert(alias_key, target_key);
             }
         }
         // A whole-module alias (`import "./b" as dep`) is recorded so the rewrite
@@ -415,7 +455,7 @@ pub fn expand_with_stdlib_ctx(
     if let Some(ctx) = ctx {
         for ext in external_modules {
             let key = external_module_key(&ext.host, &ext.user, &ext.repo, &ext.source_path);
-            let mut rename = external_import_rename_map(&ext.file, ctx);
+            let mut rename = external_import_rename_map(&ext.file, ctx, Some(&ext.source));
             // A bare stdlib import (`import std/net`, no selectors) used through a
             // qualifier inside an external package, the same #831 case as the
             // local path above.
@@ -426,6 +466,14 @@ pub fn expand_with_stdlib_ctx(
             // external module is recorded too, so a qualified `dep.fn()` resolves
             // to b's namespaced symbol after the import declaration is stripped.
             for (alias_key, target_key) in whole_module_external_alias_renames(&ext.file, ctx) {
+                rename.insert(alias_key, target_key);
+            }
+            // External package files may import sibling files with a local path.
+            // Their import declarations are stripped during merge too, so keep
+            // whole-module aliases for those sibling modules.
+            for (alias_key, target_key) in
+                whole_module_external_local_alias_renames(&ext.file, ctx, &ext.source)
+            {
                 rename.insert(alias_key, target_key);
             }
             for name in top_level_fn_names(&ext.file) {
@@ -787,12 +835,12 @@ fn import_rename_map(
     map
 }
 
-/// Collect the whole-module alias imports of `file` (`import "./b" as dep`, an
-/// alias with no selector list) as `(alias rename key, target module key)`
-/// pairs. A merged module strips its own import declarations, so a qualified
-/// `dep.member` call would otherwise lose the binding the alias stood for; the
-/// merge rewrite uses these to namespace it instead. Only local (`./`, `../`)
-/// imports are handled here.
+/// Collect the whole-module imports of `file` (`import "./b"` or
+/// `import "./b" as dep`, with no selector list) as `(alias rename key, target
+/// module key)` pairs. A merged module strips its own import declarations, so a
+/// qualified `dep.member` or `b.member` call would otherwise lose the binding
+/// the import stood for; the merge rewrite uses these to namespace it instead.
+/// Only local (`./`, `../`) imports are handled here.
 fn whole_module_alias_renames(
     file: &File,
     importing: &Path,
@@ -801,9 +849,6 @@ fn whole_module_alias_renames(
     let mut out = Vec::new();
     for decl in &file.items {
         let DeclKind::Import(import) = &decl.kind else {
-            continue;
-        };
-        let Some(alias) = &import.alias else {
             continue;
         };
         if !import.selectors.is_empty() {
@@ -816,8 +861,16 @@ fn whole_module_alias_renames(
             continue;
         }
         if let Some(loaded) = loader.load(importing, path) {
+            let alias = import.alias.clone().unwrap_or_else(|| {
+                loaded
+                    .canonical_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(path)
+                    .to_string()
+            });
             let key = local_module_key(&loaded.canonical_path);
-            out.push((alias_rename_key(alias), key));
+            out.push((alias_rename_key(&alias), key));
         }
     }
     out
@@ -861,16 +914,13 @@ fn whole_module_stdlib_alias_renames(file: &File) -> Vec<(String, String)> {
 }
 
 /// Like [`whole_module_alias_renames`] but for a `github.com/...` whole-module
-/// alias inside an external module, mapping the alias to the target package's
+/// import, mapping the alias (explicit or default) to the target package's
 /// `ext.` namespace key. The two share the `key.member` mangling, so the same
 /// rewrite handles a qualified call through either kind of alias.
 fn whole_module_external_alias_renames(file: &File, ctx: &PackageContext) -> Vec<(String, String)> {
     let mut out = Vec::new();
     for decl in &file.items {
         let DeclKind::Import(import) = &decl.kind else {
-            continue;
-        };
-        let Some(alias) = &import.alias else {
             continue;
         };
         if !import.selectors.is_empty() {
@@ -884,8 +934,53 @@ fn whole_module_external_alias_renames(file: &File, ctx: &PackageContext) -> Vec
         };
         let source = format!("github.com/{}/{}", gh.user, gh.repo);
         if let Some(src_path) = ctx.external_source_path(&source, &gh.subpath) {
+            let alias = import.alias.clone().unwrap_or_else(|| {
+                gh.subpath
+                    .last()
+                    .cloned()
+                    .unwrap_or_else(|| gh.repo.clone())
+            });
             let key = external_module_key(&gh.host, &gh.user, &gh.repo, &src_path);
-            out.push((alias_rename_key(alias), key));
+            out.push((alias_rename_key(&alias), key));
+        }
+    }
+    out
+}
+
+fn whole_module_external_local_alias_renames(
+    file: &File,
+    ctx: &PackageContext,
+    source: &str,
+) -> Vec<(String, String)> {
+    let Some(gh) = GithubPath::parse(source) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for decl in &file.items {
+        let DeclKind::Import(import) = &decl.kind else {
+            continue;
+        };
+        if !import.selectors.is_empty() {
+            continue;
+        }
+        let ImportSource::Quoted(path) = &import.source else {
+            continue;
+        };
+        if !(path.starts_with("./") || path.starts_with("../")) {
+            continue;
+        }
+        if let Some(src_path) =
+            ctx.external_local_source_path(source, file.span.file.as_ref().as_path(), path)
+        {
+            let alias = import.alias.clone().unwrap_or_else(|| {
+                src_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(path)
+                    .to_string()
+            });
+            let key = external_module_key(&gh.host, &gh.user, &gh.repo, &src_path);
+            out.push((alias_rename_key(&alias), key));
         }
     }
     out
@@ -894,6 +989,7 @@ fn whole_module_external_alias_renames(file: &File, ctx: &PackageContext) -> Vec
 /// One loaded external package source file plus the package identity it
 /// belongs to, so the merge can build its `ext.` namespace key.
 struct ExternalModule {
+    source: String,
     host: String,
     user: String,
     repo: String,
@@ -935,17 +1031,23 @@ fn load_external_modules(
     local_modules: &[File],
     ctx: &PackageContext,
 ) -> Result<Vec<ExternalModule>, RavenError> {
-    let mut queue: Vec<(String, Vec<String>)> = external_import_targets(user);
+    let mut queue: Vec<(String, PathBuf)> = Vec::new();
+    for (source, subpath) in external_import_targets(user) {
+        if let Some(path) = ctx.external_source_path(&source, &subpath) {
+            queue.push((source, path));
+        }
+    }
     for m in local_modules {
-        queue.extend(external_import_targets(m));
+        for (source, subpath) in external_import_targets(m) {
+            if let Some(path) = ctx.external_source_path(&source, &subpath) {
+                queue.push((source, path));
+            }
+        }
     }
     let mut loaded_paths: BTreeSet<PathBuf> = BTreeSet::new();
     let mut out: Vec<ExternalModule> = Vec::new();
 
-    while let Some((source, subpath)) = queue.pop() {
-        let Some(path) = ctx.external_source_path(&source, &subpath) else {
-            continue;
-        };
+    while let Some((source, path)) = queue.pop() {
         if !loaded_paths.insert(path.clone()) {
             continue;
         }
@@ -966,7 +1068,17 @@ fn load_external_modules(
         // Follow this file's own external imports (to sibling files in the
         // same package or to other packages).
         for (dep_source, dep_subpath) in external_import_targets(&module_file) {
-            queue.push((dep_source, dep_subpath));
+            if let Some(path) = ctx.external_source_path(&dep_source, &dep_subpath) {
+                queue.push((dep_source, path));
+            }
+        }
+        // Follow local imports declared by a cached package file. They resolve
+        // relative to the importing package source and are checked to stay
+        // inside the package root before any read happens.
+        for (_, dep) in local_import_targets(&module_file) {
+            if let Some(path) = ctx.external_local_source_path(&source, &path, &dep) {
+                queue.push((source.clone(), path));
+            }
         }
         // Read the package's cached manifest and queue each dependency's
         // entry file so a transitively required package merges even when
@@ -974,12 +1086,15 @@ fn load_external_modules(
         if let Some(manifest_path) = ctx.package_manifest_path(&source) {
             if let Ok(manifest) = crate::manifest::Manifest::load(&manifest_path) {
                 for dep in &manifest.dependencies {
-                    queue.push((dep.path.clone(), Vec::new()));
+                    if let Some(path) = ctx.external_source_path(&dep.path, &[]) {
+                        queue.push((dep.path.clone(), path));
+                    }
                 }
             }
         }
 
         out.push(ExternalModule {
+            source,
             host: gh.host,
             user: gh.user,
             repo: gh.repo,
@@ -996,7 +1111,11 @@ fn load_external_modules(
 /// to the sibling's `ext.` namespaced symbol. Mirrors [`import_rename_map`]
 /// for the external case. Selectors that name a type keep their own name
 /// and need no rename.
-fn external_import_rename_map(file: &File, ctx: &PackageContext) -> HashMap<String, String> {
+fn external_import_rename_map(
+    file: &File,
+    ctx: &PackageContext,
+    current_source: Option<&str>,
+) -> HashMap<String, String> {
     let mut map = HashMap::new();
     for decl in &file.items {
         let DeclKind::Import(import) = &decl.kind else {
@@ -1029,11 +1148,28 @@ fn external_import_rename_map(file: &File, ctx: &PackageContext) -> HashMap<Stri
                 }
             }
             ImportSource::Quoted(path) => {
-                let Some(gh) = GithubPath::parse(path) else {
-                    continue;
-                };
-                let source = format!("github.com/{}/{}", gh.user, gh.repo);
-                let Some(src_path) = ctx.external_source_path(&source, &gh.subpath) else {
+                let (gh, src_path) = if let Some(gh) = GithubPath::parse(path) {
+                    let source = format!("github.com/{}/{}", gh.user, gh.repo);
+                    let Some(src_path) = ctx.external_source_path(&source, &gh.subpath) else {
+                        continue;
+                    };
+                    (gh, src_path)
+                } else if path.starts_with("./") || path.starts_with("../") {
+                    let Some(source) = current_source else {
+                        continue;
+                    };
+                    let Some(gh) = GithubPath::parse(source) else {
+                        continue;
+                    };
+                    let Some(src_path) = ctx.external_local_source_path(
+                        source,
+                        file.span.file.as_ref().as_path(),
+                        path,
+                    ) else {
+                        continue;
+                    };
+                    (gh, src_path)
+                } else {
                     continue;
                 };
                 let Ok(text) = std::fs::read_to_string(&src_path) else {
@@ -1045,8 +1181,12 @@ fn external_import_rename_map(file: &File, ctx: &PackageContext) -> HashMap<Stri
                 let key = external_module_key(&gh.host, &gh.user, &gh.repo, &src_path);
                 let fns = top_level_fn_names(&target);
                 let types = top_level_type_names(&target);
+                let globals = top_level_global_names(&target);
                 for sel in &import.selectors {
-                    if fns.contains(&sel.name) || types.contains(&sel.name) {
+                    if fns.contains(&sel.name)
+                        || types.contains(&sel.name)
+                        || globals.contains(&sel.name)
+                    {
                         map.insert(sel.local().to_string(), mangle_external_fn(&key, &sel.name));
                     }
                 }
@@ -2036,6 +2176,83 @@ mod tests {
     }
 
     #[test]
+    fn external_local_source_path_rejects_existing_escape() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        let cache = std::env::temp_dir().join(format!(
+            "raven_ext_escape_{}_{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let pkg_dir = cache.join("github.com").join("acme").join("pkg@v1.0.0");
+        std::fs::create_dir_all(&pkg_dir).expect("mkdir package");
+        std::fs::write(pkg_dir.join("lib.rv"), "fun inside() -> Int { return 1 }\n")
+            .expect("write lib");
+        let outside = pkg_dir.parent().expect("package parent").join("escape.rv");
+        std::fs::write(&outside, "fun outside() -> Int { return 2 }\n").expect("write escape");
+
+        let lock = crate::lock::LockFile {
+            version: crate::lock::LOCK_VERSION,
+            packages: vec![crate::lock::LockedPackage {
+                source: "github.com/acme/pkg".to_string(),
+                version: "v1.0.0".to_string(),
+                hash: "sha256:abc".to_string(),
+            }],
+        };
+        let ctx = PackageContext::new(cache.clone(), &lock);
+        let lib = ctx
+            .external_source_path("github.com/acme/pkg", &[])
+            .expect("lib path");
+        assert!(
+            ctx.external_local_source_path("github.com/acme/pkg", &lib, "../escape")
+                .is_none(),
+            "an existing local import outside the cached package root must be rejected"
+        );
+
+        std::fs::remove_dir_all(&cache).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_source_path_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        let cache = std::env::temp_dir().join(format!(
+            "raven_ext_symlink_escape_{}_{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let pkg_dir = cache.join("github.com").join("acme").join("pkg@v1.0.0");
+        let outside_dir = cache.join("outside");
+        std::fs::create_dir_all(&pkg_dir).expect("mkdir package");
+        std::fs::create_dir_all(&outside_dir).expect("mkdir outside");
+        std::fs::write(
+            outside_dir.join("util.rv"),
+            "fun outside() -> Int { return 2 }\n",
+        )
+        .expect("write outside");
+        symlink(outside_dir.join("util.rv"), pkg_dir.join("util.rv")).expect("create symlink");
+
+        let lock = crate::lock::LockFile {
+            version: crate::lock::LOCK_VERSION,
+            packages: vec![crate::lock::LockedPackage {
+                source: "github.com/acme/pkg".to_string(),
+                version: "v1.0.0".to_string(),
+                hash: "sha256:abc".to_string(),
+            }],
+        };
+        let ctx = PackageContext::new(cache.clone(), &lock);
+        assert!(
+            ctx.external_source_path("github.com/acme/pkg", &["util".to_string()])
+                .is_none(),
+            "a symlinked source outside the cached package root must be rejected"
+        );
+
+        std::fs::remove_dir_all(&cache).ok();
+    }
+
+    #[test]
     fn external_function_merges_under_ext_namespace() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static N: AtomicUsize = AtomicUsize::new(0);
@@ -2073,7 +2290,10 @@ mod tests {
         );
         let (combined, _sites) = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
 
-        let key = external_module_key("github.com", "acme", "greet", &src_path);
+        let resolved_src = ctx
+            .external_source_path("github.com/acme/greet", &["lib".to_string()])
+            .expect("resolved source path");
+        let key = external_module_key("github.com", "acme", "greet", &resolved_src);
         let mangled = mangle_external_fn(&key, "shout");
         let present = combined
             .items
@@ -2140,8 +2360,11 @@ mod tests {
         );
         let (combined, _sites) = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
 
+        let resolved_src = ctx
+            .external_source_path("github.com/acme/greet", &["lib".to_string()])
+            .expect("resolved source path");
         let ext_shout = mangle_external_fn(
-            &external_module_key("github.com", "acme", "greet", &src_path),
+            &external_module_key("github.com", "acme", "greet", &resolved_src),
             "shout",
         );
         let loc_loud = mangle_local_fn(&local_module_key(&canon), "loud");
@@ -2164,6 +2387,241 @@ mod tests {
     }
 
     #[test]
+    fn external_local_selector_import_is_loaded_and_rewritten() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        let cache = std::env::temp_dir().join(format!(
+            "raven_ext_local_selector_{}_{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let pkg_dir = cache.join("github.com").join("acme").join("calc@v1.0.0");
+        std::fs::create_dir_all(&pkg_dir).expect("mkdir");
+        std::fs::write(
+            pkg_dir.join("rv.toml"),
+            "[package]\nname = \"calc\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("toml");
+        std::fs::write(
+            pkg_dir.join("lib.rv"),
+            "import \"./util\" { value }\nfun answer() -> Int { return value() }\n",
+        )
+        .expect("lib");
+        std::fs::write(
+            pkg_dir.join("util.rv"),
+            "fun value() -> Int { return 42 }\n",
+        )
+        .expect("util");
+
+        let lock = crate::lock::LockFile {
+            version: crate::lock::LOCK_VERSION,
+            packages: vec![crate::lock::LockedPackage {
+                source: "github.com/acme/calc".to_string(),
+                version: "v1.0.0".to_string(),
+                hash: "sha256:abc".to_string(),
+            }],
+        };
+        let ctx = PackageContext::new(cache.clone(), &lock);
+        let user = parse_src(
+            "import \"github.com/acme/calc\" { answer }\nfun main() { print(answer()) }\n",
+        );
+        let (combined, _sites) = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
+
+        let lib_path = ctx
+            .external_source_path("github.com/acme/calc", &[])
+            .expect("lib path");
+        let util_path = ctx
+            .external_local_source_path("github.com/acme/calc", &lib_path, "./util")
+            .expect("util path");
+        let answer = mangle_external_fn(
+            &external_module_key("github.com", "acme", "calc", &lib_path),
+            "answer",
+        );
+        let value = mangle_external_fn(
+            &external_module_key("github.com", "acme", "calc", &util_path),
+            "value",
+        );
+        let answer_fn = combined
+            .items
+            .iter()
+            .find_map(|d| match &d.kind {
+                DeclKind::Function(f) if f.name == answer => Some(f),
+                _ => None,
+            })
+            .expect("answer merged");
+        let mut idents = Vec::new();
+        collect_fn_body_idents(&answer_fn.body, &mut idents);
+        assert!(
+            idents.iter().any(|n| *n == value),
+            "answer should call {value}, got {idents:?}"
+        );
+
+        std::fs::remove_dir_all(&cache).ok();
+    }
+
+    #[test]
+    fn external_whole_module_default_alias_is_rewritten() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        let cache = std::env::temp_dir().join(format!(
+            "raven_ext_whole_alias_{}_{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let base = cache.join("github.com").join("acme");
+        let app_dir = base.join("app@v1.0.0");
+        let dep_dir = base.join("dep@v2.0.0");
+        std::fs::create_dir_all(&app_dir).expect("mkdir app");
+        std::fs::create_dir_all(&dep_dir).expect("mkdir dep");
+        std::fs::write(
+            app_dir.join("rv.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\
+             [dependencies]\n\"github.com/acme/dep\" = \"v2.0.0\"\n",
+        )
+        .expect("app toml");
+        std::fs::write(
+            dep_dir.join("rv.toml"),
+            "[package]\nname = \"dep\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("dep toml");
+        std::fs::write(
+            app_dir.join("lib.rv"),
+            "import \"github.com/acme/dep\"\nfun answer() -> Int { return dep.value() }\n",
+        )
+        .expect("app lib");
+        std::fs::write(dep_dir.join("lib.rv"), "fun value() -> Int { return 7 }\n")
+            .expect("dep lib");
+
+        let lock = crate::lock::LockFile {
+            version: crate::lock::LOCK_VERSION,
+            packages: vec![
+                crate::lock::LockedPackage {
+                    source: "github.com/acme/app".to_string(),
+                    version: "v1.0.0".to_string(),
+                    hash: "sha256:app".to_string(),
+                },
+                crate::lock::LockedPackage {
+                    source: "github.com/acme/dep".to_string(),
+                    version: "v2.0.0".to_string(),
+                    hash: "sha256:dep".to_string(),
+                },
+            ],
+        };
+        let ctx = PackageContext::new(cache.clone(), &lock);
+        let user = parse_src(
+            "import \"github.com/acme/app\" { answer }\nfun main() { print(answer()) }\n",
+        );
+        let (combined, _sites) = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
+
+        let app_path = ctx
+            .external_source_path("github.com/acme/app", &[])
+            .expect("app path");
+        let dep_path = ctx
+            .external_source_path("github.com/acme/dep", &[])
+            .expect("dep path");
+        let answer = mangle_external_fn(
+            &external_module_key("github.com", "acme", "app", &app_path),
+            "answer",
+        );
+        let value = mangle_external_fn(
+            &external_module_key("github.com", "acme", "dep", &dep_path),
+            "value",
+        );
+        let answer_fn = combined
+            .items
+            .iter()
+            .find_map(|d| match &d.kind {
+                DeclKind::Function(f) if f.name == answer => Some(f),
+                _ => None,
+            })
+            .expect("answer merged");
+        let mut idents = Vec::new();
+        collect_fn_body_idents(&answer_fn.body, &mut idents);
+        assert!(
+            idents.iter().any(|n| *n == value),
+            "answer should call {value}, got {idents:?}"
+        );
+
+        std::fs::remove_dir_all(&cache).ok();
+    }
+
+    #[test]
+    fn local_module_external_whole_module_alias_is_rewritten() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        let cache = std::env::temp_dir().join(format!(
+            "raven_local_ext_whole_alias_{}_{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let dep_dir = cache.join("github.com").join("acme").join("dep@v1.0.0");
+        std::fs::create_dir_all(&dep_dir).expect("mkdir dep");
+        std::fs::write(
+            dep_dir.join("rv.toml"),
+            "[package]\nname = \"dep\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("dep toml");
+        std::fs::write(dep_dir.join("lib.rv"), "fun value() -> Int { return 9 }\n")
+            .expect("dep lib");
+
+        let lock = crate::lock::LockFile {
+            version: crate::lock::LOCK_VERSION,
+            packages: vec![crate::lock::LockedPackage {
+                source: "github.com/acme/dep".to_string(),
+                version: "v1.0.0".to_string(),
+                hash: "sha256:dep".to_string(),
+            }],
+        };
+        let ctx = PackageContext::new(cache.clone(), &lock);
+
+        let (proj, entry) = write_temp_project(
+            &[
+                (
+                    "helper.rv",
+                    "import \"github.com/acme/dep\"\nfun via() -> Int { return dep.value() }\n",
+                ),
+                (
+                    "main.rv",
+                    "import \"./helper\" { via }\nfun main() { print(via()) }\n",
+                ),
+            ],
+            "main.rv",
+        );
+        let canon = proj.join("helper.rv").canonicalize().expect("canon");
+        let user = parse_at(
+            "import \"./helper\" { via }\nfun main() { print(via()) }\n",
+            &entry,
+        );
+        let (combined, _sites) = expand_with_stdlib_ctx(&user, Some(&ctx)).expect("expand");
+
+        let dep_path = ctx
+            .external_source_path("github.com/acme/dep", &[])
+            .expect("dep path");
+        let via = mangle_local_fn(&local_module_key(&canon), "via");
+        let value = mangle_external_fn(
+            &external_module_key("github.com", "acme", "dep", &dep_path),
+            "value",
+        );
+        let via_fn = combined
+            .items
+            .iter()
+            .find_map(|d| match &d.kind {
+                DeclKind::Function(f) if f.name == via => Some(f),
+                _ => None,
+            })
+            .expect("via merged");
+        let mut idents = Vec::new();
+        collect_fn_body_idents(&via_fn.body, &mut idents);
+        assert!(
+            idents.iter().any(|n| *n == value),
+            "via should call {value}, got {idents:?}"
+        );
+
+        std::fs::remove_dir_all(&cache).ok();
+        std::fs::remove_dir_all(&proj).ok();
+    }
+
+    #[test]
     fn external_stdlib_free_function_import_is_renamed() {
         // A dependency that imports a std free function must have its call
         // sites renamed to the std namespace when merged, the same as its
@@ -2178,7 +2636,7 @@ mod tests {
         let file = parse_src(
             "import std/time { now_millis }\nfun stamp() -> Int { return now_millis() }\n",
         );
-        let map = external_import_rename_map(&file, &ctx);
+        let map = external_import_rename_map(&file, &ctx, None);
         assert_eq!(
             map.get("now_millis"),
             Some(&mangle_stdlib_fn("time", "now_millis"))

--- a/stdlib/std/process.rv
+++ b/stdlib/std/process.rv
@@ -14,6 +14,7 @@
 // list is the empty String. See docs/v2/specs/std-process.md.
 
 import std/error
+import std/string
 
 struct Output {
     code: Int,
@@ -54,6 +55,19 @@ fun join_args(args: List<String>) -> String {
     return out
 }
 
+fun validate_args(args: List<String>) -> Result<Bool, Error> {
+    let nul = __str_from_byte(0)
+    let i = 0
+    let n = args.len()
+    while i < n {
+        if args[i].contains(nul) {
+            return Err(Error { kind: "process", message: "process argument contains NUL byte" })
+        }
+        i = i + 1
+    }
+    return Ok(true)
+}
+
 // Pull the finished child `id` into an Output and free the registry entry.
 fun collect(id: Int) -> Output {
     let out = Output {
@@ -70,6 +84,7 @@ fun collect(id: Int) -> Output {
 // exit is still Ok. On a spawn failure returns Err tagged with kind
 // "process".
 fun run(program: String, args: List<String>) -> Result<Output, Error> {
+    validate_args(args)?
     let id = raven_process_run(program, join_args(args), "")
     if id == 0 {
         return Err(Error { kind: "process", message: raven_process_last_error() })
@@ -80,6 +95,7 @@ fun run(program: String, args: List<String>) -> Result<Output, Error> {
 // Like `run`, but feeds `input` to the child's stdin (which is then
 // closed).
 fun run_with_input(program: String, args: List<String>, input: String) -> Result<Output, Error> {
+    validate_args(args)?
     let id = raven_process_run(program, join_args(args), input)
     if id == 0 {
         return Err(Error { kind: "process", message: raven_process_last_error() })

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1952,6 +1952,18 @@ fn proc_argv_preserves_empty_arg() {
 }
 
 #[test]
+fn proc_argv_rejects_nul_arg() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    compile_link_run_and_check(
+        "proc_nul_arg_parent.rv",
+        "process argument contains NUL byte\n",
+        &runtime,
+    );
+}
+
+#[test]
 fn proc_binary_io_compiles_and_runs() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
## Summary

- Harden rvpm package boundary handling for `[ffi].sources` and cached external package source reads.
- Fix external package local imports, dependency whole-module aliases, and local-module dependency aliases during stdlib/package merge.
- Reject NUL bytes in `std/process` argv before calling the runtime, and reject Windows reserved package names.
- Bump the workspace patch version from 2.19.10 to 2.19.17 and add one changelog entry per fixed issue.

## Fixed Issues

Closes #848
Closes #849
Closes #850
Closes #851
Closes #852
Closes #853
Closes #854

Excluded by request: #214, #215, #224.

## Validation

- `cargo test -p raven --lib`
- `cargo test -p raven --test codegen_smoke proc_argv_rejects_nul_arg`
- `cargo test -p raven --test rvpm_build`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package-name validation to reject reserved Windows device names.
  - Prevented process arguments containing NUL bytes from being accepted.
  - Strengthened handling of cached packages and external imports to avoid path escape issues.
  - Preserved module aliases more consistently when merging imports and external packages.
  - Added safer handling for `[ffi].sources` so paths must stay within the package root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->