### PR TITLE
docs: synchronize Raven and rvpm documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
 
 <p align="center">
   <a href="https://martian56.github.io/raven/">Documentation</a>
-  ·
+  &middot;
   <a href="https://raven.ufazien.com/">Website</a>
-  ·
+  &middot;
   <a href="https://github.com/martian56/raven/releases">Releases</a>
-  ·
+  &middot;
   <a href="https://github.com/martian56/raven/issues">Issues</a>
 </p>
 
@@ -74,6 +74,8 @@ rvpm new my_app
 cd my_app
 rvpm run          # builds and runs src/main.rv
 rvpm fmt          # format the .rv sources
+rvpm test         # run test_* functions in *_test.rv files
+rvpm dist         # package the application for distribution
 ```
 
 ### Build from source
@@ -95,6 +97,7 @@ The `raven` and `rvpm` binaries land in `target/release/`.
 - Getting started: [https://martian56.github.io/raven/v2/guide/getting-started/](https://martian56.github.io/raven/v2/guide/getting-started/)
 - Language reference: [https://martian56.github.io/raven/v2/guide/language-reference/](https://martian56.github.io/raven/v2/guide/language-reference/)
 - Standard library: [https://martian56.github.io/raven/v2/guide/standard-library/](https://martian56.github.io/raven/v2/guide/standard-library/)
+- rvpm: [https://martian56.github.io/raven/v2/guide/rvpm/](https://martian56.github.io/raven/v2/guide/rvpm/)
 
 ## Technologies Used
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,9 @@ raven build hello.rv -o hello
 - **Concurrency.** Lightweight goroutines with `spawn` and channels for passing values between them.
 - **C FFI.** Declare `extern "C"` functions and call into native libraries, with C numeric types, pointers, callbacks, and small structs by value.
 - **Metaprogramming.** `@derive` for the common traits and JSON, declarative macros, and compile time plus runtime reflection.
-- **Tooling that ships with the language.** One canonical formatter (`rvpm fmt`), GitHub direct packages (`rvpm`), and a VS Code extension.
+- **Tooling that ships with the language.** `rvpm` scaffolds, resolves,
+  builds, runs, tests, documents, formats, and packages applications; a VS
+  Code extension provides editor support.
 
 ## A fuller taste
 
@@ -84,6 +86,8 @@ fun main() {
 - Want the whole surface of the language? See the [Language Reference](v2/guide/language-reference.md).
 - Looking for what the standard library gives you? The [Standard Library](v2/guide/standard-library.md) page walks through every module.
 - Managing dependencies and builds? Read the [rvpm guide](v2/guide/rvpm.md).
+- Shipping an application? See [rvpm dist](v2/specs/rvpm-dist.md) for archives
+  and native Linux and Windows packages.
 
 ## Install
 

--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -1,12 +1,19 @@
 # Raven v2 docs
 
-Specs, plans, and design docs for Raven v2.0, the compiled, GC'd, OOP-via-traits rewrite of Raven that lives on the `v2.x` branch until release.
+Specs and design notes for Raven v2, the compiled, GC'd,
+OOP-via-traits language shipped from `main`. User-facing documentation starts
+with [Getting started](./guide/getting-started.md); files under `specs/` include
+current implementation references and clearly labeled historical design
+records.
 
 | Document | Purpose |
 |---|---|
-| [`2026-05-22-v2-roadmap.md`](./2026-05-22-v2-roadmap.md) | The top-level roadmap. Read this first. Covers the language design, compiler pipeline, runtime, rvpm, and 13-phase release plan. |
+| [Getting started](./guide/getting-started.md) | The entry point to the language guide, tutorials, standard library, and rvpm documentation. |
+| `specs/` | Compiler, runtime, standard-library, and tooling implementation specifications. |
+| [`2026-05-22-v2-roadmap.md`](./2026-05-22-v2-roadmap.md) | Historical roadmap for the v2 rewrite. Its phase and branch notes describe the development plan, not current status. |
 
-As each phase begins, its own spec lands in this directory alongside the roadmap.
+New implementation specifications live in `specs/`; completed user-facing
+features must also be reflected in `guide/`.
 
 ## v1 documentation
 

--- a/docs/v2/guide/language-reference.md
+++ b/docs/v2/guide/language-reference.md
@@ -56,13 +56,14 @@ fun main() {
 }
 ```
 
-At module level a `const` is a compile-time constant: it requires both a
-type and a value, and its initializer must be a constant expression (a
-literal, or an arithmetic, comparison, bitwise, or boolean combination of
-literals), which is folded and inlined at each use site.
+At module level a `const` is a compile-time constant. A literal initializer
+can infer its type; other constant expressions need an explicit annotation.
+The initializer must be a literal, or an arithmetic, comparison, bitwise, or
+boolean combination of literals. It is folded and inlined at each use site.
 
 ```rust
 const MAX: Int = 100
+const HOST = "127.0.0.1"       // inferred as String
 const SECS_PER_HOUR: Int = 60 * 60
 ```
 
@@ -85,7 +86,7 @@ Type names are PascalCase.
 | `Int`    | 64-bit signed integer |
 | `Float`  | 64-bit floating point |
 | `Bool`   | `true` or `false` |
-| `String` | UTF-8 text, heap allocated |
+| `String` | heap-allocated byte string; literals are UTF-8 |
 | `Char`   | a single Unicode scalar value |
 | `Unit`   | the empty value, written `()` |
 

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -46,14 +46,23 @@ link_args = ["-L/opt/lib"]
 [fmt]
 indent_width = 4
 wrap_width = 100
+
+[dist]
+targets = ["zip", "deb"]
+description = "Demo application"
+
+[[dist.assets]]
+source = "assets"
+dest = "assets"
 ```
 
 Sections:
 
 - `[package]` (required): `name` and `version` are required. `authors`
   defaults to empty. `edition` defaults to `v2` (accepted: `v2`, `2026`).
-- `[dependencies]` (optional): keys are `github.com/<user>/<repo>` paths
-  (optionally with a subpath); values are git refs (a tag or branch).
+- `[dependencies]` (optional): keys identify a whole repository and must be
+  bare `github.com/<user>/<repo>` paths. Values are git refs (a tag or branch).
+  Source imports may add a subpath, but manifest keys may not.
 - `[ffi]` (optional): native code linked into a program that uses the
   package. `sources` are bundled C files (relative to the package root)
   that `rvpm build` compiles and links in, `libs` are libraries to link
@@ -65,6 +74,10 @@ Sections:
   `[ffi]` sources do not.
 - `[fmt]` (optional): `indent_width` (default 4) and `wrap_width`
   (default 100) for the formatter.
+- `[dist]` (optional): package formats, output directory, application metadata,
+  extra assets, Linux package dependencies, and Windows installer settings.
+  See [Distributing applications](../specs/rvpm-dist.md) for the complete
+  schema and required platform tools.
 
 Unknown fields are rejected so typos surface early.
 
@@ -162,6 +175,28 @@ Re-resolves and rewrites `rv.lock`. With no path, every entry is
 refreshed. With a path, only that dependency's subgraph is refreshed. To
 bump a dependency, edit its ref in `rv.toml`, then run `update`.
 
+### rvpm fetch
+
+```bash
+rvpm fetch github.com/<user>/<repo>@<version>
+```
+
+Fetches one exact GitHub tag or branch into the shared cache and prints its
+directory. This is a low-level cache operation; normal projects should use
+`add` or `install`, which also maintain `rv.lock` and resolve transitive
+dependencies.
+
+### rvpm lock
+
+```bash
+rvpm lock
+```
+
+Generates `rv.lock` when it is missing or incomplete. If the lock already
+covers the manifest, the command validates every cached package against its
+recorded tree hash. `install` and `build` perform the same lock maintenance
+automatically; `lock` is useful for CI and explicit verification.
+
 ### rvpm build
 
 ```bash
@@ -173,6 +208,27 @@ lock. For an application it compiles `src/main.rv` to
 `target/raven-out/<name>` and reports the binary path. For a library it
 type-checks `lib.rv` (and its modules) without producing a binary, so a
 package author can verify the library compiles before publishing.
+
+On Windows, an `.ico` configured as `[dist.windows].icon` is also embedded
+in the executable. MSVC builds use the Windows SDK resource compiler;
+GNU builds use MinGW-w64 `windres`.
+
+### rvpm dist
+
+```bash
+rvpm dist [--target <t1,t2>] [--out-dir <dir>]
+```
+
+Builds an application and packages it as one or more of `tar`, `zip`, `deb`,
+`rpm`, `msi`, or `inno`. `--target` overrides `[dist].targets`, and
+`--out-dir` overrides `[dist].out_dir`. Without configured targets, the host
+default is `zip` on Windows and `tar` elsewhere. Libraries are rejected
+because they do not produce an application binary.
+
+Assets may be files or directories. Directories are copied recursively while
+preserving nested files and empty directories. See
+[Distributing applications](../specs/rvpm-dist.md) for manifest fields,
+artifact names, and the external packaging tool required by each format.
 
 ### rvpm run
 

