### PR TITLE
feat(rvpm): add workspaces and registered commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +576,7 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "fs2",
  "serde",
  "sha2",
  "target-lexicon",
@@ -1017,6 +1028,28 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ cranelift-object = "0.108"
 # Locates the MSVC `link.exe` toolchain via the Windows registry so the
 # driver can link Cranelift's MSVC-flavor objects on windows-msvc hosts.
 cc = "1.2"
+# Cross-process package build locks for binary and fingerprint publication.
+fs2 = "0.4"
 # Supplies the host target triple to key linker selection.
 target-lexicon = "0.12"
 # rv.toml manifest parsing for the rvpm package manager.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ rvpm test         # run test_* functions in *_test.rv files
 rvpm dist         # package the application for distribution
 ```
 
+rvpm also supports multi-package workspaces, explicit package selection, and
+manifest-defined compiled commands. See the [rvpm guide](https://martian56.github.io/raven/v2/guide/rvpm/#workspaces).
+
 ### Build from source
 
 For contributors, or to track the latest commit:

--- a/docs/v2/guide/rvpm.md
+++ b/docs/v2/guide/rvpm.md
@@ -26,6 +26,56 @@ library. Both also write a `.gitignore` that ignores the generated
 `target/raven-out/<name>` (with a `.exe` extension on Windows); a library
 has no `main`, so it is type-checked rather than compiled to a binary.
 
+## Workspaces
+
+A workspace groups several ordinary packages under one repository. The root
+`rv.toml` may be virtual:
+
+```toml
+[workspace]
+members = ["apps/api", "apps/worker", "tools/schema"]
+default-member = "api"
+
+[commands]
+schema = { package = "schema", args = ["migrate"] }
+```
+
+Each member directory has its own `rv.toml`, `rv.lock`, dependencies, and
+`target/` output. A root manifest may also contain `[package]`; that root
+package is included automatically and must not appear in `members`. A virtual
+root contains only `[workspace]` and optional `[commands]` sections.
+
+Member paths are relative to the root and must remain inside it. rvpm rejects
+missing manifests, duplicate paths, duplicate package names, symlink escapes,
+unknown defaults, and commands that name unknown packages. When invoked from a
+member or one of its nested directories, rvpm discovers the workspace by
+walking upward and selects that member. At the root it selects
+`default-member`, or the sole member when only one exists. Use `-p <name>` to
+select explicitly.
+
+`rvpm build --workspace` and `rvpm test --workspace` process every member.
+`rvpm workspace list` prints the discovered packages and commands.
+
+### Registered commands
+
+A `[commands]` entry is structured data, not a shell command. Its `package`
+must name an application member. rvpm builds that package through the normal
+compiler and dependency pipeline, then executes it. `args` provides arguments
+that are prepended to those supplied at invocation:
+
+```bash
+rvpm run schema up
+# executes the schema package with: migrate up
+```
+
+The executable is stored in the member's normal `target/raven-out` directory.
+rvpm records a fingerprint of local package files, dependency hashes, compiler,
+and runtime. A later
+command reuses the executable when those inputs are unchanged. Arguments and
+the executable's exit code are forwarded unchanged. Use
+`rvpm run -p api -- schema` when `schema` should be an ordinary argument to
+`api` instead of a registered command.
+
 ## The rv.toml manifest
 
 ```toml
@@ -54,6 +104,12 @@ description = "Demo application"
 [[dist.assets]]
 source = "assets"
 dest = "assets"
+
+[workspace]
+members = ["tools/schema"]
+
+[commands]
+schema = { package = "schema", args = [] }
 ```
 
 Sections:
@@ -78,6 +134,11 @@ Sections:
   extra assets, Linux package dependencies, and Windows installer settings.
   See [Distributing applications](../specs/rvpm-dist.md) for the complete
   schema and required platform tools.
+- `[workspace]` (optional): relative package member directories and an optional
+  `default-member` package name. A manifest with this section is a workspace
+  root.
+- `[commands]` (optional): structured executable commands. Each entry selects a
+  workspace application by package name and may provide default `args`.
 
 Unknown fields are rejected so typos surface early.
 
@@ -200,7 +261,7 @@ automatically; `lock` is useful for CI and explicit verification.
 ### rvpm build
 
 ```bash
-rvpm build
+rvpm build [-p <package> | --workspace]
 ```
 
 Ensures dependencies are installed and builds the package context from the
@@ -208,6 +269,9 @@ lock. For an application it compiles `src/main.rv` to
 `target/raven-out/<name>` and reports the binary path. For a library it
 type-checks `lib.rv` (and its modules) without producing a binary, so a
 package author can verify the library compiles before publishing.
+
+Inside a workspace, `-p` builds one named member and `--workspace` builds every
+member. With neither option, the current, default, or sole member is selected.
 
 On Windows, an `.ico` configured as `[dist.windows].icon` is also embedded
 in the executable. MSVC builds use the Windows SDK resource compiler;
@@ -233,7 +297,7 @@ artifact names, and the external packaging tool required by each format.
 ### rvpm run
 
 ```bash
-rvpm run [program arguments]
+rvpm run [-p <package>] [command | program arguments]
 ```
 
 Builds the application (the same path as `build`), then runs the produced
@@ -241,16 +305,23 @@ binary, forwarding any arguments after `run` and exiting with the
 program's exit code. A library has no executable, so `run` reports that
 and exits non-zero; use `build` to type-check a library.
 
+When the first argument matches a workspace `[commands]` entry, rvpm runs that
+command's package instead. `-p` always selects a package directly and disables
+registered-command matching.
+
 ### rvpm test
 
 ```bash
-rvpm test
+rvpm test [-p <package> | --workspace]
 ```
 
 Discovers and runs the package's tests. A test is a zero-argument function
 named `test_*` in a `*_test.rv` file anywhere in the package (commonly
 under `src/` or a `tests/` directory). It asserts with `std/test`; a failed
 assertion panics, which the runner reports as a failure.
+
+Inside a workspace, `-p` tests one named member and `--workspace` tests all
+members, returning failure if any member fails.
 
 ```rust
 // src/math_test.rv
@@ -276,6 +347,15 @@ test result: FAILED. 1 passed; 1 failed
 Test function names must be unique within a file. Libraries are supported:
 a `*_test.rv` at the package root that imports `./lib` works without a
 `src/main.rv`.
+
+### rvpm workspace
+
+```bash
+rvpm workspace [list]
+```
+
+Discovers the workspace root from the current directory and lists its package
+names, paths, and registered commands.
 
 ### rvpm fmt
 

--- a/docs/v2/specs/rvpm.md
+++ b/docs/v2/specs/rvpm.md
@@ -347,6 +347,56 @@ have an `_in(..., cache_root)` variant that takes an explicit cache root so
 they can be tested against a pre-seeded temporary cache without the global
 `RVPM_CACHE_DIR` override.
 
+## Workspace discovery and validation
+
+An `rv.toml` containing `[workspace]` is a workspace root. The root can also
+contain `[package]`; when it does, that package is an implicit member. Without
+`[package]`, the root is virtual and may contain only `[workspace]` and
+`[commands]`.
+
+```toml
+[workspace]
+members = ["apps/api", "tools/admin"]
+default-member = "api"
+
+[commands]
+admin = { package = "admin", args = ["serve"] }
+```
+
+`members` contains relative directory paths. Loading canonicalizes the root and
+every member, rejects lexical parent or absolute components, verifies that the
+canonical member remains under the root, and requires an `rv.toml` package
+manifest in every member. Canonical paths and package names must be unique.
+`default-member` and every command `package` refer to package names, not member
+paths, and must resolve during workspace loading.
+
+Discovery walks from the current directory toward the filesystem root and
+loads the nearest manifest with `[workspace]`. Selection order is an explicit
+`-p` name, the deepest member containing the current directory, the configured
+default, then the sole member. Multiple members with no applicable selection
+produce an error. Outside a workspace, the nearest ordinary package manifest
+retains the existing single-package behavior.
+
+`build --workspace` and `test --workspace` visit members in manifest order and
+fail if any member operation fails. `workspace list` reports the validated
+members and commands.
+
+## Registered command execution
+
+`[commands].<name>` is a table with a required `package` name and optional
+string-array `args`. It cannot contain a shell string or unknown fields. When
+the first unconsumed argument to `rvpm run` matches a command, rvpm selects its
+application member, prepends the configured arguments, appends invocation
+arguments, builds the member, and starts the resulting executable directly
+without a shell. The child exit code becomes the rvpm exit code. Explicit `-p`
+selection disables command matching.
+
+Successful application builds write `<binary>.fingerprint`. The digest covers
+local package files outside `.git` and `target`, locked dependency content
+hashes, target identity, and compiler and runtime metadata. An existing binary
+with the same digest is reused. A failed rebuild does not replace the saved
+digest, so stale output cannot become current.
+
 ## Entry file and output path conventions
 
 - The package entry file is `src/main.rv`, relative to the project root
