### PR TITLE
feat: write to a spawned child's stdin (write_stdin, close_stdin)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.23.0"
+version = "2.24.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"

--- a/examples/v2/proc_stdin_child.rv
+++ b/examples/v2/proc_stdin_child.rv
@@ -1,0 +1,18 @@
+// golden:skip - the child half of the std/process stdin streaming smoke test
+// (codegen_smoke.rs: process_stdin_streams_to_child). Reads a line at a time
+// from its stdin and echoes it back as "got:<line>", until stdin closes (an
+// empty read means end of input), then prints "done" and exits 0. The parent
+// (proc_stdin_parent.rv) feeds it through write_stdin and close_stdin.
+
+import std/io { println, read_line }
+
+fun main() {
+    while true {
+        let line = read_line()
+        if line == "" {
+            println("done")
+            return
+        }
+        println("got:${line}")
+    }
+}

--- a/examples/v2/proc_stdin_parent.rv
+++ b/examples/v2/proc_stdin_parent.rv
@@ -1,0 +1,70 @@
+// golden:skip - std/process stdin streaming parent, checked in codegen_smoke.rs
+// (process_stdin_streams_to_child). Drives write_stdin / close_stdin against
+// the child in RAVEN_PROC_CHILD (proc_stdin_child.rv):
+//
+// 1. Write "hello", drain the echo, and print "echo1" once "got:hello" comes
+//    back, proving stdin reaches a still-running child.
+// 2. Write "world", close stdin, then a write after close returns false, so
+//    print "closed".
+// 3. Wait for exit, then confirm the second echo ("echo2") and the child's
+//    end-of-input "done", then the exit code (0).
+//
+// Expected stdout:
+//   echo1
+//   closed
+//   echo2
+//   done
+//   0
+import std/io { println }
+import std/string
+import std/process { Child, start }
+import std/sync { sleep_millis }
+import std/env { get_env }
+
+fun main() {
+    let child_path = get_env("RAVEN_PROC_CHILD")
+    let none: List<String> = []
+    match start(child_path, none) {
+        Ok(c) -> {
+            // 1. Write a line and drain until its echo streams back.
+            let wrote = c.write_stdin("hello\n")
+            let seen = ""
+            let tries = 0
+            while !seen.contains("got:hello") && tries < 400 {
+                seen = seen.concat(c.read_stdout())
+                sleep_millis(10)
+                tries = tries + 1
+            }
+            if wrote && seen.contains("got:hello") {
+                println("echo1")
+            }
+
+            // 2. Write a second line, close stdin, and prove a later write fails.
+            c.write_stdin("world\n")
+            c.close_stdin()
+            if !c.write_stdin("late\n") {
+                println("closed")
+            }
+
+            // 3. Wait, then confirm the second echo and the child's EOF marker.
+            let code = c.wait()
+            let more = 0
+            while !seen.contains("done") && more < 200 {
+                seen = seen.concat(c.read_stdout())
+                sleep_millis(5)
+                more = more + 1
+            }
+            if seen.contains("got:world") {
+                println("echo2")
+            }
+            if seen.contains("done") {
+                println("done")
+            }
+            println("${code}")
+            c.free()
+        },
+        Err(e) -> {
+            println("spawn failed: ${e.message()}")
+        },
+    }
+}

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -217,6 +217,7 @@ fn process_next_id() -> i64 {
 /// exit status once observed so poll stays cheap after exit.
 struct SpawnEntry {
     child: process::Child,
+    stdin: Arc<Mutex<Option<process::ChildStdin>>>,
     stdout: Arc<Mutex<Vec<u8>>>,
     stderr: Arc<Mutex<Vec<u8>>>,
     code: Option<i64>,
@@ -2544,7 +2545,10 @@ pub extern "C" fn raven_process_spawn(
 
     let mut command = process::Command::new(program);
     command.args(&args);
-    command.stdin(process::Stdio::null());
+    // stdin is piped and kept open so the caller can stream to a long-lived
+    // child (write_stdin / close_stdin); this is what a persistent protocol
+    // such as MCP over stdio needs.
+    command.stdin(process::Stdio::piped());
     command.stdout(process::Stdio::piped());
     command.stderr(process::Stdio::piped());
 
@@ -2556,6 +2560,7 @@ pub extern "C" fn raven_process_spawn(
         }
     };
 
+    let stdin = Arc::new(Mutex::new(child.stdin.take()));
     let stdout = Arc::new(Mutex::new(Vec::new()));
     let stderr = Arc::new(Mutex::new(Vec::new()));
     if let Some(pipe) = child.stdout.take() {
@@ -2570,6 +2575,7 @@ pub extern "C" fn raven_process_spawn(
         id,
         SpawnEntry {
             child,
+            stdin,
             stdout,
             stderr,
             code: None,
@@ -2577,6 +2583,58 @@ pub extern "C" fn raven_process_spawn(
     );
     process_clear_error();
     id
+}
+
+/// Write `data`'s bytes to the spawned child `id`'s stdin, returning the
+/// number of bytes written, or -1 for an unknown id, an already-closed
+/// stdin, or a write error (for example a broken pipe after the child
+/// exited). Only the child's stdin lock is held during the write, not the
+/// registry, so a slow write does not block reads or polls on other
+/// children. The bytes are flushed before returning.
+#[no_mangle]
+pub extern "C" fn raven_process_write_stdin(id: i64, data: *const object::String) -> i64 {
+    let bytes = {
+        let ptr = object::raven_string_bytes(data);
+        let len = object::raven_string_len(data) as usize;
+        if ptr.is_null() || len == 0 {
+            Vec::new()
+        } else {
+            // SAFETY: a Raven String holds `len` initialized bytes.
+            unsafe { slice::from_raw_parts(ptr, len).to_vec() }
+        }
+    };
+    let handle = {
+        let registry = spawn_registry().lock().unwrap();
+        match registry.get(&id) {
+            Some(entry) => Arc::clone(&entry.stdin),
+            None => return -1,
+        }
+    };
+    let mut guard = handle.lock().unwrap();
+    match guard.as_mut() {
+        Some(pipe) => match pipe.write_all(&bytes).and_then(|_| pipe.flush()) {
+            Ok(()) => bytes.len() as i64,
+            Err(_) => -1,
+        },
+        None => -1,
+    }
+}
+
+/// Close the spawned child `id`'s stdin, sending EOF. Returns 1 when the
+/// pipe was closed (or was already closed), 0 for an unknown id. A later
+/// write_stdin on the same id returns -1.
+#[no_mangle]
+pub extern "C" fn raven_process_close_stdin(id: i64) -> i64 {
+    let handle = {
+        let registry = spawn_registry().lock().unwrap();
+        match registry.get(&id) {
+            Some(entry) => Arc::clone(&entry.stdin),
+            None => return 0,
+        }
+    };
+    // Dropping the ChildStdin closes the pipe.
+    *handle.lock().unwrap() = None;
+    1
 }
 
 /// Whatever the spawned child `id` wrote to stdout since the last read,

--- a/stdlib/std/process.rv
+++ b/stdlib/std/process.rv
@@ -41,6 +41,8 @@ extern "C" {
     fun raven_process_spawn(program: String, args_nul_joined: String) -> Int
     fun raven_process_read_stdout(id: Int) -> String
     fun raven_process_read_stderr(id: Int) -> String
+    fun raven_process_write_stdin(id: Int, data: String) -> Int
+    fun raven_process_close_stdin(id: Int) -> Int
     fun raven_process_poll(id: Int) -> Int
     fun raven_process_kill(id: Int) -> Int
     fun raven_process_spawn_free(id: Int)
@@ -48,9 +50,9 @@ extern "C" {
 
 // A child started with `start`, still possibly running. Output streams in:
 // read_stdout and read_stderr drain whatever arrived since the last read,
-// poll and running report status without blocking, wait blocks until exit,
-// and kill stops it. Call free when done with the handle; freeing does not
-// kill a running child.
+// write_stdin feeds its stdin and close_stdin sends EOF, poll and running
+// report status without blocking, wait blocks until exit, and kill stops it.
+// Call free when done with the handle; freeing does not kill a running child.
 struct Child {
     id: Int,
 }
@@ -65,6 +67,23 @@ impl Child {
     // Whatever the child wrote to stderr since the last read.
     fun read_stderr(self) -> String {
         return raven_process_read_stderr(self.id)
+    }
+
+    // Write `data` to the child's stdin, returning true when every byte was
+    // written. False means the stdin was already closed, the child had
+    // exited (a broken pipe), or the handle is unknown. The bytes are
+    // flushed, so a line the child is waiting on arrives without delay. A
+    // String is a byte buffer, so binary data passes through unchanged.
+    fun write_stdin(self, data: String) -> Bool {
+        return raven_process_write_stdin(self.id, data) >= 0
+    }
+
+    // Close the child's stdin, sending EOF. A child reading until end of
+    // input (for example `cat`, or a filter) proceeds once stdin closes.
+    // Later write_stdin calls return false.
+    fun close_stdin(self) {
+        let ignored = raven_process_close_stdin(self.id)
+        return
     }
 
     // The exit code once the child has exited, None while it runs. A child

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -1884,6 +1884,40 @@ fn process_program_compiles_and_runs() {
 }
 
 #[test]
+fn process_stdin_streams_to_child() {
+    let Some(runtime) = supported_runtime() else {
+        return;
+    };
+    // Writing to a long-lived child's stdin (write_stdin) and closing it
+    // (close_stdin) end to end. The child echoes each stdin line as
+    // "got:<line>" and prints "done" at end of input; the parent writes
+    // "hello", drains the echo, writes "world", closes stdin (a later write
+    // then fails), waits, and confirms both echoes plus the EOF marker.
+    let child = build_example_binary("proc_stdin_child.rv", &runtime);
+    let parent = build_example_binary("proc_stdin_parent.rv", &runtime);
+
+    let output = Command::new(&parent.binary)
+        .env("RAVEN_PROC_CHILD", &child.binary)
+        .output()
+        .expect("run proc_stdin_parent binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    cleanup(&child.tmp);
+    cleanup(&parent.tmp);
+    assert!(
+        output.status.success(),
+        "proc_stdin_parent exited non zero: status={:?} stderr={}",
+        output.status,
+        stderr
+    );
+    assert_eq!(
+        stdout, "echo1\nclosed\necho2\ndone\n0\n",
+        "unexpected stdout for proc_stdin_parent: {:?}",
+        stdout
+    );
+}
+
+#[test]
 fn process_stdin_broken_pipe_does_not_kill() {
     let Some(runtime) = supported_runtime() else {
         return;


### PR DESCRIPTION
## Why

`start` wired a spawned child's stdin to `Stdio::null()`, so the streaming process API could read a child's output but never send it input. That rules out any persistent request/response protocol over a subprocess, MCP over stdio among them (the reason I need it: it is the transport rook's MCP client will use).

## What

- Pipe the spawned child's stdin and keep the handle in `SpawnEntry` as `Arc<Mutex<Option<ChildStdin>>>`.
- `raven_process_write_stdin(id, data)`: write bytes and flush; returns bytes written, or -1 for an unknown id, a closed stdin, or a broken pipe. Only the child's stdin lock is held during the write, **not** the registry, so a slow write cannot block reads/polls on other children.
- `raven_process_close_stdin(id)`: drop the pipe to send EOF.
- `Child.write_stdin(data) -> Bool` and `Child.close_stdin()` in `std/process`. A String is a byte buffer, so binary input passes through unchanged.

## Tests

- New `proc_stdin_parent.rv` / `proc_stdin_child.rv` pair and the `process_stdin_streams_to_child` smoke test: write a line, drain the echo from a **still-running** child, close stdin, confirm a post-close write returns false and the child sees EOF, exit 0.
- All existing process/spawn/sigpipe smoke tests still pass (piping stdin instead of nulling it does not change their behavior, since those children do not read stdin).
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets` adds no new warnings.

Ships as 2.24.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added child-process stdin streaming support, including writing to stdin and closing it to send EOF.
  * Introduced new process examples demonstrating parent/child stdin interaction.
* **Bug Fixes**
  * Child processes now keep stdin available after launch instead of starting with it closed.
* **Tests**
  * Added an end-to-end smoke test covering stdin writes, EOF handling, and expected output.
* **Chores**
  * Bumped the workspace version to `2.24.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->