--- a/docs/v2/guide/stdlib/http.md
+++ b/docs/v2/guide/stdlib/http.md
@@ -22,7 +22,10 @@ fun main() {
 ## Importing
 
 ```rust
-import std/http { get, post, put, delete, patch, head, request }
+import std/http {
+    get, post, put, delete, patch, head,
+    request, request_with_timeout, stream,
+}
 ```
 
 Select the functions you use. The `HttpResponse` type comes in with the
@@ -177,6 +180,90 @@ fun main() {
 `get`, `post`, `put`, and `delete` are thin wrappers: `get` and `delete`
 pass `""` for both body and headers, while `post` and `put` pass your body
 and `""` for headers.
+
+### `request_with_timeout(method, url, body, headers, timeout_ms) -> Result<HttpResponse, Error>`
+
+Like `request`, with an overall deadline for connecting, sending, and reading
+the complete response body. A positive `timeout_ms` replaces the default;
+zero or a negative value keeps the normal client timeouts. A deadline failure
+is an `Err` with error kind `"http"`.
+
+```rust
+import std/http { request_with_timeout }
+
+fun main() {
+    match request_with_timeout(
+        "POST",
+        "https://example.com/infer",
+        "{\"prompt\":\"hello\"}",
+        "Content-Type: application/json",
+        120_000,
+    ) {
+        Ok(resp) -> print(resp.body),
+        Err(e) -> print("request failed: ${e.message}"),
+    }
+}
+```
+
+Use this form for endpoints that legitimately take longer than the default,
+such as model inference. It still buffers the entire response; use `stream`
+when the body should be consumed as it arrives.
+
+## Streaming responses
+
+### `stream(method, url, body, headers, timeout_ms) -> Result<HttpStream, Error>`
+
+Open a request without buffering its complete body. The returned `HttpStream`
+already contains `status_code`, `status_text`, and `headers`. Its timeout is
+per connection/read operation rather than an overall stream deadline, so a
+healthy server-sent-event stream can remain open indefinitely.
+
+```rust
+struct HttpStream {
+    id: Int,
+    status_code: Int,
+    status_text: String,
+    headers: String,
+}
+```
+
+Call `read_chunk()` repeatedly. It returns at most 8 KiB, `Ok("")` at the end
+of the body, or `Err` for a failed or timed-out read. Only one goroutine should
+read a stream at a time. Always call `close()` when finished to release the
+connection and runtime handle.
+
+```rust
+import std/http { stream }
+
+fun main() {
+    match stream("GET", "https://example.com/events", "", "", 30_000) {
+        Ok(body) -> {
+            let done = false
+            while !done {
+                match body.read_chunk() {
+                    Ok(chunk) -> {
+                        if chunk.length() == 0 {
+                            done = true
+                        } else {
+                            print(chunk)
+                        }
+                    },
+                    Err(e) -> {
+                        print("stream failed: ${e.message}")
+                        done = true
+                    },
+                }
+            }
+            body.close()
+        },
+        Err(e) -> print("could not open stream: ${e.message}"),
+    }
+}
+```
+
+A non-2xx response still opens successfully, letting you read its error body.
+Only DNS, connection, TLS, timeout, or malformed-response failures return
+`Err` from `stream` itself.
 
 ## Worked example: fetch and report
 

--- a/docs/v2/guide/stdlib/math.md
+++ b/docs/v2/guide/stdlib/math.md
@@ -180,6 +180,10 @@ Natural logarithm (the C `log`).
 
 Base-2 logarithm.
 
+### `log10(x: Float) -> Float`
+
+Base-10 logarithm.
+
 ```rust
 import std/math { log2 }
 
@@ -193,9 +197,9 @@ fun main() {
 Round toward minus infinity, toward plus infinity, to the nearest whole
 value, and toward zero. Each returns a whole-valued `Float`.
 
-### `sin(x: Float) -> Float` and `cos(x: Float) -> Float`
+### `sin(x: Float) -> Float`, `cos(x: Float) -> Float`, and `tan(x: Float) -> Float`
 
-Sine and cosine, with the angle in radians.
+Sine, cosine, and tangent, with the angle in radians.
 
 ### `asin(x: Float) -> Float`, `acos(x: Float) -> Float`, `atan(x: Float) -> Float`
 

--- a/docs/v2/guide/stdlib/process.md
+++ b/docs/v2/guide/stdlib/process.md
@@ -1,9 +1,8 @@
 # std/process
 
-Run external programs and read back their output. A run spawns the program,
-waits for it to finish, and hands you the captured exit code, stdout, and
-stderr as an `Output` value. There is no streaming: a child runs to
-completion in a single call.
+Run external programs either to completion or as a live child. `run` waits and
+returns captured output; `start` returns a `Child` that can exchange stdin,
+drain stdout and stderr incrementally, poll or wait for exit, and be killed.
 
 ```rust
 import std/process { run }
@@ -20,11 +19,11 @@ fun main() {
 ## Importing
 
 ```rust
-import std/process { run, run_with_input }
+import std/process { run, run_with_input, start }
 ```
 
-Bring in just the functions you call. The `success` method on `Output` comes
-in with the type and needs no separate selector.
+Bring in just the functions you call. `Output`, `Child`, and their methods
+come in with the module and need no separate selectors.
 
 ## The `Output` type
 
@@ -56,7 +55,109 @@ fun main() {
 }
 ```
 
+## The `Child` type
+
+```rust
+struct Child { id: Int }
+```
+
+`start` returns a handle to a child that may still be running. Its opaque
+`id` is managed by the runtime; use the methods below instead of inspecting
+the field.
+
+### `read_stdout(self) -> String` and `read_stderr(self) -> String`
+
+Drain all bytes accumulated on that stream since the previous read. An empty
+string means nothing new is available. Each stream retains at most 8 MiB; keep
+draining a noisy long-running child if every byte matters.
+
+### `write_stdin(self, data: String) -> Bool`
+
+Write and flush `data` to the child's stdin. It returns `false` if stdin was
+closed, the child exited, the pipe broke, or the handle is no longer valid.
+Raven strings are byte buffers, so binary data is passed through unchanged.
+
+### `close_stdin(self)`
+
+Close stdin and send EOF. Call this after the final write when the child waits
+for end of input before producing output or exiting.
+
+### `poll(self) -> Option<Int>` and `running(self) -> Bool`
+
+`poll` returns `None` while the child runs and `Some(code)` once it exits.
+`running` is the boolean form. A signal termination without an OS exit code is
+reported as `-1`.
+
+### `wait(self) -> Int`
+
+Wait for exit and return the code. Waiting polls with a short scheduler-aware
+sleep, so other Raven goroutines continue to run.
+
+### `kill(self) -> Bool`
+
+Stop the child. It returns `true` when the kill was delivered or the process
+had already exited.
+
+### `free(self)`
+
+Release the handle after collecting the final output and status. `free` does
+not kill a running process, although the runtime still guarantees it will be
+reaped after exit.
+
 ## Running a program
+
+### `start(program: String, args: List<String>) -> Result<Child, Error>`
+
+Start a child without waiting. Runtime reader threads continuously collect
+stdout and stderr so the process does not block on full pipes. Drain the
+buffers while it runs and call `free` when finished.
+
+```rust
+import std/process { start }
+import std/sync { sleep_millis }
+
+fun main() {
+    let args = ["--version"]
+    match start("git", args) {
+        Ok(child) -> {
+            while child.running() {
+                let chunk = child.read_stdout()
+                if chunk.length() > 0 {
+                    print(chunk)
+                }
+                sleep_millis(10)
+            }
+            print(child.read_stdout())       // drain bytes written before exit
+            let code = child.wait()
+            child.free()
+            print("exit ${code}")
+        },
+        Err(e) -> print("could not start git: ${e.message}"),
+    }
+}
+```
+
+For an interactive child, call `write_stdin` as needed and then
+`close_stdin` to send EOF:
+
+```rust
+import std/process { start }
+
+fun main() {
+    let no_args: List<String> = []
+    match start("cat", no_args) {
+        Ok(child) -> {
+            child.write_stdin("hello\n")
+            child.close_stdin()
+            let code = child.wait()
+            print(child.read_stdout())
+            child.free()
+            print("exit ${code}")
+        },
+        Err(e) -> print(e.message),
+    }
+}
+```
 
 ### `run(program: String, args: List<String>) -> Result<Output, Error>`
 
@@ -165,8 +266,8 @@ fun main() {
 
 ## Notes
 
-- A run captures stdout and stderr in full before returning. There is no
-  incremental or streaming output.
+- `run` and `run_with_input` capture stdout and stderr in full before
+  returning. Use `start` for incremental output or interactive stdin.
 - An argument that itself contains a NUL byte (`\0`) is not supported.
 - A child that reads no stdin under `run` sees end of input immediately.
   Under `run_with_input`, a broken pipe (the child exits without reading) is
@@ -175,5 +276,6 @@ fun main() {
 ## See also
 
 - [std/error](error.md) for the `Error` type and the `Result` model used by
-  `run` and `run_with_input`.
+  `run`, `run_with_input`, and `start`.
+- [std/sync](sync.md) for scheduler-aware sleeps while polling a child.
 - [std/string](string.md) for trimming and inspecting captured output.

--- a/docs/v2/specs/codegen.md
+++ b/docs/v2/specs/codegen.md
@@ -13,9 +13,9 @@ heap value construction: structs, enums (including `Option` and
 returned, passed, and invoked through their value), all with garbage
 collector root frames.
 
-Rich stdlib collection methods (`List` and `Map` operations beyond
-construction) are out of scope here and tracked by the follow up issues
-listed below.
+The back end also lowers collection literals and operations, trait-object
+coercion and dispatch, C FFI calls, reflection, propagation, `defer`, and the
+safepoints required by the parallel runtime.
 
 ## Pipeline position
 
@@ -61,13 +61,14 @@ Primitive Raven values map to fixed Cranelift types:
 | `Bool`   | `types::I8`    | `0` or `1`. Logical operators produce the same width so `if` over a `Bool` compares against zero. |
 | `Int`    | `types::I64`   | Signed 64 bit integers. Overflow is wrap on add, sub, mul (matching Cranelift defaults). Division by zero traps via Cranelift's `sdiv` semantics on supported targets; an explicit zero check is inserted on targets where this is not guaranteed. |
 | `Float`  | `types::F64`   | IEEE 754 doubles. |
-| `Char`   | `types::I32`   | Reserved. The MVP does not exercise `Char` operations; ground work only. |
+| `Char`   | `types::I32`   | A Unicode scalar value used by character literals and operations. |
 | `Str`    | pointer        | A heap object pointer. String literals reaching the `print` intrinsic still pull bytes from the static data table directly; a `Str` flowing through a local is a single traced GC pointer. |
-| `Struct`, `Enum`, `Option`, `Result`, `List`, `Function` | pointer | A single GC pointer to a heap object. Struct and enum construction, field access, and closure allocation are lowered (see the heap value section below). `List` and `Map` rich methods, and trait object dispatch, remain tracked by issues #66 and the stdlib issues. |
+| `Struct`, `Enum`, `Option`, `Result`, `List`, `Map`, `Set`, `Function` | pointer | A single traced GC pointer to a heap object. Construction, field/index access, collection operations, closures, and monomorphized method calls lower through their MIR operations or runtime helpers. A `dyn Trait` value is represented by a traced object plus its dispatch metadata. |
 
 The calling convention is whatever Cranelift picks for the host triple
-(the system V AMD64 ABI on x86_64 Linux and Windows, ARM64 ABI on
-aarch64). The backend never inspects the chosen convention. Parameters
+(the System V AMD64 ABI on x86_64 Linux, the Windows x64 ABI on Windows,
+and the platform AArch64 ABI). The backend never inspects the chosen
+convention. Parameters
 are passed through the standard Cranelift `Signature`; aggregate
 returns are not used in the MVP because every supported return type is
 a single scalar or absent.
@@ -639,29 +640,11 @@ circuits with a successful exit. On a correctly configured host it links
 and runs the program for real and asserts the output. The unit tests
 that only consult MIR lowering do not depend on a linker.
 
-## Out of scope (tracked by follow up issues)
+## Out of scope
 
-* ~~Trait object (`dyn Trait`) dispatch through vtables (issue #66).~~
-  Implemented: a trait object is a boxed fat pointer, vtables are emitted
-  as read-only data, and a `dyn` method call dispatches through the
-  vtable. See `docs/v2/specs/dyn-trait.md`. Static trait method calls are
-  monomorphized by MIR into direct calls.
-* ~~Calling closure values and capturing closures (lambda body lifting and
-  capture analysis).~~ Implemented: capture analysis lifts each lambda
-  body into a standalone function, captures free variables by value, and
-  invokes closure values through an indirect call. See the Closures
-  section above.
-* ~~`defer` ordering and runtime hooks.~~ Implemented: function-scoped
-  defers register a thunk closure on a per-call runtime defer frame and
-  run in LIFO order at every return path before leaving the GC frame. See
-  `docs/v2/specs/defer.md`.
-* String interpolation (issue #69) and C FFI (issue #70).
-* ~~`List<T>` literals, indexing, and the built-in methods (`len`,
-  `is_empty`, `push`, `pop`, `get`).~~ Implemented: see the Lists section
-  above.
-* `Map` and `Set` literals and methods, and richer iterator pipelines
-  built on the collections (issues #71 onwards).
-* Cross platform installer packaging (issue #92).
+* Debug information and debugger integration.
+* Incremental or cross compilation; Raven currently compiles for the host.
+* Async functions, generators, exception unwinding, and drop tracking.
 
 ## Test coverage
 

--- a/docs/v2/specs/concurrency-parallelism.md
+++ b/docs/v2/specs/concurrency-parallelism.md
@@ -1,10 +1,16 @@
 # Concurrency: multi-core parallelism
 
+> **Status:** Historical design record. The multi-core epic is implemented,
+> but later refinements superseded some proposed details here. See
+> [gc.md](gc.md) and [mn-scheduler.md](mn-scheduler.md) for the current
+> per-thread heaps, stop-the-world coordination, and elastic worker pool.
+> Sections labeled "current state" describe the pre-implementation baseline.
+
 ## Goal
 
 Run goroutines across several OS threads so independent goroutines execute in
-parallel on multiple cores, replacing the current single-OS-thread cooperative
-model. This is the epic tracked by #212; this document is its design and slice
+parallel on multiple cores, replacing the former single-OS-thread cooperative
+model. This was the epic tracked by #212; this document is its design and slice
 plan. It builds on the shipped cooperative scheduler (see
 `docs/v2/specs/concurrency.md`) and is the prerequisite design for the filed
 follow-ups: M:N scheduler (#237), thread-safe/parallel GC (#238), select
@@ -89,9 +95,10 @@ options are (in increasing complexity):
 
 ## Scheduler: M:N over an OS thread pool (#237)
 
-- A fixed pool of OS worker threads (default: available parallelism), each
+- A baseline pool of OS worker threads (default: available parallelism), each
   running a scheduler loop that pulls a ready goroutine and runs it to its next
-  yield point.
+  yield point. The shipped runtime adds bounded temporary replacements around
+  blocking syscalls and retires excess workers after the burst.
 - A shared ready queue (start) or per-worker queues with work-stealing (perf
   follow-up). Per-OS-thread "current goroutine" state replaces the single
   global current.

--- a/docs/v2/specs/concurrency.md
+++ b/docs/v2/specs/concurrency.md
@@ -14,7 +14,8 @@ collector implementation that makes them parallel is specified in
 Raven ships:
 
 * an **M:N scheduler** that multiplexes many green threads (goroutines)
-  onto a pool of worker OS threads (one per core), so goroutines run in
+  onto a baseline pool of worker OS threads (one per core), adding bounded
+  temporary replacements around blocking syscalls, so goroutines run in
   parallel,
 * the `spawn` surface form that starts a goroutine from a closure,
 * unbuffered (rendezvous) and buffered channels with blocking `send` and

--- a/docs/v2/specs/dyn-trait.md
+++ b/docs/v2/specs/dyn-trait.md
@@ -177,13 +177,7 @@ the GC root frame section of `docs/v2/specs/codegen.md`.
   rejected with a clear error.
 * Associated types in trait objects.
 * Auto-trait bounds (`dyn Trait + Send`).
-* Heterogeneous `List<dyn Trait>` as a runnable showcase. The fat pointer
-  is a single GC pointer, so it fits the existing one-word collection
-  storage, but two pieces are missing: the type checker does not yet push
-  an expected `dyn` element type down to each array element to coerce it,
-  and the `List` element access methods (`get`, `push`) are themselves
-  deferred to the stdlib collection issues. A trait object stored in a
-  list would box correctly today; building and reading such a list end to
-  end lands with those issues.
-```
-
+* A heterogeneous list literal whose elements are different concrete
+  implementors. The array checker unifies concrete element types before
+  applying an expected `dyn Trait` element coercion. `List<dyn Trait>` storage
+  and methods work once values have already been coerced.

--- a/docs/v2/specs/ffi.md
+++ b/docs/v2/specs/ffi.md
@@ -151,15 +151,15 @@ already uses for runtime symbols such as `raven_println_str`.
 
 ## Linking boundary
 
-On `x86_64-pc-windows-msvc` the link step already puts the C runtime on
-the link line (`/defaultlib:msvcrt`), so CRT-provided symbols such as
-`strlen`, `abs`, and `printf` resolve without any extra flags. The CRT is
-the only library guaranteed to link in this release.
+On `x86_64-pc-windows-msvc` the link step puts the C runtime on the link line
+(`/defaultlib:msvcrt`), so CRT-provided symbols such as `strlen`, `abs`, and
+`printf` resolve without extra flags.
 
-Symbols from any other library are out of scope here. Per-project link
-flags (an `[ffi]` section in `rv.toml` passing `-l<lib>` or `.lib`
-entries) arrive with `rvpm build`, tracked by issue #81. Until then a
-non-CRT symbol surfaces as an unresolved-symbol error at link time.
+For other symbols, `[ffi]` in `rv.toml` supplies bundled C `sources`, library
+names in `libs`, and raw `link_args`. `rvpm build` collects those settings from
+the root package and every transitive dependency, compiles the sources with a
+host-compatible C compiler, and passes the libraries and arguments to the
+linker. Paths in `sources` must remain within their package root.
 
 ## Variadic C functions
 

--- a/docs/v2/specs/gc.md
+++ b/docs/v2/specs/gc.md
@@ -8,8 +8,10 @@ collector reclaims every heap object the per-kind layouts in
 `Box`) once the running program can no longer reach it.
 
 The design target is correctness and simplicity first: a stop-the-world,
-single-threaded, tracing mark-and-sweep collector with precise roots
-supplied by a shadow stack the code generator maintains. Throughput
+tracing mark-and-sweep collector with precise roots supplied by shadow stacks
+the code generator maintains. Raven goroutines may run in parallel across an
+OS-thread pool; the collector coordinates those mutators at safepoints.
+Throughput
 optimisations (generational nurseries, incremental marking, Cranelift
 stack maps) are out of scope and are listed at the end.
 
@@ -17,33 +19,38 @@ stack maps) are out of scope and are listed at the end.
 
 The collector is a two-phase tracing mark-and-sweep:
 
-1. **Mark.** Starting from every root on the shadow stack, follow each
-   object's internal pointers (per its `tag`) and set a mark bit on
-   every object reached. Because marking traces the live object graph,
+1. **Mark.** Starting from every registered thread and parked-goroutine root,
+   follow each object's internal pointers (per its `tag`) and stamp every
+   object reached with the current collection epoch. Because marking traces
+   the live object graph,
    it reclaims cycles that reference counting would leak: object A
    pointing at B pointing back at A is collected when neither is rooted.
-2. **Sweep.** Walk the list of every allocated object. Any object whose
-   mark bit is clear is unreachable: free its owned buffers, then free
-   the object itself. Any object whose mark bit is set survives; clear
-   its mark bit so the next cycle starts from a clean slate.
+2. **Sweep.** Walk the initiating thread's allocation list. Any object whose
+   stamp differs from the current epoch is unreachable: free its owned
+   buffers, then free the object itself. An object stamped with the current
+   epoch survives. The next collection uses a fresh epoch, so no clear pass is
+   needed.
 
 The collector is **stop the world**: a collection runs to completion
 before the mutator (the compiled program) resumes. There is no
 concurrent or incremental marking.
 
-The collector is **single threaded**. v2.0 compiled programs are single
-threaded, so the global collector state (the all-objects list, the byte
-counters, the shadow stack) is plain global state guarded by that
-assumption rather than a lock. Calling any runtime entry point from more
-than one thread is undefined in v2.0.
+The mark-and-sweep cycle itself is **single threaded**, but Raven mutators are
+not. Each worker thread owns its allocation list, byte counters, and current
+shadow stack. Every live thread registers that stack in a process-wide root
+registry, while parked goroutine roots and buffered channel values are exposed
+through the scheduler. A collector stops all in-Raven threads at allocation or
+loop-back-edge safepoints, scans the complete root set, and sweeps only the
+initiating thread's allocation list. Globally unique mark epochs distinguish
+the current cycle from marks written by another thread's collection.
 
-### Mark bit
+### Mark epoch
 
-The mark bit lives in `ObjectHeader.gc_bits`, the field reserved for
-exactly this purpose in `runtime.md`. Bit 0 (`GC_MARK_BIT = 0x1`) is the
-mark; the remaining bits stay zero, reserved for a future colour scheme.
-Using the existing header field keeps every object exactly the size the
-layout spec already pins; the collector adds no per-object words.
+The current mark epoch lives in `ObjectHeader.gc_bits`, the field reserved for
+collector state in `runtime.md`. Epochs are process-wide, monotonically
+allocated non-zero `u32` values, so two worker collections cannot confuse a
+stale mark for their own. Using the existing header field keeps every object
+exactly the size the layout spec pins; the collector adds no per-object words.
 
 ## Shadow-stack root ABI
 
@@ -176,18 +183,17 @@ rooted slot the same way `mid` is rooted.
 
 ## Object bookkeeping
 
-The sweeper must visit every live object. The collector keeps a global
-**all-objects list**: a `Vec<*mut ObjectHeader>` recording the base
-pointer of every object handed out by `raven_gc_alloc`. The list is a
-side table, not an intrusive header field, so the 16-byte `ObjectHeader`
-keeps the exact shape pinned in `object-layout.md`; no object grows by a
-`next` word.
+The sweeper must visit every object allocated by its worker. Each thread keeps
+an **all-objects list**: a `Vec<*mut ObjectHeader>` recording the base pointer
+of every object it receives from `raven_gc_alloc`. The list is a side table,
+not an intrusive header field, so the 16-byte `ObjectHeader` keeps the exact
+shape pinned in `object-layout.md`; no object grows by a `next` word.
 
-Each allocation appends its base pointer. Sweep walks the vector,
-retaining survivors (and clearing their mark bit) and dropping freed
+Each allocation appends its base pointer. Sweep walks the current thread's
+vector, retaining objects stamped with its collection epoch and dropping freed
 entries; the retained order does not matter.
 
-Two global counters back the trigger and the tests: `bytes_allocated`
+Two per-thread counters back the trigger and the tests: `bytes_allocated`
 tracks live object-body bytes (the bytes handed out by
 `raven_gc_alloc`) and drives the collection threshold, and
 `live_objects` counts live objects so tests can assert bounded liveness
@@ -236,9 +242,9 @@ The back end emits one `raven_struct_register` call per type in the
 program entry shim, before running `main`, so every struct or enum value
 is traceable from its first allocation. Registering the same id twice is
 harmless (the back end always supplies the same or a wider mask for a
-given id; enum types union their variants' masks). The descriptors live
-in a thread-local map alongside the shadow stack, consistent with the
-single-threaded collector model.
+given id; enum types union their variants' masks). The descriptors live in a
+process-wide read-mostly map. Registration completes before goroutines start,
+and every worker collection sees the same masks.
 
 ### Why the layouts carry pointer-kind flags
 
@@ -265,10 +271,10 @@ yet supply them.
 
 ## Sweeping and buffer freeing
 
-Sweep walks the all-objects list once. For each object:
+Sweep walks the initiating thread's all-objects list once. For each object:
 
-* If the mark bit is clear, the object is dead. The sweeper frees the
-  object's **owned buffers** first, then the object body:
+* If the object's stamp differs from the current epoch, it is dead. The
+  sweeper frees the object's **owned buffers** first, then the object body:
   * `String`: free `bytes` (`cap` bytes, align 1).
   * `List`: free `elements` (`cap * element_size` bytes,
     `element_align`).
@@ -281,8 +287,9 @@ Sweep walks the all-objects list once. For each object:
   `BOX_PAYLOAD_OFFSET + header.len`). The collector decrements
   `bytes_allocated` by the body size and `live_objects` by one for each
   freed object.
-* If the mark bit is set, the object survives. Clear the mark bit and
-  retain it in the list.
+* If the object carries the current epoch, it survives and remains in the
+  list. Its stamp is left in place; a later collection compares against a new
+  epoch.
 
 Owned buffers are **plain allocations** owned by their object, not
 separate GC objects. They are never on the all-objects list, never
@@ -349,11 +356,9 @@ register with the collector.
   their whole lifetime. The slot-address shadow stack is forward
   compatible with a future moving collector, but v2.0 never relocates an
   object.
-* **Multiple threads.** Global collector state assumes a single mutator.
-* **Codegen emission of root frames.** This document defines the ABI
-  codegen targets; the prologue and epilogue emission is issue #67. The
-  collector ships with a Rust-side test harness that plays codegen's
-  role.
+* **Parallel marking or sweeping.** Raven mutators run across multiple OS
+  threads, but one thread performs each collection cycle after stopping the
+  world.
 
 ## Test coverage
 

--- a/docs/v2/specs/generics.md
+++ b/docs/v2/specs/generics.md
@@ -54,7 +54,8 @@ parameter names with the `Binding::GenericParam { owner, name }` variant
 * Associated types and projections (`<T as Iterator>::Item`).
 * Full trait coherence enforcement (orphan rules) beyond the existing
   duplicate-impl check.
-* `dyn Trait`. Tracked separately in issue #66.
+* `dyn Trait`. Specified separately in `dyn-trait.md` and supported by the
+  shipped type checker and back end.
 * Variance.
 
 ## The `Ty` representation

--- a/docs/v2/specs/mir.md
+++ b/docs/v2/specs/mir.md
@@ -290,10 +290,6 @@ visible in diffs.
 
 ## Out of scope
 
-* Closure capture analysis. Lambdas lower into `ClosureCreate` with an
-  empty capture list. Full capture rewriting is tracked by issue #62.
-* `dyn Trait` virtual dispatch. Trait method calls are resolved to
-  concrete functions during type checking; `dyn` lowering is issue #66.
 * Async, generators, drop tracking, borrow analysis.
 * Cross-file monomorphization: the v2 pipeline still operates per file.
 

--- a/docs/v2/specs/mn-scheduler.md
+++ b/docs/v2/specs/mn-scheduler.md
@@ -1,5 +1,8 @@
 # M:N scheduler implementation blueprint
 
+> **Status:** Implemented. "Current scheduler" below names the old
+> single-threaded baseline; "target model" describes the runtime that ships.
+
 The final piece of the Go-style multi-core parallelism epic (#212/#237). The GC
 half is complete and merged (registry #351, coordinator #354+#357, epoch #356,
 collector wiring #358, back-end safepoint markers #359); this document is the
@@ -22,11 +25,14 @@ code in the project and must be built deliberately, not improvised.
 
 ## Target model
 
-A fixed pool of worker OS threads (default `available_parallelism`) plus the
-main thread. Goroutines (including ones that migrate) run on whichever worker
-pulls them; `corosensei` coroutines are `Send`, so a coroutine may resume on a
-different thread than it last ran on, as long as only one thread resumes a given
-coroutine at a time (guaranteed by popping it from the ready queue exclusively).
+The steady-state pool has one worker OS thread per available core (up to the
+runtime cap), plus the main thread. When a worker enters a blocking syscall,
+the pool may start a temporary replacement so runnable goroutines do not
+starve; excess workers retire after the blocking burst. Goroutines (including
+ones that migrate) run on whichever worker pulls them; `corosensei` coroutines
+are `Send`, so a coroutine may resume on a different thread than it last ran
+on, as long as only one thread resumes a given coroutine at a time (guaranteed
+by popping it from the ready queue exclusively).
 
 The GC is already correct for this: each OS thread keeps its own heap and sweeps
 only that heap, the registry makes a collection scan every thread's roots, and

--- a/docs/v2/specs/object-layout.md
+++ b/docs/v2/specs/object-layout.md
@@ -52,10 +52,12 @@ Field offsets on 64-bit:
 
 * Alignment: 8.
 * `header.tag = TAG_STRING`.
-* `header.len` is the UTF-8 byte length, not the codepoint count.
+* `header.len` is the byte length, not a codepoint count.
 * `header.cap` is the allocated byte capacity of `bytes`.
-* `bytes` points to an owned buffer of `cap` bytes. The first `len` bytes
-  are valid UTF-8. The remaining `cap - len` bytes are undefined.
+* `bytes` points to an owned buffer of `cap` bytes. The first `len` bytes are
+  the string payload and may contain arbitrary bytes; string literals and
+  text-producing APIs emit UTF-8. The remaining `cap - len` bytes are
+  undefined.
 * When `cap == 0`, `bytes` is null.
 
 ## List

--- a/docs/v2/specs/parser.md
+++ b/docs/v2/specs/parser.md
@@ -297,9 +297,11 @@ Most errors render as `expected X, found Y`. Hints are attached at call sites wh
 ## Deferred to follow up issues
 
 * **Tuples.** `(a, b)` parses but produces `ParseError::UnsupportedTuple`. Pattern tuples are similarly deferred. The grammar is in place for v2.x.
-* **String interpolation splitting.** The lexer preserves `${...}` segments verbatim in `StringLit`. Re tokenizing them into expression fragments is tracked in issue #69.
-* **`::` semantics.** The token is accepted in trial paths but rejected in real ones, except inside `extern` ABIs where it is not used. Resolver level path syntax lands when name resolution does.
-* **Attribute and visibility modifiers.** No `@deriving`, no `pub`, no `mut` keyword in v2.0. The parser does not consume them.
+* **`::` path semantics.** The token is reserved, but Raven source uses module aliases and `.` for qualified access.
+* **Visibility and mutability modifiers.** Raven has no `pub` or `mut`
+  keyword. Bindings introduced with `let` are mutable; names beginning with
+  `_` are treated as internal by `rvpm doc`. Item attributes are supported for
+  `@derive(...)` and `@repr(C)`.
 
 ## Test coverage
 

--- a/docs/v2/specs/runtime.md
+++ b/docs/v2/specs/runtime.md
@@ -5,15 +5,15 @@
 `raven-runtime` is the small Rust crate that compiled v2 programs link
 against at run time. The compiler back-end emits machine code that calls
 into a fixed C ABI surface for heap allocation, panicking, and the few
-intrinsic operations the back-end does not want to open-code (string
-printing, eventually GC entry points). The crate is therefore the
+intrinsic operations the back-end does not want to open-code (strings,
+collections, I/O, process and network services, scheduling, and GC entry
+points). The crate is therefore the
 boundary between the static Raven world and the host operating system.
 
-This document specifies the scaffolding shape only. The crate is created
-as a workspace member, exposes its symbols, and pins object header
-constants the back-end and later GC work will both depend on. The real
-allocator and the tracing collector arrive in follow-up issues (#64 and
-#65), and trait object dispatch lands with #66.
+The crate exposes a stable C ABI, owns the heap object layouts and tracing
+collector, runs the M:N goroutine scheduler, and provides the host-backed
+operations used by the bundled standard library. The compiler links its
+static library into every Raven executable.
 
 ## Pipeline position
 
@@ -57,9 +57,9 @@ intentionally short. New symbols are added as later issues need them.
 | `raven_alloc` | `fn(size: usize, align: usize) -> *mut u8` | Returns a fresh allocation of `size` bytes aligned to `align`. Returns null on allocation failure. The current implementation forwards to `std::alloc::alloc` with a `Layout` built from the arguments. |
 | `raven_dealloc` | `fn(ptr: *mut u8, size: usize, align: usize)` | Frees an allocation previously returned by `raven_alloc` with the same `size` and `align`. Passing a null pointer is a no-op. |
 | `raven_panic` | `fn(msg_ptr: *const u8, msg_len: usize) -> !` | Writes the UTF-8 slice `msg_ptr[..msg_len]` to standard error with a `raven panic: ` prefix and a trailing newline, then exits the process with status 101 (Rust panic code). Does not return. |
-| `raven_print_str` | `fn(ptr: *const u8, len: usize)` | Writes the UTF-8 slice to standard output without a trailing newline. |
-| `raven_println_str` | `fn(ptr: *const u8, len: usize)` | Writes the UTF-8 slice to standard output followed by a single `\n`. |
-| `raven_string_from_bytes` | `fn(ptr: *const u8, len: usize) -> *mut String` | Allocates a GC-managed `String` and copies `len` UTF-8 bytes into it. A zero `len` or null `ptr` yields an empty string. The back-end promotes static string literals into heap String values with this. |
+| `raven_print_str` | `fn(ptr: *const u8, len: usize)` | Writes the byte slice to standard output without a trailing newline. |
+| `raven_println_str` | `fn(ptr: *const u8, len: usize)` | Writes the byte slice to standard output followed by a single `\n`. |
+| `raven_string_from_bytes` | `fn(ptr: *const u8, len: usize) -> *mut String` | Allocates a GC-managed `String` and copies `len` bytes into it. A zero `len` or null `ptr` yields an empty string. The back-end promotes static string literals into heap String values with this. |
 | `raven_string_concat` | `fn(a: *const String, b: *const String) -> *mut String` | Allocates a fresh GC `String` whose bytes are the concatenation of `a` then `b`. Either input may be null (treated as empty). The interpolation concat chain folds through this. |
 | `raven_int_to_string` | `fn(value: i64) -> *mut String` | Allocates a GC `String` with the base-ten rendering of `value`; negatives carry a leading `-`, zero renders `0`. |
 | `raven_bool_to_string` | `fn(value: i8) -> *mut String` | Allocates a GC `String` of `true` or `false`; any nonzero `value` is `true`. |
@@ -67,9 +67,8 @@ intentionally short. New symbols are added as later issues need them.
 | `raven_char_to_string` | `fn(value: u32) -> *mut String` | Allocates a GC `String` holding the single Unicode scalar `value`; an invalid code point renders the replacement character `U+FFFD`. |
 
 All string-shaped entries take a raw pointer plus length so the codegen
-back-end does not need to know any Rust slice layout. The bytes are
-assumed valid UTF-8; the runtime does not re-validate them, mirroring
-the type-checker invariant. The `raven_*_to_string` and
+back-end does not need to know any Rust slice layout. Raven `String` is a byte
+buffer: only APIs that interpret text require UTF-8. The `raven_*_to_string` and
 `raven_string_concat` constructors return GC pointers to `String`
 objects (tag `TAG_STRING`) allocated through `raven_gc_alloc`, so the
 collector traces and frees them like any other heap value.
@@ -83,7 +82,7 @@ header:
 #[repr(C)]
 pub struct ObjectHeader {
     pub tag: u32,      // discriminator: which kind of object this is
-    pub gc_bits: u32,  // mark / colour bits reserved for the future collector
+    pub gc_bits: u32,  // current GC mark epoch
     pub len: u32,      // logical length (string bytes, list elements, ...)
     pub cap: u32,      // capacity in elements; 0 when not applicable
 }
@@ -95,51 +94,39 @@ Constraints:
 * `align_of::<ObjectHeader>() == 4`, but objects are allocated at
   `OBJECT_ALIGN = 8` so the payload after the header is aligned for any
   primitive Raven value.
-* `tag` is read by `raven_panic` (when a debug build wants to print the
-  object kind) and by the GC once it lands. The current scaffold writes
-  it once at allocation time and never inspects it.
-* `gc_bits` carries the collector's mark bit (`GC_MARK_BIT`, bit 0); the
-  remaining bits stay zero and are reserved for a future colour scheme.
-  See `docs/v2/specs/gc.md`.
+* `tag` is written at allocation and read by diagnostics and by the collector
+  to choose the object's tracing and buffer-freeing layout.
+* `gc_bits` carries the non-zero mark epoch of the most recent collection that
+  reached the object. Each collection uses a fresh process-wide epoch, avoiding
+  a separate clear-marks pass. See `docs/v2/specs/gc.md`.
 
 ## Tag constants
 
 | Constant | Value | Meaning |
 |----------|-------|---------|
-| `TAG_STRING` | `0x01` | UTF-8 string. `len` is byte length, `cap` is allocated bytes. |
+| `TAG_STRING` | `0x01` | Byte string. `len` is byte length, `cap` is allocated bytes. |
 | `TAG_LIST` | `0x02` | Boxed `List<T>`. `len` is element count, `cap` is allocation slots. |
 | `TAG_MAP` | `0x03` | Boxed `Map<K, V>`. `len` is entry count, `cap` is bucket count. |
 | `TAG_SET` | `0x04` | Boxed `Set<T>`. `len` is entry count, `cap` is bucket count. |
 | `TAG_CLOSURE` | `0x05` | Closure object: function pointer plus a tail of captures. |
-| `TAG_BOX` | `0x06` | Generic heap box. Reserved for trait-object payloads (#66). |
+| `TAG_BOX` | `0x06` | Generic heap box used by trait objects, reflection, and other boxed payloads. |
 
-Constants live in `raven-runtime/src/object.rs` and are re-exported from
-the crate root. Code generation reads them through the C ABI eventually,
-but for now the compiler imports them directly because the back-end is
-also Rust.
+Constants live in `raven-runtime/src/object/mod.rs` and are re-exported from the
+crate root. The Rust back end imports them directly so compiler and runtime
+agree on every object tag.
 
-## Out of scope for this PR
+## Out of scope
 
-* Real allocator behaviour. The current `raven_alloc` is `std::alloc`
-  passthrough. A bump or slab allocator is issue #64.
-* Garbage collection. `gc_bits` is reserved but unused.
-* Full object layouts for `String`, `List`, `Map`, `Set`, `Closure`.
-  This scaffold fixes only the shared header; the per-kind layouts land
-  with issue #65 and are documented in `docs/v2/specs/object-layout.md`.
-* Trait object dispatch tables. The `BOX` tag exists as a placeholder;
-  the actual vtable shape lands in issue #66.
-* Async, threading, FFI safety beyond the stated symbols.
+* Moving, generational, incremental, or concurrently marking collection.
+* Async/await and an event-loop runtime; Raven's concurrency model is
+  goroutines scheduled over an OS-thread pool.
+* Sandboxing native calls. `extern "C"`, raw pointers, and host I/O carry the
+  same trust and safety obligations as their underlying platform APIs.
 
 ## Test coverage
 
-* Inline unit tests in `raven-runtime/src/lib.rs`:
-  * `ObjectHeader` size is 16 bytes.
-  * `ObjectHeader` alignment divides `OBJECT_ALIGN`.
-  * Round-tripping an allocation through `raven_alloc` and
-    `raven_dealloc` does not abort.
-  * `raven_println_str` accepts an empty slice without panic.
-* Integration test `raven-runtime/tests/abi.rs`:
-  * Calls the four allocation-shaped entry points across an
-    allocate-write-deallocate cycle.
-  * Verifies that the staticlib actually links from a separate crate
-    boundary (catches `crate-type` regressions).
+* Inline unit tests cover allocation, every object layout, tracing and
+  cross-thread roots, stop-the-world coordination, scheduler/channel behavior,
+  reflection, TLS configuration, and host-service registries.
+* Integration tests under `raven-runtime/tests/` pin the exported ABI and
+  object layouts and exercise collection through the crate boundary.

--- a/docs/v2/specs/rv-toml.md
+++ b/docs/v2/specs/rv-toml.md
@@ -3,10 +3,9 @@
 Every Raven package is described by an `rv.toml` manifest at its root.
 The manifest declares the package identity, its dependencies on other
 Raven packages, optional native linker pass-through, and optional
-formatter settings. This document defines the schema parsed by
-`raven::manifest`. Dependency version-constraint resolution and the
-wiring of `[ffi]` into the link step land in later rvpm work; this
-schema defines and parses those fields but does not act on them yet.
+formatter and distribution settings. This document defines the schema parsed
+by `raven::manifest`. `rvpm` resolves dependencies, compiles and links `[ffi]`
+sources, and packages applications according to `[dist]`.
 
 The manifest is parsed by `Manifest::from_toml_str` (string) and
 `Manifest::load` (path). Unknown fields in any section are rejected so
@@ -29,23 +28,21 @@ A table whose keys are GitHub import paths and whose values are raw
 version-constraint strings. An absent or empty table means no
 dependencies.
 
-- Keys must be `github.com/<user>/<repo>` paths, optionally with a
-  subpath (`github.com/<user>/<repo>/<sub>...`). These are the same
-  strings used by `import "github.com/..."` in source, validated by the
-  shared `raven::resolve::GithubPath` parser so the manifest and the
-  resolver agree on package identity. A key that is not a recognized
-  GitHub path is rejected with a clear message.
+- Keys must be bare `github.com/<user>/<repo>` paths because one dependency
+  identifies one whole repository. An import in Raven source may append a
+  path within that package, but a manifest key with a subpath is rejected.
 - Values are the raw constraint strings, for example `"1.0"` or
-  `"v1.2.3"`. They are stored as written. Constraint parsing and version
-  resolution are deferred to later rvpm work.
+  `"v1.2.3"`. They are currently treated as literal Git refs. Semver-range
+  selection is future work.
 
 ### `[ffi]` (optional)
 
-Native linker pass-through. Parsed and exposed here; wiring into the
-actual link step is a later concern.
+Native sources and linker configuration. `rvpm build` collects this section
+from the root package and all transitive dependencies.
 
 | Field       | Type            | Required | Default | Notes |
 |-------------|-----------------|----------|---------|-------|
+| `sources`   | Array of String | no       | `[]`    | C source files relative to the package root. Each path must stay inside that root after canonicalization. |
 | `libs`      | Array of String | no       | `[]`    | Library names to link, for example `["m", "z"]`. |
 | `link_args` | Array of String | no       | `[]`    | Extra raw linker arguments. |
 
@@ -59,6 +56,33 @@ defaults.
 | `indent_width` | Int  | no       | `4`     | Spaces per indent level. |
 | `wrap_width`   | Int  | no       | `100`   | Target column for wrapping. |
 
+`indent_width` must be in `1..=16`; `wrap_width` must be in `40..=200`.
+
+### `[dist]` (optional)
+
+Controls `rvpm dist`. Every field is optional; without the section, `dist`
+uses `target/dist` and produces `zip` on Windows or `tar` elsewhere.
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `targets` | Array of String | host archive | Any of `tar`, `zip`, `deb`, `rpm`, `msi`, `inno`. |
+| `out_dir` | String | `target/dist` | Output directory relative to the package root. |
+| `display_name` | String | package name | Human-facing installer name. |
+| `description` | String | `<name> <version>` | One-line package description. |
+| `license` | String | empty | SPDX-style license label. |
+| `homepage` | String | empty | Project URL. |
+| `maintainer` | String | first package author | Debian maintainer. |
+| `vendor` | String | maintainer | RPM vendor and MSI manufacturer. |
+
+Each `[[dist.assets]]` entry has a required `source` and `dest`. A source may
+be a file or directory; directories are copied recursively, including empty
+directories. Both paths must be relative forward-slash paths without `..`.
+
+`[dist.linux]` accepts `depends`, `section`, and `priority`.
+`[dist.windows]` accepts an executable/installer `icon`, a stable MSI
+`upgrade_code`, and `add_to_path` for MSI PATH integration. See
+[rvpm dist](rvpm-dist.md) for format behavior and examples.
+
 ## Examples
 
 ### Minimal
@@ -70,7 +94,8 @@ version = "0.0.1"
 ```
 
 This parses with `edition = "v2"`, no authors, no dependencies, default
-`[ffi]`, and default `[fmt]`.
+`[ffi]`, default `[fmt]`, and no explicit `[dist]` section. Running `rvpm dist`
+still applies the host archive and `target/dist` defaults.
 
 ### Full
 
@@ -86,12 +111,21 @@ edition = "v2"
 "github.com/acme/json" = "v2.3.1"
 
 [ffi]
+sources = ["c/sqlite3.c"]
 libs = ["m", "z"]
 link_args = ["-L/opt/lib"]
 
 [fmt]
 indent_width = 2
 wrap_width = 80
+
+[dist]
+targets = ["zip", "deb"]
+license = "MIT"
+
+[[dist.assets]]
+source = "README.md"
+dest = "share/doc/demo/README.md"
 ```
 
 ## Diagnostics
@@ -108,11 +142,14 @@ output:
 
 ## `rvpm init`
 
-`rvpm init [name]` scaffolds a new package in the current directory:
+`rvpm init [name] [--lib]` scaffolds a new package in the current directory:
 
 - Writes `rv.toml` with `[package]` (`name`, `version = "0.1.0"`,
   `edition = "v2"`) and an empty `[dependencies]` table. When `name` is
   omitted it defaults to the current directory name.
-- Writes `src/main.rv` with a hello-world `main` that compiles under the
-  `raven` build.
+- Writes `src/main.rv` with a hello-world `main`, or `lib.rv` when `--lib`
+  is passed.
 - Refuses to overwrite an existing `rv.toml`.
+
+`rvpm new <name> [--lib]` writes the same scaffold in a fresh `<name>/`
+directory.

--- a/docs/v2/specs/rvpm-dist.md
+++ b/docs/v2/specs/rvpm-dist.md
@@ -61,6 +61,11 @@ prefix per format: `/usr/` for deb and rpm (the binary goes to
 folder for msi and inno. When `source` is a directory, rvpm copies its entire
 tree beneath `dest`, preserving nested and empty directories.
 
+The package version and every free-form metadata value reject control
+characters before any packaging file is generated. This prevents a manifest
+value from injecting extra Debian control fields, RPM directives, or installer
+script lines.
+
 ## Formats and their tools
 
 rvpm generates each format's packaging text and shells out to the format's

--- a/docs/v2/specs/std-process.md
+++ b/docs/v2/specs/std-process.md
@@ -9,7 +9,7 @@ Raven.
 ## Import
 
 ```rust
-import std/process { run, run_with_input, start, Child }
+import std/process { run, run_with_input, start }
 ```
 
 The methods on `Output` and `Child` come in with the types and need no
@@ -32,6 +32,8 @@ impl Output {
 impl Child {
     fun read_stdout(self) -> String   // drained since the last read, "" when nothing new
     fun read_stderr(self) -> String
+    fun write_stdin(self, data: String) -> Bool
+    fun close_stdin(self)
     fun poll(self) -> Option<Int>     // None while running, Some(code) once exited
     fun running(self) -> Bool
     fun wait(self) -> Int             // block (polling) until exit
@@ -64,8 +66,9 @@ child (killing an already-exited child reports success). `free` drops the
 registry entry without killing, so a caller that wants the child stopped
 must `kill` first; reaping is still guaranteed, since a freed child whose
 exit was not yet observed is handed to a background waiter that collects it
-when it exits, never leaving a zombie. The child's stdin is null: it sees
-end of input immediately and does not inherit the parent's terminal.
+when it exits, never leaving a zombie. A started child receives a piped stdin:
+`write_stdin` writes and flushes bytes, while `close_stdin` sends EOF. The pipe
+does not inherit the parent's terminal.
 
 ## Argument encoding (NUL-joined)
 
@@ -117,4 +120,7 @@ covers an unknown id.
 child that reads stdin sees end of input at once. `run_with_input` writes
 the given `input` and then closes stdin. A broken pipe (the child exits
 without reading) is ignored: the run still yields the child's captured
-output.
+output. A child returned by `start` keeps stdin open; `write_stdin` returns
+`false` after exit, a broken pipe, an unknown handle, or an explicit `close_stdin`.
+Writes are flushed immediately, and callers should close stdin when the child
+needs EOF to proceed.

--- a/docs/v2/specs/tycheck.md
+++ b/docs/v2/specs/tycheck.md
@@ -4,7 +4,12 @@
 
 Statically validate a resolved Raven file. Given a `ResolvedFile` (the output of `src/resolve`), the type checker assigns a concrete type to every expression, verifies operator and call sites, checks struct, trait, impl, and enum declarations against their uses, and confirms that every `match` is exhaustive. The output is a `TypedFile` that pairs the resolved AST with a `TypeMap` (expression span to inferred type) and a `TypeEnv` (declaration to signature).
 
-The type checker is total: every malformed program produces a `RavenError::Type(TypeError, Span, Option<String>)` anchored at the offending source range. It does not infer general generic parameters in this release. `Option<T>`, `Result<T, E>`, and `List<T>` are recognized as built in generic types; any other generic declaration in source is rejected with `GenericsNotYetSupported`, leaving the full mechanism for a follow up issue.
+The type checker is total: every malformed program produces a
+`RavenError::Type(TypeError, Span, Option<String>)` anchored at the offending
+source range. It supports local inference, user-declared generic functions and
+types, trait bounds, generic impls, built-in collection types, and `dyn Trait`.
+See `generics.md` and `dyn-trait.md` for the extensions to the foundational
+rules in this document.
 
 ## Pipeline position
 
@@ -19,37 +24,32 @@ The type checker consumes nodes from `src/ast` plus the resolver's `ResolutionMa
 The AST carries a textual `Type` (`src/ast/ty.rs`) that mirrors what the user wrote. The type checker uses its own internal representation, `Ty`, for several reasons:
 
 * Decoupling: the textual form may contain unresolved paths or sugar (`T?` for `Option<T>`). `Ty` stores the resolved form.
-* Hashing: `Ty` is cheap to compare and copy, while `Type` carries spans and nested paths.
-* Future generics: a later PR introduces type variables and substitution; threading those through the AST type would be invasive.
+* Normalization: `Ty` is cheap to compare and clone, while `Type` carries spans and unresolved nested paths.
+* Generics: inference variables and substitutions stay internal to the checker
+  instead of being threaded through the source AST.
 
 ```rust
 pub enum Ty {
-    Unit,
-    Bool,
-    Int,
-    Float,
-    Char,
-    Str,
-    /// A built in or user declared struct. Generic arguments are reserved
-    /// for the built in generic types and produce errors elsewhere.
-    Struct { id: DeclId, args: Vec<Ty> },
-    Enum   { id: DeclId, args: Vec<Ty> },
-    /// `Option<T>` and `Result<T, E>` and `List<T>` use synthetic ids so
-    /// they do not collide with user declarations.
+    Unit, Bool, Int, Float, Char, Str,
+    Struct { id: DeclId, name: String, args: Vec<Ty> },
+    Enum   { id: DeclId, name: String, args: Vec<Ty> },
     Option(Box<Ty>),
     Result(Box<Ty>, Box<Ty>),
     List(Box<Ty>),
-    /// `fun(A, B) -> C` function type. Used for lambdas and function items.
     Function { params: Vec<Ty>, ret: Box<Ty> },
-    /// `Self` inside an `impl` block, bound to the implementing type.
-    SelfTy,
-    /// An unknown placeholder. Produced when an earlier error already
-    /// reported the problem, so cascades do not spam the user.
+    Dyn { name: String, methods: Vec<String> },
+    SelfTy(Box<Ty>),
+    Any,
+    Ffi(FfiTy),
+    Param(ParamId),
+    Var(InferVarId),
     Error,
 }
 ```
 
-There is no `Unknown` inference variable in this release. Lambdas without parameter annotations require a context type or are rejected with `TypeMismatch`.
+Inference variables are created for generic use sites and unannotated values.
+Lambda parameters may infer from a contextual function type; otherwise they
+need annotations.
 
 ## Algorithm
 
@@ -67,7 +67,10 @@ Walk every top level `Decl` once and populate a `TypeEnv`:
 * Each `Const` and module level `Let` records its annotated type (the initializer is checked in pass 2).
 * Built in generic types (`Option`, `Result`, `List`) are pre populated.
 
-Generic parameter lists are checked for emptiness. A non empty `GenericParam` list on any user item raises `GenericsNotYetSupported`. Type paths referenced in field types, return types, and so on are resolved using the resolver's binding for the head segment, then mapped to `Ty`.
+Generic parameter lists are collected with their trait bounds. Type paths
+referenced in field types, return types, and so on are resolved using the
+resolver's binding for the head segment, then mapped to `Ty`; use sites create
+fresh inference variables and verify bounds after unification.
 
 ### Pass 2: body checking
 
@@ -154,7 +157,8 @@ impl Int {
 
 The implementing type is resolved the same way any type path is resolved, so `impl Int`, `impl String`, `impl<T> List<T>`, `impl Bool`, `impl Char`, `impl Float`, `impl<T> Set<T>`, and `impl<K, V> Map<K, V>` all collect into the same method table the type checker uses for user structs. Inside the body, `self` is the built in receiver and `Self` is the built in type. Resolution then matches the receiver against the impl's `self_ty` exactly as for a user type, so `21.doubled()` resolves to the `Int` impl method.
 
-`Set` and `Map` are recognized as built in type names for the purpose of accepting an `impl` head, but their value types are not yet wired through lowering; an `impl<T> Set<T>` collects and resolves but is not exercised end to end until those types land.
+`Set` and `Map` use the same generic impl collection, resolution,
+monomorphization, and lowering paths as other generic types.
 
 ### Precedence vs hard coded inherent methods
 
@@ -183,18 +187,23 @@ The check runs after each arm body has been typed so that pattern binding types 
 
 ## Built in generic types
 
-Three generic shapes are hard coded:
+Five built-in generic shapes receive dedicated literal or constructor handling:
 
 * `Option<T>`. Variants: `None`, `Some(T)`. Constructed by writing `None` or `Some(value)` at a use site whose context type fixes `T`. The resolver already accepts `Option` and `Result` as built in type names; the type checker recognizes the variant identifiers when the contextual type is known.
 * `Result<T, E>`. Variants: `Ok(T)`, `Err(E)`.
 * `List<T>`. The array literal `[a, b, c]` infers `T` as the unified element type. Empty list literals require a context type and are otherwise rejected with `TypeMismatch`.
 * `Set<T>` and `Map<K, V>` (bundled `std/collections` types). The set literal `{a, b}` types as `Set<T>` with `T` unified across the elements; the map literal `["k": v]` (and the empty `[:]`) types as `Map<K, V>` with `K` and `V` unified across the keys and values. The literal binds to the imported `Set`/`Map` declaration, so it requires `import std/collections` in scope and otherwise reports a `TypeError`. `T` and `K` carry the declarations' `Eq` bound. HIR lowers the literals to the `Set.new()`/`Map.new()` constructors plus an `add`/`set` per element or pair.
 
-Member access against these types goes through a small inherent method table. None of these types participate in the general generic mechanism: their `T` and `E` are pattern matched directly by the type checker. When the full generic mechanism lands (issue #59), these special cases collapse into the unified path.
+These built-in literal forms receive dedicated contextual inference. Their
+declared methods, generic parameters, trait bounds, and implementations then
+participate in the normal generic method and trait-resolution paths.
 
 ## The `?` operator
 
-`expr?` (`ExprKind::Try`) is parsed but not fully typed in this release. Encountering it produces a `TypeError::Custom("? operator is not yet supported, defer to HIR lowering")` so the user gets a clear message rather than a panic. End to end handling lives with the HIR lowering issue (#60).
+`expr?` requires an `Option<T>` or `Result<T, E>`. In a function returning the
+matching container, it unwraps `Some`/`Ok` and returns `None`/`Err` early. The
+type checker verifies the container and residual types; HIR lowers the
+operation to the corresponding match and early return.
 
 ## Errors
 
@@ -208,9 +217,12 @@ Member access against these types goes through a small inherent method table. No
 * `NonExhaustiveMatch { missing }`.
 * `RedundantPattern`.
 * `UnknownType(name)`.
-* `GenericsNotYetSupported`. Removed when issue #59 lands.
+* `CannotInferType` and `OccursCheck { var, ty }`.
+* `BoundNotSatisfied { ty, trait_name }`.
+* `GenericArityMismatch { decl, expected, actual }`.
+* `OverlappingImpls { ty, trait_name, candidates }`.
 * `NotCallable(actual)`.
-* `Custom(String)` for one off shapes (missing struct fields, unsupported `?`, etc.).
+* `Custom(String)` for one-off shapes such as missing struct fields.
 
 All variants reach the user via `RavenError::Type(error, span, hint)`. The renderer in `RavenError::display` is extended to handle the new arm.
 
@@ -225,21 +237,10 @@ Recovery uses the `Ty::Error` placeholder (which unifies with anything) to suppr
 
 The collection pass (Pass 1) stays fail-fast: a malformed signature stops it, because later items depend on the collected signatures. `check_file_all` returns `Result<TypedFile, Vec<RavenError>>`; the driver renders each error with the #283 renderer, separated by a blank line. `check_file` remains a thin wrapper returning only the first error, for callers (tests, golden harnesses) that surface one.
 
-## Out of scope
-
-* User defined generic functions, structs, and traits land in
-  `docs/v2/specs/generics.md`. The same document tracks the
-  Hindley-Milner inference flavor and trait-bound verification used by
-  the v2 checker once that feature ships.
-* `dyn Trait` trait objects. Tracked in issue #66.
-* C FFI extern signatures beyond syntactic acceptance. Tracked in issue #70.
-* `defer` semantics. Tracked in issue #68.
-* End to end `?` propagation. Tracked with HIR lowering in issue #60.
-* String interpolation expansion (handled by parser side lowering later).
-* Cross module member resolution against imported modules. The type checker recognizes the import target but defers member lookups against std modules to the HIR lowering pass.
-* Parser-level error recovery (reporting several parse errors in one compile). A syntax error still stops the parser at the first one; the multi-error recovery here is for the type checker's body pass. Parser recovery is a follow-up under issue #284.
-
 ## Tests
 
-* Unit tests inline at `src/tycheck/tests.rs`: cover primitives, arithmetic, comparisons, struct literal and field access, method dispatch, enum variant construction, `match` exhaustiveness on `Option` and `Result`, `if` branch unification, redundant patterns, unknown fields, ambiguous methods, undefined methods, and rejection of unsupported generics.
+* Unit tests inline at `src/tycheck/tests.rs`: cover primitives, arithmetic,
+  comparisons, struct literal and field access, method dispatch, enum variant
+  construction, exhaustive matches, generics and bounds, trait objects,
+  propagation, redundant patterns, and error recovery.
 * Golden snapshot tests at `tests/tycheck_golden.rs` over a corpus at `tests/tycheck_corpus/`. Each `.rv` source has a committed `.rv.types` baseline produced by dumping every expression site and its inferred type. Refresh with `RAVEN_UPDATE_TYCHECK_GOLDEN=1`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,7 +128,9 @@ nav:
       - std/option: v2/guide/stdlib/option.md
       - std/ffi: v2/guide/stdlib/ffi.md
       - std/test: v2/guide/stdlib/test.md
-  - rvpm: v2/guide/rvpm.md
+  - rvpm:
+    - Overview and commands: v2/guide/rvpm.md
+    - Distributing applications: v2/specs/rvpm-dist.md
   - GitHub: https://github.com/martian56/raven
   - VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=martian56.raven-language
 

--- a/raven-runtime/src/gc.rs
+++ b/raven-runtime/src/gc.rs
@@ -1,5 +1,5 @@
-//! Stop-the-world, single-threaded, tracing mark-and-sweep garbage
-//! collector for compiled Raven v2 programs.
+//! Stop-the-world, tracing mark-and-sweep garbage collector for compiled
+//! Raven v2 programs with parallel mutators.
 //!
 //! The collector finds its roots through a shadow stack the code
 //! generator maintains: a runtime-owned stack of the addresses of the
@@ -7,14 +7,11 @@
 //! a frame's root array on entry and unregisters it on exit. See
 //! `docs/v2/specs/gc.md` for the full design and the ABI contract.
 //!
-//! # Single-threaded assumption
-//!
-//! v2.0 compiled programs are single threaded. The collector state
-//! lives in `thread_local!` cells, so each thread that ever touches the
-//! runtime gets its own independent heap and shadow stack. Sharing GC
-//! objects across threads is undefined in v2.0; the thread-local form
-//! simply keeps the global state sound under Rust's aliasing rules
-//! without a lock.
+//! Each worker owns an allocation list and shadow stack. A process-wide root
+//! registry and stop-the-world coordinator park parallel Raven mutators at
+//! safepoints before a collection scans every thread and parked goroutine.
+//! The initiating thread then sweeps only its own allocation list; globally
+//! unique mark epochs keep cross-thread marking sound.
 
 use crate::object::structval::{STRUCT_FIELDS_OFFSET, STRUCT_FIELD_SLOT};
 use crate::object::{
@@ -727,8 +724,8 @@ fn collect() {
     }
 }
 
-/// Mark phase: starting from every root, set the mark bit on every
-/// reachable object. Tracing uses an explicit work stack so a deep or
+/// Mark phase: starting from every root, stamp every reachable object with the
+/// current collection epoch. Tracing uses an explicit work stack so a deep or
 /// cyclic graph cannot overflow the native stack.
 fn mark() {
     let mut work: Vec<*mut ObjectHeader> = Vec::new();

--- a/raven-runtime/src/lib.rs
+++ b/raven-runtime/src/lib.rs
@@ -449,13 +449,11 @@ pub extern "C" fn raven_panic(msg_ptr: *const u8, msg_len: usize) -> ! {
     process::exit(101);
 }
 
-/// Write a UTF-8 byte slice to standard output without a trailing
-/// newline.
+/// Write a byte slice to standard output without a trailing newline.
 ///
 /// # Safety
 ///
-/// `ptr` must point to `len` initialized UTF-8 bytes, or `len` must be
-/// zero.
+/// `ptr` must point to `len` initialized bytes, or `len` must be zero.
 #[no_mangle]
 pub extern "C" fn raven_print_str(ptr: *const u8, len: usize) {
     if len == 0 || ptr.is_null() {
@@ -471,13 +469,11 @@ pub extern "C" fn raven_print_str(ptr: *const u8, len: usize) {
     let _ = handle.write_all(bytes);
 }
 
-/// Write a UTF-8 byte slice to standard output followed by a single
-/// `\n`.
+/// Write a byte slice to standard output followed by a single `\n`.
 ///
 /// # Safety
 ///
-/// `ptr` must point to `len` initialized UTF-8 bytes, or `len` must be
-/// zero.
+/// `ptr` must point to `len` initialized bytes, or `len` must be zero.
 #[no_mangle]
 pub extern "C" fn raven_println_str(ptr: *const u8, len: usize) {
     // See `raven_print_str`: ignore SIGPIPE so a closed stdout reader cannot


### PR DESCRIPTION
## What changed

- document every shipped `rvpm` command and the complete `rv.toml` distribution schema
- add current `std/process` child-process and stdin APIs plus HTTP timeout and streaming APIs
- fill standard-library and language-reference gaps, including math functions, byte-string behavior, and inferred module constants
- expose `rvpm dist` in the published navigation and improve feature discovery from the landing pages
- reconcile compiler, runtime, GC, concurrency, FFI, MIR, and type-checker specs with the implementation

## Why

The user-facing guides lagged recent Raven and rvpm releases, while several foundational specs still described pre-generics, pre-M:N, or pre-GC implementation milestones as current behavior. That made shipped features difficult to discover and left contradictory guidance in the documentation tree.

## Impact

Users can now find and use the current packaging, process, HTTP, language, and standard-library surfaces from the published site. Contributor-facing specs now distinguish historical design records from the architecture that ships.

## Validation

- `mkdocs build --strict`
- `cargo fmt --all -- --check`
- `cargo test --locked --lib` (676 passed)
- `cargo test --locked -p raven-runtime --lib` (129 passed)
- compiled the new `std/http` and `std/process` guide examples with `raven build`
