### PR TITLE
fix(resolve): rewrite lambda signature types when merging modules

### DIFF
--- a/src/resolve/stdlib.rs
+++ b/src/resolve/stdlib.rs
@@ -1708,7 +1708,24 @@ fn rewrite_expr(expr: &mut Expr, rename: &HashMap<String, String>) {
                 None => rewrite_block(body, rename),
             }
         }
-        ExprKind::Lambda { params, body, .. } => {
+        ExprKind::Lambda {
+            params, ret, body, ..
+        } => {
+            // Parameter and return type annotations name types in the
+            // enclosing module scope, so rewrite them with the full map,
+            // exactly as `rewrite_fn` does for a named function. Without
+            // this, a merged package's mangled type names leave the bare
+            // annotation unresolved ("cannot find `T` in scope"). Value
+            // parameters shadow only globals in the body, never a type name,
+            // so the annotations use `rename`, not the shadowed map.
+            for p in params.iter_mut() {
+                if let Some(t) = &mut p.ty {
+                    rewrite_type(t, rename);
+                }
+            }
+            if let Some(r) = ret {
+                rewrite_type(r, rename);
+            }
             // Lambda parameters shadow a global of the same name in the body.
             let bound: Vec<String> = params.iter().map(|p| p.name.clone()).collect();
             let inner = rename_without_shadowed(rename, &bound);
@@ -2759,6 +2776,37 @@ mod tests {
         let typed =
             crate::tycheck::check_file(&resolved).expect("imported const should type check");
         crate::hir::lower_file(&typed).expect("imported const should lower");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn lambda_parameter_type_from_merged_module_resolves() {
+        // A lambda whose parameter and return type name a type from another
+        // module must have those annotations rewritten to the mangled name by
+        // the rename pass. Without that, resolution fails with
+        // "cannot find `T` in scope" for the lambda signature even though the
+        // same type resolves fine as a plain parameter, return, or let type.
+        let main_src = "import \"./widget\" { Widget, make }\n\
+             fun apply(w: Widget, f: fun(Widget) -> Widget) -> Widget { return f(w) }\n\
+             fun main() {\n    let id = fun(x: Widget) -> Widget = x\n    print(apply(make(), id).n)\n}\n";
+        let (dir, entry) = write_temp_project(
+            &[
+                (
+                    "widget.rv",
+                    "struct Widget { n: Int }\nfun make() -> Widget { return Widget { n: 7 } }\n",
+                ),
+                ("main.rv", main_src),
+            ],
+            "main.rv",
+        );
+        let user = parse_at(main_src, &entry);
+        let combined = expand_with_stdlib(&user).expect("expand");
+        let mut loader = FsLoader;
+        let resolved = super::super::resolve_file(&combined, &mut loader)
+            .expect("lambda parameter type from a merged module should resolve");
+        let typed =
+            crate::tycheck::check_file(&resolved).expect("lambda parameter type should type check");
+        crate::hir::lower_file(&typed).expect("lambda parameter type should lower");
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## Problem

A named type used as a **closure parameter or return type** fails name resolution with `cannot find \`T\` in scope` when a project is built through `rvpm` (package mode), even though the exact same type resolves correctly as a plain function parameter, a return type, or a `let` annotation. Single-file `raven build` is unaffected.

Because Raven requires closure parameters to be annotated (there is no inference for them), this blocks every higher-order library API expressed over a named type: iterator callbacks, event handlers, ORM row mappers, and so on. A consumer simply cannot write `fun(x: SomeType) -> SomeType` when building through rvpm.

### Minimal reproduction (package mode)

```raven
// lib.rv
struct Handler { name: String }
// ...

// lib_test.rv
import "./lib" { Handler }
fun demo() {
    let f = fun(x: Handler) -> Handler = x   // error: cannot find `Handler` in scope
}
```

`let h: Handler = ...` and `fun helper(h: Handler)` in the same file resolve fine; only the closure signature fails.

## Root cause

The stdlib expansion pass merges modules and rewrites every type annotation to its mangled, module-qualified name via `rewrite_type`. `rewrite_fn` does this for named-function parameter and return types, `rewrite_stmt` does it for `let` annotations, and struct/enum/const/impl are all covered. The `rewrite_expr` `ExprKind::Lambda` arm rewrote only the lambda **body**, never its parameter or return type annotations, so those kept the bare name that no longer exists in the merged module scope.

## Fix

Rewrite the lambda parameter and return type annotations with the full rename map in the `ExprKind::Lambda` arm, mirroring `rewrite_fn`. Value parameters still shadow only globals in the body, so the annotations correctly use the unshadowed map.

## Tests

- New regression test `lambda_parameter_type_from_merged_module_resolves` in `src/resolve/stdlib.rs`: a lambda whose parameter and return type come from a merged module now expands, resolves, type-checks, and lowers.
- Full suite green locally: 685 lib tests plus all integration suites, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unresolved type references in lambda parameter and return type annotations when modules are merged.
  * Lambda expressions now correctly resolve, type-check, and compile when their annotations refer to types from another module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->