@@ -408,7 +458,7 @@ smoke harness unchanged for bundled and local programs.
 ## rvpm build
 
 ```
-rvpm build
+rvpm build [-p <package> | --workspace]
 ```
 
 `build` loads `rv.toml`, ensures dependencies are installed (the install
@@ -421,7 +471,7 @@ the package context, then compiles `src/main.rv` to
 ## rvpm run
 
 ```
-rvpm run [program arguments]
+rvpm run [-p <package>] [command | program arguments]
 ```
 
 `run` builds the package (the same path as `build`), then runs the produced

--- a/docs/v2/specs/rvpm.md
+++ b/docs/v2/specs/rvpm.md
@@ -395,7 +395,11 @@ Successful application builds write `<binary>.fingerprint`. The digest covers
 local package files outside `.git` and `target`, locked dependency content
 hashes, target identity, and compiler and runtime metadata. An existing binary
 with the same digest is reused. A failed rebuild does not replace the saved
-digest, so stale output cannot become current.
+digest, so stale output cannot become current. Builders hold a cross-process
+lock scoped to the package binary from the reuse check through compilation and
+fingerprint publication. The fingerprint is written to a temporary sibling and
+renamed into place while the lock is held, preventing concurrent builders from
+publishing a mismatched binary and digest.
 
 ## Entry file and output path conventions
 

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -15,6 +15,7 @@ use raven::manifest::Manifest;
 use raven::ops;
 use raven::pkg;
 use raven::resolve::GithubPath;
+use raven::workspace::{self, Workspace};
 
 /// `rvpm build`/`run` invoke the compiler, which recurses deeply (derive
 /// expansion, type checking), enough to overflow the default main-thread stack
@@ -103,6 +104,7 @@ fn dispatch() -> ExitCode {
         Some("test") => cmd_test(&args[1..]),
         Some("doc") => run(cmd_doc(&args[1..])),
         Some("fmt") => cmd_fmt(&args[1..]),
+        Some("workspace") => run(cmd_workspace(&args[1..])),
         Some("cache") => match cmd_cache(&args[1..]) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
@@ -567,9 +569,23 @@ fn cmd_build(args: &[String]) -> Result<Vec<String>, String> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return Ok(vec![build_usage()]);
     }
-    reject_extra_args(args, "build", &["--help", "-h"], 0)?;
+    let selection = parse_package_selection(args, "build", true)?;
     let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
-    let report = with_fetch_progress(|| ops::build(&cwd)).map_err(|e| e.to_string())?;
+    if selection.all {
+        let workspace = Workspace::discover(&cwd)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("no workspace root found from '{}'", cwd.display()))?;
+        let mut lines = Vec::new();
+        for member in workspace.members() {
+            let report = with_fetch_progress(|| ops::build(&member.root))
+                .map_err(|e| format!("package '{}': {}", member.name, e))?;
+            lines.extend(report.outcome_lines);
+        }
+        return Ok(lines);
+    }
+    let project = workspace::resolve_package(&cwd, selection.package.as_deref())
+        .map_err(|e| e.to_string())?;
+    let report = with_fetch_progress(|| ops::build(&project)).map_err(|e| e.to_string())?;
     Ok(report.outcome_lines)
 }
 
