### PR TITLE
build: prepare Raven 2.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Raven are documented in this file.
 
+## [2.26.1] - 2026-07-14
+
+### Fixed
+
+- The module merge pass now rewrites the parameter and return type annotations of a lambda, not just its body. A closure whose parameter or return type named a type from another module previously failed to resolve when built through `rvpm` (package mode) with "cannot find `T` in scope", even though the same type resolved as a plain parameter, return, or `let` annotation. Because closure parameters must be annotated, this had blocked every higher-order library API expressed over a named type. (#889)
+
 ## [2.26.0] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "2.26.0"
+version = "2.26.1"
 dependencies = [
  "cc",
  "cranelift-codegen",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "raven-runtime"
-version = "2.26.0"
+version = "2.26.1"
 dependencies = [
  "chrono",
  "corosensei",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "raven-runtime"]
 
 [workspace.package]
-version = "2.26.0"
+version = "2.26.1"
 edition = "2021"
 authors = ["martian56"]
 license = "MIT"


### PR DESCRIPTION
Patch release bundling the lambda signature type resolution fix.

## Included

- fix(resolve): rewrite lambda signature types when merging modules (#889)

## Release prep

- Bump workspace version 2.26.0 to 2.26.1 (Cargo.toml, Cargo.lock).
- Add the 2.26.1 CHANGELOG entry under Fixed.

Cutting the `v2.26.1` tag after this merges triggers the release build.