### PR TITLE
build: prepare Raven 2.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.26.0] - 2026-07-14
+
+### Added
+
+- `rvpm` now supports multi-package workspaces with secure upward discovery, current/default/explicit member selection, workspace-wide builds and tests, and structured manifest commands that compile and run application members without a shell. Application binaries are reused through input fingerprints, with cross-process locking and atomic fingerprint publication protecting concurrent builds. (#886)
+
 ## [2.25.6] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.25.6"
+version = "2.26.0"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.25.6"
+version = "2.26.0"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.25.6"
+version = "2.26.0"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the Raven workspace and runtime from 2.25.6 to 2.26.0
- add the 2.26.0 changelog entry for rvpm workspaces and registered commands
- keep package metadata and lockfile versions synchronized

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all --check`
- `cargo check --workspace`

This is a minor release because it adds new rvpm functionality.