### PR TITLE
feat(rvpm): embed icons in Windows executables

### DIFF
--- a/docs/v2/specs/rvpm-dist.md
+++ b/docs/v2/specs/rvpm-dist.md
@@ -49,7 +49,7 @@ section = "utils"                  # deb
 priority = "optional"              # deb
 
 [dist.windows]
-icon = "assets/rook.ico"           # Inno Setup icon
+icon = "assets/rook.ico"           # embedded executable and Inno Setup icon
 upgrade_code = "9f0c86a1-2b3c-4d5e-8f90-112233445566"  # msi upgrade GUID
 add_to_path = true                 # msi appends the install dir to system PATH
 ```
@@ -89,6 +89,11 @@ manifest so it never changes by accident.
 directory to the system PATH, so a command-line tool is callable from a
 terminal after installing (the other installers still leave PATH alone).
 The uninstaller removes the entry.
+
+On Windows, `[dist.windows].icon` is compiled into the executable produced by
+`rvpm build`, so Explorer and the taskbar can display the application icon. The
+same `.ico` is also used as the Inno Setup installer icon. MSVC builds use the
+Windows SDK resource compiler (`rc.exe`); GNU builds use MinGW-w64 `windres`.
 
 ## What is out of scope
 

--- a/src/codegen/linker.rs
+++ b/src/codegen/linker.rs
@@ -121,12 +121,12 @@ fn host_triple_string() -> String {
     Triple::host().to_string()
 }
 
-/// Native code to link into the program, gathered from the `[ffi]` sections of
-/// a project and its dependencies: object files compiled from bundled C
-/// sources, system library names (`-l`), and raw linker arguments.
+/// Native inputs to link into the program: object files compiled from bundled
+/// C sources, a Windows resource when configured, system library names (`-l`),
+/// and raw linker arguments.
 #[derive(Debug, Clone, Default)]
 pub struct NativeLink {
-    /// Object files (compiled from bundled C sources) to link in.
+    /// Object and resource files to link in.
     pub objects: Vec<PathBuf>,
     /// System library names to link, passed as `-l<name>` (or `<name>.lib`).
     pub libs: Vec<String>,
@@ -249,6 +249,104 @@ pub fn compile_c_sources(
         objects.push(object);
     }
     Ok(objects)
+}
+
+/// Compile an `.ico` file into a native Windows resource that the linker can
+/// embed in the executable. MSVC targets use the Windows SDK's `rc.exe`;
+/// GNU targets use MinGW-w64's `windres`.
+pub fn compile_windows_icon(icon: &Path, out_dir: &Path) -> Result<PathBuf, CodegenError> {
+    if !icon.is_file() {
+        return Err(CodegenError::Target(format!(
+            "Windows icon '{}' does not exist or is not a file",
+            icon.display()
+        )));
+    }
+    std::fs::create_dir_all(out_dir)
+        .map_err(|e| CodegenError::Target(format!("create native build dir: {}", e)))?;
+
+    // Give the resource script a fixed local filename. This avoids quoting and
+    // escaping an arbitrary absolute Windows path in RC syntax.
+    let local_icon = out_dir.join("raven_app.ico");
+    std::fs::copy(icon, &local_icon)
+        .map_err(|e| CodegenError::Target(format!("copy Windows icon: {}", e)))?;
+    let script = out_dir.join("raven_app.rc");
+    std::fs::write(&script, "1 ICON \"raven_app.ico\"\n")
+        .map_err(|e| CodegenError::Target(format!("write Windows resource script: {}", e)))?;
+
+    let triple = Triple::host();
+    if is_windows_msvc(&triple) {
+        let resource = out_dir.join("raven_app.res");
+        let mut cmd = cc::windows_registry::find_tool(&host_triple_string(), "rc.exe")
+            .ok_or_else(|| {
+                CodegenError::Target(
+                    "cannot embed the Windows icon because rc.exe was not found; install the Windows SDK through the Visual Studio C++ Build Tools"
+                        .to_string(),
+                )
+            })?
+            .to_command();
+        cmd.current_dir(out_dir)
+            .arg("/nologo")
+            .arg("/fo")
+            .arg("raven_app.res")
+            .arg("raven_app.rc");
+        run_resource_compiler(cmd, "rc.exe", &resource)?;
+        Ok(resource)
+    } else if is_windows_gnu(&triple) {
+        let resource = out_dir.join("raven_app.o");
+        let windres = find_on_path(&["windres.exe", "windres"]).ok_or_else(|| {
+            CodegenError::Target(
+                "cannot embed the Windows icon because windres was not found; install a MinGW-w64 toolchain and put windres on PATH"
+                    .to_string(),
+            )
+        })?;
+        let mut cmd = Command::new(windres);
+        cmd.current_dir(out_dir).args([
+            "raven_app.rc",
+            "--output-format=coff",
+            "-o",
+            "raven_app.o",
+        ]);
+        run_resource_compiler(cmd, "windres", &resource)?;
+        Ok(resource)
+    } else {
+        Err(CodegenError::Target(
+            "Windows executable icons can only be compiled for a Windows target".to_string(),
+        ))
+    }
+}
+
+fn run_resource_compiler(mut cmd: Command, name: &str, output: &Path) -> Result<(), CodegenError> {
+    let result = cmd
+        .output()
+        .map_err(|e| CodegenError::Target(format!("{} failed to launch: {}", name, e)))?;
+    if !result.status.success() {
+        return Err(CodegenError::Target(format!(
+            "{} failed while compiling the Windows icon:\n{}",
+            name,
+            String::from_utf8_lossy(&result.stderr).trim()
+        )));
+    }
+    if !output.is_file() {
+        return Err(CodegenError::Target(format!(
+            "{} did not produce '{}'",
+            name,
+            output.display()
+        )));
+    }
+    Ok(())
+}
+
+fn find_on_path(names: &[&str]) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        for name in names {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 /// True when `object` exists and was built from the current contents of

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -108,8 +108,8 @@ pub fn build_binary(
 }
 
 /// Compile `input` to a native executable like [`build_binary`], additionally
-/// linking the `native` FFI inputs (compiled C archives, `-l` libraries, and
-/// raw linker arguments) gathered from `[ffi]` sections.
+/// linking the `native` inputs (compiled C objects, Windows resources, `-l`
+/// libraries, and raw linker arguments) gathered by rvpm.
 pub fn build_binary_native(
     input: &Path,
     output: &Path,

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -205,7 +205,8 @@ impl Default for DistLinux {
 /// The `[dist.windows]` subsection, shared by the msi and inno backends.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DistWindows {
-    /// An .ico file relative to the package root, used by the installers.
+    /// An .ico file relative to the package root, embedded in Windows
+    /// executables and used by the Inno installer.
     pub icon: String,
     /// The stable GUID that lets an msi upgrade an installed older version.
     /// Required by the msi backend; generate one once and keep it.

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -254,8 +254,8 @@ pub fn add_in(
     })
 }
 
-/// Collect the native link inputs from a project and its dependencies' `[ffi]`
-/// sections, compiling any bundled C sources into a single static archive.
+/// Collect native link inputs from the project: its Windows icon resource and
+/// the `[ffi]` sections of the project and its dependencies.
 fn gather_native_link(
     project_dir: &Path,
     manifest: &Manifest,
@@ -291,11 +291,24 @@ fn gather_native_link(
         }
     }
 
-    let objects = if sources.is_empty() {
+    let mut objects = if sources.is_empty() {
         Vec::new()
     } else {
         linker::compile_c_sources(&sources, out_dir).map_err(DriverError::from)?
     };
+    if cfg!(windows) {
+        if let Some(icon) = manifest
+            .dist
+            .as_ref()
+            .map(|dist| dist.windows.icon.as_str())
+            .filter(|icon| !icon.is_empty())
+        {
+            objects.push(
+                linker::compile_windows_icon(&project_dir.join(icon), out_dir)
+                    .map_err(DriverError::from)?,
+            );
+        }
+    }
     Ok(linker::NativeLink {
         objects,
         libs,
@@ -628,8 +641,8 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
                     source: e,
                 })?;
             }
-            // Gather native code to link from the `[ffi]` of the project and
-            // its dependencies (bundled C sources, libraries, linker args).
+            // Gather native inputs to link: `[ffi]` code from the project and
+            // its dependencies, plus the configured Windows icon resource.
             let ffi_dir = binary
                 .parent()
                 .map(|p| p.join("ffi"))

--- a/tests/rvpm_build.rs
+++ b/tests/rvpm_build.rs
@@ -17,6 +17,101 @@ use std::process::Command;
 
 use raven::codegen::linker;
 
+#[cfg(windows)]
+#[test]
+fn project_build_embeds_the_configured_windows_icon() {
+    if !supported_runtime() {
+        return;
+    }
+
+    let work = workdir();
+    let cache = work.join("cache");
+    let project = work.join("project");
+    std::fs::create_dir_all(project.join("src")).expect("mkdir project");
+    std::fs::write(
+        project.join("rv.toml"),
+        "[package]\nname = \"icon_demo\"\nversion = \"0.1.0\"\n\n[dist.windows]\nicon = \"app.ico\"\n",
+    )
+    .expect("write manifest");
+    std::fs::write(
+        project.join("src/main.rv"),
+        "fun main() { print(\"icon\") }\n",
+    )
+    .expect("write main");
+    std::fs::write(project.join("app.ico"), minimal_ico()).expect("write icon");
+
+    let build = rvpm(&project, &cache, &["build".to_string()]);
+    let binary = project.join("target/raven-out/icon_demo.exe");
+    let has_icon = build.status.success() && executable_has_group_icon(&binary);
+    cleanup(&work);
+
+    assert!(
+        build.status.success(),
+        "rvpm build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+    assert!(
+        has_icon,
+        "the built executable should contain an icon resource"
+    );
+}
+
+#[cfg(windows)]
+fn minimal_ico() -> Vec<u8> {
+    let mut icon = Vec::new();
+    icon.extend_from_slice(&[0, 0, 1, 0, 1, 0]); // ICONDIR
+    icon.extend_from_slice(&[1, 1, 0, 0, 1, 0, 32, 0]);
+    icon.extend_from_slice(&48u32.to_le_bytes());
+    icon.extend_from_slice(&22u32.to_le_bytes());
+    icon.extend_from_slice(&40u32.to_le_bytes()); // BITMAPINFOHEADER
+    icon.extend_from_slice(&1i32.to_le_bytes());
+    icon.extend_from_slice(&2i32.to_le_bytes()); // XOR + AND heights
+    icon.extend_from_slice(&1u16.to_le_bytes());
+    icon.extend_from_slice(&32u16.to_le_bytes());
+    icon.extend_from_slice(&0u32.to_le_bytes());
+    icon.extend_from_slice(&4u32.to_le_bytes());
+    icon.extend_from_slice(&[0; 16]);
+    icon.extend_from_slice(&[0x20, 0x60, 0xE0, 0xFF]); // BGRA pixel
+    icon.extend_from_slice(&[0; 4]); // padded AND mask
+    icon
+}
+
+#[cfg(windows)]
+fn executable_has_group_icon(path: &Path) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+
+    type Hmodule = *mut std::ffi::c_void;
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn LoadLibraryExW(name: *const u16, file: *mut std::ffi::c_void, flags: u32) -> Hmodule;
+        fn FindResourceW(
+            module: Hmodule,
+            name: *const u16,
+            kind: *const u16,
+        ) -> *mut std::ffi::c_void;
+        fn FreeLibrary(module: Hmodule) -> i32;
+    }
+
+    const LOAD_LIBRARY_AS_DATAFILE: u32 = 0x0000_0002;
+    const RT_GROUP_ICON: *const u16 = 14usize as *const u16;
+    const ICON_ID: *const u16 = 1usize as *const u16;
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    unsafe {
+        let module = LoadLibraryExW(
+            wide.as_ptr(),
+            std::ptr::null_mut(),
+            LOAD_LIBRARY_AS_DATAFILE,
+        );
+        if module.is_null() {
+            return false;
+        }
+        let found = !FindResourceW(module, ICON_ID, RT_GROUP_ICON).is_null();
+        FreeLibrary(module);
+        found
+    }
+}
+
 #[test]
 fn project_with_github_dependency_builds_and_runs() {
     if !supported_runtime() {


### PR DESCRIPTION
## Summary

- reuse `[dist.windows].icon` for the executable produced by `rvpm build`
- compile `.ico` files with Windows SDK `rc.exe` on MSVC or MinGW-w64 `windres` on GNU
- link the generated resource through Raven's existing native input pipeline
- retain the same icon for the Inno installer

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace`
- Windows acceptance test loads the linked PE and verifies its `RT_GROUP_ICON` resource

Fixes #872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows builds now embed the configured `.ico` file directly into the generated executable.
  * The same icon is used for both the application executable and the Inno Setup installer.

* **Documentation**
  * Clarified how the Windows icon setting affects generated executables and installers.
  * Updated native linking documentation to describe supported link inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->