@@ -628,26 +644,42 @@ fn cmd_dist(args: &[String]) -> Result<Vec<String>, String> {
 /// Build the package then run the produced binary, forwarding any args
 /// after `run` to the program and exiting with its code.
 fn cmd_run(args: &[String]) -> ExitCode {
-    // Args before a `--` separator are rvpm's; everything after is forwarded to
-    // the program verbatim. With no separator only a leading `--help`/`-h` is
-    // rvpm's, so the program can still receive `--help` (`rvpm run -- --help`,
-    // or `rvpm run somearg --help`).
     let sep = args.iter().position(|a| a == "--");
-    let rvpm_wants_help = match sep {
-        Some(i) => args[..i].iter().any(|a| a == "--help" || a == "-h"),
-        None => args
-            .first()
-            .map(|a| a == "--help" || a == "-h")
-            .unwrap_or(false),
-    };
+    let before = sep.map(|i| &args[..i]).unwrap_or(args);
+    let after = sep.map(|i| &args[i + 1..]);
+    let rvpm_wants_help = before
+        .first()
+        .map(|arg| arg == "--help" || arg == "-h")
+        .unwrap_or(false);
     if rvpm_wants_help {
         println!("{}", run_usage());
         return ExitCode::SUCCESS;
     }
-    let prog_args: Vec<String> = match sep {
-        Some(i) => args[i + 1..].to_vec(),
-        None => args.to_vec(),
-    };
+
+    let mut requested = None;
+    let mut consumed = 0usize;
+    if before.first().map(String::as_str) == Some("-p")
+        || before.first().map(String::as_str) == Some("--package")
+    {
+        let Some(name) = before.get(1) else {
+            eprintln!("rvpm: -p/--package requires a package name");
+            return ExitCode::from(1);
+        };
+        requested = Some(name.clone());
+        consumed = 2;
+    } else if let Some(name) = before
+        .first()
+        .and_then(|arg| arg.strip_prefix("--package="))
+    {
+        if name.is_empty() {
+            eprintln!("rvpm: --package requires a package name");
+            return ExitCode::from(1);
+        }
+        requested = Some(name.to_string());
+        consumed = 1;
+    }
+    let remaining = &before[consumed..];
+
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => {
@@ -655,7 +687,47 @@ fn cmd_run(args: &[String]) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    match with_fetch_progress(|| ops::run_package(&cwd, &prog_args)) {
+    let discovered = match Workspace::discover(&cwd) {
+        Ok(workspace) => workspace,
+        Err(e) => {
+            eprintln!("rvpm: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+    let registered = if requested.is_none() {
+        discovered
+            .as_ref()
+            .and_then(|workspace| remaining.first().and_then(|name| workspace.command(name)))
+    } else {
+        None
+    };
+    let (project, prog_args) =
+        if let (Some(workspace), Some(command)) = (discovered.as_ref(), registered) {
+            let member = match workspace.member(&command.package) {
+                Ok(member) => member,
+                Err(e) => {
+                    eprintln!("rvpm: {}", e);
+                    return ExitCode::from(1);
+                }
+            };
+            let mut command_args = command.args.clone();
+            match after {
+                Some(forwarded) => command_args.extend_from_slice(forwarded),
+                None => command_args.extend_from_slice(&remaining[1..]),
+            }
+            (member.root.clone(), command_args)
+        } else {
+            let project = match workspace::resolve_package(&cwd, requested.as_deref()) {
+                Ok(project) => project,
+                Err(e) => {
+                    eprintln!("rvpm: {}", e);
+                    return ExitCode::from(1);
+                }
+            };
+            let program_args = after.unwrap_or(remaining).to_vec();
+            (project, program_args)
+        };
+    match with_fetch_progress(|| ops::run_package(&project, &prog_args)) {
         Ok(code) => {
             let code: u8 = code.try_into().unwrap_or(1);
             ExitCode::from(code)
@@ -674,10 +746,13 @@ fn cmd_test(args: &[String]) -> ExitCode {
         println!("{}", test_usage());
         return ExitCode::SUCCESS;
     }
-    if let Err(e) = reject_extra_args(args, "test", &["--help", "-h"], 0) {
-        eprintln!("rvpm: {}", e);
-        return ExitCode::from(1);
-    }
+    let selection = match parse_package_selection(args, "test", true) {
+        Ok(selection) => selection,
+        Err(e) => {
+            eprintln!("rvpm: {}", e);
+            return ExitCode::from(1);
+        }
+    };
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => {
@@ -685,7 +760,48 @@ fn cmd_test(args: &[String]) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    match ops::test(&cwd) {
+    if selection.all {
+        let workspace = match Workspace::discover(&cwd) {
+            Ok(Some(workspace)) => workspace,
+            Ok(None) => {
+                eprintln!("rvpm: no workspace root found from '{}'", cwd.display());
+                return ExitCode::from(1);
+            }
+            Err(e) => {
+                eprintln!("rvpm: {}", e);
+                return ExitCode::from(1);
+            }
+        };
+        let mut failed = 0usize;
+        for member in workspace.members() {
+            println!("package {}", member.name);
+            match ops::test(&member.root) {
+                Ok(report) => {
+                    failed += report.failed;
+                    for line in report.outcome_lines {
+                        println!("{}", line);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("rvpm: package '{}': {}", member.name, e);
+                    failed += 1;
+                }
+            }
+        }
+        return if failed == 0 {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::from(1)
+        };
+    }
+    let project = match workspace::resolve_package(&cwd, selection.package.as_deref()) {
+        Ok(project) => project,
+        Err(e) => {
+            eprintln!("rvpm: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+    match ops::test(&project) {
         Ok(report) => {
             for line in &report.outcome_lines {
                 println!("{}", line);
@@ -701,6 +817,83 @@ fn cmd_test(args: &[String]) -> ExitCode {
             ExitCode::from(1)
         }
     }
+}
+
+#[derive(Debug, Default)]
+struct PackageSelection {
+    package: Option<String>,
+    all: bool,
+}
+
+fn parse_package_selection(
+    args: &[String],
+    command: &str,
+    allow_all: bool,
+) -> Result<PackageSelection, String> {
+    let mut selection = PackageSelection::default();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-p" | "--package" => {
+                i += 1;
+                let name = args
+                    .get(i)
+                    .ok_or_else(|| "-p/--package requires a package name".to_string())?;
+                if selection.package.replace(name.clone()).is_some() {
+                    return Err("a package may be selected only once".to_string());
+                }
+            }
+            "--workspace" if allow_all => selection.all = true,
+            value if value.starts_with("--package=") => {
+                let name = value.trim_start_matches("--package=");
+                if name.is_empty() {
+                    return Err("--package requires a package name".to_string());
+                }
+                if selection.package.replace(name.to_string()).is_some() {
+                    return Err("a package may be selected only once".to_string());
+                }
+            }
+            other => {
+                return Err(format!(
+                    "unknown argument '{}' for `rvpm {}`; run `rvpm {} --help`",
+                    other, command, command
+                ));
+            }
+        }
+        i += 1;
+    }
+    if selection.all && selection.package.is_some() {
+        return Err("--workspace cannot be combined with -p/--package".to_string());
+    }
+    Ok(selection)
+}
+
+fn cmd_workspace(args: &[String]) -> Result<Vec<String>, String> {
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        return Ok(vec![workspace_usage()]);
+    }
+    let subcommand = args.first().map(String::as_str).unwrap_or("list");
+    if subcommand != "list" || args.len() > 1 {
+        return Err(format!(
+            "unknown workspace subcommand '{}'; run `rvpm workspace --help`",
+            subcommand
+        ));
+    }
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    let workspace = Workspace::discover(&cwd)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("no workspace root found from '{}'", cwd.display()))?;
+    let mut lines = vec![format!("Workspace {}", workspace.root().display())];
+    for member in workspace.members() {
+        lines.push(format!("  {}  {}", member.name, member.root.display()));
+    }
+    if !workspace.commands().is_empty() {
+        lines.push("Commands".to_string());
+        for (name, command) in workspace.commands() {
+            lines.push(format!("  {}  package {}", name, command.package));
+        }
+    }
+    Ok(lines)
 }
 
 /// Generate Markdown API docs from the package sources into `target/doc`.
@@ -915,7 +1108,7 @@ fn fmt_usage() -> String {
 }
 
 fn build_usage() -> String {
-    "Usage: rvpm build".to_string()
+    "Usage: rvpm build [-p <package> | --workspace]".to_string()
 }
 
 fn dist_usage() -> String {
@@ -934,11 +1127,15 @@ fn dist_usage() -> String {
 }
 
 fn run_usage() -> String {
-    "Usage: rvpm run [program arguments]".to_string()
+    "Usage: rvpm run [-p <package>] [command | program arguments]".to_string()
 }
 
 fn test_usage() -> String {
-    "Usage: rvpm test".to_string()
+    "Usage: rvpm test [-p <package> | --workspace]".to_string()
+}
+
+fn workspace_usage() -> String {
+    "Usage: rvpm workspace [list]".to_string()
 }
 
 fn doc_usage() -> String {
@@ -978,6 +1175,7 @@ fn print_usage() {
     println!("  fetch <pkg>    Fetch 'github.com/<user>/<repo>@<version>' into the shared cache");
     println!("  lock           Generate or validate rv.lock for the current package");
     println!("  cache <sub>    Inspect or clear the shared package cache (dir/list/clean)");
+    println!("  workspace      List workspace packages and registered commands");
     println!("  help           Print this message");
     println!("  version        Print the rvpm version (also --version, -V)");
     println!();

--- a/src/bin/rvpm.rs
+++ b/src/bin/rvpm.rs
@@ -711,9 +711,9 @@ fn cmd_run(args: &[String]) -> ExitCode {
                 }
             };
             let mut command_args = command.args.clone();
-            match after {
-                Some(forwarded) => command_args.extend_from_slice(forwarded),
-                None => command_args.extend_from_slice(&remaining[1..]),
+            command_args.extend_from_slice(&remaining[1..]);
+            if let Some(forwarded) = after {
+                command_args.extend_from_slice(forwarded);
             }
             (member.root.clone(), command_args)
         } else {
@@ -724,7 +724,10 @@ fn cmd_run(args: &[String]) -> ExitCode {
                     return ExitCode::from(1);
                 }
             };
-            let program_args = after.unwrap_or(remaining).to_vec();
+            let mut program_args = remaining.to_vec();
+            if let Some(forwarded) = after {
+                program_args.extend_from_slice(forwarded);
+            }
             (project, program_args)
         };
     match with_fetch_progress(|| ops::run_package(&project, &prog_args)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,3 +35,4 @@ pub mod pkg;
 pub mod resolve;
 pub mod span;
 pub mod tycheck;
+pub mod workspace;

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -905,19 +905,6 @@ impl WorkspaceManifest {
             });
         }
 
-        if !raw.dependencies.is_empty()
-            || raw.ffi.is_some()
-            || raw.fmt.is_some()
-            || raw.dist.is_some()
-        {
-            return Err(ManifestError::InvalidValue {
-                section: "workspace".to_string(),
-                field: "members".to_string(),
-                message: "a virtual workspace root may contain only [workspace] and [commands]"
-                    .to_string(),
-            });
-        }
-
         let workspace = validate_workspace(raw.workspace.expect("checked above"))?;
         if workspace.members.is_empty() {
             return Err(ManifestError::InvalidValue {

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -3,13 +3,15 @@
 //!
 //! A manifest describes one Raven package: its identity (`[package]`),
 //! its dependencies on other Raven packages (`[dependencies]`), optional
-//! native linker pass-through (`[ffi]`), and optional formatter settings
-//! (`[fmt]`). This module owns the schema and validation only. Fetching
+//! native linker pass-through (`[ffi]`), formatter settings (`[fmt]`), a
+//! workspace (`[workspace]`), and structured commands (`[commands]`). This
+//! module owns the schema and validation only. Fetching
 //! dependencies, resolving version constraints, and wiring `[ffi]` into
 //! the link step are handled by later rvpm work.
 //!
 //! See `docs/v2/specs/rv-toml.md` for the full field reference.
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::Path;
 
@@ -76,6 +78,36 @@ pub struct Manifest {
     /// already filled from `[package]`. `None` means the section is absent;
     /// `rvpm dist` then acts as if it were `Dist::with_defaults`.
     pub dist: Option<Dist>,
+    /// Workspace configuration when this package is also a workspace root.
+    pub workspace: Option<Workspace>,
+    /// Structured executable commands registered by this manifest.
+    pub commands: BTreeMap<String, RegisteredCommand>,
+}
+
+/// The optional `[workspace]` section on a package or virtual root manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Workspace {
+    /// Package directories relative to the workspace root.
+    pub members: Vec<String>,
+    /// Package name selected when a command runs from the workspace root.
+    pub default_member: Option<String>,
+}
+
+/// One `[commands]` entry. Commands select a workspace application by package
+/// name and prepend optional default arguments before invocation arguments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisteredCommand {
+    pub package: String,
+    pub args: Vec<String>,
+}
+
+/// The workspace-facing view of an `rv.toml`. Unlike [`Manifest`], this also
+/// represents a virtual workspace root that has no `[package]` section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceManifest {
+    pub package: Option<Package>,
+    pub workspace: Workspace,
+    pub commands: BTreeMap<String, RegisteredCommand>,
 }
 
 /// The `[package]` section.
@@ -495,6 +527,26 @@ struct RawManifest {
     ffi: Option<RawFfi>,
     fmt: Option<RawFmt>,
     dist: Option<RawDist>,
+    workspace: Option<RawWorkspace>,
+    #[serde(default)]
+    commands: BTreeMap<String, RawRegisteredCommand>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawWorkspace {
+    #[serde(default)]
+    members: Vec<String>,
+    #[serde(rename = "default-member")]
+    default_member: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRegisteredCommand {
+    package: String,
+    #[serde(default)]
+    args: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -565,6 +617,84 @@ struct RawDistWindows {
     icon: Option<String>,
     upgrade_code: Option<String>,
     add_to_path: Option<bool>,
+}
+
+fn validate_workspace(raw: RawWorkspace) -> Result<Workspace, ManifestError> {
+    let mut seen = std::collections::BTreeSet::new();
+    for member in &raw.members {
+        if member.trim().is_empty() {
+            return Err(ManifestError::InvalidValue {
+                section: "workspace".to_string(),
+                field: "members".to_string(),
+                message: "member paths must not be empty".to_string(),
+            });
+        }
+        if member.chars().any(char::is_control) {
+            return Err(ManifestError::InvalidValue {
+                section: "workspace".to_string(),
+                field: "members".to_string(),
+                message: format!("member path '{}' contains a control character", member),
+            });
+        }
+        if !seen.insert(member.clone()) {
+            return Err(ManifestError::InvalidValue {
+                section: "workspace".to_string(),
+                field: "members".to_string(),
+                message: format!("member path '{}' is listed more than once", member),
+            });
+        }
+    }
+    if let Some(default) = raw.default_member.as_deref() {
+        if !is_valid_package_name(default) {
+            return Err(ManifestError::InvalidValue {
+                section: "workspace".to_string(),
+                field: "default-member".to_string(),
+                message: format!("'{}' is not a valid package name", default),
+            });
+        }
+    }
+    Ok(Workspace {
+        members: raw.members,
+        default_member: raw.default_member,
+    })
+}
+
+fn validate_commands(
+    raw: BTreeMap<String, RawRegisteredCommand>,
+) -> Result<BTreeMap<String, RegisteredCommand>, ManifestError> {
+    let mut commands = BTreeMap::new();
+    for (name, command) in raw {
+        if !is_valid_package_name(&name) {
+            return Err(ManifestError::InvalidValue {
+                section: "commands".to_string(),
+                field: name,
+                message: "command names use the same portable characters as package names"
+                    .to_string(),
+            });
+        }
+        if !is_valid_package_name(&command.package) {
+            return Err(ManifestError::InvalidValue {
+                section: "commands".to_string(),
+                field: name,
+                message: format!("'{}' is not a valid package name", command.package),
+            });
+        }
+        if command.args.iter().any(|arg| arg.contains('\0')) {
+            return Err(ManifestError::InvalidValue {
+                section: "commands".to_string(),
+                field: name,
+                message: "default arguments must not contain NUL bytes".to_string(),
+            });
+        }
+        commands.insert(
+            name,
+            RegisteredCommand {
+                package: command.package,
+                args: command.args,
+            },
+        );
+    }
+    Ok(commands)
 }
 
 impl Manifest {
@@ -704,12 +834,24 @@ impl Manifest {
             None => None,
         };
 
+        let workspace = raw.workspace.map(validate_workspace).transpose()?;
+        let commands = validate_commands(raw.commands)?;
+        if workspace.is_none() && !commands.is_empty() {
+            return Err(ManifestError::InvalidValue {
+                section: "commands".to_string(),
+                field: commands.keys().next().cloned().unwrap_or_default(),
+                message: "registered commands require a [workspace] section".to_string(),
+            });
+        }
+
         Ok(Manifest {
             package,
             dependencies,
             ffi,
             fmt,
             dist,
+            workspace,
+            commands,
         })
     }
 
@@ -721,6 +863,84 @@ impl Manifest {
             source: e,
         })?;
         Manifest::from_toml_str(&text)
+    }
+}
+
+impl WorkspaceManifest {
+    /// Parse a workspace root manifest. A root may also be a normal package,
+    /// or it may be virtual and contain only `[workspace]` and `[commands]`.
+    pub fn from_toml_str(s: &str) -> Result<WorkspaceManifest, ManifestError> {
+        let raw: RawManifest =
+            toml::from_str(s).map_err(|e| ManifestError::Toml(e.message().to_string()))?;
+        if raw.workspace.is_none() {
+            return Err(ManifestError::MissingField {
+                section: "workspace".to_string(),
+                field: "members".to_string(),
+            });
+        }
+
+        if raw.package.is_some() {
+            let manifest = Manifest::from_toml_str(s)?;
+            return Ok(WorkspaceManifest {
+                package: Some(manifest.package),
+                workspace: manifest.workspace.expect("workspace was present"),
+                commands: manifest.commands,
+            });
+        }
+
+        let root: toml::Value =
+            toml::from_str(s).map_err(|e| ManifestError::Toml(e.message().to_string()))?;
+        if let Some(unexpected) = root.as_table().and_then(|table| {
+            table
+                .keys()
+                .find(|key| key.as_str() != "workspace" && key.as_str() != "commands")
+        }) {
+            return Err(ManifestError::InvalidValue {
+                section: "workspace".to_string(),
+                field: "members".to_string(),
+                message: format!(
+                    "a virtual workspace root cannot contain a [{}] section",
+                    unexpected
+                ),
+            });
+        }
+
+        if !raw.dependencies.is_empty()
+            || raw.ffi.is_some()
+            || raw.fmt.is_some()
+            || raw.dist.is_some()
+        {
+            return Err(ManifestError::InvalidValue {
+                section: "workspace".to_string(),
+                field: "members".to_string(),
+                message: "a virtual workspace root may contain only [workspace] and [commands]"
+                    .to_string(),
+            });
+        }
+
+        let workspace = validate_workspace(raw.workspace.expect("checked above"))?;
+        if workspace.members.is_empty() {
+            return Err(ManifestError::InvalidValue {
+                section: "workspace".to_string(),
+                field: "members".to_string(),
+                message: "a virtual workspace must contain at least one member".to_string(),
+            });
+        }
+        Ok(WorkspaceManifest {
+            package: None,
+            workspace,
+            commands: validate_commands(raw.commands)?,
+        })
+    }
+
+    /// Read and parse a workspace root manifest.
+    pub fn load(path: impl AsRef<Path>) -> Result<WorkspaceManifest, ManifestError> {
+        let path = path.as_ref();
+        let text = std::fs::read_to_string(path).map_err(|e| ManifestError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+        WorkspaceManifest::from_toml_str(&text)
     }
 }
 
@@ -1156,5 +1376,62 @@ upgrade_code = "9f0c86a1-2b3c-4d5e-8f90-112233445566"
         assert!(!is_safe_dist_path("a//b"));
         assert!(!is_safe_dist_path("a\\b"));
         assert!(!is_safe_dist_path("C:/x"));
+    }
+
+    #[test]
+    fn package_workspace_and_commands_parse() {
+        let src = r#"
+[package]
+name = "root"
+version = "0.1.0"
+
+[workspace]
+members = ["apps/api", "tools/schema"]
+default-member = "api"
+
+[commands]
+schema = { package = "schema", args = ["migrate"] }
+"#;
+        let manifest = Manifest::from_toml_str(src).expect("manifest parses");
+        let workspace = manifest.workspace.expect("workspace");
+        assert_eq!(workspace.members, ["apps/api", "tools/schema"]);
+        assert_eq!(workspace.default_member.as_deref(), Some("api"));
+        let command = manifest.commands.get("schema").expect("command");
+        assert_eq!(command.package, "schema");
+        assert_eq!(command.args, ["migrate"]);
+    }
+
+    #[test]
+    fn virtual_workspace_manifest_does_not_require_a_package() {
+        let src = r#"
+[workspace]
+members = ["apps/api"]
+
+[commands]
+serve = { package = "api", args = ["--port", "8080"] }
+"#;
+        let manifest = WorkspaceManifest::from_toml_str(src).expect("workspace parses");
+        assert!(manifest.package.is_none());
+        assert_eq!(manifest.workspace.members, ["apps/api"]);
+        assert_eq!(manifest.commands["serve"].args, ["--port", "8080"]);
+    }
+
+    #[test]
+    fn invalid_workspace_and_command_values_are_rejected() {
+        let duplicate = "[workspace]\nmembers = [\"app\", \"app\"]\n";
+        assert!(WorkspaceManifest::from_toml_str(duplicate).is_err());
+
+        let unknown_field =
+            "[workspace]\nmembers = [\"app\"]\n\n[commands]\nx = { package = \"app\", shell = \"echo x\" }\n";
+        assert!(WorkspaceManifest::from_toml_str(unknown_field).is_err());
+
+        let package_only = "[package]\nname = \"app\"\nversion = \"0.1.0\"\n";
+        assert!(WorkspaceManifest::from_toml_str(package_only).is_err());
+
+        let command_without_workspace = "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[commands]\nrun = { package = \"app\" }\n";
+        assert!(Manifest::from_toml_str(command_without_workspace).is_err());
+
+        let virtual_with_package_fields = "[workspace]\nmembers = [\"app\"]\n\n[dependencies]\n";
+        assert!(WorkspaceManifest::from_toml_str(virtual_with_package_fields).is_err());
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -17,6 +17,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Component, Path, PathBuf};
 
+use sha2::{Digest, Sha256};
+
 pub mod dist;
 
 use crate::codegen::linker;
@@ -641,6 +643,22 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
                     source: e,
                 })?;
             }
+            let fingerprint = build_fingerprint(project_dir, &manifest, &lock)?;
+            let fingerprint_path = fingerprint_path(&binary);
+            if binary.is_file()
+                && std::fs::read_to_string(&fingerprint_path)
+                    .map(|saved| saved == fingerprint)
+                    .unwrap_or(false)
+            {
+                return Ok(BuildReport {
+                    outcome_lines: vec![format!(
+                        "Reused {} at {}",
+                        manifest.package.name,
+                        binary.display()
+                    )],
+                    binary: Some(binary),
+                });
+            }
             // Gather native inputs to link: `[ffi]` code from the project and
             // its dependencies, plus the configured Windows icon resource.
             let ffi_dir = binary
@@ -649,6 +667,11 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
                 .unwrap_or_else(|| PathBuf::from("ffi"));
             let native = gather_native_link(project_dir, &manifest, &lock, cache_root, &ffi_dir)?;
             driver::build_binary_native(&entry, &binary, Some(&ctx), &native)?;
+            std::fs::write(&fingerprint_path, fingerprint).map_err(|source| OpError::Io {
+                action: "write build fingerprint".to_string(),
+                path: fingerprint_path,
+                source,
+            })?;
             Ok(BuildReport {
                 outcome_lines: vec![format!(
                     "Compiled {} to {}",
@@ -676,6 +699,123 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
         }
         None => Err(OpError::MissingEntry(project_dir.join(ENTRY_FILE))),
     }
+}
+
+/// Hash every input that affects a package executable. Locked dependencies are
+/// represented by their content hashes, while local Raven and FFI sources are
+/// hashed directly. The rvpm executable and runtime metadata invalidate cached
+/// output after a compiler or runtime replacement.
+fn build_fingerprint(
+    project_dir: &Path,
+    manifest: &Manifest,
+    lock: &LockFile,
+) -> Result<String, OpError> {
+    let mut digest = Sha256::new();
+    digest.update(b"raven-build-fingerprint-v1\0");
+    digest.update(env!("CARGO_PKG_VERSION").as_bytes());
+    digest.update(std::env::consts::OS.as_bytes());
+    digest.update(std::env::consts::ARCH.as_bytes());
+
+    let mut inputs = Vec::new();
+    collect_package_inputs(project_dir, project_dir, &mut inputs)?;
+    inputs.push(project_dir.join(MANIFEST_FILE_NAME));
+    let lock_path = project_dir.join(LOCK_FILE_NAME);
+    if lock_path.is_file() {
+        inputs.push(lock_path);
+    }
+    for source in &manifest.ffi.sources {
+        inputs.push(checked_ffi_source(project_dir, source)?);
+    }
+    if let Some(icon) = manifest
+        .dist
+        .as_ref()
+        .map(|dist| dist.windows.icon.as_str())
+        .filter(|icon| !icon.is_empty())
+    {
+        inputs.push(project_dir.join(icon));
+    }
+    inputs.sort();
+    inputs.dedup();
+    for path in inputs {
+        let relative = path.strip_prefix(project_dir).unwrap_or(&path);
+        digest.update(relative.to_string_lossy().as_bytes());
+        digest.update([0]);
+        let bytes = std::fs::read(&path).map_err(|source| OpError::Io {
+            action: "read build input".to_string(),
+            path: path.clone(),
+            source,
+        })?;
+        digest.update((bytes.len() as u64).to_le_bytes());
+        digest.update(bytes);
+    }
+    for package in &lock.packages {
+        digest.update(package.source.as_bytes());
+        digest.update([0]);
+        digest.update(package.version.as_bytes());
+        digest.update([0]);
+        digest.update(package.hash.as_bytes());
+        digest.update([0]);
+    }
+    hash_tool_metadata(&mut digest, std::env::current_exe().ok().as_deref());
+    let runtime = driver::locate_runtime_staticlib().ok();
+    hash_tool_metadata(
+        &mut digest,
+        runtime.as_ref().map(|runtime| runtime.path.as_path()),
+    );
+    Ok(format!("sha256:{:x}", digest.finalize()))
+}
+
+fn collect_package_inputs(
+    project_dir: &Path,
+    directory: &Path,
+    inputs: &mut Vec<PathBuf>,
+) -> Result<(), OpError> {
+    let entries = std::fs::read_dir(directory).map_err(|source| OpError::Io {
+        action: "read package directory".to_string(),
+        path: directory.to_path_buf(),
+        source,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| OpError::Io {
+            action: "read package directory".to_string(),
+            path: directory.to_path_buf(),
+            source,
+        })?;
+        if is_link_entry(&entry) {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            if path == project_dir.join("target") || entry.file_name() == ".git" {
+                continue;
+            }
+            collect_package_inputs(project_dir, &path, inputs)?;
+        } else if path.is_file() {
+            inputs.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn hash_tool_metadata(digest: &mut Sha256, path: Option<&Path>) {
+    let Some(path) = path else {
+        return;
+    };
+    digest.update(path.to_string_lossy().as_bytes());
+    if let Ok(metadata) = path.metadata() {
+        digest.update(metadata.len().to_le_bytes());
+        if let Ok(modified) = metadata.modified() {
+            if let Ok(duration) = modified.duration_since(std::time::UNIX_EPOCH) {
+                digest.update(duration.as_nanos().to_le_bytes());
+            }
+        }
+    }
+}
+
+fn fingerprint_path(binary: &Path) -> PathBuf {
+    let mut name = binary.as_os_str().to_os_string();
+    name.push(".fingerprint");
+    PathBuf::from(name)
 }
 
 /// Build the package then run the produced binary, forwarding `args` to it

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -15,8 +15,10 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 
+use fs2::FileExt;
 use sha2::{Digest, Sha256};
 
 pub mod dist;
@@ -643,6 +645,11 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
                     source: e,
                 })?;
             }
+            // Every builder and runner takes the same cross-process lock before
+            // inspecting or replacing the binary/fingerprint pair. Holding it
+            // through publication prevents concurrent builds from pairing one
+            // executable with another build's fingerprint.
+            let _build_lock = PackageBuildLock::acquire(&binary)?;
             let fingerprint = build_fingerprint(project_dir, &manifest, &lock)?;
             let fingerprint_path = fingerprint_path(&binary);
             if binary.is_file()
@@ -667,11 +674,7 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
                 .unwrap_or_else(|| PathBuf::from("ffi"));
             let native = gather_native_link(project_dir, &manifest, &lock, cache_root, &ffi_dir)?;
             driver::build_binary_native(&entry, &binary, Some(&ctx), &native)?;
-            std::fs::write(&fingerprint_path, fingerprint).map_err(|source| OpError::Io {
-                action: "write build fingerprint".to_string(),
-                path: fingerprint_path,
-                source,
-            })?;
+            atomic_write(&fingerprint_path, fingerprint.as_bytes())?;
             Ok(BuildReport {
                 outcome_lines: vec![format!(
                     "Compiled {} to {}",
@@ -701,10 +704,37 @@ pub fn build_in(project_dir: &Path, cache_root: &Path) -> Result<BuildReport, Op
     }
 }
 
+struct PackageBuildLock {
+    _file: std::fs::File,
+}
+
+impl PackageBuildLock {
+    fn acquire(binary: &Path) -> Result<PackageBuildLock, OpError> {
+        let path = sidecar_path(binary, ".lock");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|source| OpError::Io {
+                action: "open package build lock".to_string(),
+                path: path.clone(),
+                source,
+            })?;
+        FileExt::lock_exclusive(&file).map_err(|source| OpError::Io {
+            action: "lock package build".to_string(),
+            path,
+            source,
+        })?;
+        Ok(PackageBuildLock { _file: file })
+    }
+}
+
 /// Hash every input that affects a package executable. Locked dependencies are
-/// represented by their content hashes, while local Raven and FFI sources are
-/// hashed directly. The rvpm executable and runtime metadata invalidate cached
-/// output after a compiler or runtime replacement.
+/// represented by their content hashes, while local package files are hashed
+/// directly. The rvpm executable and runtime metadata invalidate cached output
+/// after a compiler or runtime replacement.
 fn build_fingerprint(
     project_dir: &Path,
     manifest: &Manifest,
@@ -813,9 +843,54 @@ fn hash_tool_metadata(digest: &mut Sha256, path: Option<&Path>) {
 }
 
 fn fingerprint_path(binary: &Path) -> PathBuf {
+    sidecar_path(binary, ".fingerprint")
+}
+
+fn sidecar_path(binary: &Path, suffix: &str) -> PathBuf {
     let mut name = binary.as_os_str().to_os_string();
-    name.push(".fingerprint");
+    name.push(suffix);
     PathBuf::from(name)
+}
+
+fn atomic_write(path: &Path, contents: &[u8]) -> Result<(), OpError> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+    let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+    let mut temp_name = path.as_os_str().to_os_string();
+    temp_name.push(format!(".tmp-{}-{}", std::process::id(), sequence));
+    let temp = PathBuf::from(temp_name);
+    let result = (|| -> Result<(), OpError> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)
+            .map_err(|source| OpError::Io {
+                action: "create temporary build fingerprint".to_string(),
+                path: temp.clone(),
+                source,
+            })?;
+        file.write_all(contents).map_err(|source| OpError::Io {
+            action: "write temporary build fingerprint".to_string(),
+            path: temp.clone(),
+            source,
+        })?;
+        file.sync_all().map_err(|source| OpError::Io {
+            action: "sync temporary build fingerprint".to_string(),
+            path: temp.clone(),
+            source,
+        })?;
+        std::fs::rename(&temp, path).map_err(|source| OpError::Io {
+            action: "publish build fingerprint".to_string(),
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
 }
 
 /// Build the package then run the produced binary, forwarding `args` to it
@@ -1839,6 +1914,40 @@ mod tests {
         } else {
             assert!(p.ends_with("target/raven-out/demo"));
         }
+    }
+
+    #[test]
+    fn package_build_lock_serializes_publishers() {
+        let proj = TempProject::new("build-lock");
+        let binary = output_binary_path(&proj.root, "demo");
+        std::fs::create_dir_all(binary.parent().unwrap()).unwrap();
+        let first = PackageBuildLock::acquire(&binary).expect("first lock");
+        let (tx, rx) = std::sync::mpsc::channel();
+        let second_binary = binary.clone();
+        let waiter = std::thread::spawn(move || {
+            let second = PackageBuildLock::acquire(&second_binary).expect("second lock");
+            tx.send(()).unwrap();
+            drop(second);
+        });
+
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "the second publisher acquired the package lock too early"
+        );
+        drop(first);
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("second publisher acquires after release");
+        waiter.join().unwrap();
+    }
+
+    #[test]
+    fn atomic_write_replaces_an_existing_fingerprint() {
+        let proj = TempProject::new("atomic-fingerprint");
+        let path = proj.root.join("demo.fingerprint");
+        atomic_write(&path, b"old").expect("first publication");
+        atomic_write(&path, b"new").expect("replacement publication");
+        assert_eq!(std::fs::read(&path).unwrap(), b"new");
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,458 @@
+//! rvpm workspace discovery, validation, and package selection.
+//!
+//! A workspace root is an `rv.toml` containing `[workspace]`. It may also be
+//! a package, or it may be virtual and contain only workspace configuration
+//! and registered commands. Each member remains an ordinary package with its
+//! own manifest, lock, dependencies, and build output.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+use crate::manifest::{Manifest, ManifestError, RegisteredCommand, WorkspaceManifest};
+use crate::ops::MANIFEST_FILE_NAME;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceMember {
+    pub name: String,
+    pub root: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct Workspace {
+    root: PathBuf,
+    members: Vec<WorkspaceMember>,
+    default_member: Option<String>,
+    commands: BTreeMap<String, RegisteredCommand>,
+}
+
+#[derive(Debug)]
+pub enum WorkspaceError {
+    Io {
+        action: String,
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Manifest(ManifestError),
+    InvalidMember {
+        member: String,
+        message: String,
+    },
+    DuplicatePackage(String),
+    UnknownPackage(String),
+    UnknownCommandPackage {
+        command: String,
+        package: String,
+    },
+    NoWorkspace(PathBuf),
+    NoPackageSelected(PathBuf),
+}
+
+impl fmt::Display for WorkspaceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WorkspaceError::Io {
+                action,
+                path,
+                source,
+            } => write!(f, "cannot {} '{}': {}", action, path.display(), source),
+            WorkspaceError::Manifest(error) => write!(f, "{}", error),
+            WorkspaceError::InvalidMember { member, message } => {
+                write!(f, "invalid workspace member '{}': {}", member, message)
+            }
+            WorkspaceError::DuplicatePackage(name) => write!(
+                f,
+                "workspace package name '{}' is used by more than one member",
+                name
+            ),
+            WorkspaceError::UnknownPackage(name) => {
+                write!(f, "workspace has no package named '{}'", name)
+            }
+            WorkspaceError::UnknownCommandPackage { command, package } => write!(
+                f,
+                "workspace command '{}' names unknown package '{}'",
+                command, package
+            ),
+            WorkspaceError::NoWorkspace(path) => write!(
+                f,
+                "no workspace root found from '{}'; expected an rv.toml with [workspace]",
+                path.display()
+            ),
+            WorkspaceError::NoPackageSelected(root) => write!(
+                f,
+                "workspace '{}' has multiple packages and no default-member; select one with -p <name>",
+                root.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for WorkspaceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            WorkspaceError::Io { source, .. } => Some(source),
+            WorkspaceError::Manifest(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<ManifestError> for WorkspaceError {
+    fn from(value: ManifestError) -> Self {
+        WorkspaceError::Manifest(value)
+    }
+}
+
+impl Workspace {
+    /// Load and fully validate the workspace rooted at `root`.
+    pub fn load(root: &Path) -> Result<Workspace, WorkspaceError> {
+        let root = canonicalize(root, "canonicalize workspace root")?;
+        let root_manifest_path = root.join(MANIFEST_FILE_NAME);
+        let root_manifest = WorkspaceManifest::load(&root_manifest_path)?;
+        let mut members = Vec::new();
+        let mut names = BTreeSet::new();
+        let mut paths = BTreeSet::new();
+
+        if let Some(package) = root_manifest.package {
+            names.insert(package.name.clone());
+            paths.insert(root.clone());
+            members.push(WorkspaceMember {
+                name: package.name,
+                root: root.clone(),
+            });
+        }
+
+        for configured in &root_manifest.workspace.members {
+            validate_member_path(configured)?;
+            let joined = root.join(configured);
+            if !joined.is_dir() {
+                return Err(WorkspaceError::InvalidMember {
+                    member: configured.clone(),
+                    message: format!("directory '{}' does not exist", joined.display()),
+                });
+            }
+            let member_root = canonicalize(&joined, "canonicalize workspace member")?;
+            if member_root == root {
+                return Err(WorkspaceError::InvalidMember {
+                    member: configured.clone(),
+                    message: "the root package is included automatically".to_string(),
+                });
+            }
+            if !member_root.starts_with(&root) {
+                return Err(WorkspaceError::InvalidMember {
+                    member: configured.clone(),
+                    message: "resolved path escapes the workspace root".to_string(),
+                });
+            }
+            if !paths.insert(member_root.clone()) {
+                return Err(WorkspaceError::InvalidMember {
+                    member: configured.clone(),
+                    message: "another member resolves to the same directory".to_string(),
+                });
+            }
+            let manifest_path = member_root.join(MANIFEST_FILE_NAME);
+            if !manifest_path.is_file() {
+                return Err(WorkspaceError::InvalidMember {
+                    member: configured.clone(),
+                    message: format!("'{}' is missing", manifest_path.display()),
+                });
+            }
+            let manifest = Manifest::load(&manifest_path)?;
+            if !names.insert(manifest.package.name.clone()) {
+                return Err(WorkspaceError::DuplicatePackage(manifest.package.name));
+            }
+            members.push(WorkspaceMember {
+                name: manifest.package.name,
+                root: member_root,
+            });
+        }
+
+        if let Some(default) = root_manifest.workspace.default_member.as_deref() {
+            if !names.contains(default) {
+                return Err(WorkspaceError::UnknownPackage(default.to_string()));
+            }
+        }
+        for (name, command) in &root_manifest.commands {
+            if !names.contains(&command.package) {
+                return Err(WorkspaceError::UnknownCommandPackage {
+                    command: name.clone(),
+                    package: command.package.clone(),
+                });
+            }
+        }
+
+        Ok(Workspace {
+            root,
+            members,
+            default_member: root_manifest.workspace.default_member,
+            commands: root_manifest.commands,
+        })
+    }
+
+    /// Search `start` and its ancestors for the nearest workspace manifest.
+    pub fn discover(start: &Path) -> Result<Option<Workspace>, WorkspaceError> {
+        let start = canonicalize(start, "canonicalize current directory")?;
+        for dir in start.ancestors() {
+            let manifest = dir.join(MANIFEST_FILE_NAME);
+            if manifest.is_file() && manifest_has_workspace(&manifest)? {
+                return Workspace::load(dir).map(Some);
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn members(&self) -> &[WorkspaceMember] {
+        &self.members
+    }
+
+    pub fn command(&self, name: &str) -> Option<&RegisteredCommand> {
+        self.commands.get(name)
+    }
+
+    pub fn commands(&self) -> &BTreeMap<String, RegisteredCommand> {
+        &self.commands
+    }
+
+    pub fn member(&self, name: &str) -> Result<&WorkspaceMember, WorkspaceError> {
+        self.members
+            .iter()
+            .find(|member| member.name == name)
+            .ok_or_else(|| WorkspaceError::UnknownPackage(name.to_string()))
+    }
+
+    /// Select an explicit package, the package containing `current`, the
+    /// configured default, or the sole workspace member in that order.
+    pub fn select<'a>(
+        &'a self,
+        current: &Path,
+        requested: Option<&str>,
+    ) -> Result<&'a WorkspaceMember, WorkspaceError> {
+        if let Some(name) = requested {
+            return self.member(name);
+        }
+        let current = canonicalize(current, "canonicalize current directory")?;
+        if let Some(member) = self
+            .members
+            .iter()
+            .filter(|member| current.starts_with(&member.root))
+            .max_by_key(|member| member.root.components().count())
+        {
+            return Ok(member);
+        }
+        if let Some(default) = self.default_member.as_deref() {
+            return self.member(default);
+        }
+        if self.members.len() == 1 {
+            return Ok(&self.members[0]);
+        }
+        Err(WorkspaceError::NoPackageSelected(self.root.clone()))
+    }
+}
+
+/// Resolve a package from a workspace or fall back to the nearest standalone
+/// package manifest for backwards-compatible single-package behavior.
+pub fn resolve_package(start: &Path, requested: Option<&str>) -> Result<PathBuf, WorkspaceError> {
+    if let Some(workspace) = Workspace::discover(start)? {
+        return Ok(workspace.select(start, requested)?.root.clone());
+    }
+    if requested.is_some() {
+        return Err(WorkspaceError::NoWorkspace(start.to_path_buf()));
+    }
+    let start = canonicalize(start, "canonicalize current directory")?;
+    for dir in start.ancestors() {
+        if dir.join(MANIFEST_FILE_NAME).is_file() {
+            return Ok(dir.to_path_buf());
+        }
+    }
+    Err(WorkspaceError::Io {
+        action: "find package manifest".to_string(),
+        path: start.join(MANIFEST_FILE_NAME),
+        source: std::io::Error::new(std::io::ErrorKind::NotFound, "rv.toml was not found"),
+    })
+}
+
+fn validate_member_path(member: &str) -> Result<(), WorkspaceError> {
+    let path = Path::new(member);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(WorkspaceError::InvalidMember {
+            member: member.to_string(),
+            message: "paths must be relative and stay inside the workspace root".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn manifest_has_workspace(path: &Path) -> Result<bool, WorkspaceError> {
+    let text = std::fs::read_to_string(path).map_err(|source| WorkspaceError::Io {
+        action: "read".to_string(),
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let value: toml::Value = toml::from_str(&text).map_err(|error| {
+        WorkspaceError::Manifest(ManifestError::Toml(error.message().to_string()))
+    })?;
+    Ok(value
+        .as_table()
+        .map(|table| table.contains_key("workspace"))
+        .unwrap_or(false))
+}
+
+fn canonicalize(path: &Path, action: &str) -> Result<PathBuf, WorkspaceError> {
+    let canonical = path.canonicalize().map_err(|source| WorkspaceError::Io {
+        action: action.to_string(),
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(normalize_windows_verbatim(canonical))
+}
+
+#[cfg(not(windows))]
+fn normalize_windows_verbatim(path: PathBuf) -> PathBuf {
+    path
+}
+
+/// `std::fs::canonicalize` returns `\\?\` paths on Windows. Rust accepts
+/// those paths, but tools in the MSVC build chain do not consistently accept
+/// them on command lines. Rebuild ordinary drive and UNC paths component by
+/// component without converting non-Unicode names through a string.
+#[cfg(windows)]
+fn normalize_windows_verbatim(path: PathBuf) -> PathBuf {
+    use std::path::Prefix;
+
+    let mut components = path.components();
+    let Some(Component::Prefix(prefix)) = components.next() else {
+        return path;
+    };
+    let mut normalized = match prefix.kind() {
+        Prefix::VerbatimDisk(drive) => PathBuf::from(format!("{}:\\", drive as char)),
+        Prefix::VerbatimUNC(server, share) => {
+            let mut root = PathBuf::from(r"\\");
+            root.push(server);
+            root.push(share);
+            root
+        }
+        _ => return path,
+    };
+    for component in components {
+        if !matches!(component, Component::RootDir) {
+            normalized.push(component.as_os_str());
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn virtual_workspace_loads_and_selects_members() {
+        let root = tempdir("select");
+        write(
+            &root.join("rv.toml"),
+            "[workspace]\nmembers = [\"apps/api\", \"tools/task\"]\ndefault-member = \"api\"\n\n[commands]\ncheck = { package = \"task\", args = [\"all\"] }\n",
+        );
+        package(&root.join("apps/api"), "api");
+        package(&root.join("tools/task"), "task");
+
+        let workspace = Workspace::load(&root).expect("workspace loads");
+        assert_eq!(workspace.members().len(), 2);
+        assert_eq!(workspace.select(&root, None).unwrap().name, "api");
+        assert_eq!(
+            workspace.member("task").unwrap().root,
+            normalize_windows_verbatim(root.join("tools/task").canonicalize().unwrap())
+        );
+        assert_eq!(workspace.command("check").unwrap().args, ["all"]);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn discovery_from_a_nested_member_prefers_that_member() {
+        let root = tempdir("discover");
+        write(
+            &root.join("rv.toml"),
+            "[workspace]\nmembers = [\"one\", \"two\"]\n",
+        );
+        package(&root.join("one"), "one");
+        package(&root.join("two"), "two");
+        let nested = root.join("two/src/deep");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let workspace = Workspace::discover(&nested).unwrap().unwrap();
+        assert_eq!(workspace.select(&nested, None).unwrap().name, "two");
+        cleanup(&root);
+    }
+
+    #[test]
+    fn member_escape_and_duplicate_names_are_rejected() {
+        let base = tempdir("invalid");
+        let root = base.join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        package(&base.join("outside"), "outside");
+        write(
+            &root.join("rv.toml"),
+            "[workspace]\nmembers = [\"../outside\"]\n",
+        );
+        assert!(matches!(
+            Workspace::load(&root),
+            Err(WorkspaceError::InvalidMember { .. })
+        ));
+
+        write(
+            &root.join("rv.toml"),
+            "[workspace]\nmembers = [\"a\", \"b\"]\n",
+        );
+        package(&root.join("a"), "same");
+        package(&root.join("b"), "same");
+        assert!(matches!(
+            Workspace::load(&root),
+            Err(WorkspaceError::DuplicatePackage(name)) if name == "same"
+        ));
+        cleanup(&base);
+    }
+
+    fn package(root: &Path, name: &str) {
+        std::fs::create_dir_all(root).unwrap();
+        write(
+            &root.join("rv.toml"),
+            &format!("[package]\nname = \"{}\"\nversion = \"0.1.0\"\n", name),
+        );
+    }
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn tempdir(label: &str) -> PathBuf {
+        let mut root = std::env::temp_dir();
+        root.push(format!(
+            "raven-workspace-{}-{}-{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn cleanup(root: &Path) {
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/tests/rvpm_workspace.rs
+++ b/tests/rvpm_workspace.rs
@@ -1,0 +1,231 @@
+//! End-to-end coverage for rvpm workspaces and registered commands.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use raven::codegen::linker;
+
+#[test]
+fn workspace_list_works_from_a_nested_member_directory() {
+    let _guard = test_lock();
+    let root = fixture();
+    let nested = root.join("apps/api/src/nested");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let output = rvpm(&nested, &["workspace", "list"]);
+    cleanup(&root);
+
+    assert!(
+        output.status.success(),
+        "workspace list failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("api"), "stdout: {}", stdout);
+    assert!(stdout.contains("tool"), "stdout: {}", stdout);
+    assert!(stdout.contains("show"), "stdout: {}", stdout);
+}
+
+#[test]
+fn package_selection_and_registered_commands_build_and_run() {
+    let _guard = test_lock();
+    if !supported_runtime() {
+        return;
+    }
+    let root = fixture();
+
+    let selected = rvpm(&root, &["run", "-p", "api"]);
+    assert!(
+        selected.status.success(),
+        "selected run failed: {}",
+        String::from_utf8_lossy(&selected.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&selected.stdout), "api\n");
+    let api_binary = binary(&root.join("apps/api"), "api");
+    let first_modified = api_binary.metadata().unwrap().modified().unwrap();
+    let selected_again = rvpm(&root, &["run", "-p", "api"]);
+    assert!(selected_again.status.success());
+    assert_eq!(
+        api_binary.metadata().unwrap().modified().unwrap(),
+        first_modified,
+        "an unchanged command target should reuse its compiled binary"
+    );
+    write(
+        &root.join("apps/api/src/main.rv"),
+        "fun main() { print(\"api changed\") }\n",
+    );
+    let selected_after_change = rvpm(&root, &["run", "-p", "api"]);
+    assert!(selected_after_change.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&selected_after_change.stdout),
+        "api changed\n"
+    );
+
+    let command = rvpm(&root, &["run", "show", "extra"]);
+    assert!(
+        command.status.success(),
+        "registered command failed: {}",
+        String::from_utf8_lossy(&command.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&command.stdout), "base\nextra\n");
+
+    let separated = rvpm(&root, &["run", "show", "--", "tail"]);
+    assert!(
+        separated.status.success(),
+        "registered command with separator failed: {}",
+        String::from_utf8_lossy(&separated.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&separated.stdout), "base\ntail\n");
+
+    let failed = rvpm(&root, &["run", "fail"]);
+    cleanup(&root);
+    assert_eq!(failed.status.code(), Some(7));
+}
+
+#[test]
+fn workspace_build_compiles_every_member() {
+    let _guard = test_lock();
+    if !supported_runtime() {
+        return;
+    }
+    let root = fixture();
+    let output = rvpm(&root, &["build", "--workspace"]);
+    let api = binary(&root.join("apps/api"), "api").is_file();
+    let tool = binary(&root.join("tools/tool"), "tool").is_file();
+    cleanup(&root);
+
+    assert!(
+        output.status.success(),
+        "workspace build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(api, "api binary was not built");
+    assert!(tool, "tool binary was not built");
+}
+
+fn fixture() -> PathBuf {
+    let root = workdir();
+    write(
+        &root.join("rv.toml"),
+        r#"[workspace]
+members = ["apps/api", "tools/tool"]
+default-member = "api"
+
+[commands]
+show = { package = "tool", args = ["base"] }
+fail = { package = "tool", args = ["fail"] }
+"#,
+    );
+    package(
+        &root.join("apps/api"),
+        "api",
+        "fun main() { print(\"api\") }\n",
+    );
+    package(
+        &root.join("tools/tool"),
+        "tool",
+        r#"import std/env { args, exit }
+
+fun main() {
+    let all = args()
+    if all.len() > 1 && all[1] == "fail" {
+        exit(7)
+    }
+    let i = 1
+    while i < all.len() {
+        print(all[i])
+        i = i + 1
+    }
+}
+"#,
+    );
+    root
+}
+
+fn package(root: &Path, name: &str, source: &str) {
+    write(
+        &root.join("rv.toml"),
+        &format!("[package]\nname = \"{}\"\nversion = \"0.1.0\"\n", name),
+    );
+    write(&root.join("src/main.rv"), source);
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+fn rvpm(current_dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rvpm"))
+        .args(args)
+        .current_dir(current_dir)
+        .env("RVPM_CACHE_DIR", current_dir.join(".cache"))
+        .output()
+        .expect("run rvpm")
+}
+
+fn supported_runtime() -> bool {
+    if !linker::linker_available() {
+        eprintln!("rvpm_workspace: skipping, no linker available for the host");
+        return false;
+    }
+    if locate_runtime().is_none() {
+        eprintln!("rvpm_workspace: skipping, raven_runtime staticlib is not built");
+        return false;
+    }
+    true
+}
+
+fn locate_runtime() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("RAVEN_RUNTIME_LIB") {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let name = if cfg!(windows) {
+        "raven_runtime.lib"
+    } else {
+        "libraven_runtime.a"
+    };
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    ["target/debug", "target/release"]
+        .iter()
+        .map(|directory| root.join(directory).join(name))
+        .find(|path| path.is_file())
+}
+
+fn binary(root: &Path, name: &str) -> PathBuf {
+    root.join("target/raven-out").join(if cfg!(windows) {
+        format!("{}.exe", name)
+    } else {
+        name.to_string()
+    })
+}
+
+fn workdir() -> PathBuf {
+    let mut root = std::env::temp_dir();
+    root.push(format!(
+        "rvpm-workspace-cli-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    root
+}
+
+fn cleanup(root: &Path) {
+    let _ = std::fs::remove_dir_all(root);
+}
+
+fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/tests/rvpm_workspace.rs
+++ b/tests/rvpm_workspace.rs
@@ -77,6 +77,20 @@ fn package_selection_and_registered_commands_build_and_run() {
     );
     assert_eq!(String::from_utf8_lossy(&separated.stdout), "base\ntail\n");
 
+    let mixed_command = rvpm(&root, &["run", "show", "extra", "--", "tail"]);
+    assert!(mixed_command.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&mixed_command.stdout),
+        "base\nextra\ntail\n"
+    );
+
+    let mixed_package = rvpm(&root, &["run", "-p", "tool", "extra", "--", "tail"]);
+    assert!(mixed_package.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&mixed_package.stdout),
+        "extra\ntail\n"
+    );
+
     let failed = rvpm(&root, &["run", "fail"]);
     cleanup(&root);
     assert_eq!(failed.status.code(), Some(7));


### PR DESCRIPTION
## Summary

- add virtual and package workspace roots with validated member discovery
- select members with `-p`, or build and test every member with `--workspace`
- add structured `[commands]` entries that compile and run application members
- forward command arguments and exit codes without invoking a shell
- cache application builds with fingerprints that cover package and toolchain inputs
- document workspace layout, selection, commands, and caching
- add parser, validation, security, nested discovery, CLI, cache, argument, and exit-code tests

## Why

rvpm previously assumed one package in the current directory. This prevented repositories from managing several Raven applications and gave compiled project tools no portable command registration model.

## Validation

- `cargo fmt --all --check`
- `cargo clippy`
- `cargo build --verbose`
- `cargo test --verbose`
- `mkdocs build`

Fixes #886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace support for managing and selecting multiple packages.
  * Added workspace-wide and package-specific build and test options.
  * Added registered commands and the `rvpm workspace list` command.
  * Added automatic reuse of unchanged compiled applications.

* **Documentation**
  * Expanded guides, specifications, and quick-start content with workspace configuration, commands, validation, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->