### PR TITLE
Release 2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.25.0] - 2026-07-10
+
+### Added
+
+- `Int.to_float()` and `Float.to_int()` convert between the two numeric types. There are no implicit numeric coercions, so the conversion is always explicit, and `to_int` truncates toward zero. (#874)
+
 ## [2.24.1] - 2026-07-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.24.1"
+version = "2.25.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.24.1"
+version = "2.25.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.24.1"
+version = "2.25.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
Minor release for the numeric conversions added in #874.

- Bump the workspace version to 2.25.0.
- Add the 2.25.0 changelog entry (`Int.to_float()` / `Float.to_int()`).
- Sync `Cargo.lock` to the new version.

Tagging `v2.25.0` after merge triggers the release workflow.