### PR TITLE
fix(rvpm): accept CRLF files in fmt check

### DIFF
--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -788,7 +788,16 @@ fn cmd_fmt(args: &[String]) -> ExitCode {
                 continue;
             }
         };
-        if formatted == src {
+        // The formatter emits canonical LF newlines. In check-only mode,
+        // accept an otherwise canonical CRLF working copy so Windows checkout
+        // settings do not make every Raven source appear unformatted. Writing
+        // mode still canonicalizes the file to LF as before.
+        let is_formatted = if check {
+            formatted == src.replace("\r\n", "\n")
+        } else {
+            formatted == src
+        };
+        if is_formatted {
             continue;
         }
         if check {

--- a/tests/rvpm_fmt.rs
+++ b/tests/rvpm_fmt.rs
@@ -63,6 +63,23 @@ fn check_passes_on_canonical_file() {
 }
 
 #[test]
+fn check_passes_on_canonical_file_with_crlf_line_endings() {
+    let dir = workdir();
+    let file = dir.join("clean.rv");
+    let crlf = CANONICAL.replace('\n', "\r\n");
+    std::fs::write(&file, &crlf).unwrap();
+
+    let out = rvpm(&dir, &["fmt", "--check", "clean.rv"]);
+
+    assert!(
+        out.status.success(),
+        "canonical CRLF file should pass --check: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), crlf);
+}
+
+#[test]
 fn fmt_with_no_paths_formats_src_dir() {
     let dir = workdir();
     let src = dir.join("src");


### PR DESCRIPTION
## Summary

- make `rvpm fmt --check` compare canonical content independently of CRLF versus LF line endings
- preserve the existing write-mode behavior that canonicalizes formatted files to LF
- add an end-to-end regression test that verifies a canonical CRLF file passes without being rewritten

## Root cause

The formatter always emits LF output, and check mode compared that output byte-for-byte with the source. A Windows checkout using CRLF therefore appeared unformatted even when its Raven syntax and layout were canonical.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace`

Fixes #868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `rvpm fmt --check` now correctly accepts files using Windows-style CRLF line endings when their content is otherwise properly formatted.
  * Check mode preserves the file’s existing line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->