### PR TITLE
feat: std/http request timeouts and a streaming client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Raven are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `std/http` gains `request_with_timeout(method, url, body, headers, timeout_ms)`: a positive `timeout_ms` is an overall deadline for the whole request, so slow endpoints such as model inference APIs no longer hit the fixed 10 second read timeout. (#859)
+- `std/http` gains a streaming client: `stream(method, url, body, headers, timeout_ms)` returns an `HttpStream` with the status and headers captured at open and a `read_chunk()` that pulls the body as the server sends it, enabling server-sent events and chunked responses. The timeout applies per read, so long-lived streams stay open. (#860)
+
 ## [2.20.0] - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Raven are documented in this file.
 
-## [Unreleased]
+## [2.21.0] - 2026-07-03
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.20.0"
+version = "2.21.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/docs/v2/specs/std-http.md
+++ b/docs/v2/specs/std-http.md
@@ -98,6 +98,47 @@ The runtime builds the ureq agent with fixed timeouts so a hung server
 cannot wedge a program or a test: 5 seconds to connect, 10 seconds to read,
 and 10 seconds to write.
 
+Endpoints that legitimately take longer (model inference APIs, slow report
+generators) use `request_with_timeout(method, url, body, headers,
+timeout_ms)`: a positive `timeout_ms` is an overall deadline covering the
+connect, the send, and reading the whole body, and a deadline overrun
+surfaces as an `Err` like any other transport failure. `timeout_ms <= 0`
+keeps the defaults, so `request_with_timeout(m, u, b, h, 0)` behaves
+exactly like `request(m, u, b, h)`.
+
+## Streaming
+
+`stream(method, url, body, headers, timeout_ms)` opens a request without
+buffering the body: the returned `HttpStream` carries the `status_code`,
+`status_text`, and `headers` captured at open, and `read_chunk()` pulls the
+body as the server sends it, at most 8 KiB per call, returning `Ok("")`
+when the stream ends. This is how to consume server-sent events, chunked
+transfers, and bodies too large or too slow to hold whole. `close()`
+releases the stream and its connection.
+
+Streaming semantics differ from the buffered path in three ways:
+
+* The timeout is per operation, not overall: a positive `timeout_ms` bounds
+  the connect and each individual read, because a healthy stream may stay
+  open for minutes. A read that outlives it is an `Err` from `read_chunk`.
+* A non-2xx status opens normally (the error body is often worth reading);
+  only a transport failure is an `Err` from `stream`.
+* One read at a time per stream: the runtime hands the reader to the read
+  in flight, and a concurrent `read_chunk` on the same stream observes end
+  of stream rather than blocking.
+
+Chunk boundaries follow socket reads and carry no meaning; a consumer
+reassembles or splits on its own framing (for SSE, blank-line-delimited
+events).
+
+The runtime side registers the open response in a stream registry keyed by
+the same id space as buffered responses (`raven_http_stream_open`,
+`raven_http_stream_read`, `raven_http_stream_status`,
+`raven_http_stream_status_text`, `raven_http_stream_headers`,
+`raven_http_stream_close`). The registry lock is never held across a
+blocking read: the reader is taken out of the entry for the read's
+duration and put back after.
+
 ## FFI path
 
 This module uses `extern "C"` blocks binding raven-runtime symbols

--- a/examples/v2/http_timeout_stream.rv
+++ b/examples/v2/http_timeout_stream.rv
@@ -1,0 +1,111 @@
+// Exercises request_with_timeout and the streaming client against an
+// in-process std/http server: a short deadline on a slow route times out, a
+// generous one succeeds, and a large body arrives over multiple stream
+// chunks that reassemble exactly.
+// golden:skip (binds a port and depends on timing, so it is not diffed by
+// the golden suite; run it directly to verify the client paths).
+
+import std/http { Server, Request, Response, request_with_timeout, stream }
+import std/io { println }
+import std/string
+import std/time { sleep_millis }
+
+// Six copies of a 16 KiB body, comfortably past the 8 KiB chunk size.
+fun big_text() -> String {
+    let piece = "0123456789abcdef".repeat(1024)
+    return piece.repeat(6)
+}
+
+fun slow(req: Request) -> Response {
+    sleep_millis(600)
+    return Response.text("finally done")
+}
+
+fun big(req: Request) -> Response {
+    return Response.text(big_text())
+}
+
+fun serve() {
+    let app = Server.new()
+    app.get("/slow", slow)
+    app.get("/big", big)
+    app.listen("127.0.0.1:8193")
+}
+
+// The server binds in a goroutine; retry until it answers.
+fun wait_ready() {
+    let tries = 0
+    while tries < 50 {
+        match request_with_timeout("GET", "http://127.0.0.1:8193/big", "", "", 2000) {
+            Ok(r) -> {
+                return
+            },
+            Err(e) -> {
+                sleep_millis(20)
+            },
+        }
+        tries = tries + 1
+    }
+}
+
+fun main() {
+    spawn(fun() -> Unit {
+        serve()
+    })
+    wait_ready()
+
+    // A deadline shorter than the handler's sleep must surface as an Err.
+    match request_with_timeout("GET", "http://127.0.0.1:8193/slow", "", "", 150) {
+        Ok(r) -> {
+            println("short deadline: unexpectedly ok")
+        },
+        Err(e) -> {
+            println("short deadline: timed out as expected")
+        },
+    }
+
+    // A generous deadline outlives the sleep and succeeds.
+    match request_with_timeout("GET", "http://127.0.0.1:8193/slow", "", "", 5000) {
+        Ok(r) -> {
+            println("long deadline: ${r.status_code} ${r.body}")
+        },
+        Err(e) -> {
+            println("long deadline failed: ${e.message}")
+        },
+    }
+
+    // Stream the large body and reassemble it.
+    match stream("GET", "http://127.0.0.1:8193/big", "", "", 5000) {
+        Ok(s) -> {
+            println("stream status: ${s.status_code}")
+            let total = 0
+            let chunks = 0
+            let reading = true
+            let assembled = ""
+            while reading {
+                match s.read_chunk() {
+                    Ok(chunk) -> {
+                        if chunk.length() == 0 {
+                            reading = false
+                        } else {
+                            total = total + chunk.length()
+                            chunks = chunks + 1
+                            assembled = assembled.concat(chunk)
+                        }
+                    },
+                    Err(e) -> {
+                        println("read failed: ${e.message}")
+                        reading = false
+                    },
+                }
+            }
+            s.close()
+            println("chunks: more than one: ${chunks > 1}")
+            println("bytes: ${total}")
+            println("reassembled exactly: ${assembled == big_text()}")
+        },
+        Err(e) -> {
+            println("stream open failed: ${e.message}")
+        },
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -246,10 +246,31 @@ fn http_registry() -> &'static Mutex<HashMap<i64, HttpResp>> {
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Issue the next HTTP response id.
+/// Issue the next HTTP response id. Shared by the buffered-response and
+/// streaming registries, so an id is unique across both.
 fn http_next_id() -> i64 {
     static NEXT_ID: AtomicI64 = AtomicI64::new(1);
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// A live streaming response: the status line and headers captured at open,
+/// the body left unread behind a reader that `raven_http_stream_read` pulls
+/// chunk by chunk. The reader is `take`n out of the entry for the duration
+/// of a read so the registry lock is never held across a blocking read; it
+/// is `None` while a read is in flight, after end of stream, and for a
+/// bodiless (HEAD) response, all of which read as end of stream.
+struct HttpStreamEntry {
+    status: i64,
+    status_text: std::string::String,
+    // Response headers as `Key: Value` lines joined by `\n`.
+    headers: std::string::String,
+    reader: Option<Box<dyn Read + Send + Sync + 'static>>,
+}
+
+/// The process-wide streaming-response registry, ids from `http_next_id`.
+fn http_stream_registry() -> &'static Mutex<HashMap<i64, HttpStreamEntry>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<i64, HttpStreamEntry>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// An entry in the socket registry. A listener or a stream is kept
@@ -1580,17 +1601,19 @@ fn http_reason(code: u16) -> &'static str {
     }
 }
 
-/// Capture a ureq response into an owned `HttpResp`, reading the status,
-/// reason, headers, and body eagerly (reading the body consumes the
-/// response).
-fn http_capture(resp: ureq::Response, head_request: bool) -> Option<HttpResp> {
-    let status = resp.status();
+/// The response's reason phrase, falling back to the standard phrase for
+/// its status code when the server sent none.
+fn http_status_text(resp: &ureq::Response) -> std::string::String {
     let reason = resp.status_text();
-    let status_text = if reason.is_empty() {
-        http_reason(status).to_string()
+    if reason.is_empty() {
+        http_reason(resp.status()).to_string()
     } else {
         reason.to_string()
-    };
+    }
+}
+
+/// The response headers as `Key: Value` lines joined by `\n`.
+fn http_header_lines(resp: &ureq::Response) -> std::string::String {
     let mut header_lines: Vec<std::string::String> = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for name in resp.headers_names() {
@@ -1605,7 +1628,16 @@ fn http_capture(resp: ureq::Response, head_request: bool) -> Option<HttpResp> {
             header_lines.push(format!("{name}: {value}"));
         }
     }
-    let headers = header_lines.join("\n");
+    header_lines.join("\n")
+}
+
+/// Capture a ureq response into an owned `HttpResp`, reading the status,
+/// reason, headers, and body eagerly (reading the body consumes the
+/// response).
+fn http_capture(resp: ureq::Response, head_request: bool) -> Option<HttpResp> {
+    let status = resp.status();
+    let status_text = http_status_text(&resp);
+    let headers = http_header_lines(&resp);
     // A 1xx, 204, or 304 response, and any response to a HEAD request, carries no
     // body even when Content-Length advertises the length the body would have, so
     // an empty body is correct and must not be reported as a truncated transfer.
@@ -1679,6 +1711,35 @@ pub extern "C" fn raven_http_request(
     body: *const object::String,
     headers: *const object::String,
 ) -> i64 {
+    http_request_impl(method, url, body, headers, 0)
+}
+
+/// Like [`raven_http_request`], with an overall deadline. A positive
+/// `timeout_ms` bounds the whole request (connect, send, and reading the
+/// body); `timeout_ms <= 0` keeps the default timeouts.
+///
+/// # Safety
+///
+/// `method`, `url`, `body`, and `headers` must be valid
+/// `raven_string_from_bytes`-built `String`s.
+#[no_mangle]
+pub extern "C" fn raven_http_request_timeout(
+    method: *const object::String,
+    url: *const object::String,
+    body: *const object::String,
+    headers: *const object::String,
+    timeout_ms: i64,
+) -> i64 {
+    http_request_impl(method, url, body, headers, timeout_ms)
+}
+
+fn http_request_impl(
+    method: *const object::String,
+    url: *const object::String,
+    body: *const object::String,
+    headers: *const object::String,
+    timeout_ms: i64,
+) -> i64 {
     let (Some(method), Some(url), Some(headers)) =
         (env_name(method), env_name(url), env_name(headers))
     else {
@@ -1690,21 +1751,24 @@ pub extern "C" fn raven_http_request(
     // The method, URL, and header lines are still text.
     let body = string_bytes(body).to_vec();
 
-    let agent = ureq::AgentBuilder::new()
-        .timeout_connect(Duration::from_secs(5))
-        .timeout_read(Duration::from_secs(10))
-        .timeout_write(Duration::from_secs(10))
-        .build();
+    // A positive timeout is an overall deadline: ureq's `timeout` covers the
+    // connect, the send, and every body read together, which is the right
+    // bound for "this request may take up to N ms". Without one, the
+    // defaults stand: 5s connect, 10s per read and write.
+    let agent = if timeout_ms > 0 {
+        ureq::AgentBuilder::new()
+            .timeout_connect(Duration::from_secs(5))
+            .timeout(Duration::from_millis(timeout_ms as u64))
+            .build()
+    } else {
+        ureq::AgentBuilder::new()
+            .timeout_connect(Duration::from_secs(5))
+            .timeout_read(Duration::from_secs(10))
+            .timeout_write(Duration::from_secs(10))
+            .build()
+    };
 
-    let mut req = agent.request(method, url);
-    for line in headers.split('\n') {
-        if line.is_empty() {
-            continue;
-        }
-        if let Some((name, value)) = line.split_once(':') {
-            req = req.set(name.trim(), value.trim());
-        }
-    }
+    let req = http_apply_headers(agent.request(method, url), headers);
 
     // The request round-trip and reading the response body block, so run them
     // outside the collector's running set. `http_capture`/`http_store` work
@@ -1736,6 +1800,19 @@ pub extern "C" fn raven_http_request(
             }
         }
     })
+}
+
+/// Apply `Key: Value` header lines (joined by `\n`) to a request.
+fn http_apply_headers(mut req: ureq::Request, headers: &str) -> ureq::Request {
+    for line in headers.split('\n') {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            req = req.set(name.trim(), value.trim());
+        }
+    }
+    req
 }
 
 /// Status code of the stored response `id`, for example 200 or 404. An
@@ -1833,6 +1910,183 @@ pub extern "C" fn raven_http_headers(id: i64) -> *mut object::String {
 #[no_mangle]
 pub extern "C" fn raven_http_free(id: i64) {
     http_registry().lock().unwrap().remove(&id);
+}
+
+/// Open a streaming HTTP request: send it, capture the status and headers,
+/// and register the unread body behind a reader that
+/// [`raven_http_stream_read`] pulls chunk by chunk. Returns the stream id,
+/// or 0 on a transport failure with the last-error slot set. A non-2xx
+/// status opens normally; the caller reads the status and decides.
+///
+/// A positive `timeout_ms` bounds the connect and each body read
+/// individually (not the whole stream, which may legitimately stay open for
+/// minutes); `timeout_ms <= 0` keeps the defaults (5s connect, 10s reads).
+///
+/// # Safety
+///
+/// `method`, `url`, `body`, and `headers` must be valid
+/// `raven_string_from_bytes`-built `String`s.
+#[no_mangle]
+pub extern "C" fn raven_http_stream_open(
+    method: *const object::String,
+    url: *const object::String,
+    body: *const object::String,
+    headers: *const object::String,
+    timeout_ms: i64,
+) -> i64 {
+    let (Some(method), Some(url), Some(headers)) =
+        (env_name(method), env_name(url), env_name(headers))
+    else {
+        http_set_error("method, url, or headers is not valid UTF-8".to_string());
+        return 0;
+    };
+    let body = string_bytes(body).to_vec();
+
+    // Per-read timeouts, never an overall one: a stream is long-lived by
+    // design, and what must not stall is each individual read.
+    let read_write = if timeout_ms > 0 {
+        Duration::from_millis(timeout_ms as u64)
+    } else {
+        Duration::from_secs(10)
+    };
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(5))
+        .timeout_read(read_write)
+        .timeout_write(read_write)
+        .build();
+
+    let req = http_apply_headers(agent.request(method, url), headers);
+    let head_request = method.eq_ignore_ascii_case("HEAD");
+
+    // The round-trip blocks; registry inserts touch only Rust memory, so the
+    // whole open runs in the blocking region, like `raven_http_request`.
+    crate::gc::blocking(|| {
+        let result = if body.is_empty() {
+            req.call()
+        } else {
+            req.send_bytes(&body)
+        };
+        let resp = match result {
+            Ok(resp) => resp,
+            // A non-2xx status is a response; stream its body like any other.
+            Err(ureq::Error::Status(_, resp)) => resp,
+            Err(ureq::Error::Transport(t)) => {
+                http_set_error(t.to_string());
+                return 0;
+            }
+        };
+        let status = resp.status() as i64;
+        let status_text = http_status_text(&resp);
+        let headers = http_header_lines(&resp);
+        // A HEAD response carries no body whatever Content-Length claims, so
+        // it gets no reader and reads as an immediately ended stream.
+        let reader = if head_request {
+            None
+        } else {
+            Some(resp.into_reader())
+        };
+        let id = http_next_id();
+        http_stream_registry().lock().unwrap().insert(
+            id,
+            HttpStreamEntry {
+                status,
+                status_text,
+                headers,
+                reader,
+            },
+        );
+        http_clear_error();
+        id
+    })
+}
+
+/// Read the next chunk of stream `id`: whatever bytes the next socket read
+/// returns, at most 8 KiB. An empty `String` means the stream ended (the
+/// reader is dropped, releasing the connection) or, when the last-error
+/// slot is set, that the read failed. One read at a time per stream: the
+/// reader is taken out of the registry for the read's duration, so a
+/// concurrent read on the same id observes end of stream.
+#[no_mangle]
+pub extern "C" fn raven_http_stream_read(id: i64) -> *mut object::String {
+    http_clear_error();
+    let taken = {
+        let mut registry = http_stream_registry().lock().unwrap();
+        registry.get_mut(&id).and_then(|entry| entry.reader.take())
+    };
+    let Some(mut reader) = taken else {
+        // Unknown id, an ended or bodiless stream, or a concurrent read.
+        return object::raven_string_from_bytes([].as_ptr(), 0);
+    };
+
+    let mut buf = vec![0u8; 8192];
+    // The read blocks on the socket; the buffer is Rust memory, so the
+    // blocking region is sound. Allocation of the result happens after.
+    let result = crate::gc::blocking(|| reader.read(&mut buf));
+    match result {
+        // End of stream: the reader is dropped; the entry stays so the
+        // status and headers remain readable until close.
+        Ok(0) => object::raven_string_from_bytes(buf.as_ptr(), 0),
+        Ok(n) => {
+            // Put the reader back for the next read. A close that raced this
+            // read removed the entry; the reader is then dropped here.
+            if let Some(entry) = http_stream_registry().lock().unwrap().get_mut(&id) {
+                entry.reader = Some(reader);
+            }
+            object::raven_string_from_bytes(buf.as_ptr(), n)
+        }
+        Err(e) => {
+            http_set_error(e.to_string());
+            object::raven_string_from_bytes(buf.as_ptr(), 0)
+        }
+    }
+}
+
+/// Status code of stream `id`, for example 200. An unknown id yields 0.
+#[no_mangle]
+pub extern "C" fn raven_http_stream_status(id: i64) -> i64 {
+    http_stream_registry()
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|e| e.status)
+        .unwrap_or(0)
+}
+
+/// Reason phrase of stream `id`. An unknown id yields an empty `String`.
+#[no_mangle]
+pub extern "C" fn raven_http_stream_status_text(id: i64) -> *mut object::String {
+    // Copy out, then drop the lock before allocating; see
+    // `raven_http_status_text` for why.
+    let text: std::string::String = {
+        let registry = http_stream_registry().lock().unwrap();
+        registry
+            .get(&id)
+            .map(|e| e.status_text.clone())
+            .unwrap_or_default()
+    };
+    object::raven_string_from_bytes(text.as_ptr(), text.len())
+}
+
+/// All response headers of stream `id` as `Key: Value` lines joined by
+/// `\n`. An unknown id yields an empty `String`.
+#[no_mangle]
+pub extern "C" fn raven_http_stream_headers(id: i64) -> *mut object::String {
+    // Copy out, then drop the lock before allocating; see
+    // `raven_http_status_text` for why.
+    let headers: std::string::String = {
+        let registry = http_stream_registry().lock().unwrap();
+        registry
+            .get(&id)
+            .map(|e| e.headers.clone())
+            .unwrap_or_default()
+    };
+    object::raven_string_from_bytes(headers.as_ptr(), headers.len())
+}
+
+/// Drop stream `id`, closing its connection. An unknown id is a no-op.
+#[no_mangle]
+pub extern "C" fn raven_http_stream_close(id: i64) {
+    http_stream_registry().lock().unwrap().remove(&id);
 }
 
 /// The message of the most recent failed regex compile, empty when it

--- a/stdlib/std/http.rv
+++ b/stdlib/std/http.rv
@@ -29,12 +29,19 @@ struct HttpResponse {
 extern "C" {
     fun raven_http_last_error() -> String
     fun raven_http_request(method: String, url: String, body: String, headers: String) -> Int
+    fun raven_http_request_timeout(method: String, url: String, body: String, headers: String, timeout_ms: Int) -> Int
     fun raven_http_status(id: Int) -> Int
     fun raven_http_status_text(id: Int) -> String
     fun raven_http_body(id: Int) -> String
     fun raven_http_header(id: Int, name: String) -> String
     fun raven_http_headers(id: Int) -> String
     fun raven_http_free(id: Int)
+    fun raven_http_stream_open(method: String, url: String, body: String, headers: String, timeout_ms: Int) -> Int
+    fun raven_http_stream_read(id: Int) -> String
+    fun raven_http_stream_status(id: Int) -> Int
+    fun raven_http_stream_status_text(id: Int) -> String
+    fun raven_http_stream_headers(id: Int) -> String
+    fun raven_http_stream_close(id: Int)
 }
 
 // An Error tagged with kind "http", its message a context prefix joined to
@@ -53,12 +60,31 @@ fun request(
     body: String,
     headers: String,
 ) -> Result<HttpResponse, Error> {
-    let id = raven_http_request(method, url, body, headers)
+    return _collect(raven_http_request(method, url, body, headers), method)
+}
+
+// Like request, with an overall deadline: a positive timeout_ms bounds the
+// whole request (connect, send, and reading the body), and a timeout
+// surfaces as an Err like any other transport failure. timeout_ms <= 0
+// keeps the default timeouts. Use this for endpoints that take longer than
+// the defaults allow, for example model inference APIs.
+fun request_with_timeout(
+    method: String,
+    url: String,
+    body: String,
+    headers: String,
+    timeout_ms: Int,
+) -> Result<HttpResponse, Error> {
+    return _collect(raven_http_request_timeout(method, url, body, headers, timeout_ms), method)
+}
+
+// Assemble the stored response `id` into an HttpResponse and release it.
+fun _collect(id: Int, ctx: String) -> Result<HttpResponse, Error> {
     if id == 0 {
-        return Err(http_error(method))
+        return Err(http_error(ctx))
     }
     if raven_http_last_error().length() > 0 {
-        return Err(http_error(method))
+        return Err(http_error(ctx))
     }
     let resp = HttpResponse {
         status_code: raven_http_status(id),
@@ -98,6 +124,65 @@ fun patch(url: String, body: String) -> Result<HttpResponse, Error> {
 // HEAD `url` (response carries headers and status but no body).
 fun head(url: String) -> Result<HttpResponse, Error> {
     return request("HEAD", url, "", "")
+}
+
+// A streaming response: the status and headers arrive at open, the body is
+// pulled chunk by chunk with read_chunk. This is how to consume server-sent
+// events, chunked transfers, and any response too large or too slow to
+// buffer whole. Close it when done; an ended stream still holds its status
+// and headers until then.
+struct HttpStream {
+    id: Int,
+    status_code: Int,
+    status_text: String,
+    // Response headers as `Key: Value` lines joined by `\n`.
+    headers: String,
+}
+
+// Open a streaming request. A positive timeout_ms bounds the connect and
+// each body read individually (not the whole stream, which may stay open
+// for as long as the server keeps sending); timeout_ms <= 0 keeps the
+// defaults. A non-2xx status opens normally so the error body is readable;
+// only a transport failure is an Err.
+fun stream(
+    method: String,
+    url: String,
+    body: String,
+    headers: String,
+    timeout_ms: Int,
+) -> Result<HttpStream, Error> {
+    let id = raven_http_stream_open(method, url, body, headers, timeout_ms)
+    if id == 0 {
+        return Err(http_error(method))
+    }
+    if raven_http_last_error().length() > 0 {
+        return Err(http_error(method))
+    }
+    return Ok(HttpStream {
+        id: id,
+        status_code: raven_http_stream_status(id),
+        status_text: raven_http_stream_status_text(id),
+        headers: raven_http_stream_headers(id),
+    })
+}
+
+impl HttpStream {
+    // The next chunk of the body: whatever the next socket read returns, at
+    // most 8 KiB. Ok("") means the stream ended; a failed or timed-out read
+    // is an Err. One read at a time per stream.
+    fun read_chunk(self) -> Result<String, Error> {
+        let chunk = raven_http_stream_read(self.id)
+        if chunk.length() == 0 && raven_http_last_error().length() > 0 {
+            return Err(http_error("stream read"))
+        }
+        return Ok(chunk)
+    }
+
+    // Release the stream and its connection. Reading after close observes
+    // end of stream.
+    fun close(self) {
+        raven_http_stream_close(self.id)
+    }
 }
 
 // ===========================================================================


### PR DESCRIPTION
Fixes #859
Fixes #860

Two additions to the HTTP client, both runtime plus stdlib:

request_with_timeout(method, url, body, headers, timeout_ms)

- A positive timeout_ms is an overall deadline (connect, send, and reading the whole body together, via ureq's agent timeout), which is the right bound for "this request may take up to N ms". A deadline overrun surfaces as an Err like any other transport failure.
- timeout_ms <= 0 keeps the existing defaults (5s connect, 10s read/write), and request() itself is unchanged (it now shares one implementation with the timeout variant).

stream(method, url, body, headers, timeout_ms) -> HttpStream

- Opens the request, captures status/status_text/headers, and leaves the body unread behind ureq's into_reader. read_chunk() returns whatever the next socket read yields (at most 8 KiB), Ok("") at end of stream, Err on a failed or timed-out read. close() drops the reader and the connection.
- The timeout is per read, not overall, because a healthy stream can stay open for minutes; each read must still make progress within the deadline.
- A non-2xx status opens normally so the error body is readable; only transport failures are Err from stream().
- Runtime side: a stream registry alongside the response registry, same id space. The reader is taken out of the entry for a read's duration and put back after, so the registry lock is never held across a blocking read; a concurrent read on one stream observes end of stream rather than blocking. A HEAD stream has no reader and reads as immediately ended.

Docs: new Streaming section and an expanded Timeouts section in docs/v2/specs/std-http.md. CHANGELOG under Unreleased.

Verification: examples/v2/http_timeout_stream.rv (golden:skip, binds a port) runs an in-process std/http server with a slow route and a 96 KiB route. Output confirms a 150ms deadline times out against a 600ms handler, a 5s deadline succeeds, and the large body arrives in multiple chunks that reassemble byte-for-byte. cargo fmt, clippy (no new warnings), the 661-test lib suite, and the full golden suite all pass.

Motivation: these are the two runtime gaps blocking the aviary LLM gateway (and the rook agent on top of it) from long completions and token streaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP request timeout support so calls can use a custom overall deadline.
  * Added streaming HTTP responses for reading large or long-lived bodies in chunks.
  * Included a new example demonstrating timeout handling and streamed downloads.

* **Bug Fixes**
  * Improved handling of slow endpoints by avoiding the previous fixed read-timeout behavior.
  * Preserved response status and headers for streamed requests, even before the body is fully read.

* **Chores**
  * Updated the release version to 2.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->