### PR TITLE
fix(tycheck): discard values in unit contexts

### DIFF
--- a/src/hir/lower/expr.rs
+++ b/src/hir/lower/expr.rs
@@ -29,6 +29,18 @@ pub(crate) fn lower_block_to_block(
         stmts.extend(lower_stmt(s, cx)?);
     }
     let (tail, ty) = match &block.trailing {
+        // A block in unit context evaluates its trailing expression for side
+        // effects and discards the produced value. Represent it as an ordinary
+        // expression statement so MIR returns Unit from the block instead of
+        // handing a scalar/heap operand to a unit function or branch.
+        Some(e) if matches!(expected_ty.strip_self(), Ty::Unit) => {
+            let lowered = lower_expr(e, &Ty::Error, cx)?;
+            stmts.push(HirStmt {
+                kind: HirStmtKind::Expr(lowered),
+                span: e.span.clone(),
+            });
+            (None, Ty::Unit)
+        }
         Some(e) => {
             let lowered = lower_expr(e, expected_ty, cx)?;
             let ty = lowered.ty.clone();

--- a/src/hir/tests.rs
+++ b/src/hir/tests.rs
@@ -75,6 +75,38 @@ fn single_expression_body_becomes_block() {
 }
 
 #[test]
+fn unit_function_tail_is_lowered_as_a_discarded_statement() {
+    let p = lower("fun setup() -> Bool = true\nfun main() { setup() }");
+    let body = only_fn(&p, "main").body.as_ref().expect("body");
+    assert!(body.tail.is_none(), "a unit function must return Unit");
+    assert!(matches!(
+        body.stmts.last().map(|stmt| &stmt.kind),
+        Some(HirStmtKind::Expr(_))
+    ));
+}
+
+#[test]
+fn no_else_if_discards_the_then_branch_tail() {
+    let p =
+        lower("fun apply(n: Int) -> Bool = n > 0\nfun run(ready: Bool) { if ready { apply(1) } }");
+    let body = only_fn(&p, "run").body.as_ref().expect("body");
+    let HirStmtKind::Expr(if_expr) = &body.stmts.last().expect("discarded if").kind else {
+        panic!("expected the unit if as an expression statement");
+    };
+    let HirExprKind::If { then_block, .. } = &if_expr.kind else {
+        panic!("expected if expression");
+    };
+    assert!(
+        then_block.tail.is_none(),
+        "the then value must be discarded"
+    );
+    assert!(matches!(
+        then_block.stmts.last().map(|stmt| &stmt.kind),
+        Some(HirStmtKind::Expr(_))
+    ));
+}
+
+#[test]
 fn range_lowers_to_range_new() {
     let p = lower("fun r() -> () { let xs = 0..10; }");
     let f = only_fn(&p, "r");

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -251,7 +251,7 @@ fn check_function(
     match &f.body {
         FunctionBody::Block(b) => {
             let body_ty = cx.check_block(b).unwrap_or(Ty::Error);
-            if b.trailing.is_some() {
+            if b.trailing.is_some() && !matches!(ret_ty.strip_self(), Ty::Unit | Ty::Error) {
                 cx.unify_recover(&ret_ty, &body_ty, &b.span);
             } else if !matches!(ret_ty, Ty::Unit | Ty::Error) {
                 // No trailing expression and a non unit return type.
@@ -3043,7 +3043,10 @@ impl<'a, 'b> Checker<'a, 'b> {
         self.unify(&Ty::Bool, &c, &cond.span)?;
         let t = self.check_block(then_branch)?;
         let e = match else_branch {
-            None => Ty::Unit,
+            // An `if` without `else` cannot produce a value on every path, so
+            // it is a unit expression. The then branch is still checked and
+            // evaluated for side effects, but its trailing value is discarded.
+            None => return Ok(Ty::Unit),
             Some(ElseBranch::If(expr)) => self.check_expr(expr)?,
             Some(ElseBranch::Block(b)) => self.check_block(b)?,
         };
@@ -3172,14 +3175,18 @@ impl<'a, 'b> Checker<'a, 'b> {
         let body_ty = body_ty?;
         let final_ret = match declared_ret {
             Some(d) => {
-                self.unify(
-                    &d,
-                    &body_ty,
-                    match body {
-                        LambdaBody::Block(b) => &b.span,
-                        LambdaBody::Expr(e) => &e.span,
-                    },
-                )?;
+                let discards_block_tail =
+                    matches!(body, LambdaBody::Block(_)) && matches!(d.strip_self(), Ty::Unit);
+                if !discards_block_tail {
+                    self.unify(
+                        &d,
+                        &body_ty,
+                        match body {
+                            LambdaBody::Block(b) => &b.span,
+                            LambdaBody::Expr(e) => &e.span,
+                        },
+                    )?;
+                }
                 d
             }
             None => body_ty,

--- a/src/tycheck/tests.rs
+++ b/src/tycheck/tests.rs
@@ -64,6 +64,37 @@ fn const_local_is_usable() {
 }
 
 #[test]
+fn unit_function_discards_a_trailing_value() {
+    check("fun setup() -> Bool = true\nfun main() {\n    setup()\n}\n").unwrap();
+}
+
+#[test]
+fn if_without_else_discards_its_branch_value() {
+    check(
+        "fun apply(n: Int) -> Bool = n > 0\nfun run(ready: Bool) {\n    if ready {\n        apply(1)\n    }\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn unit_lambda_discards_a_trailing_value() {
+    check(
+        "fun setup() -> Bool = true\nfun main() {\n    let f = fun() -> Unit { setup() }\n    f()\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn non_unit_function_still_requires_its_declared_return_type() {
+    assert!(check("fun value() -> Int { true }").is_err());
+}
+
+#[test]
+fn if_with_else_still_requires_matching_branch_types() {
+    assert!(check("fun run(ready: Bool) { if ready { 1 } else { true } }").is_err());
+}
+
+#[test]
 fn generic_arg_violating_a_bound_is_rejected() {
     // A type written with a generic argument that does not satisfy the
     // declaration's bound is rejected at type-check, not left to surface as an


### PR DESCRIPTION
## Summary

- allow block-bodied unit functions and unit-returning lambdas to evaluate and discard a trailing value
- make an `if` without `else` a unit expression that discards its then-branch value
- lower discarded tails as HIR expression statements so MIR returns Unit while preserving side effects
- retain strict checking for non-unit function returns and mismatched `if/else` branch types

## Root cause

The type checker treated every block tail as the block's returned value, even when the surrounding function or lambda explicitly required Unit. A no-else `if` also unified its then-branch value against an implicit Unit else branch in the opposite direction, producing the confusing `should be Bool, but it's ()` diagnostic.

## Impact

Calls that return a value can now be used naturally at the end of unit blocks or no-else conditionals without a throwaway `let _ = ...` binding. The expression is still evaluated and only its result is discarded.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace`

Fixes #869