### PR TITLE
Release 2.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.24.1] - 2026-07-09
+
+### Fixed
+
+- `rvpm dist --target msi` now preserves each bundled asset's subfolder and gives files that share a base name in different folders distinct component GUIDs. The MSI generator placed every staged file directly under the application directory, which dropped subfolders and made two files with the same name (for example an `icons/revenue.png` and a `charts/revenue.png`) collide on their WiX auto component GUID, failing the link with `LGHT0369`. (#866)
+
+## [2.24.0] - 2026-07-05
+
+### Added
+
+- `std/process` gains `write_stdin(child, bytes)` and `close_stdin(child)`: write to a spawned child's standard input and then close it, so a program can feed an interactive child and signal end of input. (#865)
+
 ## [2.23.0] - 2026-07-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.23.0"
+version = "2.24.1"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.23.0"
+version = "2.24.1"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.24.0"
+version = "2.24.1"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
Patch release for the rvpm dist MSI fix merged in #866.

## Changes

- Bump the workspace version to **2.24.1** (`Cargo.toml`).
- Add the `2.24.1` changelog entry (the `rvpm dist --target msi` subfolder / duplicate-GUID fix).
- **Sync `Cargo.lock`.** The `2.24.0` bump only edited `Cargo.toml`, so the lock still pinned `raven` and `raven-runtime` at `2.23.0`; this brings both to `2.24.1` and clears that pending drift.
- Backfill the missing `2.24.0` changelog entry (the `std/process` `write_stdin`/`close_stdin` release, #865).

Tagging `v2.24.1` after merge triggers the release workflow.
