### PR TITLE
fix(tycheck): resolve imported trait bounds

### DIFF
--- a/src/hir/lower/mod.rs
+++ b/src/hir/lower/mod.rs
@@ -209,7 +209,7 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
             }))
         }
         DeclKind::Struct(s) => {
-            let params = collect_generic_params_for_owner(&s.generics, &s.span);
+            let params = collect_generic_params_for_owner(&s.generics, &s.span, cx.resolved);
             let scope = scope_from_params(&params);
             let mut fields = Vec::with_capacity(s.fields.len());
             for f in &s.fields {
@@ -227,7 +227,7 @@ fn lower_decl(decl: &Decl, cx: &LowerCtx<'_>) -> Result<Option<HirItem>, RavenEr
             }))
         }
         DeclKind::Enum(e) => {
-            let params = collect_generic_params_for_owner(&e.generics, &e.span);
+            let params = collect_generic_params_for_owner(&e.generics, &e.span, cx.resolved);
             let scope = scope_from_params(&params);
             let mut variants = Vec::with_capacity(e.variants.len());
             for v in &e.variants {
@@ -432,9 +432,17 @@ fn lower_function(
         // distinct `T` per method and break monomorphization's
         // substitution.
         let owner = extra_owner.unwrap_or(&f.span);
-        sigs.extend(collect_generic_params_for_owner(extra_generics, owner));
+        sigs.extend(collect_generic_params_for_owner(
+            extra_generics,
+            owner,
+            cx.resolved,
+        ));
     }
-    sigs.extend(collect_generic_params_for_owner(&f.generics, &f.span));
+    sigs.extend(collect_generic_params_for_owner(
+        &f.generics,
+        &f.span,
+        cx.resolved,
+    ));
     let scope = scope_from_params(&sigs);
 
     let mut params = Vec::with_capacity(f.params.len());
@@ -492,7 +500,7 @@ fn impl_self_ty(i: &Impl, cx: &LowerCtx<'_>) -> Result<(Ty, String), RavenError>
         Some(t) => t,
         None => &i.trait_or_type,
     };
-    let params = collect_generic_params_for_owner(&i.generics, &i.span);
+    let params = collect_generic_params_for_owner(&i.generics, &i.span, cx.resolved);
     let scope = scope_from_params(&params);
     let ast_ty = AstType {
         kind: crate::ast::TypeKind::Path(path.clone()),

--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -2791,6 +2791,29 @@ mod tests {
     }
 
     #[test]
+    fn imported_trait_impl_satisfies_a_generic_bound() {
+        let main_src = "import \"./t_def\" { Speak, Dog }\n\nfun call<T: Speak>(x: T) -> Int {\n    return x.sound()\n}\n\nfun main() {\n    print(call(Dog {}))\n}\n";
+        let (dir, entry) = write_temp_project(
+            &[
+                (
+                    "t_def.rv",
+                    "trait Speak {\n    fun sound(self) -> Int\n}\n\nstruct Dog {}\n\nimpl Speak for Dog {\n    fun sound(self) -> Int {\n        return 1\n    }\n}\n",
+                ),
+                ("t_main.rv", main_src),
+            ],
+            "t_main.rv",
+        );
+        let user = parse_at(main_src, &entry);
+        let combined = expand_with_stdlib(&user).expect("expand");
+        let mut loader = FsLoader;
+        let resolved = super::super::resolve_file(&combined, &mut loader)
+            .expect("imported trait and type should resolve");
+        crate::tycheck::check_file(&resolved)
+            .expect("the imported impl should satisfy the generic bound");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn json_derive_helpers_emitted_once_across_modules() {
         // Two local modules each derive a JSON trait. The shared helper free
         // functions are global and fixed-named, so they must be declared

--- a/src/resolve/walk.rs
+++ b/src/resolve/walk.rs
@@ -55,7 +55,7 @@ fn walk_decl(
     match &decl.kind {
         DeclKind::Function(f) => {
             scope.push(ScopeKind::Function);
-            push_generics(scope, &f.generics, &decl.span)?;
+            push_generics(scope, &f.generics, &decl.span, map)?;
             for p in &f.params {
                 insert_param(scope, &p.name, p.span.clone())?;
                 walk_type(&p.ty, scope, map)?;
@@ -111,7 +111,7 @@ fn walk_struct(
     map: &mut ResolutionMap,
 ) -> Result<(), RavenError> {
     scope.push(ScopeKind::Function);
-    push_generics(scope, &s.generics, &s.span)?;
+    push_generics(scope, &s.generics, &s.span, map)?;
     for f in &s.fields {
         walk_type(&f.ty, scope, map)?;
     }
@@ -131,10 +131,10 @@ fn walk_trait(
     // `SelfOutsideImpl`.
     scope.push(ScopeKind::Impl);
     let _ = scope.insert("Self", Binding::SelfType, t.span.clone());
-    push_generics(scope, &t.generics, &t.span)?;
+    push_generics(scope, &t.generics, &t.span, map)?;
     for member in &t.members {
         scope.push(ScopeKind::Impl);
-        push_generics(scope, &member.generics, &member.span)?;
+        push_generics(scope, &member.generics, &member.span, map)?;
         for p in &member.params {
             if p.name == "self" {
                 scope.insert_shadowing("self", Binding::SelfValue, p.span.clone());
@@ -155,7 +155,7 @@ fn walk_trait(
 
 fn walk_enum(e: &Enum, scope: &mut ScopeStack, map: &mut ResolutionMap) -> Result<(), RavenError> {
     scope.push(ScopeKind::Function);
-    push_generics(scope, &e.generics, &e.span)?;
+    push_generics(scope, &e.generics, &e.span, map)?;
     for v in &e.variants {
         match &v.payload {
             VariantPayload::Unit => {}
@@ -182,7 +182,7 @@ fn walk_impl(
     map: &mut ResolutionMap,
 ) -> Result<(), RavenError> {
     scope.push(ScopeKind::Impl);
-    push_generics(scope, &i.generics, &i.span)?;
+    push_generics(scope, &i.generics, &i.span, map)?;
     // Bind Self to the implementing type. The "implementing type" is
     // `for_type` if present (trait impl), else `trait_or_type` (inherent
     // impl).
@@ -194,7 +194,7 @@ fn walk_impl(
     }
     for item in &i.items {
         scope.push(ScopeKind::Function);
-        push_generics(scope, &item.generics, &item.span)?;
+        push_generics(scope, &item.generics, &item.span, map)?;
         for p in &item.params {
             if p.name == "self" {
                 scope.insert_shadowing("self", Binding::SelfValue, p.span.clone());
@@ -217,6 +217,7 @@ fn push_generics(
     scope: &mut ScopeStack,
     generics: &[crate::ast::GenericParam],
     owner: &Span,
+    map: &mut ResolutionMap,
 ) -> Result<(), RavenError> {
     for g in generics {
         scope.insert(
@@ -230,7 +231,7 @@ fn push_generics(
         // Trait bounds are themselves type paths and need their leading
         // name resolved against the current scope.
         for bound in &g.bounds {
-            walk_type_path(bound, scope, &mut ResolutionMap::new())?;
+            walk_type_path(bound, scope, map)?;
         }
     }
     Ok(())

--- a/src/tycheck/collect.rs
+++ b/src/tycheck/collect.rs
@@ -74,7 +74,7 @@ pub fn collect_declarations(
         let id = DeclId(idx);
         match &decl.kind {
             DeclKind::Struct(s) => {
-                let generics = collect_generic_params(&s.generics, &decl.span);
+                let generics = collect_generic_params(&s.generics, &decl.span, resolved);
                 env.structs.insert(
                     id,
                     StructSig {
@@ -87,7 +87,7 @@ pub fn collect_declarations(
                 );
             }
             DeclKind::Enum(e) => {
-                let generics = collect_generic_params(&e.generics, &decl.span);
+                let generics = collect_generic_params(&e.generics, &decl.span, resolved);
                 env.enums.insert(
                     id,
                     EnumSig {
@@ -99,7 +99,7 @@ pub fn collect_declarations(
                 );
             }
             DeclKind::Trait(t) => {
-                let generics = collect_generic_params(&t.generics, &decl.span);
+                let generics = collect_generic_params(&t.generics, &decl.span, resolved);
                 env.traits.insert(
                     id,
                     TraitSig {
@@ -123,7 +123,7 @@ pub fn collect_declarations(
             DeclKind::Function(f) => {
                 let mut scope = GenericScope::new();
                 scope.push();
-                let generics = collect_generic_params(&f.generics, &decl.span);
+                let generics = collect_generic_params(&f.generics, &decl.span, resolved);
                 push_generics_into_scope(&mut scope, &generics);
                 let sig = collect_fn_sig(f, resolved, env, None, &scope, generics)?;
                 scope.pop();
@@ -254,7 +254,11 @@ fn literal_ty_of(e: &Expr) -> Option<Ty> {
 /// Build a list of [`GenericParamSig`] from a parsed generic parameter
 /// list. The trait bounds are captured by name (the resolver already
 /// validated that they point at trait declarations).
-fn collect_generic_params(params: &[GenericParam], owner: &Span) -> Vec<GenericParamSig> {
+fn collect_generic_params(
+    params: &[GenericParam],
+    owner: &Span,
+    resolved: &ResolvedFile<'_>,
+) -> Vec<GenericParamSig> {
     let mut sigs: Vec<GenericParamSig> = params
         .iter()
         .enumerate()
@@ -262,13 +266,7 @@ fn collect_generic_params(params: &[GenericParam], owner: &Span) -> Vec<GenericP
             let bounds = p
                 .bounds
                 .iter()
-                .map(|b| {
-                    // The head segment name is the trait's short name.
-                    b.segments
-                        .last()
-                        .map(|s| s.name.clone())
-                        .unwrap_or_default()
-                })
+                .map(|b| canonical_trait_name(b, resolved))
                 .collect();
             GenericParamSig {
                 id: ParamId::new(owner, i, p.name.clone()),
@@ -306,6 +304,23 @@ fn collect_generic_params(params: &[GenericParam], owner: &Span) -> Vec<GenericP
         sigs[i].bound_args = per_bound;
     }
     sigs
+}
+
+/// Return the declaration name for a trait path. Imported declarations are
+/// merged under module-qualified names, while their use sites retain the
+/// source spelling, so the resolver binding is the authoritative identity.
+fn canonical_trait_name(path: &TypePath, resolved: &ResolvedFile<'_>) -> String {
+    let fallback = || type_path_name(path);
+    let Some(head) = path.segments.first() else {
+        return fallback();
+    };
+    let Some(Binding::Trait(id)) = resolved.map.lookup(&head.span) else {
+        return fallback();
+    };
+    match resolved.file.items.get(id.0).map(|decl| &decl.kind) {
+        Some(DeclKind::Trait(t)) => t.name.clone(),
+        _ => fallback(),
+    }
 }
 
 /// Resolve one type argument of a trait bound to a [`Ty`] using only the
@@ -542,7 +557,7 @@ fn fill_trait(
     let mut method_order = Vec::with_capacity(t.members.len());
     for member in &t.members {
         scope.push();
-        let m_generics = collect_generic_params(&member.generics, &member.span);
+        let m_generics = collect_generic_params(&member.generics, &member.span, resolved);
         push_generics_into_scope(&mut scope, &m_generics);
         let sig = collect_fn_sig(member, resolved, env, Some(&trait_self), &scope, m_generics)?;
         scope.pop();
@@ -619,14 +634,14 @@ fn ty_mentions_self(ty: &Ty) -> bool {
 fn fill_impl(i: &Impl, resolved: &ResolvedFile<'_>, env: &mut TypeEnv) -> Result<(), RavenError> {
     let mut scope = GenericScope::new();
     scope.push();
-    let impl_generics = collect_generic_params(&i.generics, &i.span);
+    let impl_generics = collect_generic_params(&i.generics, &i.span, resolved);
     push_generics_into_scope(&mut scope, &impl_generics);
 
     // The implementing type is `for_type` for trait impls; otherwise
     // `trait_or_type` itself.
     let (impl_path, trait_name) = match &i.for_type {
         Some(target) => {
-            let trait_name = type_path_name(&i.trait_or_type);
+            let trait_name = canonical_trait_name(&i.trait_or_type, resolved);
             (target, Some(trait_name))
         }
         None => (&i.trait_or_type, None),
@@ -636,7 +651,7 @@ fn fill_impl(i: &Impl, resolved: &ResolvedFile<'_>, env: &mut TypeEnv) -> Result
     let mut methods = HashMap::new();
     for f in &i.items {
         scope.push();
-        let m_generics = collect_generic_params(&f.generics, &f.span);
+        let m_generics = collect_generic_params(&f.generics, &f.span, resolved);
         push_generics_into_scope(&mut scope, &m_generics);
         let sig = collect_fn_sig(f, resolved, env, Some(&self_ty), &scope, m_generics)?;
         scope.pop();
@@ -1096,8 +1111,9 @@ pub fn push_into_scope(scope: &mut GenericScope, params: &[GenericParamSig]) {
 pub fn collect_generic_params_for_owner(
     params: &[GenericParam],
     owner: &Span,
+    resolved: &ResolvedFile<'_>,
 ) -> Vec<GenericParamSig> {
-    collect_generic_params(params, owner)
+    collect_generic_params(params, owner, resolved)
 }
 
 #[cfg(test)]

--- a/src/tycheck/expr.rs
+++ b/src/tycheck/expr.rs
@@ -201,7 +201,7 @@ fn check_function(
     // function's own generics.
     let fn_generics = super::collect::scope_from_params(extra_generics);
     // Layer the function's own generics on top.
-    let f_params = super::collect::collect_generic_params_for_owner(&f.generics, &f.span);
+    let f_params = super::collect::collect_generic_params_for_owner(&f.generics, &f.span, resolved);
     let mut full_scope = fn_generics;
     super::collect::push_into_scope(&mut full_scope, &f_params);
 


### PR DESCRIPTION
## Summary

- retain resolver bindings for trait paths in generic bounds
- canonicalize bound and impl trait names through resolved declarations
- cover the reported two-file imported trait/impl scenario

## Root cause

Generic bound paths were resolved into a temporary map that was immediately discarded. Type collection then kept the source-level short trait name, while imported trait declarations and impls used module-qualified names, so bound method lookup and impl matching compared different identities.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace`

Fixes #856