### PR TITLE
feat: rvpm dist msi can add the install dir to PATH

### DIFF
--- a/docs/v2/specs/rvpm-dist.md
+++ b/docs/v2/specs/rvpm-dist.md
@@ -47,6 +47,7 @@ priority = "optional"              # deb
 [dist.windows]
 icon = "assets/rook.ico"           # Inno Setup icon
 upgrade_code = "9f0c86a1-2b3c-4d5e-8f90-112233445566"  # msi upgrade GUID
+add_to_path = true                 # msi appends the install dir to system PATH
 ```
 
 Asset `source` and `dest` must be relative forward-slash paths with no `..`
@@ -79,9 +80,16 @@ install. When `[dist.windows].upgrade_code` is not set, rvpm derives a
 stable GUID from the package name and prints it with a note; pin it in the
 manifest so it never changes by accident.
 
+`[dist.windows].add_to_path = true` makes the msi append the install
+directory to the system PATH, so a command-line tool is callable from a
+terminal after installing (the other installers still leave PATH alone).
+The uninstaller removes the entry.
+
 ## What is out of scope
 
 Packages are not signed (deb signing, rpm signing, Authenticode are all
 post-processing on the produced artifacts). Cross-format scripting hooks
-(postinst and friends) and desktop shortcuts are not modeled yet. The
-installers do not modify PATH.
+(postinst and friends) and desktop shortcuts are not modeled yet. Only the
+msi modifies PATH, and only when `[dist.windows].add_to_path` is set; the
+deb and rpm install to `/usr/bin` (already on PATH) and the archives are
+unpacked wherever the user chooses.

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -209,6 +209,9 @@ pub struct DistWindows {
     /// The stable GUID that lets an msi upgrade an installed older version.
     /// Required by the msi backend; generate one once and keep it.
     pub upgrade_code: String,
+    /// When set, the msi appends the install directory to the system PATH, so
+    /// a command-line tool is callable from a terminal after installing.
+    pub add_to_path: bool,
 }
 
 impl Dist {
@@ -412,6 +415,7 @@ fn validate_dist(raw: RawDist, package: &Package) -> Result<Dist, ManifestError>
         windows: DistWindows {
             icon: windows.icon.unwrap_or_default(),
             upgrade_code: windows.upgrade_code.unwrap_or_default(),
+            add_to_path: windows.add_to_path.unwrap_or(false),
         },
     })
 }
@@ -558,6 +562,7 @@ struct RawDistLinux {
 struct RawDistWindows {
     icon: Option<String>,
     upgrade_code: Option<String>,
+    add_to_path: Option<bool>,
 }
 
 impl Manifest {

--- a/src/ops/dist.rs
+++ b/src/ops/dist.rs
@@ -560,6 +560,17 @@ fn wix_source(ctx: &DistContext, stage: &Path, upgrade_code: &str) -> String {
         ));
         refs.push_str(&format!("      <ComponentRef Id=\"{}\" />\n", id));
     }
+    // Append the install directory to the system PATH so a command-line tool
+    // is on PATH after installing. A registry value under HKLM is the
+    // component key path (an Environment element cannot be one), keyed by the
+    // package name so it is stable across versions.
+    if d.windows.add_to_path {
+        components.push_str(&format!(
+            "        <Component Id=\"PathEntry\" Guid=\"*\">\n          <RegistryValue Root=\"HKLM\" Key=\"Software\\{key}\" Name=\"Installed\" Type=\"integer\" Value=\"1\" KeyPath=\"yes\" />\n          <Environment Id=\"UpdatePath\" Name=\"PATH\" Value=\"[APPDIR]\" Permanent=\"no\" Part=\"last\" Action=\"set\" System=\"yes\" />\n        </Component>\n",
+            key = xml_escape(&ctx.name),
+        ));
+        refs.push_str("      <ComponentRef Id=\"PathEntry\" />\n");
+    }
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
@@ -946,6 +957,42 @@ depends = ["libc6 (>= 2.31)", "zlib1g"]
             wxs.contains("File1"),
             "binary and asset each get a component"
         );
+    }
+
+    #[test]
+    fn wix_source_omits_path_entry_by_default() {
+        let app = FakeApp::new("wix-nopath");
+        let ctx = app.context(WITH_ASSET);
+        let stage = ctx.work_dir.join("msi");
+        stage_tree(&ctx, &stage, "", "").expect("stage");
+        let wxs = wix_source(&ctx, &stage, "9f0c86a1-2b3c-4d5e-8f90-112233445566");
+        assert!(!wxs.contains("<Environment"));
+        assert!(!wxs.contains("PathEntry"));
+    }
+
+    #[test]
+    fn wix_source_adds_path_when_requested() {
+        let manifest = r#"
+[package]
+name = "demo"
+version = "1.2.0"
+authors = ["Ada <ada@example.com>"]
+
+[dist.windows]
+add_to_path = true
+"#;
+        let app = FakeApp::new("wix-path");
+        let ctx = app.context(manifest);
+        let stage = ctx.work_dir.join("msi");
+        stage_tree(&ctx, &stage, "", "").expect("stage");
+        let wxs = wix_source(&ctx, &stage, "9f0c86a1-2b3c-4d5e-8f90-112233445566");
+        assert!(wxs.contains("<Component Id=\"PathEntry\""));
+        assert!(wxs.contains("<ComponentRef Id=\"PathEntry\" />"));
+        assert!(wxs.contains(
+            "<Environment Id=\"UpdatePath\" Name=\"PATH\" Value=\"[APPDIR]\" Permanent=\"no\" Part=\"last\" Action=\"set\" System=\"yes\" />"
+        ));
+        // A registry value is the component key path, keyed by the package name.
+        assert!(wxs.contains("Key=\"Software\\demo\""));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`rvpm dist` previously left PATH alone for every format, so an msi-installed CLI tool was not callable from a terminal (it lands in a Program Files app folder that is not on PATH). Add an opt-in.

- `[dist.windows].add_to_path = true` makes the generated WiX include a component whose `<Environment>` element appends the install directory (`[APPDIR]`) to the system PATH (`Part="last"`, `System="yes"`); the uninstaller removes it. A `<RegistryValue>` under HKLM is the component key path, keyed by the package name (an Environment element cannot be a key path).
- Off by default, so a packaged GUI app still leaves PATH untouched. The deb and rpm formats are unaffected (they install to `/usr/bin`, already on PATH); the archives leave placement to the user.
- Spec updated, including the out-of-scope note.

## Testing

- `cargo test`: 791 pass (fmt and clippy clean). New tests assert the WiX omits the PATH component by default and, with `add_to_path = true`, includes the `PathEntry` component, its ref, the exact `<Environment>` element, and the HKLM registry key path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Windows installer setting to append the install directory to the system PATH during MSI installation.
  * The installer now removes the PATH entry when the app is uninstalled.

* **Documentation**
  * Updated the packaging spec to describe the new Windows PATH option and clarify which package formats can modify PATH.

* **Bug Fixes**
  * Improved installer behavior so PATH changes happen only when explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->