### PR TITLE
fix(vscode): highlight every token (quoted imports, variables, params, interpolation)

### DIFF
--- a/raven-vscode/package.json
+++ b/raven-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "raven-language",
   "displayName": "Raven Language",
   "description": "Syntax highlighting and language support for the Raven v2 programming language, including concurrency, derive attributes, macros, reflection, and C FFI",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "publisher": "martian56",
   "icon": "icons/raven-fullsize.png",
   "engines": {

--- a/raven-vscode/syntaxes/raven.tmLanguage.json
+++ b/raven-vscode/syntaxes/raven.tmLanguage.json
@@ -24,8 +24,10 @@
     { "include": "#types" },
     { "include": "#functionCalls" },
     { "include": "#members" },
+    { "include": "#parameters" },
     { "include": "#operators" },
-    { "include": "#punctuation" }
+    { "include": "#punctuation" },
+    { "include": "#identifiers" }
   ],
   "repository": {
     "comments": {
@@ -56,21 +58,21 @@
           "endCaptures": {
             "0": { "name": "punctuation.section.block.end.raven" }
           },
-          "patterns": [
-            { "include": "#comments" },
-            {
-              "name": "keyword.control.import.raven",
-              "match": "\\b(as)\\b"
-            },
-            {
-              "name": "variable.other.import.raven",
-              "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
-            },
-            {
-              "name": "punctuation.separator.comma.raven",
-              "match": ","
-            }
-          ]
+          "patterns": [{ "include": "#importNames" }]
+        },
+        {
+          "name": "meta.import.selective.raven",
+          "begin": "\\b(import)\\s+(\"[^\"]*\")\\s*(\\{)",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.import.raven" },
+            "2": { "name": "string.quoted.double.raven" },
+            "3": { "name": "punctuation.section.block.begin.raven" }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": { "name": "punctuation.section.block.end.raven" }
+          },
+          "patterns": [{ "include": "#importNames" }]
         },
         {
           "match": "\\b(import)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:/[a-zA-Z_][a-zA-Z0-9_]*)*)(?:\\s+(as)\\s+([a-zA-Z_][a-zA-Z0-9_]*))?",
@@ -80,6 +82,32 @@
             "3": { "name": "keyword.control.import.raven" },
             "4": { "name": "variable.other.import.raven" }
           }
+        },
+        {
+          "match": "\\b(import)\\s+(\"[^\"]*\")(?:\\s+(as)\\s+([a-zA-Z_][a-zA-Z0-9_]*))?",
+          "captures": {
+            "1": { "name": "keyword.control.import.raven" },
+            "2": { "name": "string.quoted.double.raven" },
+            "3": { "name": "keyword.control.import.raven" },
+            "4": { "name": "variable.other.import.raven" }
+          }
+        }
+      ]
+    },
+    "importNames": {
+      "patterns": [
+        { "include": "#comments" },
+        {
+          "name": "keyword.control.import.raven",
+          "match": "\\b(as)\\b"
+        },
+        {
+          "name": "variable.other.import.raven",
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+        },
+        {
+          "name": "punctuation.separator.comma.raven",
+          "match": ","
         }
       ]
     },
@@ -358,12 +386,14 @@
         { "include": "#strings" },
         { "include": "#numbers" },
         { "include": "#constants" },
+        { "include": "#keywords" },
         { "include": "#selfKeyword" },
         { "include": "#enumPath" },
         { "include": "#types" },
         { "include": "#functionCalls" },
         { "include": "#members" },
         { "include": "#operators" },
+        { "include": "#punctuation" },
         {
           "name": "variable.other.raven",
           "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
@@ -431,15 +461,17 @@
     "members": {
       "patterns": [
         {
-          "match": "\\.([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\()",
+          "match": "(\\.)([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\()",
           "captures": {
-            "1": { "name": "entity.name.function.method.raven" }
+            "1": { "name": "punctuation.accessor.raven" },
+            "2": { "name": "entity.name.function.method.raven" }
           }
         },
         {
-          "match": "\\.([a-zA-Z_][a-zA-Z0-9_]*)",
+          "match": "(\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
           "captures": {
-            "1": { "name": "variable.other.member.raven" }
+            "1": { "name": "punctuation.accessor.raven" },
+            "2": { "name": "variable.other.member.raven" }
           }
         }
       ]
@@ -529,6 +561,24 @@
         {
           "name": "punctuation.section.brackets.end.raven",
           "match": "\\]"
+        }
+      ]
+    },
+    "parameters": {
+      "patterns": [
+        {
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=:)",
+          "captures": {
+            "1": { "name": "variable.parameter.raven" }
+          }
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "variable.other.raven",
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
         }
       ]
     }


### PR DESCRIPTION
Closes #873.

## What was wrong

Several kinds of tokens carried no TextMate scope, so they stayed the editor's default text color in every theme, not just mine:

- Punctuation inside a `${...}` interpolation. Parentheses, commas, and brackets in an interpolated expression like `"n=${f(x) + arr[i]}"` were left bare. This is the case in the issue.
- Quoted import paths. The grammar only knew the unquoted `import std/foo` form, so `import "./file" { a, b }` and `import "github.com/user/repo" { A }` left the path unrecognized and the imported names unscoped.
- Plain variable uses, function parameters, and struct field names had no rule at all, so `name` in `name: String` and a bare `total` reference stayed uncolored.
- The `.` accessor in `obj.field` and `obj.method()`.

## The fix

`syntaxes/raven.tmLanguage.json`:

- Add quoted variants of both import forms (selective `{ ... }` and plain/`as`), keeping the path a string and scoping the imported names. Both forms now share one `importNames` rule.
- Include the keyword and punctuation rules inside the interpolation body so operators, parens, commas, and brackets get scoped like they do everywhere else.
- Scope the accessor dot as `punctuation.accessor` and the following name as a method or member.
- Add a rule for a name in parameter or field position (an identifier before `:`) as `variable.parameter`, and a catch all that scopes any remaining identifier as `variable.other`.

Every token now resolves to a standard scope. I checked the result by running the grammar through the real `vscode-textmate` tokenizer over a sample covering all four import forms, struct fields, function params, member access, and interpolation: zero tokens come back without a scope.

Extension bumped to 2.3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Raven syntax highlighting in VS Code for function parameters, identifiers, imports, interpolations, and member access.
  * Added support for highlighting string-based imports with optional aliases.

* **Chores**
  * Updated the VS Code extension version to 2.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->